### PR TITLE
fix(3d): powerPreference: 'high-performance' on WebGLRenderer

### DIFF
--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -182,7 +182,16 @@ const ThreeScene = (() => {
     // across the [near, far] frustum. Mitigates Z-fighting on near-coplanar
     // surfaces — block-style buildings sharing walls, water/terrain at the
     // coastline, etc. Costs a cheap shader op per fragment; free on modern GPUs.
-    renderer = new THREE.WebGLRenderer({ antialias: true, stencil: true, logarithmicDepthBuffer: true });
+    // powerPreference hints the OS to pick the discrete GPU on hybrid-graphics
+    // laptops (Optimus / AMD Switchable / Apple). Not guaranteed — driver/OS
+    // policy can override — but it's a free one-flag improvement for users
+    // who'd otherwise get stuck on the integrated chip.
+    renderer = new THREE.WebGLRenderer({
+      antialias: true,
+      stencil: true,
+      logarithmicDepthBuffer: true,
+      powerPreference: 'high-performance',
+    });
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(container.clientWidth, container.clientHeight, false);
     renderer.shadowMap.enabled = true;


### PR DESCRIPTION
## Summary

One-flag renderer config: `powerPreference: 'high-performance'` on the `WebGLRenderer` constructor. Hints to the OS to pick the discrete GPU on hybrid-graphics laptops (NVIDIA Optimus, AMD Switchable Graphics, Apple's automatic switching). Not guaranteed — driver/OS policy can override — but free, and a real win for users who'd otherwise get stuck on the integrated chip.

## What was reverted

Originally bundled with a 0.2% building instance scale shrink to mitigate coplanar Z-fighting on block-style architecture. **Reverted** — the shrink didn't reduce the residual pan-shimmer, which rules out building-vs-building coplanarity as the cause. Sub-pixel triangle aliasing during motion is the new leading suspect; addressing it would require TAA / higher-MSAA / LOD work outside this PR's scope.

## Test plan

- [ ] No visual regression (it's a GPU selection hint; should be invisible to single-GPU users)
- [ ] On a hybrid-graphics laptop, verify in `chrome://gpu` that `Compositor information → graphics_feature_status` reports the discrete GPU as the WebGL renderer (or otherwise observe higher idle FPS than before — at parity is also fine, since some systems honor it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)