### PR TITLE
fix(3d): canvas CSS sizing + cap renderer DPR at 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
-#### Fixed pin/canvas misalignment on fractional DPR + capped renderer pixel ratio at 1.5
+#### Pin/canvas alignment on fractional DPR + capped renderer DPR at 1.5
 
-Two related fixes for users on non-1.0 device-pixel-ratio displays — Windows scaling, Retina, 4K@200%, etc.
-
-- **Pins now line up with the WebGL scene on any DPR.** The `WebGLRenderer` is initialised with `setSize(w, h, false)` (`updateStyle:false`), which deliberately avoids inline `style.width` / `style.height` on the `<canvas>`. The intent — documented in [`three-scene.js`](assets/js/three-scene.js) — was for the canvas to inherit `width: 100% / height: 100%` from CSS, but that rule was missing from [`style.css`](assets/css/style.css). With no explicit dimensions, an absolutely-positioned **replaced element** like `<canvas>` falls back to its intrinsic size (the `width`/`height` HTML attributes, which Three.js sets to `floor(clientWidth × DPR) × floor(clientHeight × DPR)`) — overflowing the container by ~25% at DPR 1.25, ~50% at DPR 1.5, ~100% at DPR 2.0. The `CSS2DRenderer` overlay (a `<div>`, not replaced) correctly fills the container, so pins projected to CSS-pixel positions sat dozens to hundreds of pixels off the buildings/terrain underneath. New `#map-3d > canvas { width: 100%; height: 100% }` rule restores the intended sizing — the GPU still renders at the higher drawingBuffer resolution, the browser scales the output to the container, and the two layers align.
-- **Renderer pixel ratio capped at `NCZ.MAX_DEVICE_PIXEL_RATIO = 1.5`.** GPU fragment cost scales as DPR², so the uncapped path on Retina (DPR 2.0) costs 78% more shader work than capping at 1.5 for a soft-edge difference most users won't notice. CSS2DRenderer rasterises HTML at the real device DPR regardless, so pin labels, popup text, and tooltips remain pixel-perfect — only the WebGL scene (terrain, buildings, roads, metro, district lines) is downsampled. No-op for anyone at DPR ≤ 1.5, which is most desktops. The debug-info dump's "Renderer DPR" line now reports the capped value while "Display ... DPR" still reports the raw `window.devicePixelRatio`, so a single dump shows whether the cap is active.
-
-The first fix is purely a correctness bug (visible on the work-laptop dump at DPR 1.25 and 1.5); the second is a free perf win on top, since both touch the same renderer-init path.
-
-New constant in [`constants.js`](assets/js/constants.js):
-
-- `NCZ.MAX_DEVICE_PIXEL_RATIO` (1.5) — clamp passed to `renderer.setPixelRatio()`. Re-tunable without code changes if a quality preset wants to push it lower (Low) or higher (High).
+- Pins drifted off the WebGL scene on any DPR > 1.0 (~25% off at 1.25, ~50% at 1.5). The `<canvas>` was missing a `width:100%; height:100%` CSS rule, so it fell back to its intrinsic drawingBuffer size while the `CSS2DRenderer` overlay correctly filled the container. Added the missing rule in [`style.css`](assets/css/style.css).
+- Capped `renderer.setPixelRatio` at `NCZ.MAX_DEVICE_PIXEL_RATIO = 1.5`. Saves ~44% GPU pixel work on Retina / 4K@200% displays; no-op for anyone at DPR ≤ 1.5.
 
 #### Object3D naming for Needle Inspector hierarchy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Fixed pin/canvas misalignment on fractional DPR + capped renderer pixel ratio at 1.5
