### PR TITLE
perf(3d): freeze static matrices + tighten camera frustum

### DIFF
--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -166,8 +166,8 @@ NCZ.DISTRICT_LINE_OPACITY   = 0.85;
 // ── Three.js 3D scene ──────────────────────────────────────────────────────────
 
 // Camera — orthographic projection, positioned above world centre looking straight down
-NCZ.CAMERA_NEAR     = -50000;           // near plane behind the camera (orthographic — not a clip distance)
-NCZ.CAMERA_FAR      =  50000;           // far plane in front; large to ensure terrain/buildings never clip
+NCZ.CAMERA_NEAR     = -20000;           // near plane behind the camera (orthographic — not a clip distance)
+NCZ.CAMERA_FAR      =  20000;           // far plane in front; sized for max-tilt + max-pan worst case (~23k) with margin
 NCZ.CAMERA_HEIGHT   =  10000;           // Y position above world centre (CET units)
 
 // Camera controls (OrbitControls) — source: TweakDB WorldMap.FreeCameraSettingsDefault

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -98,6 +98,14 @@ const ThreeScene = (() => {
     });
   }
 
+  // Freeze world matrices on a fully-positioned static subtree so Three.js
+  // skips the per-frame matrix-update traversal beneath it. Computes once,
+  // then disables the auto-update flag the parent uses to recurse in.
+  function freezeStatic(obj) {
+    obj.updateMatrixWorld(true);
+    obj.matrixWorldAutoUpdate = false;
+  }
+
   // Hoisted singleton: MeshoptDecoder is attached so GLBs encoded with
   // EXT_meshopt_compression decode transparently. The decoder is a no-op for
   // uncompressed GLBs (the extension is only triggered when present). The
@@ -385,6 +393,9 @@ const ThreeScene = (() => {
       layers.water   = waterScene;
       layers.cliffs  = cliffsScene;
       scene.add(terrainScene, waterScene, cliffsScene);
+      freezeStatic(terrainScene);
+      freezeStatic(waterScene);
+      freezeStatic(cliffsScene);
 
       // Fit camera frustum to the terrain bounding box
       const box = new THREE.Box3().setFromObject(terrainScene);
@@ -512,6 +523,8 @@ const ThreeScene = (() => {
       layers.metro = metroGroup;
 
       scene.add(roadsGroup, metroGroup);
+      freezeStatic(roadsGroup);
+      freezeStatic(metroGroup);
       stepProgress(); // roads done
     } catch (err) {
       console.error('[NCZ] Roads/metro GLB load failed:', err);
@@ -556,6 +569,7 @@ const ThreeScene = (() => {
       _districtSub   = subGroup;
       layers.districts = parent;
       scene.add(parent);
+      freezeStatic(parent);
       stepProgress(); // districts done
     } catch (err) {
       console.error('[NCZ] District lines load failed:', err);
@@ -632,6 +646,7 @@ const ThreeScene = (() => {
 
       layers.landmarks = group;
       scene.add(group);
+      freezeStatic(group);
       console.log(`[NCZ] Landmarks: ${LANDMARK_META.length} placed`);
       stepProgress();
     } catch (err) {
@@ -713,6 +728,7 @@ const ThreeScene = (() => {
 
       layers.buildings = group;
       scene.add(group);
+      freezeStatic(group);
       console.log(`[NCZ] Buildings: ${DISTRICT_META.length} districts loaded`);
     } catch (err) {
       console.error('[NCZ] Buildings load failed:', err);


### PR DESCRIPTION
## Summary

Two cumulative wins from the [Three.js tips audit](../wiki/sources/threejs-tips-audit.md):

- **`matrixWorldAutoUpdate = false` on static subtrees** — terrain, water, cliffs, roads/borders, metro, districts, landmarks, building InstancedMeshes. Skips the per-frame matrix-update traversal under each frozen root.
- **Camera frustum tightened from ±50000 → ±20000** — orthographic depth range halved. Worst-case depth (max 70° tilt + max pan to world edge) is ~23k, so 20k leaves comfortable margin.

Dynamic objects keep default auto-update: sun light, sun sphere, camera, shadow camera (whose target/position is moved by `updateShadowFrustum`).

## Why

`matrixAutoUpdate = false` is called out in two separate sections of the discoverthreejs.com tips page (Updating Objects + Performance #1) and was the biggest unclaimed win in the audit. The frustum tighten was on the same audit's actionable list — net precision benefit is small with `logarithmicDepthBuffer` already enabled, but no reason to keep the budget 2.5× larger than needed.

## How it works

`Object3D.matrixWorldAutoUpdate` controls whether the **parent's** `updateMatrixWorld()` recurses into a child. Setting it `false` on a freshly-positioned subtree (after one explicit `updateMatrixWorld(true)`) freezes the world matrices for that whole branch — children's local transforms are never re-composed because the traversal never reaches them. For our scene tree (~10 group roots, tens of thousands of instances under InstancedMesh), the savings are mostly on the group nodes; per-instance matrices ride on `setMatrixAt()` and weren't affected by `matrixAutoUpdate` anyway.

## Test plan

- [ ] Map loads without visual regressions on Cloudflare preview
- [ ] Pan + tilt to extremes, watch for any clipping at world edges (frustum tighten)
- [ ] `?debug=1` — confirm FPS unchanged or slightly higher (CPU saving on iGPU should be most visible here)
- [ ] Sun slider still moves dirLight + sun sphere visibly (sanity check that we didn't accidentally freeze a dynamic node)
- [ ] District zoom transitions still toggle visibility correctly
- [ ] Theme transitions still apply colour changes (visibility toggles + material updates don't need matrix recompose)
- [ ] Flyover playback unaffected
- [ ] Shadows still render correctly under sun motion (shadow camera is independent — should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)