### PR TITLE
data: rename author digitalb0yfriend → thumbsuckerr (13 locations)

### DIFF
--- a/data/locations/162c46e6-9163-43d9-b4a8-5b2a58d68786.json
+++ b/data/locations/162c46e6-9163-43d9-b4a8-5b2a58d68786.json
@@ -2,7 +2,7 @@
     "id": "162c46e6-9163-43d9-b4a8-5b2a58d68786",
     "name": "402 north oak - brutalist apartment house home",
     "authors": [
-        "digitalb0yfriend"
+        "thumbsuckerr"
     ],
     "credits": "manavortex, ArcadieCalliope, Breezypunk, bnbc",
     "coordinates": [

--- a/data/locations/2189690b-50e9-45ea-9054-45c620067905.json
+++ b/data/locations/2189690b-50e9-45ea-9054-45c620067905.json
@@ -2,7 +2,7 @@
     "id": "2189690b-50e9-45ea-9054-45c620067905",
     "name": "dogtown hideout revamp - apartment",
     "authors": [
-        "digitalb0yfriend"
+        "thumbsuckerr"
     ],
     "credits": "",
     "coordinates": [

--- a/data/locations/2db9e21f-b8d1-4553-9960-683a198b3b21.json
+++ b/data/locations/2db9e21f-b8d1-4553-9960-683a198b3b21.json
@@ -2,7 +2,7 @@
     "id": "2db9e21f-b8d1-4553-9960-683a198b3b21",
     "name": "Afterlife unit a - apartment",
     "authors": [
-        "digitalb0yfriend"
+        "thumbsuckerr"
     ],
     "credits": "",
     "coordinates": [

--- a/data/locations/3f2ec0c6-735a-44db-8bd5-eebc90eed162.json
+++ b/data/locations/3f2ec0c6-735a-44db-8bd5-eebc90eed162.json
@@ -2,7 +2,7 @@
     "id": "3f2ec0c6-735a-44db-8bd5-eebc90eed162",
     "name": "esoterica tech den apartment",
     "authors": [
-        "digitalb0yfriend"
+        "thumbsuckerr"
     ],
     "credits": "",
     "coordinates": [

--- a/data/locations/494ee0c2-3769-4fb5-923e-8195259c8b74.json
+++ b/data/locations/494ee0c2-3769-4fb5-923e-8195259c8b74.json
@@ -2,7 +2,7 @@
     "id": "494ee0c2-3769-4fb5-923e-8195259c8b74",
     "name": "moxxx lair - apartment",
     "authors": [
-        "digitalb0yfriend"
+        "thumbsuckerr"
     ],
     "credits": "",
     "coordinates": [

--- a/data/locations/60eae637-2f81-4471-8d50-54e40dd5871b.json
+++ b/data/locations/60eae637-2f81-4471-8d50-54e40dd5871b.json
@@ -2,7 +2,7 @@
     "id": "60eae637-2f81-4471-8d50-54e40dd5871b",
     "name": "laguna oasis (apartment house)",
     "authors": [
-        "digitalb0yfriend"
+        "thumbsuckerr"
     ],
     "credits": "",
     "coordinates": [

--- a/data/locations/7418710e-b2be-4ff8-9a24-aa84cfc371cd.json
+++ b/data/locations/7418710e-b2be-4ff8-9a24-aa84cfc371cd.json
@@ -2,7 +2,7 @@
     "id": "7418710e-b2be-4ff8-9a24-aa84cfc371cd",
     "name": "northside garage flat",
     "authors": [
-        "digitalb0yfriend"
+        "thumbsuckerr"
     ],
     "credits": "",
     "coordinates": [

--- a/data/locations/8e758ce9-d27a-44b9-b1a7-b248b327dc4d.json
+++ b/data/locations/8e758ce9-d27a-44b9-b1a7-b248b327dc4d.json
@@ -2,7 +2,7 @@
     "id": "8e758ce9-d27a-44b9-b1a7-b248b327dc4d",
     "name": "RIOT penthouse - apartment",
     "authors": [
-        "digitalb0yfriend"
+        "thumbsuckerr"
     ],
     "credits": "",
     "coordinates": [

--- a/data/locations/9a9ebc33-5ce3-4cff-9335-9b2b953f7df9.json
+++ b/data/locations/9a9ebc33-5ce3-4cff-9335-9b2b953f7df9.json
@@ -2,7 +2,7 @@
     "id": "9a9ebc33-5ce3-4cff-9335-9b2b953f7df9",
     "name": "little china loft - apartment",
     "authors": [
-        "digitalb0yfriend"
+        "thumbsuckerr"
     ],
     "credits": "",
     "coordinates": [

--- a/data/locations/a1ee8689-6c2d-4f04-9fe2-1e0c90843050.json
+++ b/data/locations/a1ee8689-6c2d-4f04-9fe2-1e0c90843050.json
@@ -2,7 +2,7 @@
     "id": "a1ee8689-6c2d-4f04-9fe2-1e0c90843050",
     "name": "orbital nest - apartment",
     "authors": [
-        "digitalb0yfriend"
+        "thumbsuckerr"
     ],
     "credits": "",
     "coordinates": [

--- a/data/locations/a8cedde8-5bde-4778-8512-fc299f568a6c.json
+++ b/data/locations/a8cedde8-5bde-4778-8512-fc299f568a6c.json
@@ -2,7 +2,7 @@
     "id": "a8cedde8-5bde-4778-8512-fc299f568a6c",
     "name": "pacifica pier hideout - apartment",
     "authors": [
-        "digitalb0yfriend"
+        "thumbsuckerr"
     ],
     "credits": "",
     "coordinates": [

--- a/data/locations/fc5c9819-755a-415c-ae35-a8e19c3a04fe.json
+++ b/data/locations/fc5c9819-755a-415c-ae35-a8e19c3a04fe.json
@@ -2,7 +2,7 @@
     "id": "fc5c9819-755a-415c-ae35-a8e19c3a04fe",
     "name": "the glen v.1 apartment",
     "authors": [
-        "digitalb0yfriend"
+        "thumbsuckerr"
     ],
     "credits": "",
     "coordinates": [

--- a/data/locations/fd105a52-717b-4c3f-8d74-d98e915a21c1.json
+++ b/data/locations/fd105a52-717b-4c3f-8d74-d98e915a21c1.json
@@ -2,7 +2,7 @@
     "id": "fd105a52-717b-4c3f-8d74-d98e915a21c1",
     "name": "Petrel st unit - apartment",
     "authors": [
-        "digitalb0yfriend"
+        "thumbsuckerr"
     ],
     "credits": "",
     "coordinates": [


### PR DESCRIPTION
## Summary

- Mod author changed their Nexus handle from `digitalb0yfriend` to `thumbsuckerr`
- Updated `authors` field across all 13 of their location entries
- No other fields changed

## Test plan

- [ ] CI validate-mods passes (build + schema + tag check)
- [ ] Spot-check a few updated files to confirm only the author name changed