### PR TITLE
feat(3d): name every Object3D for Needle Inspector legibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Object3D naming for Needle Inspector hierarchy
+
+Every Object3D in the scene now has a `.name` so the Needle Inspector reads as English (`buildings-westbrook`, `landmark-3dmap_obelisk`, `pin: Crystal Palace Resort`) instead of Three.js's auto-generated `Group_335` / `mesh_0`. Pure metadata — no behaviour change.
+
+- **Top-level scene entities** in [`three-scene.js`](assets/js/three-scene.js): `main-scene`, `schema-camera`, `sun`, `sun-target`, `ambient-light`, `sun-sphere`, `terrain`, `water`, `cliffs`, `roads`, `metro`, `districts`, `landmarks`, `buildings`, plus `flyover-camera` from [`flyover.js`](assets/js/flyover.js) when the showcase runs.
+- **Per-instance names** so the Inspector filter is actually useful: `buildings-<district>` for each district's InstancedMesh, `landmark-<glb-filename>` for each landmark, `district-outline-<id>` and `subdistrict-outline-<dist>/<sub>` for boundary lines.
+- **Pin/cluster/popup/tooltip names** in [`three-markers.js`](assets/js/three-markers.js): each pin is `pin: <mod.name>`, each popup is `popup: <mod.name>`, the singleton tooltip is `pin-tooltip`, cluster bubbles update per recompute to `cluster (N mods)`. Typing `pin:` in the Inspector filter shows only pins; `cluster` shows only clusters.
+- **`nameSubtree(root, prefix)` helper** walks each loaded GLB and gives every descendant a prefixed, type-tagged name (`road-mesh-0`, `metro-line2-3`, etc.). A regex overrides WolvenKit/Blender-baked generic names like `mesh_0` while preserving any genuinely descriptive name an artist might have set.
+
+Driven by wiring up the Needle Inspector Chrome extension to the dev server. Pre-naming, every loaded GLB collapsed to `Group_NNN → mesh_0`; post-naming, every node identifies itself.
+
 #### ThreeMarkers — pins on a Three.js layer + Pins overlay toggle + showcase camera follow
 
 Pins, clusters, popup and tooltip CSS2DObjects now sit on a dedicated Three.js scene-graph layer (`NCZ.LAYER_PINS = 1`) rather than living silently on the default layer. Cameras opt into the marker overlay through `Camera.layers`, which means visibility is now governed by the same primitive Three.js uses for everything else.

