### PR TITLE
feat(3d): runtime setter for building edge highlight intensity

### DIFF
--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -976,6 +976,19 @@ const ThreeScene = (() => {
     }
   }
 
+  // Runtime control of the building edge highlight intensity. The shader's
+  // uEdgeIntensity uniform is captured from NCZ.BUILDING_EDGE_INTENSITY at
+  // material-compile time, so changing the constant alone doesn't propagate
+  // to live materials — this iterates the existing shader refs and updates them.
+  // Diagnostic use: set to 0 to test whether shimmer disappears entirely;
+  // future Stage 2 quality preset use: dim/disable highlight on Low.
+  function setBuildingEdgeIntensity(value) {
+    for (const mat of buildingMaterials) {
+      const sh = mat.userData.shader;
+      if (sh && sh.uniforms.uEdgeIntensity) sh.uniforms.uEdgeIntensity.value = value;
+    }
+  }
+
   // Comprehensive diagnostic snapshot — bound to the "Copy debug info" button
   // and exposed for console use. Logs human-readable text, copies it to the
   // clipboard, and returns the structured object for programmatic use.
@@ -1413,7 +1426,7 @@ const ThreeScene = (() => {
     }
   }
 
-  return { init, startRenderLoop, stopRenderLoop, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, getSunElevation, setSunSphereVisible, getCameraState, setCameraState, getSceneColorVars, getRenderInfo, setOverrideMaterial, dumpDebugInfo };
+  return { init, startRenderLoop, stopRenderLoop, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, getSunElevation, setSunSphereVisible, getCameraState, setCameraState, getSceneColorVars, getRenderInfo, setOverrideMaterial, setBuildingEdgeIntensity, dumpDebugInfo };
 })();
 
 window.NCZ.ThreeScene = ThreeScene;


### PR DESCRIPTION
## Summary

Adds `NCZ.ThreeScene.setBuildingEdgeIntensity(value)` — iterates the live `buildingMaterials[]` and updates each shader's `uEdgeIntensity` uniform.

Why a setter is needed: the uniform value is captured at material-compile time from `NCZ.BUILDING_EDGE_INTENSITY`; mutating the constant from the console alone doesn't propagate to existing materials.

## Immediate use — pan-shimmer diagnostic

Once Cloudflare ships **<https://feat-edge-intensity-setter.nc-zoning-board-dev.pages.dev/>**:

1. Append `?debug=1`, switch to 3D
2. Tilt camera, pan around — confirm shimmer is still visible (current baseline)
3. Open DevTools console, run: `NCZ.ThreeScene.setBuildingEdgeIntensity(0)`
4. Pan again

**Expected outcome split:**

- **If shimmer disappears entirely** → edge highlight is the sole cause. We can then revisit the fade-out fix from PR #625 (now closed) or pick a different mitigation (lower default intensity, gate behind a quality preset, etc.)
- **If shimmer remains** → edge highlight is just a contributor; there's another cause we haven't isolated. We close out the shimmer thread for now.

To restore: `NCZ.ThreeScene.setBuildingEdgeIntensity(0.15)` (or whatever current `NCZ.BUILDING_EDGE_INTENSITY` is).

## Future use — Stage 2 quality preset

This setter is also the natural lever for `Low` quality mode to dim or disable the highlight (saves a small amount of fragment shader work + simpler visual identity for low-spec hardware). So it's not a single-use diagnostic — it earns its keep as a runtime knob.

## Test plan

- [ ] Preview loads, 3D scene renders normally with default edge intensity
- [ ] `NCZ.ThreeScene.setBuildingEdgeIntensity(0)` in console → edges visibly disappear from buildings
- [ ] `NCZ.ThreeScene.setBuildingEdgeIntensity(1.0)` → edges much more prominent than default
- [ ] `NCZ.ThreeScene.setBuildingEdgeIntensity(0.15)` → returns to default look
- [ ] Capture pan-shimmer observation at intensity=0 (the actual diagnostic) — paste outcome in PR comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)