### PR TITLE
fix(3d): assert sRGB-correct colour pipeline explicitly

### DIFF
--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -200,6 +200,12 @@ const ThreeScene = (() => {
       logarithmicDepthBuffer: true,
       powerPreference: 'high-performance',
     });
+    // Make the sRGB-correct colour pipeline explicit. These match Three.js r170
+    // defaults (since r152 / r155 respectively) but stating them here protects
+    // the scene's appearance against future Three.js default changes — both flags
+    // have shifted in past major versions.
+    THREE.ColorManagement.enabled = true;
+    renderer.outputColorSpace     = THREE.SRGBColorSpace;
     renderer.setPixelRatio(window.devicePixelRatio);
     renderer.setSize(container.clientWidth, container.clientHeight, false);
     renderer.shadowMap.enabled = true;
@@ -1338,7 +1344,10 @@ const ThreeScene = (() => {
     // Only cast shadows if the user has enabled them AND the sun is above NCZ.SHADOW_MIN_ELEV°
     _dirLight.castShadow = _shadowsOn && (el * 180 / Math.PI) > NCZ.SHADOW_MIN_ELEV;
 
-    // Colour: warm orange at horizon → neutral white above ~NCZ.SUN_COLOR_ELEV°
+    // Colour: warm orange at horizon → neutral white above ~NCZ.SUN_COLOR_ELEV°.
+    // setRGB writes linear-light values directly (ColorManagement does NOT convert
+    // these from sRGB the way a hex string would be). Tuned by eye with sRGB output
+    // gamma-encode active — do not "convert" them.
     const elevDeg = el * 180 / Math.PI;
     const t = Math.min(1, Math.max(0, elevDeg / NCZ.SUN_COLOR_ELEV));
     _dirLight.color.setRGB(1, 0.45 + t * 0.55, 0.1 + t * 0.9);


### PR DESCRIPTION
## Summary

Audit-#3 from [Three.js tips audit](../wiki/sources/threejs-tips-audit.md) — verifies the colour pipeline is sRGB-correct and makes that explicit in code.

- `THREE.ColorManagement.enabled = true` at renderer init
- `renderer.outputColorSpace = THREE.SRGBColorSpace` at renderer init
- Comment in `setSunPosition()` flagging that direct `setRGB()` writes linear-light values

## Why

Both flags match Three.js r170 defaults (since r152 / r155). The audit confirmed our scene was already rendering sRGB-correctly — `new THREE.Color('#hex')` parses sRGB → linear, `MeshLambertMaterial.color` operates in linear, output gamma-encode matches the source hex. **No runtime change.**

The reason to assert it explicitly: Three.js has flipped defaults in *both* of these flags in the past two years, and silently shifted scene appearance for any project relying on defaults. r152 enabled ColorManagement; r155 swapped `outputEncoding` → `outputColorSpace` and changed the default. Stating both flags here means the scene's appearance is decoupled from future default changes.

The `setRGB()` comment is preventative: those values are tuned by eye in linear-light. If a future maintainer runs another colour-space audit and starts "fixing" hex-string style sRGB→linear conversions on `setRGB` calls, the orange sunset would shift. The comment forecloses that mistake.

## Test plan

- [ ] Cloudflare preview loads, scene looks visually identical to dev (the whole point)
- [ ] Sun slider transitions still go from warm orange at horizon → white at noon
- [ ] Theme transitions still apply correctly across all 5 themes
- [ ] No console warnings about deprecated APIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)