### PR TITLE
sytle(theme):swapped the location overhaul and new location category colours on the synthwave theme

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -283,10 +283,10 @@ html.theme-synthwave {
     --white-86: rgba(255, 228, 245, 0.86);
 
     /* Theme category colors */
-    --category-location-overhaul: var(--secondary);
-    --category-location-overhaul-glow: var(--secondary-40);
-    --category-new-location: var(--tertiary);
-    --category-new-location-glow: var(--tertiary-40);
+    --category-location-overhaul: var(--tertiary);
+    --category-location-overhaul-glow: var(--tertiary-40);
+    --category-new-location: var(--secondary);
+    --category-new-location-glow: var(--secondary-40);
     --category-other: var(--gray);
     --category-other-glow: var(--gray-40);
 


### PR DESCRIPTION
as requsted by Kao, swapped the location category colours around, so that overhaul was cyan, and new location was magenta. This is so that on both the Night Corp theme, and the Synthwave theme, the Overhaul category colours are the same (for consistency).