### PR TITLE
fix(3d): show debug-dump RAM as power-of-2 range, not floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@ New helper script: [`scripts/query_terrain_heights.py`](scripts/query_terrain_he
 #### Debug dump — RAM as power-of-2 range, not floor
 
 - The hardware-info section of the debug dump previously showed `Memory: ≥X GB (approx)` from `navigator.deviceMemory`. The `≥` was correct in spirit but readers were silently parsing it as "approximately X" — a 64 GB system reported "≥32 GB" and a 16 GB system reported "≥8 GB", suggesting much smaller hardware tiers than the user actually had.
-- Root cause is the API itself: `navigator.deviceMemory` returns the largest power of 2 strictly less than the actual RAM (Chrome ignores the spec's 8 GB cap but still applies the rounding). The actual RAM therefore always falls in `(reported, 2 × reported]`. There is no better browser API for total system memory — `performance.memory.jsHeapSizeLimit` is the V8 heap cap (2–4 GB), unrelated to physical RAM.
-- Display now shows the half-open range explicitly: `Memory: 32–64 GB (Chrome reports power-of-2 floor)`. Same data, no room for misreading the floor as a precise figure. Trailing parenthetical signals the limitation is browser-side, not a bug in the dump.
+- Root cause is the API itself: `navigator.deviceMemory` is Chromium-only (Firefox and Safari return `undefined` and fall through to `Memory: unknown`). Where it IS supported, the value is the largest power of 2 strictly less than the actual RAM — Chromium ignores the spec's 8 GB cap but still applies the rounding. The actual RAM therefore always falls in `(reported, 2 × reported]`. There is no better browser API for total system memory — `performance.memory.jsHeapSizeLimit` is the V8 heap cap (2–4 GB), unrelated to physical RAM.
+- Display now shows the half-open range explicitly: `Memory: 32–64 GB (browser reports power-of-2 floor)`. Same data, no room for misreading the floor as a precise figure. Phrased as "browser" rather than "Chrome" since the rounding is observable in every Chromium variant (Edge, Brave, Vivaldi, etc.). Trailing parenthetical signals the limitation is browser-side, not a bug in the dump.
 
 #### Static-subtree matrix freeze + camera frustum tighten (PR #629)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ New constants in [`constants.js`](assets/js/constants.js):
 
 New helper script: [`scripts/query_terrain_heights.py`](scripts/query_terrain_heights.py) — raycasts the terrain GLB at given CET (X, Y) coordinates, used to compute safe teleport heights for the coordinate-system experiment. Documents the axis-convention mismatch with `generate_terrain_contours.py` (corrected pattern in the new script's comments).
 
+#### Debug dump — RAM as power-of-2 range, not floor
+
+- The hardware-info section of the debug dump previously showed `Memory: ≥X GB (approx)` from `navigator.deviceMemory`. The `≥` was correct in spirit but readers were silently parsing it as "approximately X" — a 64 GB system reported "≥32 GB" and a 16 GB system reported "≥8 GB", suggesting much smaller hardware tiers than the user actually had.
+- Root cause is the API itself: `navigator.deviceMemory` returns the largest power of 2 strictly less than the actual RAM (Chrome ignores the spec's 8 GB cap but still applies the rounding). The actual RAM therefore always falls in `(reported, 2 × reported]`. There is no better browser API for total system memory — `performance.memory.jsHeapSizeLimit` is the V8 heap cap (2–4 GB), unrelated to physical RAM.
+- Display now shows the half-open range explicitly: `Memory: 32–64 GB (Chrome reports power-of-2 floor)`. Same data, no room for misreading the floor as a precise figure. Trailing parenthetical signals the limitation is browser-side, not a bug in the dump.
+
 #### Static-subtree matrix freeze + camera frustum tighten (PR #629)
 
 - `matrixWorldAutoUpdate = false` on terrain, water, cliffs, roads/borders, metro, districts, landmarks, and the buildings InstancedMesh group. Each subtree's world matrices are computed once after positioning and then frozen — Three.js's per-frame `updateMatrixWorld()` traversal skips the entire branch instead of walking thousands of nodes only to find no work

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -1225,13 +1225,16 @@ const ThreeScene = (() => {
     lines.push(`GPU:           ${dump.hardware.gpu}`);
     lines.push(`Vendor:        ${dump.hardware.vendor}`);
     // navigator.hardwareConcurrency returns logical processors (threads), not physical cores.
-    // navigator.deviceMemory is quantised to the largest power of 2 strictly less than the
-    // actual RAM (spec caps at 8 GB; Chrome ignores the cap but still applies the rounding —
-    // verified by user reports of 64 GB → 32 and 16 GB → 8). The actual RAM therefore lies in
-    // (reported, 2 × reported]; we display that half-open range so readers don't misread the
-    // floor as a precise figure.
+    // navigator.deviceMemory is implemented only in Chromium-based browsers (Chrome, Edge,
+    // Brave, etc.); Firefox and Safari return undefined, which falls through to "unknown".
+    // Where it IS supported, the value is quantised to the largest power of 2 strictly less
+    // than the actual RAM (spec caps at 8 GB; Chromium ignores the cap but still applies the
+    // rounding — verified by user reports of 64 GB → 32 and 16 GB → 8). The actual RAM
+    // therefore lies in (reported, 2 × reported]; we display that half-open range so readers
+    // don't misread the floor as a precise figure. Phrased as "browser reports …" rather
+    // than naming Chrome, since the rounding is observable in every Chromium variant.
     const memText = typeof dump.hardware.deviceMemoryGB === 'number'
-      ? `${dump.hardware.deviceMemoryGB}–${dump.hardware.deviceMemoryGB * 2} GB (Chrome reports power-of-2 floor)`
+      ? `${dump.hardware.deviceMemoryGB}–${dump.hardware.deviceMemoryGB * 2} GB (browser reports power-of-2 floor)`
       : 'unknown';
     lines.push(`CPU threads:   ${dump.hardware.hardwareConcurrency}    Memory: ${memText}`);
     lines.push(`Max texture:   ${dump.hardware.maxTextureSize}`);

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -1225,11 +1225,13 @@ const ThreeScene = (() => {
     lines.push(`GPU:           ${dump.hardware.gpu}`);
     lines.push(`Vendor:        ${dump.hardware.vendor}`);
     // navigator.hardwareConcurrency returns logical processors (threads), not physical cores.
-    // navigator.deviceMemory is power-of-2 floor-rounded and clamped (spec max 8 GB; Chrome
-    // returns higher values but still floor-rounded), so "≥X GB (approx)" reflects the API's
-    // lossiness rather than implying false precision.
+    // navigator.deviceMemory is quantised to the largest power of 2 strictly less than the
+    // actual RAM (spec caps at 8 GB; Chrome ignores the cap but still applies the rounding —
+    // verified by user reports of 64 GB → 32 and 16 GB → 8). The actual RAM therefore lies in
+    // (reported, 2 × reported]; we display that half-open range so readers don't misread the
+    // floor as a precise figure.
     const memText = typeof dump.hardware.deviceMemoryGB === 'number'
-      ? `≥${dump.hardware.deviceMemoryGB} GB (approx)`
+      ? `${dump.hardware.deviceMemoryGB}–${dump.hardware.deviceMemoryGB * 2} GB (Chrome reports power-of-2 floor)`
       : 'unknown';
     lines.push(`CPU threads:   ${dump.hardware.hardwareConcurrency}    Memory: ${memText}`);
     lines.push(`Max texture:   ${dump.hardware.maxTextureSize}`);


### PR DESCRIPTION
## Summary

- `navigator.deviceMemory` is the source for the debug-dump `Memory:` line. The API is Chromium-only (Firefox 150 and Safari return `undefined` → display "Memory: unknown"). Where it IS supported, the value is the largest power of 2 *strictly less than* the actual RAM — Chromium ignores the spec's 8 GB cap but still applies the rounding. So the actual RAM is always in `(reported, 2 × reported]`.
- Two real-world reports confirmed this: 64 GB system (Chrome) → reported 32 (displayed "≥32 GB"); 16 GB system (Chrome) → reported 8 (displayed "≥8 GB"); 64 GB system (Firefox 150) → undefined → displayed "unknown". Readers were silently parsing "≥8 GB (approx)" as "approximately 8 GB" rather than "at least 8 GB", under-estimating their hardware tier by 1–2× when debugging perf issues.
- Display now shows the half-open range explicitly: `Memory: 32–64 GB (browser reports power-of-2 floor)`. Same data, leaves no room for misreading the floor as a precise figure. Phrased as "browser reports …" rather than naming Chrome, since the rounding is observable in every Chromium variant (Edge, Brave, Vivaldi).

No behaviour change beyond the wording of one debug-dump line; comment updated to document the API quirk and the Firefox/Safari undefined-fallthrough so the next person doesn't reach for a "better" API that doesn't exist (`performance.memory.jsHeapSizeLimit` is the V8 heap cap, unrelated).

## Test plan

- [ ] Open the 3D view on a known-RAM Chromium system, copy debug dump, confirm `Memory:` line shows a `X–2X GB` range with X = the previous "≥X" floor
- [ ] Verify the range matches the actual RAM (e.g. 64 GB system → "32–64 GB"; 16 GB system → "8–16 GB")
- [ ] Open the 3D view on Firefox, confirm `Memory: unknown` (deviceMemory is undefined there)
- [ ] Sanity-check the rest of the debug dump is unchanged (FPS, draw calls, GPU, threads, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)