### PR TITLE
fix(ci): validate-json always reports status on every PR

### DIFF
--- a/.github/workflows/validate-mods.yml
+++ b/.github/workflows/validate-mods.yml
@@ -3,16 +3,8 @@ name: Validate Mod Data
 on:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'data/locations/**.json'
-      - 'data/tags.json'
-      - 'mods.schema.json'
   push:
     branches: [ main ]
-    paths:
-      - 'data/locations/**.json'
-      - 'data/tags.json'
-      - 'mods.schema.json'
 
 jobs:
   validate-json:
@@ -20,12 +12,33 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for data file changes
+        id: changes
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          CHANGED=$(git diff --name-only "$BASE" "${{ github.sha }}" 2>/dev/null \
+            | grep -E '^(data/locations/|data/tags\.json|mods\.schema\.json)' || true)
+          if [ -n "$CHANGED" ]; then
+            echo "data_changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "data_changed=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Build mods.json
+        if: steps.changes.outputs.data_changed == 'true'
         run: node scripts/build_mods.js
 
       - name: Validate JSON Schema against Data
+        if: steps.changes.outputs.data_changed == 'true'
         run: npx -y ajv-cli validate -s mods.schema.json -d mods.json
 
       - name: Validate Tags consistency
+        if: steps.changes.outputs.data_changed == 'true'
         run: node scripts/validate_tags.js


### PR DESCRIPTION
## Summary
- `validate-json` was a required status check but used `paths:` filters on the trigger
- When a PR didn't touch data files, the workflow never ran → GitHub showed "Expected — Waiting for status" indefinitely, blocking merge
- This affected all non-data PRs including Aki's UI PRs (#250, #251, #243) and the JS refactor PR (#272)

## Fix
- Remove `paths:` filters from the `on:` trigger (job now always runs)
- Add `fetch-depth: 0` to checkout so `git diff` has full history
- Add a "Check for data file changes" step that diffs against the PR base (or previous push commit) and sets `data_changed` output
- Gate `Build mods.json`, `Validate JSON Schema`, and `Validate Tags` behind `if: steps.changes.outputs.data_changed == 'true'`

**Result:** Every PR gets an instant green `validate-json` check. Data PRs still run full validation as before.

## Test plan
- [x] Merge this PR — confirm `validate-json` runs and passes on this PR itself (no data files changed → steps skipped, job green)
- [ ] Open a mod submission PR touching `data/locations/` — confirm all three validation steps run

🤖 Generated with [Claude Code](https://claude.com/claude-code)