### PR TITLE
fix(3d): derivative-aware width on building edge highlight — kills shimmer

### DIFF
--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -768,7 +768,11 @@ const ThreeScene = (() => {
           'vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + totalEmissiveRadiance;',
           `vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + totalEmissiveRadiance;
           float _ed = min( min( vLocalUv.x, 1.0 - vLocalUv.x ), min( vLocalUv.y, 1.0 - vLocalUv.y ) );
-          float _ef = (1.0 - pow( clamp( _ed / uEdgeThickness, 0.0, 1.0 ), uEdgeSharpness )) * uEdgeIntensity;
+          // Scale thickness up to at least ~1.5px on screen — kills sub-pixel
+          // aliasing/shimmer when buildings are viewed at distance or oblique angles.
+          // fwidth(_ed) = |dFdx(_ed)| + |dFdy(_ed)|, the screen-space derivative.
+          float _eThick = max( uEdgeThickness, fwidth( _ed ) * 1.5 );
+          float _ef = (1.0 - pow( clamp( _ed / _eThick, 0.0, 1.0 ), uEdgeSharpness )) * uEdgeIntensity;
           outgoingLight = mix( outgoingLight, uEdgeColor, _ef );`
         );
     };


### PR DESCRIPTION
## Summary

Fixes the long-standing pan-shimmer on buildings and landmarks. Confirmed via process of elimination:

- Shadows off → still shimmers (rules out shadow map aliasing)
- Override material on → can't see (expected — override strips edge highlight)
- Terrain / roads no shimmer → not basemap layer aliasing
- Got worse when edge highlight was implemented → causal link

So we narrowed it to the building edge highlight shader. The shader at [`three-scene.js:768-772`](assets/js/three-scene.js#L768-L772) computed edge intensity from a fixed UV-space thickness (`uEdgeThickness = 0.05`), but that band becomes sub-pixel wide on screen at distance or oblique angles. Adjacent pixels sample dramatically different `_ef` values; slight UV motion during pan shifts which pixels land where.

Note that this isn't fixed by:

- Mipmaps (the edge UVs come from `BoxGeometry` face UVs, not from a sampled texture)
- Anisotropic filtering (same reason — no texture is being sampled for this calc)
- MSAA (operates on geometric edges, not procedurally-shaded ones)
- Higher pixel ratio (helps, but only marginally and at perf cost)

## The fix

One added line — scale the effective thickness by `fwidth(_ed)`, the screen-space derivative, so the band stays at least ~1.5px wide on screen regardless of distance/angle:

```glsl
float _ed = min( min( vLocalUv.x, 1.0 - vLocalUv.x ), min( vLocalUv.y, 1.0 - vLocalUv.y ) );
float _eThick = max( uEdgeThickness, fwidth( _ed ) * 1.5 );  // <-- new
float _ef = (1.0 - pow( clamp( _ed / _eThick, 0.0, 1.0 ), uEdgeSharpness )) * uEdgeIntensity;
```

`fwidth()` is built-in in WebGL2 (Three.js's default), no extension declaration needed. Standard pattern for procedural edges in fragment shaders — same approach used by [Inigo Quilez](https://iquilezles.org/articles/distance/) for procedural lines, and built into the `fwAnti` examples in the Three.js demos.

## Visual preservation

- At zoom levels where the band was already several pixels wide, `max()` resolves to `uEdgeThickness` and behavior is **identical** to before. No visible change.
- At distances/angles where the band would have been sub-pixel, `max()` resolves to the derivative — band gets wider on screen but `pow()` falloff still gives the soft transition. Highlight stays present and stable instead of pixel-flickering.

## Test plan

Once Cloudflare ships **<https://feat-edge-highlight-aa.nc-zoning-board-dev.pages.dev/>**:

- [ ] Tilt camera to ~45-60°, pan around, especially looking at distant buildings — shimmer should be gone
- [ ] Close-up buildings — edge highlight should look identical to dev (no visual regression at normal viewing distance)
- [ ] Theme cycle — edge color should still update correctly per theme
- [ ] Capture a debug-info-dump on the iGPU laptop — `fwidth()` is essentially free; FPS should be unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)