### PR TITLE
fix: coordinate transform accuracy + satellite WebP

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -537,14 +537,7 @@ async function initMap() {
     map.setMaxBounds(pannableBounds);
   }
 
-  L.tileLayer("assets/tiles/{z}/{x}/{y}.png", {
-    minZoom: 0,
-    maxNativeZoom: 5,
-    maxZoom: 8,
-    tileSize: 256,
-    noWrap: true,
-    bounds: mapBounds,
-  }).addTo(map);
+  L.imageOverlay("assets/img/satellite_8k.webp", mapBounds).addTo(map);
 
   map.invalidateSize();
   map.fitBounds(mapBounds);

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -73,11 +73,21 @@ NCZ.SEARCH_DEBOUNCE_MS = 200;
 NCZ.SITE_URL      = "https://nczoning.net";
 NCZ.URL_PARAM_MOD = "mod";
 
-// CET <-> Leaflet transform calibration
-NCZ.CET_TO_LEAFLET_X_SCALE = 0.0208623;
-NCZ.CET_TO_LEAFLET_Y_SCALE = 0.02101335;
-NCZ.CET_TO_LEAFLET_X_OFFSET = 132.8016;
-NCZ.CET_TO_LEAFLET_Y_OFFSET = -93.68566;
+// Map world extent (CET world-space)
+// Source: Realistic Map 8k mod terrain quad UV mapping — the authoritative projection
+// for the satellite image (satellite_8k.webp) and terrain tiles.
+// See docs/coordinate-system.md for derivation and why TweakDB bounds differ.
+NCZ.WORLD_MIN_X = -6298;
+NCZ.WORLD_MAX_X =  5815;
+NCZ.WORLD_MIN_Y = -7684;
+NCZ.WORLD_MAX_Y =  4427;
+
+// CET <-> Leaflet transform derived coefficients (from WORLD_MIN/MAX)
+// Used by cetToLeaflet() and the scale indicator for distance conversion.
+NCZ.CET_TO_LEAFLET_X_SCALE = 256 / (NCZ.WORLD_MAX_X - NCZ.WORLD_MIN_X);  // 0.02113734
+NCZ.CET_TO_LEAFLET_Y_SCALE = 256 / (NCZ.WORLD_MAX_Y - NCZ.WORLD_MIN_Y);  // 0.02113385
+NCZ.CET_TO_LEAFLET_X_OFFSET = -NCZ.WORLD_MIN_X * NCZ.CET_TO_LEAFLET_X_SCALE;
+NCZ.CET_TO_LEAFLET_Y_OFFSET = -NCZ.WORLD_MAX_Y * NCZ.CET_TO_LEAFLET_Y_SCALE;
 // Set this if you want to calibrate CET units to physical meters.
 // Default assumes 1 CET unit ~= 1 meter.
 NCZ.CET_UNITS_PER_METER = 1;

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -31,9 +31,11 @@ NCZ.toNexusUid = function (modId) {
 };
 
 // Forward: CET (x, y) → Leaflet [lat, lng]
+// Derived from the Realistic Map 8k mod terrain quad UV mapping.
+// See docs/coordinate-system.md for the full derivation.
 NCZ.cetToLeaflet = function (cetX, cetY) {
-  const lat = (NCZ.CET_TO_LEAFLET_Y_SCALE * cetY) + NCZ.CET_TO_LEAFLET_Y_OFFSET;
-  const lng = (NCZ.CET_TO_LEAFLET_X_SCALE * cetX) + NCZ.CET_TO_LEAFLET_X_OFFSET;
+  const lng = (cetX - NCZ.WORLD_MIN_X) / (NCZ.WORLD_MAX_X - NCZ.WORLD_MIN_X) * 256;
+  const lat = (cetY - NCZ.WORLD_MAX_Y) / (NCZ.WORLD_MAX_Y - NCZ.WORLD_MIN_Y) * 256;
   return [lat, lng];
 };
 


### PR DESCRIPTION
## Summary

- Replace the 16-point manual calibration CET-to-Leaflet transform with mathematically exact coefficients derived from the Realistic Map 8k mod terrain quad UV mapping
- Add `WORLD_MIN/MAX` constants as the single source of truth for map world extent
- Transform coefficients now derived from these constants instead of hardcoded calibration values
- Scale indicator accuracy improves automatically (reads same constants)
- Replace satellite tile pyramid (`assets/tiles/`) with single 9.6 MB WebP image overlay — eliminates tile-loading seams and simplifies serving

**Pin drift:** ~0.25 Leaflet units near center (negligible), up to ~2 units at map edges (~6-16px at max zoom). All pins now align exactly with the satellite image projection.

See `docs/coordinate-system.md` for the full derivation and why TweakDB bounds differ from the render extent.

## Test plan

- [ ] Verify pins still align with satellite image at known locations (Afterlife, Konpeki Plaza)
- [ ] Verify scale indicator shows reasonable distances
- [ ] Check edge-of-map pins (Badlands, Pacifica) haven't drifted visibly
- [ ] Verify satellite image loads correctly as single WebP (no tile seams)
- [ ] Check zoom levels 0-8 still work smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)