### PR TITLE
feat(migration): Add workflow to fix incorrect coordinates from project

### DIFF
--- a/.github/workflows/fix-coords-from-project.yml
+++ b/.github/workflows/fix-coords-from-project.yml
@@ -1,0 +1,50 @@
+name: Fix Incorrect Coordinates from Project
+
+on:
+  workflow_dispatch:   # Manual trigger only
+
+jobs:
+  fix-coords:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Fix coordinates from project
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROJECTS_PAT }}
+        run: node scripts/fix_coords_from_project.js
+
+      - name: Check for changes
+        id: changes
+        run: git diff --quiet data/locations/ || echo "changed=true" >> $GITHUB_OUTPUT
+
+      - name: Rebuild mods.json
+        if: steps.changes.outputs.changed == 'true'
+        run: node scripts/build_mods.js
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.changed == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.ACTIONS_PAT }}
+          commit-message: "data: fix incorrect coordinates (batch ${{ github.run_number }})"
+          title: "data: fix incorrect coordinates (batch ${{ github.run_number }})"
+          body: "Automated coordinate correction from migration project."
+          branch: fix-coords-${{ github.run_number }}
+          delete-branch: true
+
+      - name: Auto-merge PR
+        if: steps.changes.outputs.changed == 'true' && steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ steps.cpr.outputs.pull-request-number }} --squash --auto