+
+Two related fixes for users on non-1.0 device-pixel-ratio displays — Windows scaling, Retina, 4K@200%, etc.
+
+- **Pins now line up with the WebGL scene on any DPR.** The `WebGLRenderer` is initialised with `setSize(w, h, false)` (`updateStyle:false`), which deliberately avoids inline `style.width` / `style.height` on the `<canvas>`. The intent — documented in [`three-scene.js`](assets/js/three-scene.js) — was for the canvas to inherit `width: 100% / height: 100%` from CSS, but that rule was missing from [`style.css`](assets/css/style.css). With no explicit dimensions, an absolutely-positioned **replaced element** like `<canvas>` falls back to its intrinsic size (the `width`/`height` HTML attributes, which Three.js sets to `floor(clientWidth × DPR) × floor(clientHeight × DPR)`) — overflowing the container by ~25% at DPR 1.25, ~50% at DPR 1.5, ~100% at DPR 2.0. The `CSS2DRenderer` overlay (a `<div>`, not replaced) correctly fills the container, so pins projected to CSS-pixel positions sat dozens to hundreds of pixels off the buildings/terrain underneath. New `#map-3d > canvas { width: 100%; height: 100% }` rule restores the intended sizing — the GPU still renders at the higher drawingBuffer resolution, the browser scales the output to the container, and the two layers align.
+- **Renderer pixel ratio capped at `NCZ.MAX_DEVICE_PIXEL_RATIO = 1.5`.** GPU fragment cost scales as DPR², so the uncapped path on Retina (DPR 2.0) costs 78% more shader work than capping at 1.5 for a soft-edge difference most users won't notice. CSS2DRenderer rasterises HTML at the real device DPR regardless, so pin labels, popup text, and tooltips remain pixel-perfect — only the WebGL scene (terrain, buildings, roads, metro, district lines) is downsampled. No-op for anyone at DPR ≤ 1.5, which is most desktops. The debug-info dump's "Renderer DPR" line now reports the capped value while "Display ... DPR" still reports the raw `window.devicePixelRatio`, so a single dump shows whether the cap is active.
+
+The first fix is purely a correctness bug (visible on the work-laptop dump at DPR 1.25 and 1.5); the second is a free perf win on top, since both touch the same renderer-init path.
+
+New constant in [`constants.js`](assets/js/constants.js):
+
+- `NCZ.MAX_DEVICE_PIXEL_RATIO` (1.5) — clamp passed to `renderer.setPixelRatio()`. Re-tunable without code changes if a quality preset wants to push it lower (Low) or higher (High).
+
 #### Object3D naming for Needle Inspector hierarchy
 
 Every Object3D in the scene now has a `.name` so the Needle Inspector reads as English (`buildings-westbrook`, `landmark-3dmap_obelisk`, `pin: Crystal Palace Resort`) instead of Three.js's auto-generated `Group_335` / `mesh_0`. Pure metadata — no behaviour change.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -27,6 +27,18 @@
     position: relative;
 }
 
+/* Force the WebGLRenderer canvas to fill its container.
+   Three.js is initialised with `setSize(w, h, false)` (updateStyle:false), so
+   it never writes inline width/height onto <canvas>. Without this rule, the
+   canvas — a replaced element — falls back to its intrinsic dimensions (the
+   drawingBuffer pixel size, = clientSize × devicePixelRatio), which overflows
+   the container on any DPR > 1.0 and shifts the WebGL scene off the CSS2D pin
+   overlay. See three-scene.js:225 for the renderer setup. */
+#map-3d > canvas {
+    width: 100%;
+    height: 100%;
+}
+
 /* Overlay toggles — floats over the map, above the view toggle */
 #overlay-controls {
     position: absolute;

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -175,6 +175,14 @@ NCZ.DISTRICT_LINE_OPACITY   = 0.85;
 
 // ── Three.js 3D scene ──────────────────────────────────────────────────────────
 
