### PR TITLE
perf(3d): render only when something changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Render-on-demand
+
+- The 3D scene's rAF loop now runs only when something has actually changed (camera moved, damping in progress, sun/theme/layer/material updated, pins added) instead of unconditionally re-rendering every frame. Idle map views cost zero GPU/CPU; saves battery on every machine and recovers headroom on weaker iGPUs (Intel UHD without Iris Xe was the worst case). Implemented in [`three-scene.js`](assets/js/three-scene.js) via a new `requestRender()` entrypoint hooked into every state-mutating helper, with a `_suppressed` flag that prevents in-flight color tweens from racing the flyover camera.
+- ThreeMarkers added a private `_redraw()` helper that forwards to `ThreeScene.requestRender()` and is called from every pin/popup/cluster state mutation, plus the camera fly-tween (which mutates camera position/zoom directly without firing OrbitControls 'change'). The fly-tween now self-extends the loop until completion.
+
 #### Pin/canvas alignment on fractional DPR + capped renderer DPR at 1.5
 
 - Pins drifted off the WebGL scene on any DPR > 1.0 (~25% off at 1.25, ~50% at 1.5). The `<canvas>` was missing a `width:100%; height:100%` CSS rule, so it fell back to its intrinsic drawingBuffer size while the `CSS2DRenderer` overlay correctly filled the container. Added the missing rule in [`style.css`](assets/css/style.css).

