### PR TITLE
spike(3d): WebGPU vs WebGL perf measurement (do not merge)

### DIFF
--- a/scripts/webgpu_buildings_spike.html
+++ b/scripts/webgpu_buildings_spike.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>WebGPU vs WebGL — building instance perf spike</title>
+  <style>
+    body { margin: 0; background: #0a192f; overflow: hidden; font-family: monospace; color: #fff; }
+    #info {
+      position: fixed; top: 8px; left: 8px; padding: 10px 14px;
+      background: rgba(0, 0, 0, 0.78); color: #00f0ff;
+      font-size: 12px; line-height: 1.7;
+      border: 1px solid #00f0ff; z-index: 100;
+      max-width: 420px;
+    }
+    #info a { color: #ffb300; text-decoration: none; font-weight: bold; }
+    #info a:hover { text-decoration: underline; }
+    #info strong { color: #fff; }
+    #info em { color: #8892b0; font-style: normal; display: block; margin-top: 6px; }
+    .err { color: #ff5555; }
+  </style>
+  <script type="importmap">
+  {
+    "imports": {
+      "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.webgpu.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/"
+    }
+  }
+  </script>
+</head>
+<body>
+  <div id="info">Loading...</div>
+  <script type="module">
+    // Phase 0 spike — does WebGPU outperform WebGL on the work laptop's Intel UHD?
+    //
+    // Synthesises 255,532 instanced cubes (= total of 8 production building districts)
+    // scattered over a Night-City-sized 12km × 12km area. Same material/lighting setup
+    // as production (MeshLambertMaterial + Directional + Ambient). Continuous render
+    // with slow camera rotation so we measure throughput under load, not idle.
+    //
+    // A/B switch:    ?renderer=webgpu|webgl   (default webgpu)
+    // Ramp testing:  ?count=N                 (default 255532)
+    //
+    // Procedure on the work laptop:
+    //   1. Open in Chrome with default URL
+    //   2. Wait ~5s for FPS to stabilise; read avg from Stats panel
+    //   3. Click "→ WEBGL" link in info bar; wait ~5s; compare
+    //   4. Optional: ?count=50000 / 100000 / 500000 to test scaling
+    import * as THREE from 'three';
+    import { WebGPURenderer } from 'three';
+    import Stats from 'three/addons/libs/stats.module.js';
+
+    const url           = new URL(window.location.href);
+    const rendererType  = url.searchParams.get('renderer') || 'webgpu';
+    const instanceCount = parseInt(url.searchParams.get('count') || '255532', 10);
+    const worldSize     = 12000;   // NC extent in CET units
+    const dprCap        = 1.5;     // matches production NCZ.MAX_DEVICE_PIXEL_RATIO
+    const info          = document.getElementById('info');
+
+    function fail(msg) {
+      info.innerHTML = `<span class="err">⚠ ${msg}</span>`;
+      throw new Error(msg);
+    }
+
+    // ── Renderer ──────────────────────────────────────────────────────────
+    let renderer;
+    let gpuLabel = 'unknown';
+    if (rendererType === 'webgpu') {
+      if (!navigator.gpu) fail('WebGPU not supported on this browser. <a href="?renderer=webgl">Try WebGL</a>.');
+      renderer = new WebGPURenderer({ antialias: true });
+      await renderer.init();
+      try {
+        const adapter = renderer.backend?.adapter;
+        const desc = adapter?.info?.description || adapter?.info?.vendor || adapter?.info?.architecture;
+        gpuLabel = desc ? `WebGPU (${desc})` : 'WebGPU';
+      } catch { gpuLabel = 'WebGPU'; }
+    } else {
+      renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
+      try {
+        const gl = renderer.getContext();
+        const ext = gl.getExtension('WEBGL_debug_renderer_info');
+        gpuLabel = ext ? gl.getParameter(ext.UNMASKED_RENDERER_WEBGL) : 'WebGL2';
+      } catch { gpuLabel = 'WebGL2'; }
+    }
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, dprCap));
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(renderer.domElement);
+
+    // ── Scene + camera (orthographic top-down, matches production SCHEMA view) ──
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color('#0a192f');
+
+    const aspect   = window.innerWidth / window.innerHeight;
+    const frustumH = 7000;
+    const camera = new THREE.OrthographicCamera(
+      -frustumH * aspect, frustumH * aspect,
+       frustumH, -frustumH,
+       1, 50000,
+    );
+    camera.position.set(0, 12000, 0);
+    camera.up.set(0, 1, 0);
+    camera.lookAt(0, 0, 0);
+
+    const sun = new THREE.DirectionalLight(0xffffff, 0.7);
+    sun.position.set(-10000, 15000, -10000);
+    scene.add(sun);
+    scene.add(new THREE.AmbientLight(0xffffff, 0.3));
+
+    // ── 255k instanced cubes ──────────────────────────────────────────────
+    const geo = new THREE.BoxGeometry(1, 1, 1);
+    const mat = new THREE.MeshLambertMaterial({ color: '#7a8fa0' });
+    const mesh = new THREE.InstancedMesh(geo, mat, instanceCount);
+    mesh.frustumCulled = false; // matches production no-op behaviour
+
+    const dummy = new THREE.Object3D();
+    for (let i = 0; i < instanceCount; i++) {
+      dummy.position.set(
+        (Math.random() - 0.5) * worldSize,
+        50 + Math.random() * 200,
+        (Math.random() - 0.5) * worldSize,
+      );
+      dummy.scale.set(
+        30 + Math.random() * 80,
+        100 + Math.random() * 400,
+        30 + Math.random() * 80,
+      );
+      dummy.updateMatrix();
+      mesh.setMatrixAt(i, dummy.matrix);
+    }
+    mesh.instanceMatrix.needsUpdate = true;
+    scene.add(mesh);
+
+    // ── Stats panel ──────────────────────────────────────────────────────
+    const stats = new Stats();
+    stats.showPanel(0);
+    stats.dom.style.left = '8px';
+    stats.dom.style.top  = '180px';
+    document.body.appendChild(stats.dom);
+
+    // ── Info bar ─────────────────────────────────────────────────────────
+    const swap     = rendererType === 'webgpu' ? 'webgl' : 'webgpu';
+    const swapHref = `?renderer=${swap}${instanceCount !== 255532 ? `&count=${instanceCount}` : ''}`;
+    info.innerHTML = `
+      Mode: <strong>${rendererType.toUpperCase()}</strong> &nbsp; <a href="${swapHref}">→ swap to ${swap.toUpperCase()}</a><br>
+      Instances: <strong>${instanceCount.toLocaleString()}</strong><br>
+      DPR: <strong>${renderer.getPixelRatio()}</strong> (capped at ${dprCap})<br>
+      Canvas: <strong>${window.innerWidth}×${window.innerHeight}</strong><br>
+      GPU: <strong>${gpuLabel}</strong>
+      <em>Wait ~5s for FPS to stabilise; read avg from the Stats panel below.</em>
+    `;
+
+    // ── Continuous render loop with slow camera rotation ─────────────────
+    // Continuous because we want throughput; render-on-demand isn't relevant here.
+    // Camera moves so the load matches "user actively panning," not idle.
+    let t = 0;
+    renderer.setAnimationLoop(() => {
+      stats.begin();
+      t += 0.003;
+      camera.position.x = Math.sin(t) * 200;
+      camera.position.z = Math.cos(t) * 200;
+      camera.lookAt(0, 0, 0);
+      renderer.render(scene, camera);
+      stats.end();
+    });
+
+    window.addEventListener('resize', () => {
+      const a = window.innerWidth / window.innerHeight;
+      camera.left  = -frustumH * a;
+      camera.right =  frustumH * a;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+  </script>
+</body>
+</html>

--- a/scripts/webgpu_buildings_spike.html
+++ b/scripts/webgpu_buildings_spike.html
@@ -46,6 +46,10 @@
     //   2. Wait ~5s for FPS to stabilise; read avg from Stats panel
     //   3. Click "→ WEBGL" link in info bar; wait ~5s; compare
     //   4. Optional: ?count=50000 / 100000 / 500000 to test scaling
+    // `three` is mapped to three.webgpu.js (has WebGPURenderer + all base classes
+    // like Scene/Camera/BoxGeometry/MeshLambertMaterial). WebGLRenderer lives in
+    // the separate three.module.js build and gets dynamically imported below
+    // only when the user picks ?renderer=webgl.
     import * as THREE from 'three';
     import { WebGPURenderer } from 'three';
     import Stats from 'three/addons/libs/stats.module.js';
@@ -75,7 +79,11 @@
         gpuLabel = desc ? `WebGPU (${desc})` : 'WebGPU';
       } catch { gpuLabel = 'WebGPU'; }
     } else {
-      renderer = new THREE.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
+      // WebGLRenderer lives in three.module.js (the WebGL-only build), not in
+      // three.webgpu.js. Dynamic-import only when needed so the WebGPU path
+      // doesn't pay the cost of loading two builds.
+      const webglMod = await import('https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js');
+      renderer = new webglMod.WebGLRenderer({ antialias: true, powerPreference: 'high-performance' });
       try {
         const gl = renderer.getContext();
         const ext = gl.getExtension('WEBGL_debug_renderer_info');


### PR DESCRIPTION
## Purpose

Phase 0 spike for the WebGPU migration discussed in conversation 2026-05-07. **This PR is for Cloudflare Pages preview only — do not merge.** Once the work-laptop measurement is recorded, close the PR and delete the branch.

## What it does

`scripts/webgpu_buildings_spike.html` synthesises 255,532 instanced cubes (= total of all 8 production building districts) scattered over a Night-City-sized 12km × 12km area. Same `MeshLambertMaterial` + Directional/Ambient lighting + DPR cap of 1.5 as production. Camera slow-rotates so load is realistic (continuous, not render-on-demand — we want throughput).

A/B via URL flag:

- `?renderer=webgpu` (default) — uses Three.js `WebGPURenderer`
- `?renderer=webgl` — uses `WebGLRenderer` for comparison

Optional ramp testing:

- `?count=50000` / `100000` / `500000`

## How to use on the work laptop

1. Open the Cloudflare preview URL + `/scripts/webgpu_buildings_spike.html` (defaults to WebGPU)
2. Wait ~5 seconds for the FPS reading in the Stats panel to stabilise
3. Record the avg FPS
4. Click the "→ WEBGL" link in the info bar
5. Wait ~5s; record avg FPS
6. Compare

Decision rule: if WebGPU shows +15% or better on Intel UHD, the migration buys real perf and we proceed with confidence. If flat or negative, we still have non-perf reasons to migrate (delete `onBeforeCompile` workarounds, kill the depth-packing shim, future-proof) but the urgency is different.

## Test plan

- [ ] Cloudflare preview deploys successfully
- [ ] Page loads on the work laptop in WebGPU mode without console errors
- [ ] Page loads in WebGL mode without console errors
- [ ] FPS reading visible and stable in both modes
- [ ] GPU label correctly identifies the work laptop's Intel UHD adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)