+// WebGLRenderer pixel-ratio cap. GPU fragment cost scales as DPR², so on
+// high-DPI displays (Retina 2.0, 4K@200% 2.0, 1440p@200% 2.0, etc.) the
+// uncapped path costs 78%+ more shader work than 1.5 for a soft-edge difference
+// the user is unlikely to notice — pin/popup/tooltip text is unaffected because
+// CSS2DRenderer rasterises HTML at the real device DPR regardless. The cap is a
+// no-op for everyone at DPR ≤ 1.5, so most desktops see zero change.
+NCZ.MAX_DEVICE_PIXEL_RATIO = 1.5;
+
 // Camera — orthographic projection, positioned above world centre looking straight down
 NCZ.CAMERA_NEAR     = -20000;           // near plane behind the camera (orthographic — not a clip distance)
 NCZ.CAMERA_FAR      =  20000;           // far plane in front; sized for max-tilt + max-pan worst case (~23k) with margin

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -200,8 +200,11 @@ const ThreeScene = (() => {
     loadingFillEl = container.querySelector('.scene-loading__fill');
 
     // Renderer — pass updateStyle:false so Three.js never writes px dimensions
-    // onto the canvas element. The canvas is kept at width/height:100% in CSS
-    // so it always fills #map-3d without ever pushing surrounding layout elements.
+    // onto the canvas element. The canvas is kept at width/height:100% via the
+    // `#map-3d > canvas` rule in style.css so it always fills #map-3d without
+    // pushing surrounding layout elements (and without falling back to its
+    // intrinsic drawingBuffer size, which would misalign with the CSS2D pin
+    // overlay on any DPR > 1.0).
     // logarithmicDepthBuffer: redistributes depth precision logarithmically
     // across the [near, far] frustum. Mitigates Z-fighting on near-coplanar
     // surfaces — block-style buildings sharing walls, water/terrain at the
@@ -222,7 +225,10 @@ const ThreeScene = (() => {
     // have shifted in past major versions.
     THREE.ColorManagement.enabled = true;
     renderer.outputColorSpace     = THREE.SRGBColorSpace;
-    renderer.setPixelRatio(window.devicePixelRatio);
+    // Cap effective DPR — see NCZ.MAX_DEVICE_PIXEL_RATIO. The debug-dump
+    // "Renderer DPR" line shows the capped value; "Display ... DPR" still shows
+    // the raw window.devicePixelRatio, so the two diverge for capped users.
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, NCZ.MAX_DEVICE_PIXEL_RATIO));
     renderer.setSize(container.clientWidth, container.clientHeight, false);
     renderer.shadowMap.enabled = true;
     renderer.shadowMap.type    = THREE.PCFSoftShadowMap;


### PR DESCRIPTION
## Summary

Two related fixes for users on non-1.0 device-pixel-ratio displays — Windows scaling, Retina, 4K@200%, etc. Bug surfaced from a debug-info dump on a 1440p laptop at 150% Windows scaling (DPR 1.25 / 1.5) where pins were dozens to hundreds of pixels off the buildings underneath.

- **Pin/canvas misalignment on fractional DPR.** `WebGLRenderer` is initialised with `setSize(w, h, false)` (`updateStyle:false`), which skips inline `style.width`/`style.height` on `<canvas>`. The intent — documented in [`three-scene.js`](assets/js/three-scene.js) — was for CSS to set `width:100%/height:100%`, but that rule was missing from [`style.css`](assets/css/style.css). With no explicit dimensions, an absolutely-positioned **replaced** element like `<canvas>` falls back to its intrinsic size (drawingBuffer = `clientSize × DPR`), overflowing the container by 25–100% on DPR 1.25–2.0. The `CSS2DRenderer` overlay (a `<div>`, not replaced) correctly fills the container, so the two layers drifted apart. New `#map-3d > canvas { width:100%; height:100% }` rule restores the intended sizing — GPU still renders at the higher drawingBuffer resolution, browser scales it to fit, layers align.
- **Renderer pixel ratio capped at `NCZ.MAX_DEVICE_PIXEL_RATIO = 1.5`.** GPU fragment cost scales as DPR², so capping is a ~44% perf win at DPR 2.0 for a soft-edge difference most users won't notice. CSS2DRenderer rasterises HTML at the real device DPR, so pin labels, popup text, and tooltips remain pixel-perfect — only the WebGL scene (terrain, buildings, roads, metro, district lines) is downsampled. No-op for anyone at DPR ≤ 1.5.

The debug-dump "Renderer DPR" line now reports the capped value while the "Display ... DPR" line still reports raw `window.devicePixelRatio`, so a single dump shows whether the cap is active.

## Math against the reported dumps

| DPR | container CSS px | canvas drawingBuffer / CSS box (before fix) | Mismatch (before fix) |
|---|---|---|---|
| 1.5  | 1707 × 725  | 2560 × 1087 | ~50% overflow → ~426 px pin drift |
| 1.25 | 1536 × 630  | 1920 × 787  | ~25% overflow → ~192 px pin drift |
| 1.08 | 1631 × 791  | 1761 × 854  | ~8% overflow → ~65 px pin drift  |
| 1.0  | n × m       | n × m       | none — which is why this slipped through |

After fix: canvas CSS box = container CSS box on every DPR.

## Test plan

- [ ] Cloudflare Pages preview loads on Windows @ 150% scaling (DPR 1.5), pins land on the corresponding buildings/landmarks
- [ ] Same on Windows @ 125% scaling (DPR 1.25)
- [ ] Same on standard 1080p @ 100% scaling (DPR 1.0) — should be visually identical to before
- [ ] Same on 1080p @ 108% Chrome zoom (DPR 1.08) — pins should now align
- [ ] Debug-info dump shows `Renderer: DPR 1.5 ...` while `Display: ... DPR 2` (or similar) on a Retina display, confirming the cap engages
- [ ] Buildings, terrain, roads, metro, district lines, shadows still render correctly (no visible artefacts from the canvas resize path or from the DPR cap)
- [ ] Showcase flyover camera still tracks correctly — uses the same renderer, so `getPixelRatio()` returns the capped value there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)