--- a/assets/js/flyover.js
+++ b/assets/js/flyover.js
@@ -353,6 +353,7 @@ const Flyover = (() => {
     if (!flyCamera) {
       const canvas = NCZ.ThreeScene.getCanvasElement();
       flyCamera = new THREE.PerspectiveCamera(FLYOVER_FOV, canvas.clientWidth / canvas.clientHeight, FLYOVER_CAM_NEAR, FLYOVER_CAM_FAR);
+      flyCamera.name = 'flyover-camera';
     }
 
     // Hand the marker overlay's CSS2DRenderer the flyover camera so pins,

--- a/assets/js/three-markers.js
+++ b/assets/js/three-markers.js
@@ -150,6 +150,7 @@ const ThreeMarkers = (() => {
     tooltipInner.append(tooltipText, tooltipArrow);
     tooltipAnchor.appendChild(tooltipInner);
     tooltipObj = new CSS2DObject(tooltipAnchor);
+    tooltipObj.name = 'pin-tooltip';
     tooltipObj.layers.set(NCZ.LAYER_PINS);
     tooltipObj.visible = false;
     tooltipObj.renderOrder = 999;
@@ -234,6 +235,7 @@ const ThreeMarkers = (() => {
       el.addEventListener('mouseleave', () => hideTooltip());
 
       const css = new CSS2DObject(el);
+      css.name = `pin: ${mod.name}`;
       css.layers.set(NCZ.LAYER_PINS);
       css.position.set(tx, ty, tz);
       css.userData.modData = mod;
@@ -386,6 +388,7 @@ const ThreeMarkers = (() => {
       root.className = `marker-cluster marker-cluster-step marker-cluster-step-${colorStep}`;
       root.querySelector('span').textContent = String(count);
       cluster.userData.modIds = group.map(g => g.id);
+      cluster.name = `cluster (${count} mods)`;
       cluster.visible = true;
     }
     // Hide unused pool entries from a previous larger cluster set
@@ -451,6 +454,7 @@ const ThreeMarkers = (() => {
     root.style.cursor = 'pointer';
     root.innerHTML = '<div><span>0</span></div>';
     const obj = new CSS2DObject(root);
+    obj.name = `cluster-pool-${_clusterPool.length}`;
     obj.layers.set(NCZ.LAYER_PINS);
     root.addEventListener('click', (e) => {
       e.stopPropagation();
@@ -513,6 +517,7 @@ const ThreeMarkers = (() => {
     }
 
     popup = new CSS2DObject(anchor);
+    popup.name = `popup: ${mod.name}`;
     popup.layers.set(NCZ.LAYER_PINS);
     // High renderOrder so CSS2DRenderer's depth-based zIndex sorter ranks the
     // popup above all pins. Backed up by a CSS `!important` z-index on

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -100,6 +100,20 @@ const ThreeScene = (() => {
     });
   }
 
+  // Give every descendant of `root` a prefixed, type-tagged name so the Needle
+  // Inspector hierarchy reads as English instead of "mesh_0". WolvenKit/Blender
+  // bakes generic names like "mesh_0", "Object_3", "Cube.001" — those are
+  // overwritten. Any descriptive name (e.g. "Crystal_Palace_Tower") is kept.
+  const NAME_GENERIC = /^(mesh|object|node|cube|sphere|group|geometry|line|primitive)[\s._\d]*$/i;
+  function nameSubtree(root, prefix) {
+    let i = 0;
+    root.traverse(obj => {
+      if (obj === root) return;
+      if (obj.name && !NAME_GENERIC.test(obj.name)) return;
+      obj.name = `${prefix}-${obj.type.toLowerCase()}-${i++}`;
+    });
+  }
+
   // Freeze world matrices on a fully-positioned static subtree so Three.js
   // skips the per-frame matrix-update traversal beneath it. Computes once,
   // then disables the auto-update flag the parent uses to recurse in.
@@ -224,6 +238,7 @@ const ThreeScene = (() => {
 
     // Scene background matches theme primary color
     scene = new THREE.Scene();
+    scene.name = 'main-scene';
     scene.background = readThemeColor('--primary', '#0a192f');
 
     // Orthographic camera — frustum updated after terrain loads
@@ -234,6 +249,7 @@ const ThreeScene = (() => {
        frustumH, -frustumH,
       NCZ.CAMERA_NEAR, NCZ.CAMERA_FAR
     );
+    camera.name = 'schema-camera';
     // Positioned above world centre, looking straight down.
     // Z = -WORLD_CY because GLB_Z = -CET_Y.
     camera.position.set(NCZ.WORLD_CX, NCZ.CAMERA_HEIGHT, -NCZ.WORLD_CY);
@@ -244,6 +260,7 @@ const ThreeScene = (() => {
     // Lighting — direction set to current real sun position via SunCalc if available,
     // otherwise falls back to the default NW hillshade direction.
     _dirLight = new THREE.DirectionalLight(0xffffff, 1.0 - NCZ.AMBIENT_INTENSITY);
+    _dirLight.name = 'sun';
     _dirLight.position.copy(SUN_DIR).multiplyScalar(NCZ.SUN_DIST);
 
     // Shadow map: 4096² covers the ~14 000-unit world at ~3.4 units/texel.
@@ -261,10 +278,12 @@ const ThreeScene = (() => {
 
     // Centre the shadow frustum on Night City, not the world origin
     _dirLight.target.position.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
+    _dirLight.target.name = 'sun-target';
 
     scene.add(_dirLight);
     scene.add(_dirLight.target);
     _ambLight = new THREE.AmbientLight(0xffffff, NCZ.AMBIENT_INTENSITY);
+    _ambLight.name = 'ambient-light';
     scene.add(_ambLight);
     // Sun position is applied by app.js via the slider once terrain has loaded.
 
@@ -274,6 +293,7 @@ const ThreeScene = (() => {
       new THREE.SphereGeometry(NCZ.SUN_SPHERE_RADIUS, 16, 16),
       new THREE.MeshBasicMaterial({ color: 0xffcc44 })
     );
+    _sunSphere.name = 'sun-sphere';
     _sunSphere.visible = false;
     scene.add(_sunSphere);
 
@@ -496,6 +516,13 @@ const ThreeScene = (() => {
       // CET pos (-2255, -3050) → GLB offset X=-2255, Z=+3050
       cliffsScene.position.set(-2255, 0, 3050);
 
+      terrainScene.name = 'terrain';
+      waterScene.name   = 'water';
+      cliffsScene.name  = 'cliffs';
+      nameSubtree(terrainScene, 'terrain');
+      nameSubtree(waterScene,   'water');
+      nameSubtree(cliffsScene,  'cliffs');
+
       layers.terrain = terrainScene;
       layers.water   = waterScene;
       layers.cliffs  = cliffsScene;
@@ -545,6 +572,13 @@ const ThreeScene = (() => {
       roadsScene.rotation.y   = Math.PI;
       metroScene.rotation.y   = Math.PI;
       bordersScene.rotation.y = Math.PI;
+
+      roadsScene.name   = 'roads-loaded';
+      metroScene.name   = 'metro-loaded';
+      bordersScene.name = 'road-borders-loaded';
+      nameSubtree(roadsScene,   'road');
+      nameSubtree(metroScene,   'metro');
+      nameSubtree(bordersScene, 'road-border');
 
       const roadColor   = readThemeColor('--overlay-road-color',        '#504b41');
       const borderColor = readThemeColor('--overlay-road-border-color', '#1ec3c8');
@@ -620,14 +654,20 @@ const ThreeScene = (() => {
 
       const stRoads   = makeSeeThrough(roadsScene,  roadsMat);
       const stBorders = makeSeeThrough(bordersScene, bordersMat);
+      stRoads.name    = 'roads-seethrough';
+      stBorders.name  = 'road-borders-seethrough';
+      nameSubtree(stRoads,   'road-st');
+      nameSubtree(stBorders, 'road-border-st');
       stRoads.traverse(o => { if (o.isMesh) o.renderOrder = 1; });
       stBorders.traverse(o => { if (o.isMesh) o.renderOrder = 1; });
 
       const roadsGroup = new THREE.Group();
+      roadsGroup.name = 'roads';
       roadsGroup.add(roadsScene, bordersScene, stRoads, stBorders);
       metroScene.traverse(o => { if (o.isMesh) o.renderOrder = 2; });
 
       const metroGroup = new THREE.Group();
+      metroGroup.name = 'metro';
       metroGroup.add(metroScene);
 
       layers.roads = roadsGroup;
@@ -649,6 +689,9 @@ const ThreeScene = (() => {
       const outerGroup  = new THREE.Group(); // districts with subs — zoom-out only
       const alwaysGroup = new THREE.Group(); // no-sub districts + canonical:false subs — always visible
       const subGroup    = new THREE.Group(); // canonical subdistricts — zoom-in only
+      outerGroup.name  = 'districts-outer';
+      alwaysGroup.name = 'districts-always';
+      subGroup.name    = 'subdistricts';
 
       for (const dist of data.districts) {
         const color = new THREE.Color(window.NCZ.DISTRICT_COLORS[dist.id] || '#ffffff');
@@ -657,21 +700,26 @@ const ThreeScene = (() => {
 
         // District outline — always group if no canonical subs, outer group otherwise
         if (dist.polygon?.length) {
-          (hasSubs ? outerGroup : alwaysGroup).add(buildLine(dist.polygon, color, window.NCZ.DISTRICT_LINE_WIDTH));
+          const line = buildLine(dist.polygon, color, window.NCZ.DISTRICT_LINE_WIDTH);
+          line.name = `district-outline-${dist.id}`;
+          (hasSubs ? outerGroup : alwaysGroup).add(line);
         }
 
         for (const sub of dist.subdistricts || []) {
           if (!sub.polygon?.length) continue;
+          const line = buildLine(sub.polygon, color, window.NCZ.SUBDISTRICT_LINE_WIDTH);
+          line.name = `subdistrict-outline-${dist.id}/${sub.id}`;
           if (sub.canonical === false) {
-            alwaysGroup.add(buildLine(sub.polygon, color, window.NCZ.SUBDISTRICT_LINE_WIDTH)); // casino etc — always visible
+            alwaysGroup.add(line); // casino etc — always visible
           } else {
-            subGroup.add(buildLine(sub.polygon, color, window.NCZ.SUBDISTRICT_LINE_WIDTH));    // zoom-gated
+            subGroup.add(line);    // zoom-gated
           }
         }
       }
 
       // Wrap all three in a parent so districts toggle works as a unit
       const parent = new THREE.Group();
+      parent.name = 'districts';
       parent.add(alwaysGroup, outerGroup, subGroup);
       subGroup.visible  = false;
       outerGroup.visible = true;
@@ -729,9 +777,11 @@ const ThreeScene = (() => {
       );
 
       const group = new THREE.Group();
+      group.name = 'landmarks';
       for (const { file, cetX, cetY, cetZ, qi, qj, qk, qr } of LANDMARK_META) {
         const source = glbMap[file];
         const container = new THREE.Group();
+        container.name = `landmark-${file.replace(/\.glb$/, '')}`;
 
         // CET (Z-up) → Three.js (Y-up): x=qi, y=qk, z=-qj, w=qr
         const entityQ = new THREE.Quaternion(qi, qk, -qj, qr).normalize();
@@ -752,6 +802,7 @@ const ThreeScene = (() => {
           mesh.receiveShadow = true;
           container.add(mesh);
         });
+        nameSubtree(container, container.name);
         group.add(container);
       }
 
@@ -771,6 +822,7 @@ const ThreeScene = (() => {
     try {
       const baseGeo = new THREE.BoxGeometry(1, 1, 1);
       const group   = new THREE.Group();
+      group.name = 'buildings';
       const dummy   = new THREE.Object3D();
 
       for (const meta of DISTRICT_META) {
@@ -784,6 +836,7 @@ const ThreeScene = (() => {
         // Pre-allocate mesh for max possible instances; trim count after decode.
         const mat  = buildBuildingMaterial(meta, await loadMDds(meta.mDds));
         const mesh = new THREE.InstancedMesh(baseGeo, mat, blockW * blockH);
+        mesh.name = `buildings-${meta.name}`;
 
         let validCount = 0;
         for (let y = 0; y < blockH; y++) {


### PR DESCRIPTION
## Summary

Pure metadata change. Adds `.name` to every Object3D in the Three.js scene so the [Needle Inspector](https://chromewebstore.google.com/search/needle%20inspector) hierarchy reads as English (`buildings-westbrook`, `landmark-3dmap_obelisk`, `pin: Crystal Palace Resort`) instead of Three.js's auto-generated `Group_335` / `mesh_0`.

- Top-level scene entities named directly: `main-scene`, `schema-camera`, `sun`, `sun-target`, `ambient-light`, `sun-sphere`, `terrain`, `water`, `cliffs`, `roads`, `metro`, `districts`, `landmarks`, `buildings`, `flyover-camera`
- Per-instance names so the Inspector filter is useful: `buildings-<district>`, `landmark-<glb>`, `district-outline-<id>`, `subdistrict-outline-<dist>/<sub>`, `pin: <mod.name>`, `popup: <mod.name>`, `cluster (N mods)`
- New `nameSubtree(root, prefix)` helper walks each loaded GLB and gives every descendant a prefixed, type-tagged name. Regex overrides WolvenKit/Blender-baked generic names (`mesh_0`, `Cube.001`) while preserving any genuinely descriptive name an artist might have set

No behaviour change, no rendering difference. The whole PR is `obj.name = "..."` lines plus one 8-line helper.

## Test plan

- [x] Verified via Needle Inspector probe: zero `mesh_0` / `Group_NNN` entries remain in the scene hierarchy
- [x] Scene loads correctly (terrain, water, cliffs, roads, metro, buildings, landmarks all render)
- [x] Pins, clusters, popups, tooltips work as before
- [ ] Reviewer: open Needle Inspector on the Cloudflare preview, filter by `pin:` or `buildings-` to confirm names land