### PR TITLE
fix(3d): logarithmicDepthBuffer — Z-fighting mitigation

### DIFF
--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -178,7 +178,11 @@ const ThreeScene = (() => {
     // Renderer — pass updateStyle:false so Three.js never writes px dimensions
     // onto the canvas element. The canvas is kept at width/height:100% in CSS
     // so it always fills #map-3d without ever pushing surrounding layout elements.
-    renderer = new THREE.WebGLRenderer({ antialias: true, stencil: true });
+    // logarithmicDepthBuffer: redistributes depth precision logarithmically
+    // across the [near, far] frustum. Mitigates Z-fighting on near-coplanar
+    // surfaces — block-style buildings sharing walls, water/terrain at the
+    // coastline, etc. Costs a cheap shader op per fragment; free on modern GPUs.
+    renderer = new THREE.WebGLRenderer({ antialias: true, stencil: true, logarithmicDepthBuffer: true });
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(container.clientWidth, container.clientHeight, false);
     renderer.shadowMap.enabled = true;


### PR DESCRIPTION
## Summary

One-line renderer config change: `logarithmicDepthBuffer: true`. Targets the pan-shimmer that's been narrowed down to Z-fighting between near-coplanar surfaces.

## Diagnosis chain

| Diagnostic | Result | Conclusion |
|---|---|---|
| AF on `_m` texture (#624) | Didn't fix | Not texture aliasing |
| Edge highlight off (`setBuildingEdgeIntensity(0)`) | Reduced but didn't fix | Edge highlight is a contributor, not the cause |
| Shadows off | Didn't fix | Not shadow map aliasing |
| `setLayerVisibility('terrain'/'cliffs'/'water', false)` | Shimmer unchanged on buildings | Not building-vs-terrain Z-fight |
| Visible most on **vertical edges of buildings** | — | Block-style buildings sharing walls (BoxGeometry instances at coplanar XY) |
| Coastline flickers during flyover | — | Water plane and terrain at same Y at the shore — same Z-fighting category |

## Why logarithmicDepthBuffer

Distributes depth precision logarithmically across the frustum rather than uniformly — significantly improves resolution near coplanar surfaces. Standard mitigation for the exact pattern we have. Cheap fragment-shader op, no per-asset changes needed.

## Test plan

Once Cloudflare ships **<https://feat-log-depth-buffer.nc-zoning-board-dev.pages.dev/>**:

- [ ] Tilt camera, pan around — vertical-edge shimmer on buildings should be visibly reduced or gone
- [ ] Trigger flyover — coastline near Pacifica should not flicker at the water/terrain boundary
- [ ] Capture a debug-info-dump on the iGPU laptop — should show no FPS regression
- [ ] No visual regression on close-up viewing (buildings, landmarks at high zoom should look identical)

## If this only partially fixes it

Follow-ups, in order of impact:

1. **Lift water by ~0.05 m** — fixes coastline if log-depth alone doesn't
2. **Slight building instance shrink** (×0.998) — adds sub-pixel air gap between adjacent walls

🤖 Generated with [Claude Code](https://claude.com/claude-code)