--- a/scripts/fix_coords_from_project.js
+++ b/scripts/fix_coords_from_project.js
@@ -1,0 +1,298 @@
+/**
+ * fix_coords_from_project.js
+ *
+ * Reads all "Incorrect Coords" items from the Z/Yaw migration GitHub Project,
+ * overwrites X, Y (and optionally Z, Yaw) in data/locations/*.json, then marks
+ * each item "Processed".
+ *
+ * Required project fields:
+ *   X Coordinate  (number) — new CET X value (required)
+ *   Y Coordinate  (number) — new CET Y value (required)
+ *   Z Coordinate  (number) — new Z value (optional, keeps existing if blank)
+ *   Yaw           (number) — new Yaw value (optional, keeps existing if blank)
+ *
+ * Usage:
+ *   GITHUB_TOKEN=<projects_token> node scripts/fix_coords_from_project.js
+ */
+
+'use strict';
+
+const fs   = require('fs');
+const path = require('path');
+
+const GITHUB_GQL     = 'https://api.github.com/graphql';
+const PROJECT_OWNER  = 'spuddeh';
+const PROJECT_NUMBER = 3;
+const LOCATIONS_DIR  = path.join(__dirname, '..', 'data', 'locations');
+
+const TOKEN = process.env.GITHUB_TOKEN;
+if (!TOKEN) {
+  console.error('Error: GITHUB_TOKEN environment variable is not set.');
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL helper
+// ---------------------------------------------------------------------------
+
+async function ghQuery(query, variables = {}) {
+  const res = await fetch(GITHUB_GQL, {
+    method:  'POST',
+    headers: {
+      'Content-Type':  'application/json',
+      'Authorization': `Bearer ${TOKEN}`,
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await res.json();
+  if (json.errors) throw new Error(JSON.stringify(json.errors, null, 2));
+  return json.data;
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: Get project meta, field IDs, and status option IDs
+// ---------------------------------------------------------------------------
+
+async function getProjectMeta() {
+  const data = await ghQuery(`
+    query($login: String!, $number: Int!) {
+      user(login: $login) {
+        projectV2(number: $number) {
+          id title
+          fields(first: 40) {
+            nodes {
+              ... on ProjectV2Field             { id name }
+              ... on ProjectV2SingleSelectField { id name options { id name } }
+            }
+          }
+        }
+      }
+    }
+  `, { login: PROJECT_OWNER, number: PROJECT_NUMBER });
+
+  const project = data.user.projectV2;
+  console.log(`Project: "${project.title}" (${project.id})\n`);
+
+  const fieldMap = {};
+  for (const f of project.fields.nodes) fieldMap[f.name] = f;
+
+  const statusField = fieldMap['Status'];
+  if (!statusField?.options) {
+    throw new Error('Status field not found or not a single-select field.');
+  }
+
+  const incorrectOption = statusField.options.find(o => o.name === 'Incorrect Coords');
+  const processedOption = statusField.options.find(o => o.name === 'Processed');
+
+  if (!incorrectOption) {
+    throw new Error(
+      'Status field has no "Incorrect Coords" option.\n' +
+      `Add it at: https://github.com/users/${PROJECT_OWNER}/projects/${PROJECT_NUMBER}/settings`
+    );
+  }
+  if (!processedOption) {
+    throw new Error(
+      'Status field has no "Processed" option.\n' +
+      `Add it at: https://github.com/users/${PROJECT_OWNER}/projects/${PROJECT_NUMBER}/settings`
+    );
+  }
+
+  if (!fieldMap['CET X']) {
+    throw new Error(
+      'Project is missing a "CET X" field.\n' +
+      `Add a Number field named "CET X" at: https://github.com/users/${PROJECT_OWNER}/projects/${PROJECT_NUMBER}/settings`
+    );
+  }
+  if (!fieldMap['CET Y']) {
+    throw new Error(
+      'Project is missing a "CET Y" field.\n' +
+      `Add a Number field named "CET Y" at: https://github.com/users/${PROJECT_OWNER}/projects/${PROJECT_NUMBER}/settings`
+    );
+  }
+
+  return { projectId: project.id, fieldMap, statusField, incorrectOption, processedOption };
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: Load all "Incorrect Coords" items from the project
+// ---------------------------------------------------------------------------
+
+async function loadIncorrectItems(projectId, fieldMap, incorrectOptionId) {
+  const uuidFieldId   = fieldMap['UUID']?.id;
+  const sourceFieldId = fieldMap['Source']?.id;
+  const xFieldId      = fieldMap['CET X']?.id;
+  const yFieldId      = fieldMap['CET Y']?.id;
+  const zFieldId      = fieldMap['Z Coordinate']?.id;
+  const yawFieldId    = fieldMap['Yaw']?.id;
+  const statusFieldId = fieldMap['Status']?.id;
+
+  const items = [];
+  let cursor = null, hasNextPage = true;
+
+  while (hasNextPage) {
+    const data = await ghQuery(`
+      query($projectId: ID!, $cursor: String) {
+        node(id: $projectId) {
+          ... on ProjectV2 {
+            items(first: 100, after: $cursor) {
+              nodes {
+                id
+                fieldValues(first: 20) {
+                  nodes {
+                    ... on ProjectV2ItemFieldTextValue {
+                      text
+                      field { ... on ProjectV2Field { id } }
+                    }
+                    ... on ProjectV2ItemFieldNumberValue {
+                      number
+                      field { ... on ProjectV2Field { id } }
+                    }
+                    ... on ProjectV2ItemFieldSingleSelectValue {
+                      optionId
+                      field { ... on ProjectV2SingleSelectField { id } }
+                    }
+                  }
+                }
+              }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+        }
+      }
+    `, { projectId, cursor });
+
+    const page = data.node.items;
+    for (const item of page.nodes) {
+      const fields = {};
+      for (const fv of item.fieldValues.nodes) {
+        const fieldId = fv.field?.id;
+        if (!fieldId) continue;
+        if (fv.text     !== undefined) fields[fieldId] = fv.text;
+        if (fv.number   !== undefined) fields[fieldId] = fv.number;
+        if (fv.optionId !== undefined) fields[fieldId] = fv.optionId;
+      }
+
+      if (fields[statusFieldId] !== incorrectOptionId) continue;
+
+      items.push({
+        itemId:  item.id,
+        uuid:    fields[uuidFieldId]   ?? null,
+        source:  fields[sourceFieldId] ?? null,
+        x:       fields[xFieldId]      ?? null,
+        y:       fields[yFieldId]      ?? null,
+        z:       fields[zFieldId]      ?? null,
+        yaw:     fields[yawFieldId]    ?? null,
+      });
+    }
+
+    hasNextPage = page.pageInfo.hasNextPage;
+    cursor      = page.pageInfo.endCursor;
+  }
+
+  return items;
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: Set item status to Processed
+// ---------------------------------------------------------------------------
+
+async function setProcessed(projectId, itemId, statusFieldId, processedOptionId) {
+  await ghQuery(`
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+      updateProjectV2ItemFieldValue(input: {
+        projectId: $projectId, itemId: $itemId, fieldId: $fieldId,
+        value: { singleSelectOptionId: $optionId }
+      }) { projectV2Item { id } }
+    }
+  `, {
+    projectId,
+    itemId,
+    fieldId:  statusFieldId,
+    optionId: processedOptionId,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log('=== NC Zoning Board — Fix Coordinates from Project ===\n');
+
+  const { projectId, fieldMap, statusField, incorrectOption, processedOption } = await getProjectMeta();
+
+  console.log('Loading "Incorrect Coords" items from project...');
+  const items = await loadIncorrectItems(projectId, fieldMap, incorrectOption.id);
+  console.log(`Found ${items.length} item(s)\n`);
+
+  if (items.length === 0) {
+    console.log('Nothing to process.');
+    return;
+  }
+
+  let updated = 0, skipped = 0, failed = 0;
+
+  for (const item of items) {
+    const label = item.uuid || item.itemId;
+    process.stdout.write(`${label} ... `);
+
+    try {
+      if (item.x === null || item.y === null || item.z === null || item.yaw === null) {
+        const missing = ['x','y','z','yaw'].filter(k => item[k] === null).join(', ');
+        console.log(`skip — missing fields: ${missing}`);
+        skipped++;
+        continue;
+      }
+
+      if (item.source === 'nexus-auto') {
+        console.log('skip — nexus-auto (contact author to update their Nexus page)');
+        skipped++;
+        continue;
+      }
+
+      const filePath = path.join(LOCATIONS_DIR, `${item.uuid}.json`);
+      if (!fs.existsSync(filePath)) {
+        console.log(`skip — file not found: ${item.uuid}.json`);
+        skipped++;
+        continue;
+      }
+
+      const existing = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+      const oldCoords = existing.coordinates;
+
+      // Always update X and Y; use new Z if provided, else keep existing
+      const newZ = item.z !== null ? item.z : (oldCoords[2] ?? null);
+      existing.coordinates = newZ !== null
+        ? [item.x, item.y, newZ]
+        : [item.x, item.y];
+
+      // Update Yaw if provided; remove if explicitly cleared (not applicable here — null means keep)
+      if (item.yaw !== null) {
+        existing.yaw = item.yaw;
+      }
+
+      fs.writeFileSync(filePath, JSON.stringify(existing, null, 4) + '\n');
+      await setProcessed(projectId, item.itemId, statusField.id, processedOption.id);
+
+      const coordStr = existing.coordinates.join(', ');
+      const yawStr   = item.yaw !== null ? `  yaw=${item.yaw}` : '';
+      console.log(`✓  [${coordStr}]${yawStr}`);
+      updated++;
+
+    } catch (err) {
+      console.log(`✗  ${err.message}`);
+      failed++;
+    }
+  }
+
+  console.log('\n--- Summary ---');
+  console.log(`Updated:  ${updated}`);
+  console.log(`Skipped:  ${skipped}`);
+  console.log(`Failed:   ${failed}`);
+
+  if (updated > 0) {
+    console.log('\nRun `node scripts/build_mods.js` to rebuild mods.json');
+  }
+}
+
+main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
Add a new on-demand GitHub Actions workflow (`fix-coords-from-project.yml`) and script (`fix_coords_from_project.js`) to process project items marked **Incorrect Coords**.

When triggered manually, the workflow reads all project items with that status, requires all four fields to be filled (CET X, CET Y, Z Coordinate, Yaw), overwrites the coordinates in the location JSON files, marks each item **Processed**, and opens a PR with the changes.

Follows the same pattern as the existing `apply-z-from-project` workflow.