### PR TITLE
fix(3d): anisotropic filtering on _m texture — kills oblique-view shimmer

### DIFF
--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -141,6 +141,12 @@ const ThreeScene = (() => {
     tex.generateMipmaps = true;
     tex.minFilter = THREE.LinearMipmapLinearFilter;
     tex.magFilter = THREE.LinearFilter;
+    // Anisotropic filtering — fixes shimmer on surfaces viewed at oblique angles
+    // (terrain/buildings tilted toward the camera). Mips alone aren't enough because
+    // mip selection picks based on the smaller of the screen-space derivatives —
+    // an elongated texture footprint still aliases along the long axis. AF samples
+    // multiple texels along that axis. Free-ish on modern GPUs (fixed-function path).
+    tex.anisotropy = renderer.capabilities.getMaxAnisotropy();
     tex.needsUpdate = true;
     return tex;
   }


### PR DESCRIPTION
## Summary

Adds `tex.anisotropy = renderer.capabilities.getMaxAnisotropy()` to `loadMDds()` (one line, plus comment).

User-reported shimmer on tilted-camera pan: surfaces viewed at oblique angles (~45-60° tilt + pan) showed a high-frequency moiré/sparkle that mips alone weren't catching. Mips + trilinear filtering handle aliasing on surfaces perpendicular to the camera. They don't handle the *along-view-axis* aliasing that elongated texture footprints produce — mip selection is conservative (picks based on the smaller of the two screen-space derivatives), so a fragment whose footprint stretches into the distance still samples a small mip and aliases along its long axis. Anisotropic filtering does multi-tap weighted averaging along that long axis.

## Cost

Anisotropy is dedicated fixed-function on AMD/NVIDIA/Intel modern GPUs. The Radeon 840M supports up to 16x AF; modern integrated and discrete GPUs all support at least 8x. Setting to `getMaxAnisotropy()` lets the GPU pick its native max — no manual cap needed.

## Test plan

Once Cloudflare ships **<https://feat-mtex-anisotropy.nc-zoning-board-dev.pages.dev/>**:

- [ ] Load 3D view, tilt camera to ~45-60° (right-drag), pan around
- [ ] Building surfaces in the distance — shimmer / sparkle should be visibly gone or significantly reduced
- [ ] Capture a debug-info-dump on the iGPU laptop to confirm no FPS regression — AF is essentially free on hardware that supports it, but worth verifying

🤖 Generated with [Claude Code](https://claude.com/claude-code)