--- a/assets/js/three-markers.js
+++ b/assets/js/three-markers.js
@@ -59,6 +59,12 @@ const ThreeMarkers = (() => {
                                     // whose contents the cluster panel is showing
   const _projectVec = new THREE.Vector3();
 
+  // Render-on-demand bridge. ThreeScene's loop only re-renders (and re-runs
+  // our render() in turn) when explicitly asked. Anything that mutates pin
+  // visibility, position, popup state, or cluster layout without moving the
+  // camera must call this so the CSS2DRenderer pass picks the change up.
+  function _redraw() { NCZ.ThreeScene?.requestRender?.(); }
+
   // Tooltip — single reusable CSS2DObject created at attach time. Hidden by
   // default; show()/hide() toggle .visible and update text/position.
   let tooltipObj = null;
@@ -248,6 +254,7 @@ const ThreeMarkers = (() => {
     // SCHEMA load show clusters immediately rather than waiting for a click.
     _filterVisibleIds = new Set(_modsState.mods.map(m => m.id));
     recomputeClusters();
+    _redraw();
   }
 
   function setPulse(modId, on) {
@@ -267,10 +274,12 @@ const ThreeMarkers = (() => {
     tooltipText.textContent = mod.name;
     tooltipObj.position.copy(pin.position);
     tooltipObj.visible = true;
+    _redraw();
   }
 
   function hideTooltip() {
     if (tooltipObj) tooltipObj.visible = false;
+    _redraw();
   }
 
   function applyFilters(visibleIdSet) {
@@ -282,6 +291,7 @@ const ThreeMarkers = (() => {
     // Re-cluster synchronously: filter changes affect which pins exist for
     // the proximity grouper, and the user expects immediate visual feedback.
     recomputeClusters();
+    _redraw();
   }
 
   // Returns mod IDs of pins that pass the active filter (regardless of cluster
@@ -411,6 +421,7 @@ const ThreeMarkers = (() => {
       }
       _onClustersChanged(sets);
     }
+    _redraw();
   }
 
   // Mark the cluster bubble whose modIds best overlap _activeClusterMods.
@@ -441,6 +452,7 @@ const ThreeMarkers = (() => {
   function setActiveClusterMods(modSet) {
     _activeClusterMods = modSet || null;
     refreshActiveClusterMark();
+    _redraw();
   }
 
   function getOrCreateClusterObj(idx) {
@@ -529,6 +541,7 @@ const ThreeMarkers = (() => {
     pinsLayer.add(popup);
     popupModId = mod.id;
     syncUrlForMod(mod);
+    _redraw();
   }
 
   function closePopup({ silent = false } = {}) {
@@ -538,6 +551,7 @@ const ThreeMarkers = (() => {
     popup = null;
     popupModId = null;
     if (!silent) clearUrlMod();
+    _redraw();
   }
 
   // URL deep-link sync — matches the Leaflet popupopen/popupclose handlers
@@ -596,6 +610,8 @@ const ThreeMarkers = (() => {
       onComplete,
     };
     _flyLastTime = performance.now();
+    _redraw(); // Kickstart the loop — direct camera mutation in updateFlyTween
+               // doesn't fire OrbitControls 'change', so we need an explicit nudge.
   }
 
   function updateFlyTween() {
@@ -617,6 +633,8 @@ const ThreeMarkers = (() => {
       const cb = _flyTween.onComplete;
       _flyTween = null;
       cb?.();
+    } else {
+      _redraw(); // Keep the loop alive until the tween finishes.
     }
   }
 
@@ -661,6 +679,7 @@ const ThreeMarkers = (() => {
   function setActiveCamera(cam) {
     _activeCamera = cam || null;
     if (!cam) recomputeClusters();
+    _redraw();
   }
 
   // Toggle the marker overlay's membership of the schema camera's layer mask.
@@ -673,6 +692,7 @@ const ThreeMarkers = (() => {
     if (!_schemaCamera) return;
     if (visible) _schemaCamera.layers.enable(NCZ.LAYER_PINS);
     else         _schemaCamera.layers.disable(NCZ.LAYER_PINS);
+    _redraw();
   }
   function getOverlayVisible() {
     if (!_schemaCamera) return null;
@@ -701,6 +721,7 @@ const ThreeMarkers = (() => {
       // the authoritative grouped state.
       if (_clusterLayer) _clusterLayer.children.forEach(c => { c.visible = true; });
     }
+    _redraw();
   }
 
   return {

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -327,6 +327,7 @@ const ThreeScene = (() => {
       if (metroShader) metroShader.uniforms.uMetroZoom.value = camera.zoom;
       updateShadowFrustum();
       updateScaleBar();
+      requestRender();
     });
 
     // Pan bounds — clamp controls.target so the camera can't drift
@@ -374,6 +375,7 @@ const ThreeScene = (() => {
       t.z += dz;
       camera.position.x += dx;
       camera.position.z += dz;
+      requestRender();
     });
 
     window.addEventListener('resize', onResize);
@@ -410,6 +412,7 @@ const ThreeScene = (() => {
     }
     NCZ.ThreeMarkers?.onResize?.(w, h);
     updateScaleBar();
+    requestRender();
   }
 
   // ── Layer registry ─────────────────────────────────────────────────────
@@ -433,6 +436,7 @@ const ThreeScene = (() => {
     if (name === 'districts') {
       if (layers.districts) layers.districts.visible = visible;
       if (visible) updateDistrictZoom();
+      requestRender();
       return;
     }
     if (name === 'shadows') { setShadowsEnabled(visible); return; }
@@ -440,9 +444,10 @@ const ThreeScene = (() => {
     // pass owned by ThreeMarkers, gated by the schema camera's Three.js
     // Object3D.layers mask. Routing it through here keeps the overlay-controls
     // panel's [data-overlay] handler uniform across every toggle.
-    if (name === 'pins') { NCZ.ThreeMarkers?.setOverlayVisible?.(visible); return; }
+    if (name === 'pins') { NCZ.ThreeMarkers?.setOverlayVisible?.(visible); requestRender(); return; }
     if (name === 'buildings' && layers.landmarks) layers.landmarks.visible = visible;
     if (layers[name]) layers[name].visible = visible;
+    requestRender();
   }
 
   function updateDistrictZoom() {
@@ -536,6 +541,7 @@ const ThreeScene = (() => {
       freezeStatic(terrainScene);
       freezeStatic(waterScene);
       freezeStatic(cliffsScene);
+      requestRender();
 
       // Fit camera frustum to the terrain bounding box. Stored at module
       // scope so the pan-bound listener can clamp against terrain extent
@@ -680,6 +686,7 @@ const ThreeScene = (() => {
       layers.metro = metroGroup;
 
       scene.add(roadsGroup, metroGroup);
+      requestRender();
       freezeStatic(roadsGroup);
       freezeStatic(metroGroup);
       stepProgress(); // roads done
@@ -734,6 +741,7 @@ const ThreeScene = (() => {
       _districtSub   = subGroup;
       layers.districts = parent;
       scene.add(parent);
+      requestRender();
       freezeStatic(parent);
       stepProgress(); // districts done
     } catch (err) {
@@ -814,6 +822,7 @@ const ThreeScene = (() => {
 
       layers.landmarks = group;
       scene.add(group);
+      requestRender();
       freezeStatic(group);
       console.log(`[NCZ] Landmarks: ${LANDMARK_META.length} placed`);
       stepProgress();
@@ -898,6 +907,7 @@ const ThreeScene = (() => {
 
       layers.buildings = group;
       scene.add(group);
+      requestRender();
       freezeStatic(group);
       console.log(`[NCZ] Buildings: ${DISTRICT_META.length} districts loaded`);
     } catch (err) {
@@ -1101,10 +1111,27 @@ const ThreeScene = (() => {
     console.log('  NCZ.ThreeScene.dumpDebugInfo()       → full diagnostic snapshot (also bound to the "Copy debug info" button)');
   }
 
+  // Render-on-demand: rAF runs only when something has changed (camera moved,
+  // damping in progress, sun/theme/layer/material updated, pins added, or a
+  // module explicitly held the loop open via setContinuousRender). Idle map
+  // views cost zero GPU/CPU — the previous unconditional rAF chewed a full
+  // frame's worth of work even when the scene was identical to the last one.
+  // Triggered via requestRender(); any state mutation that affects pixels
+  // calls it. Damping continuation is detected from controls.update()'s
+  // return value (true = state still interpolating).
+  //
+  // _suppressed — flyover stops the schema loop and runs its own rAF that
+  // calls renderFrame(flyCamera) directly. Beat-driven transitionToColors
+  // still fires requestRender during the flyover, which would otherwise
+  // resurrect the schema renderLoop and race the flyover camera. The flag
+  // gates requestRender so the flyover's own loop stays the sole renderer.
+  let _continuousRenderRefs = 0;
+  let _suppressed = false;
+
   function renderLoop() {
-    animationId = requestAnimationFrame(renderLoop);
+    animationId = null;
     if (stats) stats.begin();
-    controls.update();
+    const dampingActive = controls.update();
     renderer.render(scene, camera);
     NCZ.ThreeMarkers?.render?.();
     if (stats) {
@@ -1112,16 +1139,18 @@ const ThreeScene = (() => {
       statsTrisPanel .update(renderer.info.render.triangles/1000, 2000);
       stats.end();
     }
-    // Frame-time sampling for dumpDebugInfo() — runs whether stats panel is on or not.
+    // Frame-time sampling for dumpDebugInfo(). Cap dt so a long idle gap
+    // between render-on-demand frames doesn't poison the rolling average —
+    // anything over 1s is treated as "loop was paused, ignore this delta".
     const _now = performance.now();
     if (_lastFrameTime) {
       const dt = _now - _lastFrameTime;
-      _frameTimes.push(dt);
-      _frameTimeSum += dt;
-      // Evict oldest while doing so still leaves ≥ FRAME_SAMPLE_DURATION_MS of data —
-      // keeps exactly the time-window we want, never under-shoots at the boundary.
-      while (_frameTimes.length > 1 && _frameTimeSum - _frameTimes[0] > FRAME_SAMPLE_DURATION_MS) {
-        _frameTimeSum -= _frameTimes.shift();
+      if (dt < 1000) {
+        _frameTimes.push(dt);
+        _frameTimeSum += dt;
+        while (_frameTimes.length > 1 && _frameTimeSum - _frameTimes[0] > FRAME_SAMPLE_DURATION_MS) {
+          _frameTimeSum -= _frameTimes.shift();
+        }
       }
     }
     _lastFrameTime = _now;
@@ -1133,17 +1162,45 @@ const ThreeScene = (() => {
       const tilt = Math.round(90 - polarDegrees);
       tiltDisplay.textContent = `Tilt: ${tilt}°`;
     }
+    if (dampingActive || _continuousRenderRefs > 0) requestRender();
   }
 
+  // Schedule one frame. Idempotent — multiple calls within the same tick
+  // collapse to a single rAF. Hook into any state change that affects pixels.
+  function requestRender() {
+    if (_suppressed) return;
+    if (animationId !== null) return;
+    if (!renderer || !scene || !camera) return;
+    animationId = requestAnimationFrame(renderLoop);
+  }
+
+  // Hold the loop open across an arbitrary number of frames. Counter-based so
+  // multiple animations (theme dissolve + sun arc + beat pulse) compose cleanly
+  // — each pairs a true/false call. Flyover doesn't use this; it bypasses the
+  // schema renderLoop entirely with its own rAF + renderFrame(flyCamera) path.
+  function setContinuousRender(active) {
+    _continuousRenderRefs = Math.max(0, _continuousRenderRefs + (active ? 1 : -1));
+    if (_continuousRenderRefs > 0) requestRender();
+  }
+
+  // Backward-compat shims — external callers (app.js view switch, flyover
+  // restart) still talk to start/stop. start = "ensure at least one frame
+  // renders soon" which on-demand satisfies via a single requestRender.
+  // start also clears the flyover suppression flag in case stopRenderLoop
+  // was the call that engaged it; stop sets it so any in-flight requestRender
+  // (e.g. from a still-running color tween) doesn't resurrect the loop.
   function startRenderLoop() {
-    if (animationId === null) renderLoop();
+    _suppressed = false;
+    requestRender();
   }
 
   function stopRenderLoop() {
+    _suppressed = true;
     if (animationId !== null) {
       cancelAnimationFrame(animationId);
       animationId = null;
     }
+    _lastFrameTime = 0; // Reset so the next frame after restart doesn't sample the gap
   }
 
   // ── Debug helpers (always exposed; useful from DevTools console) ───────
@@ -1174,6 +1231,7 @@ const ThreeScene = (() => {
     } else {
       scene.overrideMaterial = null;
     }
+    requestRender();
   }
 
   // Runtime control of the building edge highlight intensity. The shader's
@@ -1187,6 +1245,7 @@ const ThreeScene = (() => {
       const sh = mat.userData.shader;
       if (sh && sh.uniforms.uEdgeIntensity) sh.uniforms.uEdgeIntensity.value = value;
     }
+    requestRender();
   }
 
   // Comprehensive diagnostic snapshot — bound to the "Copy debug info" button
@@ -1357,6 +1416,7 @@ const ThreeScene = (() => {
     controls.autoRotate = false;
     controls.autoRotateSpeed = 0;
     controls.update();
+    requestRender();
   }
 
   function updateMaterials() {
@@ -1386,6 +1446,7 @@ const ThreeScene = (() => {
         if (sh) sh.uniforms.uEdgeColor.value.copy(edge);
       }
     }
+    requestRender();
   }
 
   // ── Color bindings registry ────────────────────────────────────────────────
@@ -1456,6 +1517,7 @@ const ThreeScene = (() => {
       const rawT = Math.min((performance.now() - start) / durationMs, 1);
       const t    = rawT * rawT * (3 - 2 * rawT);
       for (const b of bindings) if (from[b.key] && to[b.key]) b.lerp(from[b.key], to[b.key], t);
+      requestRender();
       if (rawT < 1) requestAnimationFrame(step);
     }
     requestAnimationFrame(step);
@@ -1481,6 +1543,7 @@ const ThreeScene = (() => {
       const rawT = Math.min((performance.now() - start) / durationMs, 1);
       const t    = rawT * rawT * (3 - 2 * rawT);
       for (const b of bindings) if (from[b.key]) b.lerp(from[b.key], to[b.key], t);
+      requestRender();
       if (rawT < 1) requestAnimationFrame(step);
     }
     requestAnimationFrame(step);
@@ -1548,10 +1611,12 @@ const ThreeScene = (() => {
         Math.min(1, _dirLight.color.b * 0.8),
       );
     }
+    requestRender();
   }
 
   function setSunSphereVisible(visible) {
     if (_sunSphere) _sunSphere.visible = visible;
+    requestRender();
   }
 
   function updateShadowFrustum() {
@@ -1595,6 +1660,7 @@ const ThreeScene = (() => {
       const elevDeg = Math.asin(Math.min(1, _dirLight.position.y / NCZ.SUN_DIST)) * 180 / Math.PI;
       _dirLight.castShadow = _shadowsOn && elevDeg > NCZ.SHADOW_MIN_ELEV;
     }
+    requestRender();
   }
 
   function getShadowsEnabled() { return _shadowsOn; }
@@ -1633,9 +1699,10 @@ const ThreeScene = (() => {
       const slider = document.getElementById('scene-sun-slider');
       if (slider) { slider.value = s.sunSlider; slider.dispatchEvent(new Event('input')); }
     }
+    requestRender();
   }
 
-  return { init, startRenderLoop, stopRenderLoop, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, getSunElevation, setSunSphereVisible, getCameraState, setCameraState, getSceneColorVars, getRenderInfo, setOverrideMaterial, setBuildingEdgeIntensity, dumpDebugInfo };
+  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, getSunElevation, setSunSphereVisible, getCameraState, setCameraState, getSceneColorVars, getRenderInfo, setOverrideMaterial, setBuildingEdgeIntensity, dumpDebugInfo };
 })();
 
 window.NCZ.ThreeScene = ThreeScene;


### PR DESCRIPTION
## Summary

The 3D scene's rAF loop now only fires when the next frame would actually differ from the last — camera moved, damping in progress, sun/theme/layer/material updated, pins added — instead of unconditionally re-rendering 60–280 times a second. Idle map views cost zero GPU/CPU.

Motivation: a debug-info dump from a work laptop with Intel UHD (no Iris Xe) showed 48 fps with shadows off and noticeable input lag — classic symptom of a continuous render loop saturating a weak iGPU and leaving no main-thread slack for input handling. The Radeon 840M case (840M is RDNA3, not the worst tier) had hidden how badly the unconditional loop performed on the bottom of the iGPU range.

This is the first of two perf levers we're queueing for that machine; the second is building distance culling / LOD, which targets the 3.5M tris/frame root cause. WebGPU was discussed and deferred — the bottleneck on Intel UHD is GPU fillrate, not WebGL/ANGLE driver overhead, and the migration costs are real (custom GLSL → TSL rewrites, browser-compat dual-path).

## Implementation

- **`three-scene.js`** — new `requestRender()` entrypoint. The render loop now self-stops unless `controls.update()` reports damping in progress or `_continuousRenderRefs > 0`. Hooked into every state-mutating helper: `setLayerVisibility`, `setSunPosition`, `setShadowsEnabled`, `setOverrideMaterial`, `setBuildingEdgeIntensity`, `updateMaterials`, `setCameraState`, `resetCamera`, `setSunSphereVisible`, `transitionToColors`/`transitionMaterials` per-step, `onResize`, the OrbitControls `'change'` listener, post-asset-load `scene.add` calls.
- **`_suppressed` flag** — `stopRenderLoop` now suppresses `requestRender` so the beat-driven `transitionToColors` running during a flyover can't resurrect the schema renderLoop and race the flyover camera. `startRenderLoop` clears it. Two rAF consumers fighting over the same canvas was a real bug avoided by this flag.
- **`three-markers.js`** — private `_redraw()` helper forwards to `ThreeScene.requestRender()`. Called from `setMods`, `applyFilters`, `showTooltip`, `hideTooltip`, `recomputeClusters`, `setActiveClusterMods`, `openPopup`, `closePopup`, `setActiveCamera`, `setOverlayVisible`, `setUnclusteredMode`. Fly-tween (`flyTo` / `updateFlyTween`) self-extends — direct camera mutation doesn't fire OrbitControls `'change'` so the tween manually requests the next frame until completion.
- **Frame-time sampling** caps `dt` at 1000ms so an idle gap doesn't poison the rolling average. Backward-compat: `startRenderLoop` / `stopRenderLoop` public API unchanged for app.js view switch and flyover lifecycle.

## Test plan

Tested locally — pan/zoom/tilt, damping settle, sun slider drag, theme switch, layer toggles, pin click → popup, sidebar click → fly-to-pin, filter change, showcase flyover with beat cycle, view toggle, window resize all work as before. The Stats panel FPS drops to ~0 when idle (was 60+) — the visible signal that the loop is actually paused.

For Cloudflare Pages preview validation:

- [ ] **Idle case** — open 3D view, don't touch anything. Stats panel FPS should freeze on last value within a second. Task Manager CPU/GPU usage should drop noticeably.
- [ ] **Pan / zoom / tilt** — drag, scroll, right-drag. Should feel identical to before, smooth damping for ~1s after release.
- [ ] **Sun slider** — drag through full arc. Lighting transitions continuously, no chunking.
- [ ] **Theme switch** — pick a different theme. Colors smoothly lerp, no snap.
- [ ] **Layer checkboxes** — toggle each (Districts, Roads, Metro, Buildings, Shadows, Pins). Appear/disappear immediately.
- [ ] **Pin click** — popup appears. Click again or click empty space — popup gone.
- [ ] **Sidebar mod click** — camera flies smoothly all the way to the target. Popup opens at end.
- [ ] **Filter change** — toggle a category. Pins/clusters update immediately.
- [ ] **Showcase flyover** — full run with beat cycle on. Color transitions visible during flight, animation smooth throughout, on return everything intact.
- [ ] **View toggle** — flip 2D ↔ 3D a few times. 3D view always renders its current state on entry.
- [ ] **Resize window** — scene rescales immediately.
- [ ] **Work laptop (Intel UHD)** — input lag should drop substantially vs current dev. Confirm via subjective feel + debug-info dump showing FPS panel paused on idle.

If a state change fails to redraw until the camera is wiggled, that's a missed `requestRender()` hook — file the case and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)