### PR TITLE
feat(3d): migrate Three.js scene to WebGPU (Phase 1)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -578,8 +578,12 @@ async function initMap() {
     if (viewName === "schema") {
       mapEl.style.display   = "none";
       map3dEl.style.display = "block";
-      NCZ.ThreeScene.init("map-3d");
-      NCZ.ThreeScene.startRenderLoop();
+      // ThreeScene.init() is async under WebGPURenderer (await renderer.init()).
+      // Chain startRenderLoop so the loop only ticks once the renderer is ready.
+      // First-call goes through full async init; subsequent calls early-out
+      // synchronously (initialized guard) and the chain still resolves immediately.
+      Promise.resolve(NCZ.ThreeScene.init("map-3d"))
+        .then(() => NCZ.ThreeScene.startRenderLoop());
     } else {
       map3dEl.style.display = "none";
       mapEl.style.display   = "block";

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -12,11 +12,18 @@
  */
 
 import * as THREE from 'three';
+import { attribute, uniform, texture, positionWorld, uv, vec2, float, materialColor } from 'three/tsl';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
-import { Line2 } from 'three/addons/lines/Line2.js';
+// WebGPU fat-line addons live under lines/webgpu/. The legacy WebGL versions
+// at lines/Line2.js + lines/LineMaterial.js import THREE.ShaderLib (a
+// WebGL-only registry) which the three.webgpu build does not expose, so
+// loading them at module-init time throws a SyntaxError before our code ever
+// runs. The webgpu wrapper extends LineSegments2 and pairs with the bundled
+// Line2NodeMaterial — same Line2 API, TSL-based shader, viewport size pulled
+// from the renderer automatically (no `resolution` field to keep in sync).
+import { Line2 } from 'three/addons/lines/webgpu/Line2.js';
 import { LineGeometry } from 'three/addons/lines/LineGeometry.js';
-import { LineMaterial } from 'three/addons/lines/LineMaterial.js';
 import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
 import Stats from 'three/addons/libs/stats.module.js';
 
@@ -49,7 +56,11 @@ const ThreeScene = (() => {
   let normalRoadsMat  = null;  // Normal depth-tested pass
   let normalBordersMat= null;  // Normal depth-tested pass
   let metroMat        = null;
-  let metroShader     = null; // onBeforeCompile ref for LOD zoom uniform updates
+  let metroZoomUniform = null; // TSL uniform() node — mutated from controls 'change'
+  // Captured at WebGPURenderer construction so dumpDebugInfo can introspect
+  // the antialias flag — WebGPURenderer has no getContextAttributes() to read it
+  // back from, unlike WebGLRenderer.
+  let _rendererInitParams = null;
   let buildingMeshes     = [];    // one InstancedMesh per district
   let buildingMaterials  = [];    // parallel ShaderMaterial array for theme updates
   let landmarkMat        = null;  // shared MeshLambertMaterial for all landmark GLBs
@@ -85,7 +96,7 @@ const ThreeScene = (() => {
   // Derive edge highlight colour from the building base colour.
 
   function makeHillshadeMaterial(colorVar, fallback, extra = {}) {
-    return new THREE.MeshLambertMaterial({
+    return new THREE.MeshLambertNodeMaterial({
       color: readThemeColor(colorVar, fallback),
       flatShading: true,
       side: THREE.DoubleSide,
@@ -170,7 +181,13 @@ const ThreeScene = (() => {
     // mip selection picks based on the smaller of the screen-space derivatives —
     // an elongated texture footprint still aliases along the long axis. AF samples
     // multiple texels along that axis. Free-ish on modern GPUs (fixed-function path).
-    tex.anisotropy = renderer.capabilities.getMaxAnisotropy();
+    // WebGPU exposes the limit via `renderer.backend.device.limits.maxSamplerAnisotropy`
+    // (post-init); WebGL2 fallback uses the legacy `renderer.capabilities.getMaxAnisotropy()`.
+    // Cap at 16 — the hardware ceiling on every consumer GPU since ~2009.
+    const maxAniso = renderer.backend?.device?.limits?.maxSamplerAnisotropy
+                  ?? renderer.capabilities?.getMaxAnisotropy?.()
+                  ?? 16;
+    tex.anisotropy = Math.min(16, maxAniso);
     tex.needsUpdate = true;
     return tex;
   }
@@ -191,7 +208,7 @@ const ThreeScene = (() => {
 
   // ── Scene init ─────────────────────────────────────────────────────────
 
-  function init(containerId) {
+  async function init(containerId) {
     if (initialized) return;
     initialized = true;
 
@@ -199,26 +216,33 @@ const ThreeScene = (() => {
     loadingEl     = container.querySelector('.scene-loading');
     loadingFillEl = container.querySelector('.scene-loading__fill');
 
-    // Renderer — pass updateStyle:false so Three.js never writes px dimensions
-    // onto the canvas element. The canvas is kept at width/height:100% via the
-    // `#map-3d > canvas` rule in style.css so it always fills #map-3d without
-    // pushing surrounding layout elements (and without falling back to its
-    // intrinsic drawingBuffer size, which would misalign with the CSS2D pin
-    // overlay on any DPR > 1.0).
-    // logarithmicDepthBuffer: redistributes depth precision logarithmically
-    // across the [near, far] frustum. Mitigates Z-fighting on near-coplanar
-    // surfaces — block-style buildings sharing walls, water/terrain at the
-    // coastline, etc. Costs a cheap shader op per fragment; free on modern GPUs.
-    // powerPreference hints the OS to pick the discrete GPU on hybrid-graphics
-    // laptops (Optimus / AMD Switchable / Apple). Not guaranteed — driver/OS
-    // policy can override — but it's a free one-flag improvement for users
-    // who'd otherwise get stuck on the integrated chip.
-    renderer = new THREE.WebGLRenderer({
+    // Renderer — WebGPU build with WebGL2 auto-fallback. The canvas is kept at
+    // width/height:100% via the `#map-3d > canvas` rule in style.css so it
+    // always fills #map-3d without pushing surrounding layout elements (and
+    // without falling back to its intrinsic drawingBuffer size, which would
+    // misalign with the CSS2D pin overlay on any DPR > 1.0).
+    //
+    // reversedDepthBuffer: stores depth as 1=near→0=far instead of 0=near→1=far,
+    // and uses depthCompare:'greater' instead of 'less'. Combined with WebGPU's
+    // native float depth, this redistributes precision so far-frustum surfaces
+    // keep enough resolution to avoid Z-fighting at our 3-15km zoom range.
+    // Strictly better than the old `logarithmicDepthBuffer` workaround — log-depth
+    // writes frag_depth from the fragment shader, killing the GPU's early-Z
+    // optimization. Reverse-Z achieves precision purely through projection-matrix
+    // tricks; early-Z stays on. Available on `WebGPURenderer` since Three.js r183
+    // (PR #32967, Feb 2026). Camera.reversedDepth is auto-corrected per PR #31410.
+    //
+    // (No `powerPreference` here — Chrome confirmed it's currently ignored on
+    // Windows for navigator.gpu.requestAdapter() per https://crbug.com/369219127.
+    // Hybrid-graphics laptops fall back to OS adapter selection. Watch list
+    // item: revisit if dGPU isn't getting selected.)
+    _rendererInitParams = {
       antialias: true,
       stencil: true,
-      logarithmicDepthBuffer: true,
-      powerPreference: 'high-performance',
-    });
+      reversedDepthBuffer: true,
+    };
+    renderer = new THREE.WebGPURenderer(_rendererInitParams);
+    await renderer.init();   // WebGPURenderer requires async init before any use
     // Make the sRGB-correct colour pipeline explicit. These match Three.js r170
     // defaults (since r152 / r155 respectively) but stating them here protects
     // the scene's appearance against future Three.js default changes — both flags
@@ -297,7 +321,7 @@ const ThreeScene = (() => {
     // Radius NCZ.SUN_SPHERE_RADIUS units at NCZ.SUN_SPHERE_DIST distance ≈ 1.7° apparent diameter (≈3× real sun).
     _sunSphere = new THREE.Mesh(
       new THREE.SphereGeometry(NCZ.SUN_SPHERE_RADIUS, 16, 16),
-      new THREE.MeshBasicMaterial({ color: 0xffcc44 })
+      new THREE.MeshBasicNodeMaterial({ color: 0xffcc44 })
     );
     _sunSphere.name = 'sun-sphere';
     _sunSphere.visible = false;
@@ -324,7 +348,7 @@ const ThreeScene = (() => {
     controls.update();
     controls.addEventListener('change', () => {
       updateDistrictZoom();
-      if (metroShader) metroShader.uniforms.uMetroZoom.value = camera.zoom;
+      if (metroZoomUniform) metroZoomUniform.value = camera.zoom;
       updateShadowFrustum();
       updateScaleBar();
       requestRender();
@@ -406,10 +430,10 @@ const ThreeScene = (() => {
     camera.right  =  frustumH * aspect;
     camera.updateProjectionMatrix();
     // flyCamera resize is handled in flyover.js
-    // LineMaterial needs the viewport resolution to compute pixel-width lines correctly
-    for (const mat of districtLineMaterials) {
-      mat.resolution.set(w, h);
-    }
+    // Line2NodeMaterial pulls viewport size from a TSL screen node at
+    // shader-execution time, so the legacy resolution-set loop is no longer
+    // needed here — left as a single retained `districtLineMaterials` ref so
+    // the registry still exists for any future per-material resize work.
     NCZ.ThreeMarkers?.onResize?.(w, h);
     updateScaleBar();
     requestRender();
@@ -597,43 +621,51 @@ const ThreeScene = (() => {
       const metroColor  = readThemeColor('--overlay-metro-color',       '#dcaa28');
 
       // Normal depth-tested pass — surface roads/borders sit correctly in scene
-      normalRoadsMat   = new THREE.MeshBasicMaterial({ color: roadColor,   transparent: true, opacity: 0.8 });
-      normalBordersMat = new THREE.MeshBasicMaterial({ color: borderColor, transparent: true, opacity: 0.6, blending: THREE.AdditiveBlending, depthWrite: false });
+      normalRoadsMat   = new THREE.MeshBasicNodeMaterial({ color: roadColor,   transparent: true, opacity: 0.8 });
+      normalBordersMat = new THREE.MeshBasicNodeMaterial({ color: borderColor, transparent: true, opacity: 0.6, blending: THREE.AdditiveBlending, depthWrite: false });
 
       applyMaterial(roadsScene,   normalRoadsMat);
       applyMaterial(bordersScene, normalBordersMat);
 
-      // Metro: normal depth-tested, renderOrder=1 so it renders above roads
-      metroMat = new THREE.MeshBasicMaterial({ color: metroColor, transparent: true, opacity: 0.9, blending: THREE.AdditiveBlending, depthWrite: false });
-      metroMat.onBeforeCompile = shader => {
-        metroShader = shader;
-        shader.uniforms.uMetroZoom    = { value: camera.zoom };
-        shader.uniforms.uMetroLODMed  = { value: NCZ.METRO_LOD_ZOOM_MED };
-        shader.uniforms.uMetroLODNear = { value: NCZ.METRO_LOD_ZOOM_NEAR };
-        shader.vertexShader = `
-          attribute vec3 color;
-          varying vec3 vLODColor;
-        ` + shader.vertexShader.replace(
-          '#include <color_vertex>',
-          '#include <color_vertex>\nvLODColor = color;'
-        );
-        shader.fragmentShader = `
-          uniform float uMetroZoom;
-          uniform float uMetroLODMed;
-          uniform float uMetroLODNear;
-          varying vec3 vLODColor;
-        ` + shader.fragmentShader.replace(
-          'void main() {',
-          `void main() {
-          // B=bold base line (always visible), G=regular (medium zoom), R=dashed detail (close only)
-          // B=wide solid: far zoom only (zoom < LOD_MED)
-          // G=thin solid: medium zoom only (LOD_MED < zoom < LOD_NEAR)
-          // R=dotted:     close zoom only (zoom > LOD_NEAR)
-          if (vLODColor.b > 0.5 && uMetroZoom > uMetroLODMed) discard;
-          if (vLODColor.g > 0.5 && (uMetroZoom < uMetroLODMed || uMetroZoom > uMetroLODNear)) discard;
-          if (vLODColor.r > 0.5 && uMetroZoom < uMetroLODNear) discard;`
-        );
-      };
+      // Metro: normal depth-tested, renderOrder=1 so it renders above roads.
+      //
+      // LOD discard: COLOR_0 vertex attribute carries the LOD tier as one
+      // mutually-exclusive channel per vertex (per the building/metro extraction
+      // pipeline — see `[[phase3-building-rendering]]` and the metro LOD-channel
+      // mapping note in CLAUDE.md). Discard rules:
+      //   B=wide solid:  show only at far zoom    (zoom <= LOD_MED)
+      //   G=thin solid:  show only at medium zoom (LOD_MED <= zoom <= LOD_NEAR)
+      //   R=dotted:      show only at close zoom  (zoom >= LOD_NEAR)
+      //
+      // TSL port (was `onBeforeCompile` GLSL injection on r170):
+      //   - vertex color attribute pulled via `attribute('color')`
+      //   - per-frame zoom uniform via `uniform()` node — mutate `.value` from
+      //     the controls 'change' handler (lookup at top of init())
+      //   - boolean expression composed with TSL methods (.greaterThan/.and/.or)
+      //   - `material.maskNode` is a KEEP mask (true=keep, false=discard);
+      //     we compose the discard condition for clarity then `.not()` it
+      metroMat = new THREE.MeshBasicNodeMaterial({
+        color: metroColor,
+        transparent: true,
+        opacity: 0.9,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      });
+      metroZoomUniform        = uniform(camera.zoom);
+      const uMetroLODMed_node  = uniform(NCZ.METRO_LOD_ZOOM_MED);
+      const uMetroLODNear_node = uniform(NCZ.METRO_LOD_ZOOM_NEAR);
+      const lodColor = attribute('color');
+      const discardCondition =
+        lodColor.b.greaterThan(0.5).and(metroZoomUniform.greaterThan(uMetroLODMed_node))
+          .or(
+            lodColor.g.greaterThan(0.5).and(
+              metroZoomUniform.lessThan(uMetroLODMed_node).or(metroZoomUniform.greaterThan(uMetroLODNear_node))
+            )
+          )
+          .or(
+            lodColor.r.greaterThan(0.5).and(metroZoomUniform.lessThan(uMetroLODNear_node))
+          );
+      metroMat.maskNode = discardCondition.not();
 
       function makeSeeThrough(source, mat) {
         const group = new THREE.Group();
@@ -659,8 +691,8 @@ const ThreeScene = (() => {
         stencilFunc: THREE.EqualStencilFunc, stencilRef: 2, stencilFuncMask: 0xff,
         stencilFail: THREE.KeepStencilOp, stencilZFail: THREE.KeepStencilOp, stencilZPass: THREE.KeepStencilOp,
       };
-      roadsMat   = new THREE.MeshBasicMaterial({ ...stBase, color: roadColor,   opacity: 0.8 });
-      bordersMat = new THREE.MeshBasicMaterial({ ...stBase, color: borderColor, opacity: 0.6, blending: THREE.AdditiveBlending });
+      roadsMat   = new THREE.MeshBasicNodeMaterial({ ...stBase, color: roadColor,   opacity: 0.8 });
+      bordersMat = new THREE.MeshBasicNodeMaterial({ ...stBase, color: borderColor, opacity: 0.6, blending: THREE.AdditiveBlending });
 
       applyMaterial(metroScene, metroMat);
 
@@ -751,7 +783,8 @@ const ThreeScene = (() => {
 
   // ── Buildings ──────────────────────────────────────────────────────────
   // CPU decodes _data.dds (16-bit RGBA) → InstancedMesh matrices.
-  // MeshLambertMaterial + onBeforeCompile adds _m.dds planar UV and edge highlight.
+  // MeshLambertNodeMaterial with TSL `colorNode` (_m.dds planar UV modulation)
+  // and `emissiveNode` (silhouette edge highlight). See buildBuildingMaterial.
   // Shadow casting/receiving handled automatically by Three.js.
 
   // ── Landmarks ─────────────────────────────────────────────────────────
@@ -778,7 +811,7 @@ const ThreeScene = (() => {
   async function loadLandmarks() {
     registerLoadStep(1);
     try {
-      landmarkMat = new THREE.MeshLambertMaterial({
+      landmarkMat = new THREE.MeshLambertNodeMaterial({
         color: readThemeColor('--scene-buildings', '#8aacbf'),
         flatShading: true,
       });
@@ -915,78 +948,67 @@ const ThreeScene = (() => {
     }
   }
 
-  // Build the MeshLambertMaterial for one district.
-  // onBeforeCompile patches the standard Lambert shader to add:
-  //   - world-space planar UV sampling of the _m.dds surface texture
-  //   - edge highlight matching 3d_map_cubes.mt EdgeColor/Thickness/Sharpness
+  // Build the MeshLambertNodeMaterial for one district.
+  //
+  // The TSL graph composes two effects on top of the standard Lambert pipeline:
+  //
+  //   1. `_m.dds` surface modulation (pre-lighting, via `colorNode`)
+  //      Original GLSL hook: `#include <color_fragment>`
+  //      Samples the district's `_m` heightmap with a world-space planar UV
+  //      and multiplies the diffuse colour. World position is read directly
+  //      from the `positionWorld` TSL node — Three.js routes the instance
+  //      matrix into it for `InstancedMesh` automatically, no `USE_INSTANCING`
+  //      branch required.
+  //
+  //   2. Edge highlight (post-lighting, via `emissiveNode`)
+  //      Original GLSL hook: `outgoingLight = mix(outgoingLight, edgeColor, ef)`
+  //      WebGPU has no user-facing post-lighting hook (NodeMaterial's
+  //      `outgoingLightNode` is a builder-local). `emissiveNode` is the closest
+  //      idiomatic fit — emissive is added to the lit colour at exactly the
+  //      same point in the pipeline. At our default 0.15 intensity the additive
+  //      vs mix difference is visually indistinguishable, and we keep tonemap.
+  //
+  // Per-district `uniform()` node refs are stashed on `mat.userData.tslUniforms`
+  // so the colour-binding registry (`getColorBindings.buildingsEdge`) can mutate
+  // `.value` during theme switches and flyover beat-driven colour tweens.
   function buildBuildingMaterial(meta, mTex) {
-    const mat = new THREE.MeshLambertMaterial({
+    const mat = new THREE.MeshLambertNodeMaterial({
       color: readThemeColor('--scene-buildings', '#7a8fa0'),
     });
-    mat.defines = { USE_UV: '' };  // ensure 'uv' attribute is declared in shader
 
-    mat.onBeforeCompile = (shader) => {
-      mat.userData.shader = shader;  // save for later uniform updates
+    // Per-district uniforms (the equivalents of the WebGL onBeforeCompile uniforms)
+    const uTransMin      = uniform(new THREE.Vector2(meta.transMin[0], meta.transMin[1]));
+    const uTransMax      = uniform(new THREE.Vector2(meta.transMax[0], meta.transMax[1]));
+    const uOffset        = uniform(new THREE.Vector2(meta.offset[0], meta.offset[1]));
+    const uEdgeColor     = uniform(readThemeColor('--scene-buildings-edge', '#ffffff'));
+    const uEdgeThickness = uniform(NCZ.BUILDING_EDGE_THICKNESS);
+    const uEdgeSharpness = uniform(NCZ.BUILDING_EDGE_SHARPNESS);
+    const uEdgeIntensity = uniform(NCZ.BUILDING_EDGE_INTENSITY);
+    // Surfaced for runtime mutation (theme rewire, debug intensity tweaks)
+    mat.userData.tslUniforms = { uEdgeColor, uEdgeIntensity, uEdgeThickness, uEdgeSharpness };
 
-      shader.uniforms.uTransMin      = { value: new THREE.Vector2(meta.transMin[0], meta.transMin[1]) };
-      shader.uniforms.uTransMax      = { value: new THREE.Vector2(meta.transMax[0], meta.transMax[1]) };
-      shader.uniforms.uOffset        = { value: new THREE.Vector2(...meta.offset) };
-      shader.uniforms.uMTex          = { value: mTex };
-      shader.uniforms.uEdgeColor     = { value: readThemeColor('--scene-buildings-edge', '#ffffff') };
-      shader.uniforms.uEdgeThickness = { value: NCZ.BUILDING_EDGE_THICKNESS };
-      shader.uniforms.uEdgeSharpness = { value: NCZ.BUILDING_EDGE_SHARPNESS };
-      shader.uniforms.uEdgeIntensity = { value: NCZ.BUILDING_EDGE_INTENSITY };
+    // World-space planar UV — XZ plane, normalised against the district's CET
+    // bounds. Original GLSL: vMUv = ((wx - off.x - min.x)/(max.x - min.x),
+    //                                (-wz - off.y - min.y)/(max.y - min.y))
+    const wx = positionWorld.x;
+    const wzNeg = positionWorld.z.negate();
+    const planarUv = vec2(
+      wx.sub(uOffset.x).sub(uTransMin.x).div(uTransMax.x.sub(uTransMin.x)),
+      wzNeg.sub(uOffset.y).sub(uTransMin.y).div(uTransMax.y.sub(uTransMin.y))
+    );
 
-      // ── Vertex shader — inject varyings + world-space UV ──────────────
-      shader.vertexShader = `
-        uniform vec2 uTransMin;
-        uniform vec2 uTransMax;
-        uniform vec2 uOffset;
-        varying vec2 vMUv;
-        varying vec2 vLocalUv;
-      ` + shader.vertexShader;
+    // (1) Diffuse modulation — sample _m, scale base colour
+    const mVal = texture(mTex, planarUv.clamp(0, 1)).r;
+    const modulation = float(NCZ.BUILDING_TEX_FLOOR).add(mVal.mul(NCZ.BUILDING_TEX_RANGE));
+    mat.colorNode = materialColor.mul(modulation);
 
-      // Replace project_vertex to also capture world position for planar UV.
-      // instanceMatrix * transformed gives world pos (model matrix is identity).
-      shader.vertexShader = shader.vertexShader.replace(
-        '#include <project_vertex>',
-        `vec4 mvPosition = vec4( transformed, 1.0 );
-        #ifdef USE_INSTANCING
-          mvPosition = instanceMatrix * mvPosition;
-        #endif
-        vMUv = vec2(
-          ( mvPosition.x - uOffset.x - uTransMin.x ) / ( uTransMax.x - uTransMin.x ),
-          ( -mvPosition.z - uOffset.y - uTransMin.y ) / ( uTransMax.y - uTransMin.y )
-        );
-        vLocalUv = uv;
-        mvPosition = modelViewMatrix * mvPosition;
-        gl_Position = projectionMatrix * mvPosition;`
-      );
-
-      // ── Fragment shader — _m texture modulation + edge highlight ───────
-      shader.fragmentShader = `
-        uniform sampler2D uMTex;
-        uniform vec3  uEdgeColor;
-        uniform float uEdgeThickness;
-        uniform float uEdgeSharpness;
-        uniform float uEdgeIntensity;
-        varying vec2 vMUv;
-        varying vec2 vLocalUv;
-      ` + shader.fragmentShader
-        .replace(
-          '#include <color_fragment>',
-          `#include <color_fragment>
-          float mVal = texture( uMTex, clamp( vMUv, 0.0, 1.0 ) ).r;
-          diffuseColor.rgb *= ${NCZ.BUILDING_TEX_FLOOR} + mVal * ${NCZ.BUILDING_TEX_RANGE};`
-        )
-        .replace(
-          'vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + totalEmissiveRadiance;',
-          `vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + totalEmissiveRadiance;
-          float _ed = min( min( vLocalUv.x, 1.0 - vLocalUv.x ), min( vLocalUv.y, 1.0 - vLocalUv.y ) );
-          float _ef = (1.0 - pow( clamp( _ed / uEdgeThickness, 0.0, 1.0 ), uEdgeSharpness )) * uEdgeIntensity;
-          outgoingLight = mix( outgoingLight, uEdgeColor, _ef );`
-        );
-    };
+    // (2) Edge highlight — distance-from-edge in local UV → emissive add
+    // ed = min(min(u, 1-u), min(v, 1-v)) — minimum of all 4 face-edge distances
+    // ef = (1 - pow(clamp(ed/thick, 0, 1), sharp)) * intens — sharp ramp near edge
+    const luv = uv();
+    const ed = luv.x.min(float(1).sub(luv.x)).min(luv.y).min(float(1).sub(luv.y));
+    const ef = float(1).sub(ed.div(uEdgeThickness).clamp(0, 1).pow(uEdgeSharpness)).mul(uEdgeIntensity);
+    mat.emissiveNode = uEdgeColor.mul(ef);
 
     return mat;
   }
@@ -1005,11 +1027,12 @@ const ThreeScene = (() => {
     const geometry = new LineGeometry();
     geometry.setPositions(positions);
 
-    const { clientWidth: w, clientHeight: h } = renderer.domElement;
-    const material = new LineMaterial({
+    // Line2NodeMaterial reads the viewport size from a TSL screen node at
+    // shader-execution time — no `resolution` field to keep in sync on resize
+    // like the WebGL LineMaterial required.
+    const material = new THREE.Line2NodeMaterial({
       color,
       linewidth: lineWidth,
-      resolution: new THREE.Vector2(w, h),
       depthTest: false,
       transparent: true,
       opacity: NCZ.DISTRICT_LINE_OPACITY,
@@ -1226,7 +1249,7 @@ const ThreeScene = (() => {
   function setOverrideMaterial(enabled) {
     if (!scene) return;
     if (enabled) {
-      if (!_debugOverrideMat) _debugOverrideMat = new THREE.MeshBasicMaterial({ color: 0x00ff00 });
+      if (!_debugOverrideMat) _debugOverrideMat = new THREE.MeshBasicNodeMaterial({ color: 0x00ff00 });
       scene.overrideMaterial = _debugOverrideMat;
     } else {
       scene.overrideMaterial = null;
@@ -1234,16 +1257,16 @@ const ThreeScene = (() => {
     requestRender();
   }
 
-  // Runtime control of the building edge highlight intensity. The shader's
+  // Runtime control of the building edge highlight intensity. The TSL
   // uEdgeIntensity uniform is captured from NCZ.BUILDING_EDGE_INTENSITY at
   // material-compile time, so changing the constant alone doesn't propagate
-  // to live materials — this iterates the existing shader refs and updates them.
+  // to live materials — this iterates the cached uniform refs and updates them.
   // Diagnostic use: set to 0 to test whether shimmer disappears entirely;
   // future Stage 2 quality preset use: dim/disable highlight on Low.
   function setBuildingEdgeIntensity(value) {
     for (const mat of buildingMaterials) {
-      const sh = mat.userData.shader;
-      if (sh && sh.uniforms.uEdgeIntensity) sh.uniforms.uEdgeIntensity.value = value;
+      const u = mat.userData.tslUniforms;
+      if (u?.uEdgeIntensity) u.uEdgeIntensity.value = value;
     }
     requestRender();
   }
@@ -1268,19 +1291,40 @@ const ThreeScene = (() => {
       };
     }
 
-    // GPU details via WEBGL_debug_renderer_info extension (where allowed)
+    // GPU details — two paths:
+    //   WebGPU: pull from the cached GPUAdapterInfo on the backend adapter.
+    //           WGSL spec exposes `vendor` and `architecture`/`description`;
+    //           Three.js caches whatever the browser surfaces at adapter request.
+    //   WebGL2: legacy WEBGL_debug_renderer_info extension, gated by browser
+    //           anti-fingerprinting policy (some browsers return null UNMASKED_*).
     let gpu = 'unknown', vendor = 'unknown', maxTexture = '?', maxRb = '?';
     if (renderer) {
-      const gl = renderer.getContext();
       try {
-        const ext = gl.getExtension('WEBGL_debug_renderer_info');
-        if (ext) {
-          gpu    = gl.getParameter(ext.UNMASKED_RENDERER_WEBGL);
-          vendor = gl.getParameter(ext.UNMASKED_VENDOR_WEBGL);
+        if (renderer.isWebGPURenderer) {
+          const adapterInfo = renderer.backend?.adapterInfo;
+          if (adapterInfo) {
+            gpu    = adapterInfo.description || adapterInfo.architecture || 'unknown';
+            vendor = adapterInfo.vendor || 'unknown';
+          }
+          const limits = renderer.backend?.device?.limits;
+          if (limits) {
+            maxTexture = limits.maxTextureDimension2D ?? '?';
+            // No direct renderbuffer limit in WebGPU — use storage-buffer binding size
+            // as the closest analogue; surfaces under the same "how big can a single
+            // GPU resource be" question as the WebGL value.
+            maxRb      = limits.maxStorageBufferBindingSize ?? '?';
+          }
+        } else if (renderer.getContext) {
+          const gl  = renderer.getContext();
+          const ext = gl.getExtension('WEBGL_debug_renderer_info');
+          if (ext) {
+            gpu    = gl.getParameter(ext.UNMASKED_RENDERER_WEBGL);
+            vendor = gl.getParameter(ext.UNMASKED_VENDOR_WEBGL);
+          }
+          maxTexture = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+          maxRb      = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE);
         }
-        maxTexture = gl.getParameter(gl.MAX_TEXTURE_SIZE);
-        maxRb      = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE);
-      } catch (_) { /* extension not available */ }
+      } catch (_) { /* introspection unavailable — leave defaults */ }
     }
 
     const shadowTypeNames = ['BasicShadowMap', 'PCFShadowMap', 'PCFSoftShadowMap', 'VSMShadowMap'];
@@ -1288,16 +1332,26 @@ const ThreeScene = (() => {
       timestamp: new Date().toISOString(),
       fps,
       render: renderer ? {
-        drawCalls:  renderer.info.render.calls,
-        triangles:  renderer.info.render.triangles,
-        lines:      renderer.info.render.lines,
-        geometries: renderer.info.memory.geometries,
-        textures:   renderer.info.memory.textures,
-        programs:   renderer.info.programs ? renderer.info.programs.length : 0,
+        drawCalls:    renderer.info.render.calls,
+        triangles:    renderer.info.render.triangles,
+        lines:        renderer.info.render.lines,
+        // computeCalls is a WebGPU-only stat — undefined under WebGL2 fallback.
+        computeCalls: renderer.info.render.computeCalls ?? 0,
+        geometries:   renderer.info.memory.geometries,
+        textures:     renderer.info.memory.textures,
+        // `info.programs` is a WebGL2-only array; WebGPU compiles pipelines
+        // lazily and doesn't expose a comparable count.
+        programs:     renderer.info.programs ? renderer.info.programs.length : null,
       } : null,
       rendererSettings: renderer ? {
         pixelRatio:     renderer.getPixelRatio(),
-        antialias:      !!(renderer.getContextAttributes() && renderer.getContextAttributes().antialias),
+        // No `getContextAttributes()` on WebGPURenderer — track from constructor
+        // params via a sentinel set at init time. Falls back to the legacy path
+        // for WebGL2 where the WebGL context exposes these directly.
+        antialias:      renderer.isWebGPURenderer
+                          ? !!_rendererInitParams?.antialias
+                          : !!(renderer.getContextAttributes?.() && renderer.getContextAttributes().antialias),
+        backend:        renderer.isWebGPURenderer ? 'WebGPU' : 'WebGL2',
         shadowsEnabled: renderer.shadowMap.enabled,
         shadowMapType:  shadowTypeNames[renderer.shadowMap.type] || String(renderer.shadowMap.type),
       } : null,
@@ -1332,14 +1386,16 @@ const ThreeScene = (() => {
       lines.push('FPS:           (not enough samples — render loop not running?)');
     }
     if (dump.render) {
-      lines.push(`Draw calls:    ${dump.render.drawCalls}`);
+      lines.push(`Draw calls:    ${dump.render.drawCalls}${dump.render.computeCalls ? `    Compute: ${dump.render.computeCalls}` : ''}`);
       lines.push(`Triangles:     ${dump.render.triangles.toLocaleString()}`);
-      lines.push(`Geometries:    ${dump.render.geometries}    Textures: ${dump.render.textures}    Programs: ${dump.render.programs}`);
+      // Programs is WebGL2-only — show "n/a" rather than "null" under WebGPU.
+      const programsField = dump.render.programs == null ? 'n/a (WebGPU)' : dump.render.programs;
+      lines.push(`Geometries:    ${dump.render.geometries}    Textures: ${dump.render.textures}    Programs: ${programsField}`);
     }
     if (dump.rendererSettings) {
       const r = dump.rendererSettings;
       lines.push('');
-      lines.push(`Renderer:      DPR ${r.pixelRatio} / AA ${r.antialias ? 'on' : 'off'} / Shadows ${r.shadowsEnabled ? r.shadowMapType : 'off'}`);
+      lines.push(`Renderer:      ${r.backend} / DPR ${r.pixelRatio} / AA ${r.antialias ? 'on' : 'off'} / Shadows ${r.shadowsEnabled ? r.shadowMapType : 'off'}`);
     }
     lines.push(`Display:       ${dump.display.windowSize} window, ${dump.display.screenSize} screen, ${dump.display.devicePixelRatio} DPR`);
     lines.push(`Effective px:  ${dump.display.effectivePixels.toLocaleString()}`);
@@ -1436,14 +1492,14 @@ const ThreeScene = (() => {
     // Update landmark material — shares --scene-buildings colour
     if (landmarkMat) landmarkMat.color.copy(readThemeColor('--scene-buildings', '#7a8fa0'));
 
-    // Update building materials — MeshLambertMaterial.color + onBeforeCompile edge uniform
+    // Update building materials — MeshLambertNodeMaterial.color + TSL edge-colour uniform
     if (buildingMaterials.length) {
       const base = readThemeColor('--scene-buildings', '#7a8fa0');
       const edge = readThemeColor('--scene-buildings-edge', '#ffffff');
       for (const mat of buildingMaterials) {
         mat.color.copy(base);
-        const sh = mat.userData.shader;
-        if (sh) sh.uniforms.uEdgeColor.value.copy(edge);
+        const u = mat.userData.tslUniforms;
+        if (u?.uEdgeColor) u.uEdgeColor.value.copy(edge);
       }
     }
     requestRender();
@@ -1487,9 +1543,9 @@ const ThreeScene = (() => {
         lerp:  (f, t, a) => { buildingMaterials.forEach(m => m.color.lerpColors(f, t, a)); landmarkMat?.color.lerpColors(f, t, a); },
       },
       { key: 'buildingsEdge', cssVar: '--scene-buildings-edge', fallback: '#ffffff',
-        get:   () => buildingMaterials[0]?.userData.shader?.uniforms.uEdgeColor.value.clone() ?? null,
-        reset: c  => buildingMaterials.forEach(m => { const sh = m.userData.shader; if (sh) sh.uniforms.uEdgeColor.value.copy(c); }),
-        lerp:  (f, t, a) => buildingMaterials.forEach(m => { const sh = m.userData.shader; if (sh) sh.uniforms.uEdgeColor.value.lerpColors(f, t, a); }),
+        get:   () => buildingMaterials[0]?.userData.tslUniforms?.uEdgeColor.value.clone() ?? null,
+        reset: c  => buildingMaterials.forEach(m => { const u = m.userData.tslUniforms; if (u) u.uEdgeColor.value.copy(c); }),
+        lerp:  (f, t, a) => buildingMaterials.forEach(m => { const u = m.userData.tslUniforms; if (u) u.uEdgeColor.value.lerpColors(f, t, a); }),
       },
     ];
   }

--- a/index.html
+++ b/index.html
@@ -532,12 +532,17 @@
         </div>
     </div>
 
-    <!-- Three.js import map (module scripts below resolve from here) -->
+    <!-- Three.js import map (module scripts below resolve from here)
+         WebGPU build: three.webgpu.min.js bundles WebGPURenderer + TSL +
+         WebGL2 fallback. Browsers without WebGPU silently get WebGL2.
+         TSL helpers (uniform, mix, texture, Fn, etc.) live on the 'three/tsl' subpath. -->
     <script type="importmap">
     {
       "imports": {
-        "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js",
-        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/"
+        "three":         "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.webgpu.min.js",
+        "three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.webgpu.min.js",
+        "three/tsl":     "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.tsl.min.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/"
       }
     }
     </script>

--- a/scripts/webgpu_dds_spike.html
+++ b/scripts/webgpu_dds_spike.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Phase 0 Spike #3 — DDS R8_UNORM via DataTexture under WebGPU</title>
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; background: #1a1a1a; color: #ddd;
+               font: 14px/1.4 system-ui, sans-serif; }
+  #info { position: fixed; top: 8px; left: 8px; right: 8px; padding: 10px 14px;
+          background: rgba(0, 0, 0, 0.78); border: 1px solid #444; border-radius: 6px;
+          z-index: 1; }
+  #info h1 { margin: 0 0 6px; font-size: 15px; color: #00f0ff; }
+  #info p  { margin: 4px 0; }
+  #info .pass    { color: #6f6; font-weight: bold; }
+  #info .fail    { color: #f66; font-weight: bold; }
+  #info .pending { color: #fc6; font-weight: bold; }
+  #info select { background: #222; border: 1px solid #555; color: #ddd; font: inherit;
+                 padding: 2px 6px; }
+  canvas { display: block; }
+</style>
+</head>
+<body>
+<div id="info">
+  <h1>Phase 0 Spike #3 — DDS texture (R8_UNORM, R16-RGBA) → DataTexture → WebGPU</h1>
+  <p><b>Setup:</b> mirrors <code>three-scene.js</code> <code>loadMDds()</code> (lines 157–176) —
+     reads DDS file, slices uint8 mip 0, builds <code>DataTexture(RedFormat, UnsignedByteType)</code>,
+     applies to a textured plane.</p>
+  <p><b>PASS criteria:</b> heightmap pattern visible on the plane, no console errors, anisotropy
+     applies cleanly, mips generate without warning.</p>
+  <p>District: <select id="district">
+    <option value="city_center">city_center</option>
+    <option value="watson">watson</option>
+    <option value="heywood">heywood</option>
+    <option value="westbrook">westbrook</option>
+    <option value="pacifica">pacifica</option>
+    <option value="santo_domingo">santo_domingo</option>
+    <option value="dogtown">dogtown</option>
+    <option value="spaceport">spaceport</option>
+  </select></p>
+  <p><b>Status:</b> <span id="status" class="pending">initializing renderer…</span></p>
+</div>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.webgpu.min.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/"
+  }
+}
+</script>
+
+<script type="module">
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+const status = document.getElementById('status');
+const setStatus = (text, cls = 'pending') => {
+  status.className = cls; status.textContent = text;
+};
+
+const DDS_PIXEL_OFFSET = 148;   // DDS header (128) + DX10 extension (20)
+
+// Direct port of three-scene.js loadMDds(), adapted for WebGPU device limits
+async function loadMDds(path, device) {
+  const buf    = await fetch(path).then(r => r.arrayBuffer());
+  const header = new Uint32Array(buf, 0, 32);
+  const width  = header[4];
+  const height = header[3];
+  const mip0   = new Uint8Array(buf, DDS_PIXEL_OFFSET, width * height);
+  const tex    = new THREE.DataTexture(mip0, width, height, THREE.RedFormat, THREE.UnsignedByteType);
+  tex.flipY = true;
+  tex.generateMipmaps = true;
+  tex.minFilter = THREE.LinearMipmapLinearFilter;
+  tex.magFilter = THREE.LinearFilter;
+  // WebGPU equivalent of WebGL's renderer.capabilities.getMaxAnisotropy()
+  const maxAniso = device?.limits?.maxSamplerAnisotropy ?? 16;
+  tex.anisotropy = Math.min(16, maxAniso);
+  tex.needsUpdate = true;
+  return { tex, width, height };
+}
+
+let renderer, scene, camera, controls, currentMesh = null;
+
+async function init() {
+  renderer = new THREE.WebGPURenderer({
+    antialias: true,
+    reversedDepthBuffer: true,
+  });
+  await renderer.init();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  document.body.appendChild(renderer.domElement);
+
+  scene  = new THREE.Scene();
+  scene.background = new THREE.Color(0x1a1a1a);
+  camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.1, 100);
+  camera.position.set(0, 8, 8);
+  controls = new OrbitControls(camera, renderer.domElement);
+
+  scene.add(new THREE.AmbientLight(0xffffff, 1));
+
+  await loadDistrict('city_center');
+
+  renderer.setAnimationLoop(() => {
+    controls.update();
+    renderer.render(scene, camera);
+  });
+}
+
+async function loadDistrict(name) {
+  setStatus(`loading ${name}_m.dds…`, 'pending');
+
+  if (currentMesh) {
+    scene.remove(currentMesh);
+    currentMesh.geometry.dispose();
+    currentMesh.material.dispose();
+  }
+
+  try {
+    const device = renderer.backend?.device;
+    const { tex, width, height } = await loadMDds(`../assets/dds/${name}_m.dds`, device);
+    const mat = new THREE.MeshBasicNodeMaterial({ map: tex });
+    const aspect = width / height;
+    currentMesh = new THREE.Mesh(new THREE.PlaneGeometry(8 * aspect, 8), mat);
+    currentMesh.rotation.x = -Math.PI / 2;
+    scene.add(currentMesh);
+
+    const adapterInfo = renderer.backend?.adapter
+      ? await renderer.backend.adapter.requestAdapterInfo?.().catch(() => null)
+      : null;
+    const gpuName = adapterInfo?.description || adapterInfo?.vendor || '(unknown GPU)';
+    setStatus(`PASS — ${name}_m.dds loaded (${width}×${height}, R8_UNORM) · backend=${renderer.isWebGPURenderer ? 'WebGPU' : 'WebGL2'} · GPU=${gpuName}`, 'pass');
+  } catch (err) {
+    console.error(err);
+    setStatus(`FAIL — ${err.message}`, 'fail');
+  }
+}
+
+document.getElementById('district').addEventListener('change', e => {
+  loadDistrict(e.target.value);
+});
+
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer?.setSize(window.innerWidth, window.innerHeight);
+});
+
+try {
+  await init();
+} catch (err) {
+  console.error(err);
+  setStatus(`FAIL — ${err.message}`, 'fail');
+}
+</script>
+</body>
+</html>

--- a/scripts/webgpu_reverse_z_spike.html
+++ b/scripts/webgpu_reverse_z_spike.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Phase 0 Spike #2 — Reverse-Z Smoke Check</title>
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; background: #0a0a0a; color: #ddd;
+               font: 14px/1.4 system-ui, sans-serif; }
+  #info { position: fixed; top: 8px; left: 8px; right: 8px; padding: 10px 14px;
+          background: rgba(0, 0, 0, 0.78); border: 1px solid #444; border-radius: 6px;
+          z-index: 1; }
+  #info h1 { margin: 0 0 6px; font-size: 15px; color: #00f0ff; }
+  #info p  { margin: 4px 0; }
+  #info .pass    { color: #6f6; font-weight: bold; }
+  #info .fail    { color: #f66; font-weight: bold; }
+  #info .pending { color: #fc6; font-weight: bold; }
+  #info button { background: #222; border: 1px solid #555; color: #ddd; padding: 4px 10px;
+                 font-family: inherit; font-size: 12px; cursor: pointer; margin-right: 6px; }
+  #info button:hover { background: #333; }
+  #info button.active { background: #00f0ff; color: #000; border-color: #00f0ff; }
+  canvas { display: block; }
+</style>
+</head>
+<body>
+<div id="info">
+  <h1>Phase 0 Spike #2 — Reverse-Z + WebGPU + production-scale frustum</h1>
+  <p><b>Setup:</b> 200 building-cubes scattered with near-coplanar Z (0–10) plus a far landmark
+     at Z=20000. Camera frustum near=10, far=25000 (matches production).</p>
+  <p><b>PASS criteria:</b> no Z-fighting on near-coplanar cubes AND the far landmark renders
+     without depth-precision artefacts under <code>reversedDepthBuffer: true</code>.</p>
+  <p>Compare modes: <button id="btn-reverse" class="active">reverse-Z (target)</button>
+     <button id="btn-log">log-depth (current)</button>
+     <button id="btn-default">default depth (no workaround)</button></p>
+  <p><b>Status:</b> <span id="status" class="pending">initializing renderer…</span></p>
+</div>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.webgpu.min.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/"
+  }
+}
+</script>
+
+<script type="module">
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+const status = document.getElementById('status');
+const setStatus = (text, cls = 'pending') => {
+  status.className = cls; status.textContent = text;
+};
+
+const params = new URLSearchParams(location.search);
+const initialMode = params.get('depth') || 'reverse';
+
+let renderer = null;
+let controls = null;
+let activeMode = null;
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0x0a0a0a);
+const camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 10, 25000);
+camera.position.set(0, 80, 80);
+
+scene.add(new THREE.AmbientLight(0xffffff, 0.7));
+const sun = new THREE.DirectionalLight(0xffffff, 0.8);
+sun.position.set(20, 50, 30);
+scene.add(sun);
+
+// 200 near-coplanar cubes — depth-precision stress
+const cubeGeo = new THREE.BoxGeometry(2, 0.3, 2);
+const cubeMat = new THREE.MeshLambertNodeMaterial({ color: 0x556677 });
+for (let i = 0; i < 200; i++) {
+  const c = new THREE.Mesh(cubeGeo, cubeMat);
+  c.position.set(
+    (Math.random() - 0.5) * 80,
+    Math.random() * 10,            // 0–10: tight Z range, will fight without help
+    (Math.random() - 0.5) * 80,
+  );
+  scene.add(c);
+}
+
+// Far landmark — far-frustum precision check
+const farMat = new THREE.MeshLambertNodeMaterial({ color: 0xffb300 });
+const far = new THREE.Mesh(new THREE.BoxGeometry(200, 200, 200), farMat);
+far.position.set(0, 100, -20000);
+scene.add(far);
+
+async function buildRenderer(mode) {
+  if (renderer) {
+    document.body.removeChild(renderer.domElement);
+    renderer.dispose?.();
+    controls?.dispose();
+  }
+
+  const opts = { antialias: true };
+  if (mode === 'reverse') opts.reversedDepthBuffer  = true;
+  if (mode === 'log')     opts.logarithmicDepthBuffer = true;
+
+  renderer = new THREE.WebGPURenderer(opts);
+  await renderer.init();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  document.body.appendChild(renderer.domElement);
+
+  controls = new OrbitControls(camera, renderer.domElement);
+  controls.target.set(0, 5, 0);
+
+  activeMode = mode;
+  document.querySelectorAll('#info button').forEach(b => b.classList.remove('active'));
+  document.getElementById(`btn-${mode}`)?.classList.add('active');
+
+  const adapterInfo = renderer.backend?.adapter
+    ? await renderer.backend.adapter.requestAdapterInfo?.().catch(() => null)
+    : null;
+  const gpuName = adapterInfo?.description || adapterInfo?.vendor || '(unknown GPU)';
+  setStatus(`mode=${mode} · backend=${renderer.isWebGPURenderer ? 'WebGPU' : 'WebGL2 fallback'} · GPU=${gpuName} · zoom out to inspect far landmark`, 'pass');
+
+  renderer.setAnimationLoop(() => {
+    controls.update();
+    renderer.render(scene, camera);
+  });
+}
+
+document.getElementById('btn-reverse').addEventListener('click', () => buildRenderer('reverse'));
+document.getElementById('btn-log').addEventListener('click', () => buildRenderer('log'));
+document.getElementById('btn-default').addEventListener('click', () => buildRenderer('default'));
+
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer?.setSize(window.innerWidth, window.innerHeight);
+});
+
+try {
+  await buildRenderer(initialMode);
+} catch (err) {
+  console.error(err);
+  setStatus(`FAIL — ${err.message}`, 'fail');
+}
+</script>
+</body>
+</html>

--- a/scripts/webgpu_stencil_spike.html
+++ b/scripts/webgpu_stencil_spike.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Phase 0 Spike #1 — Stencil Parity</title>
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; background: #1a1a1a; color: #ddd;
+               font: 14px/1.4 system-ui, sans-serif; }
+  #info { position: fixed; top: 8px; left: 8px; right: 8px; padding: 10px 14px;
+          background: rgba(0, 0, 0, 0.78); border: 1px solid #444; border-radius: 6px;
+          z-index: 1; pointer-events: none; }
+  #info h1 { margin: 0 0 6px; font-size: 15px; color: #00f0ff; }
+  #info p  { margin: 4px 0; }
+  #info .pass { color: #6f6; font-weight: bold; }
+  #info .fail { color: #f66; font-weight: bold; }
+  #info .pending { color: #fc6; font-weight: bold; }
+  canvas { display: block; }
+  kbd { background: #333; border: 1px solid #555; padding: 1px 6px; border-radius: 3px;
+        font-family: monospace; font-size: 12px; }
+</style>
+</head>
+<body>
+<div id="info">
+  <h1>Phase 0 Spike #1 — Material-level stencil flags under WebGPU</h1>
+  <p><b>Setup:</b> ground plane writes stencil=2 (water), 9 cubes write stencil=1 (buildings).
+     Top plane reads stencil==2 only (SeeThrough roads).</p>
+  <p><b>PASS criteria:</b> the cyan road strip is visible only between the cubes (where water
+     wrote stencil=2). It must NOT show on top of the cubes.</p>
+  <p><b>Status:</b> <span id="status" class="pending">initializing renderer…</span></p>
+  <p><kbd>Drag</kbd> orbit · <kbd>Scroll</kbd> zoom — visually verify the strip shows water-only.</p>
+</div>
+
+<script type="importmap">
+{
+  "imports": {
+    "three": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.webgpu.min.js",
+    "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/"
+  }
+}
+</script>
+
+<script type="module">
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+const status = document.getElementById('status');
+const setStatus = (text, cls = 'pending') => {
+  status.className = cls; status.textContent = text;
+};
+
+try {
+  const renderer = new THREE.WebGPURenderer({
+    stencil: true,
+    antialias: true,
+    reversedDepthBuffer: true,
+  });
+  await renderer.init();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  document.body.appendChild(renderer.domElement);
+
+  const scene  = new THREE.Scene();
+  scene.background = new THREE.Color(0x1a1a1a);
+  const camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.1, 200);
+  camera.position.set(8, 10, 14);
+
+  const controls = new OrbitControls(camera, renderer.domElement);
+  controls.target.set(0, 0, 0);
+
+  scene.add(new THREE.AmbientLight(0xffffff, 0.7));
+  const sun = new THREE.DirectionalLight(0xffffff, 0.8);
+  sun.position.set(8, 12, 6);
+  scene.add(sun);
+
+  // ── Stage 1: water plane writes stencil = 2 ────────────────────────
+  // Mirrors three-scene.js:508–511 (water material)
+  const waterMat = new THREE.MeshBasicNodeMaterial({
+    color: 0x3c4c5f,
+    transparent: true,
+    opacity: 0.6,
+    stencilWrite: true,
+    stencilRef:   2,
+    stencilFunc:  THREE.AlwaysStencilFunc,
+    stencilZPass: THREE.ReplaceStencilOp,
+  });
+  const water = new THREE.Mesh(new THREE.PlaneGeometry(20, 20), waterMat);
+  water.rotation.x = -Math.PI / 2;
+  water.position.y = 0;
+  scene.add(water);
+
+  // ── Stage 2: 9 cubes write stencil = 1 (buildings) ─────────────────
+  // Mirrors three-scene.js:897–901 (building stencil-write)
+  const buildingMat = new THREE.MeshLambertNodeMaterial({
+    color: 0x556677,
+    stencilWrite: true,
+    stencilRef:   1,
+    stencilFunc:  THREE.AlwaysStencilFunc,
+    stencilZPass: THREE.ReplaceStencilOp,
+  });
+  const cubeGeo = new THREE.BoxGeometry(1.5, 2, 1.5);
+  for (let i = -1; i <= 1; i++) {
+    for (let j = -1; j <= 1; j++) {
+      const cube = new THREE.Mesh(cubeGeo, buildingMat);
+      cube.position.set(i * 4, 1, j * 4);
+      scene.add(cube);
+    }
+  }
+
+  // ── Stage 3: SeeThrough road reads stencil == 2 only ───────────────
+  // Mirrors three-scene.js:656–663 (road SeeThrough material)
+  const roadMat = new THREE.MeshBasicNodeMaterial({
+    color: 0x1cb3bf,
+    transparent: true,
+    opacity: 0.85,
+    depthTest:    false,        // SeeThrough renders even where occluded
+    stencilWrite: true,
+    stencilWriteMask: 0x00,     // read-only — don't modify stencil
+    stencilFunc:      THREE.EqualStencilFunc,
+    stencilRef:       2,
+    stencilFuncMask:  0xff,
+    stencilFail:      THREE.KeepStencilOp,
+    stencilZFail:     THREE.KeepStencilOp,
+    stencilZPass:     THREE.KeepStencilOp,
+  });
+  const road = new THREE.Mesh(new THREE.PlaneGeometry(16, 2), roadMat);
+  road.rotation.x = -Math.PI / 2;
+  road.position.y = 3;          // above the cubes
+  road.renderOrder = 10;        // ensure it draws after stencil writers
+  scene.add(road);
+
+  // Adapter info for the status line
+  const adapterInfo = renderer.backend?.adapter
+    ? await renderer.backend.adapter.requestAdapterInfo?.().catch(() => null)
+    : null;
+  const gpuName = adapterInfo?.description || adapterInfo?.vendor || '(unknown GPU)';
+
+  setStatus(`renderer ready · backend=${renderer.isWebGPURenderer ? 'WebGPU' : 'WebGL2 fallback'} · GPU=${gpuName} · visually verify the cyan strip vs. cubes`, 'pass');
+
+  function loop() {
+    controls.update();
+    renderer.render(scene, camera);
+  }
+  renderer.setAnimationLoop(loop);
+
+  window.addEventListener('resize', () => {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+  });
+} catch (err) {
+  console.error(err);
+  setStatus(`FAIL — ${err.message}`, 'fail');
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Phase 1 of the WebGPU migration plan ([webgpu-migration-execution wiki](../tree/feat/webgpu-phase-1-foundation/wiki/sources/webgpu-migration-execution.md)) — renderer-layer swap from `WebGLRenderer` (r170) → `WebGPURenderer` (r184) plus TSL ports of the two `onBeforeCompile` shader patches.
- Visual parity confirmed at every tested viewpoint — buildings, metro LOD discard, theme switching, and Cloudflare PR preview will be the formal review checkpoint.
- Two known regressions deferred to later phases (stencil SeeThrough → Phase 4, `instancedArray` → Phase 2).

## What changed

**Renderer + import path**
- `index.html` importmap: r170 `three.module.js` → r184 `three.webgpu.min.js` + `three/tsl` + `three/webgpu` sub-paths
- `WebGLRenderer` → `WebGPURenderer({stencil, antialias, reversedDepthBuffer})` with `await renderer.init()`; `init()` becomes async, caller in `app.js` chains `startRenderLoop` via `Promise.resolve().then()`
- Drop `logarithmicDepthBuffer` for native reverse-Z (Three.js [PR #32967](https://github.com/mrdoob/three.js/pull/32967), shipped r183)
- Drop `powerPreference` (Chrome bug [#369219127](https://crbug.com/369219127) — ignored on Windows for WebGPU adapter selection)

**Material-class swaps (drop-in)**
- 11 sites: `MeshLambertMaterial` / `MeshBasicMaterial` → their `*NodeMaterial` equivalents
- `Line2` + `LineMaterial` → `lines/webgpu/Line2.js` + `Line2NodeMaterial`; resize-time `mat.resolution.set(w, h)` loop deleted (TSL screen node pulls viewport size automatically)

**TSL ports**
- Metro LOD `onBeforeCompile` → `maskNode` (declarative bool from `attribute('color')` × `uniform()` zoom thresholds)
- Building edge mix `onBeforeCompile` → `colorNode` (`_m` planar UV modulation via `positionWorld` + `texture` node) + `emissiveNode` (silhouette edge highlight via `uv()` distance ramp)
- `mat.userData.shader` → `mat.userData.tslUniforms` (four edge uniforms surfaced for theme rewire + `setBuildingEdgeIntensity`)
- `mat.defines = { USE_UV: '' }` removed (TSL accesses `uv()` directly)

**Theme + debug shims**
- `getColorBindings.buildingsEdge`, `updateMaterials()`, `setBuildingEdgeIntensity()` all retargeted to `tslUniforms`
- `getMaxAnisotropy()` chain works on both backends: `device.limits.maxSamplerAnisotropy ?? capabilities.getMaxAnisotropy?.() ?? 16`
- `dumpDebugInfo()` branches on `renderer.isWebGPURenderer`: GPU via `backend.adapterInfo`, `info.programs` shows `n/a (WebGPU)`, new `computeCalls` field, antialias captured at construction; renderer summary line gets a backend label

**Phase 0 spikes** (3 standalone HTML files in `scripts/`)
- Stencil parity, reverse-Z smoke check, DDS texture format
- All three PASS; reference patterns for future TSL work, not used in production

## Deferred to later phases

- **Phase 2** — `instancedArray` storage buffer for buildings. Current `InstancedMesh.setMatrixAt` works correctly under WebGPU; bundling with compute culling avoids a setup-then-rewrite cycle.
- **Phase 4** — Stencil-based SeeThrough roads (Pacifica tunnel and cliff tunnels) are camera-angle-dependent under WebGPU but always visible under WebGL. Suspected cause: water's `stencilZFail` defaults to `KeepStencilOp` and reverse-Z may flip depth-test outcomes the WebGL build never hit. Needs explicit Phase 4 work.
- **Phase 5 cleanup** — `info.render.triangles` reports 0 under `WebGPURenderer` despite triangles drawing correctly; `renderer.backend.adapterInfo` returns empty strings under Electron browsers (fingerprinting policy). Both internal-only diagnostics.

## Test plan

- [x] Local Chrome on dev workstation: scene renders, no console errors, ~263 fps idle
- [x] Buildings show `_m.dds` surface texture pattern + edge highlights
- [x] Metro lines correctly LOD-discarded per zoom tier (B/G/R channels at far/mid/near)
- [x] Theme switch updates building base + edge colour smoothly
- [x] `dumpDebugInfo()` returns valid output with `Renderer: WebGPU / ...`
- [ ] Cloudflare PR preview on Intel UHD work laptop — frame time within ±10% of pre-migration `dev`
- [ ] Cross-browser sanity: Firefox on main desktop
- [ ] WebGL2 fallback works (smoke-test with `forceWebGL: true` temporarily)

🤖 Generated with [Claude Code](https://claude.com/claude-code)