### PR TITLE
feat(3d): outdoor lighting + single fitted shadow map (Phase 3)

### DIFF
--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -209,14 +209,20 @@ NCZ.SHADOW_MAP_SIZE      = 2048;  // px² per cascade — 2×2048² ≈ half the
 NCZ.SHADOW_CAM_NEAR      = 1;     // per-cascade shadow camera near clip (template — CSM clones light.shadow per cascade)
 NCZ.SHADOW_CAM_FAR       = 30000; // per-cascade shadow camera far clip — must span the cascade frustum's depth in light space + the light margin (orthographic ⇒ a large range costs no precision)
 NCZ.SHADOW_LIGHT_MARGIN  = 1000;  // CET units the cascade's shadow camera sits behind its frustum bbox — headroom so tall casters' tops aren't clipped
-NCZ.SHADOW_BIAS          = -0.0005; // base depth bias — CSM scales it ×(cascade+1) so the looser far cascades get proportionally more
-NCZ.SHADOW_NORMAL_BIAS   =  0.01;  // offset along the surface normal — prevents acne on sloped faces
+// Bias: 0 is clean — native depth32float shadow textures + reverse-Z + the
+// tight per-cascade depth ranges have plenty of precision, so neither the depth
+// bias (was -0.0005 for the WebGL RGBA8-packed path) nor the normal-offset bias
+// (was 0.01) is needed. Left as knobs: CSM still scales SHADOW_BIAS ×(cascade+1),
+// so re-arm here if acne ever surfaces at extreme zoom/tilt.
+NCZ.SHADOW_BIAS          = 0;
+NCZ.SHADOW_NORMAL_BIAS   = 0;
 // Orthographic-proxy depth window. Our schema camera's native near is negative
 // (geometry can sit behind it during low showcase flyovers — see CAMERA_NEAR),
 // which would collapse CSM's view-Z-based cascade selection into one bucket. We
 // feed CSM a proxy ortho camera whose near/far hug the visible ground:
 //   near = camDist − groundHalfDepth ,  far = camDist + groundHalfDepth
-// camDist ≈ orbit radius; groundHalfDepth ≈ visibleHalf·sin(tilt) + slack.
+// where groundHalfDepth = (camera.top / zoom)·tan(tilt) + slack — the visible
+// ground's view-depth half-spread (it grows as tan(tilt), zero at top-down).
 NCZ.SHADOW_PROXY_DEPTH_SLACK = 1500; // CET units of headroom around the visible-ground depth band (covers building heights / terrain relief; keeps every caster's depth inside linearDepth ∈ [0,1])
 
 // Lighting — directional sun + ambient

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -198,36 +198,26 @@ NCZ.CAMERA_ZOOM_SPEED   = 2.0;            // zoomSpeed       (Three.js default: 
 NCZ.CAMERA_PAN_SPEED    = 1.0;            // panSpeed        (Three.js default: 1.0)         — left-drag pan rate
 NCZ.CAMERA_ROTATE_SPEED = 0.6;            // rotateSpeed     (Three.js default: 1.0)         — right-drag tilt rate; lower = more precise
 
-// Shadow map — Cascaded Shadow Maps (CSMShadowNode, WebGPU). The directional
-// sun's shadow is split into N depth cascades, each rendered into its own
-// depth32float texture and auto-fit to the slice of the camera frustum it
-// covers, so near geometry gets a tight high-res cascade and far geometry a
-// looser one. CSM positions/sizes the per-cascade shadow cameras itself —
-// see updateShadowCascades() in three-scene.js for the proxy-camera plumbing.
-NCZ.SHADOW_CASCADES      = 2;     // cascade count (2–3 sane; each cascade re-renders the shadow-casting geometry, so >3 multiplies the shadow-pass cost)
-NCZ.SHADOW_MAP_SIZE      = 2048;  // px² per cascade — 2×2048² ≈ half the texels of the old single 4096² map
-NCZ.SHADOW_CAM_NEAR      = 1;     // per-cascade shadow camera near clip (template — CSM clones light.shadow per cascade)
-NCZ.SHADOW_CAM_FAR       = 30000; // per-cascade shadow camera far clip — must span the cascade frustum's depth in light space + the light margin (orthographic ⇒ a large range costs no precision)
-NCZ.SHADOW_LIGHT_MARGIN  = 1000;  // CET units the cascade's shadow camera sits behind its frustum bbox — headroom so tall casters' tops aren't clipped
-// Bias: 0 is clean — native depth32float shadow textures + reverse-Z + the
-// tight per-cascade depth ranges have plenty of precision, so neither the depth
-// bias (was -0.0005 for the WebGL RGBA8-packed path) nor the normal-offset bias
-// (was 0.01) is needed. Left as knobs: CSM still scales SHADOW_BIAS ×(cascade+1),
-// so re-arm here if acne ever surfaces at extreme zoom/tilt.
+// Shadow map — one OrthographicCamera fitted each frame to exactly the visible-
+// ground footprint (updateShadowCamera in three-scene.js), rendered into a
+// single depth32float texture (the WebGPU `shadowMapping` pattern). No cascades:
+// our schema camera is orthographic (uniform pixels-per-world-unit), so there's
+// no perspective near/far disparity for cascaded maps to exploit — one tight map
+// is simpler and, for this camera, sharper.
+NCZ.SHADOW_MAP_SIZE      = 4096;  // px² — ~3 u/texel at a whole-city zoom; razor-sharp zoomed in (the footprint shrinks with zoom)
+NCZ.SHADOW_MAX_DISTANCE  = 12000; // CET units — cap on the footprint half-side. Keeps the shadow reasonably sharp at the zoomed-out + max-tilt extreme (where the visible ground would otherwise run ~20 km wide); ground past the cap is a clean unshadowed falloff. Never bites at normal zooms.
+NCZ.SHADOW_GROUND_MARGIN =   600; // CET units the footprint extends past the visible ground — covers building heights / terrain relief + a sliver of just-off-screen casters. Wider off-screen-caster coverage waits on the union-frustum cull (a follow-up).
+NCZ.SHADOW_CAM_NEAR      =     1; // shadow camera near clip
+NCZ.SHADOW_CAM_FAR       = 40000; // shadow camera far clip — the camera sits SUN_DIST up the sun ray, so this must still reach the far edge of the footprint even at a low sun (orthographic ⇒ a wide range costs no precision)
+// Bias: 0 is clean — native depth32float shadow textures + reverse-Z + a tight
+// map have ample precision (the old -0.0005 / 0.01 were for the WebGL
+// RGBA8-packed path). Left as knobs: re-arm if acne ever surfaces.
 NCZ.SHADOW_BIAS          = 0;
 NCZ.SHADOW_NORMAL_BIAS   = 0;
-// Orthographic-proxy depth window. Our schema camera's native near is negative
-// (geometry can sit behind it during low showcase flyovers — see CAMERA_NEAR),
-// which would collapse CSM's view-Z-based cascade selection into one bucket. We
-// feed CSM a proxy ortho camera whose near/far hug the visible ground:
-//   near = camDist − groundHalfDepth ,  far = camDist + groundHalfDepth
-// where groundHalfDepth = (camera.top / zoom)·tan(tilt) + slack — the visible
-// ground's view-depth half-spread (it grows as tan(tilt), zero at top-down).
-NCZ.SHADOW_PROXY_DEPTH_SLACK = 1500; // CET units of headroom around the visible-ground depth band (covers building heights / terrain relief; keeps every caster's depth inside linearDepth ∈ [0,1])
 
-// Lighting — directional sun + ambient
-NCZ.AMBIENT_INTENSITY  = 0.35;   // ambient light share; sun gets (1 - ambient) when at full elevation
-NCZ.SUN_DIST           = 8000;   // distance from world centre to directional light position (CET units)
+// Lighting — directional sun + hemisphere fill
+NCZ.AMBIENT_INTENSITY  = 0.35;   // hemisphere-fill share; the sun gets (1 - this) at full elevation
+NCZ.SUN_DIST           = 22000;  // CET units the sun light (and its shadow camera) sits up the sun ray from the visible-ground centre — only the direction matters for shading; large enough that the whole footprint stays in front of the shadow camera even at a low sun
 NCZ.SUN_SPHERE_DIST    = 20000;  // visible sun disc distance from world centre
 NCZ.SUN_SPHERE_RADIUS  =   600;  // CET units — ≈1.7° apparent diameter at SUN_SPHERE_DIST (≈3× real sun)
 NCZ.SUN_COLOR_ELEV     =    20;  // degrees — light is warm orange below this, neutral white above

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -209,11 +209,8 @@ NCZ.SHADOW_MAX_DISTANCE  = 12000; // CET units — cap on the footprint half-sid
 NCZ.SHADOW_GROUND_MARGIN =   600; // CET units the footprint extends past the visible ground — covers building heights / terrain relief + a sliver of just-off-screen casters. Wider off-screen-caster coverage waits on the union-frustum cull (a follow-up).
 NCZ.SHADOW_CAM_NEAR      =     1; // shadow camera near clip
 NCZ.SHADOW_CAM_FAR       = 40000; // shadow camera far clip — the camera sits SUN_DIST up the sun ray, so this must still reach the far edge of the footprint even at a low sun (orthographic ⇒ a wide range costs no precision)
-// Bias: 0 is clean — native depth32float shadow textures + reverse-Z + a tight
-// map have ample precision (the old -0.0005 / 0.01 were for the WebGL
-// RGBA8-packed path). Left as knobs: re-arm if acne ever surfaces.
-NCZ.SHADOW_BIAS          = 0;
-NCZ.SHADOW_NORMAL_BIAS   = 0;
+NCZ.SHADOW_BIAS          =     0; // NDC depth bias — 0; native depth32float + reverse-Z have ample depth precision (the old -0.0005 was for the WebGL RGBA8-packed path). The geometric self-shadow ("texel patch covers a depth range") is handled by the normal bias instead:
+NCZ.SHADOW_NORMAL_BIAS_TEXELS = 2.5; // receiver-sample offset along the surface normal, in shadow-texel widths — converted to world units per-frame by updateShadowCamera (scaling with the footprint keeps it the same texel offset at every zoom). Raise to kill residual grazing-sun acne ("the wave" on flat terrain/water); lower if shadows visibly detach from their casters at high zoom.
 
 // Lighting — directional sun + hemisphere fill
 NCZ.AMBIENT_INTENSITY  = 0.35;   // hemisphere-fill share; the sun gets (1 - this) at full elevation

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -198,17 +198,26 @@ NCZ.CAMERA_ZOOM_SPEED   = 2.0;            // zoomSpeed       (Three.js default: 
 NCZ.CAMERA_PAN_SPEED    = 1.0;            // panSpeed        (Three.js default: 1.0)         — left-drag pan rate
 NCZ.CAMERA_ROTATE_SPEED = 0.6;            // rotateSpeed     (Three.js default: 1.0)         — right-drag tilt rate; lower = more precise
 
-// Shadow map — PCFSoftShadowMap, orthographic frustum centred on Night City
-// The shadow camera sits at the sun position (NCZ.SUN_DIST away) and looks down.
-NCZ.SHADOW_MAP_SIZE    = 4096;  // px² — dynamically concentrated by zoom; ~0.07 CET units/texel at zoom=50
-NCZ.SHADOW_FRUSTUM     = 7000;  // ±7000 units at full zoom-out; scaled down by camera.zoom for sharper shadows when zoomed in
-NCZ.SHADOW_FRUSTUM_MIN =  400;  // minimum frustum radius — prevents over-concentration at extreme zoom+tilt
-NCZ.SHADOW_CAM_NEAR    =   10;  // near clip — 10 units from the light; avoids near-plane artefacts
-NCZ.SHADOW_CAM_FAR     = 25000; // far clip — must reach the terrain from the sun's position (~8000 units away) with headroom
-NCZ.SHADOW_BIAS        = -0.0005; // depth bias — small negative value reduces shadow acne (self-shadowing artefacts)
-NCZ.SHADOW_NORMAL_BIAS =  0.01;  // offset along surface normal — prevents acne on sloped faces
-NCZ.SHADOW_MIN_ELEV    =    5;   // degrees — shadow casting disabled below this sun elevation
-                                  // (avoids infinitely long degenerate projections near sunrise/sunset)
+// Shadow map — Cascaded Shadow Maps (CSMShadowNode, WebGPU). The directional
+// sun's shadow is split into N depth cascades, each rendered into its own
+// depth32float texture and auto-fit to the slice of the camera frustum it
+// covers, so near geometry gets a tight high-res cascade and far geometry a
+// looser one. CSM positions/sizes the per-cascade shadow cameras itself —
+// see updateShadowCascades() in three-scene.js for the proxy-camera plumbing.
+NCZ.SHADOW_CASCADES      = 2;     // cascade count (2–3 sane; each cascade re-renders the shadow-casting geometry, so >3 multiplies the shadow-pass cost)
+NCZ.SHADOW_MAP_SIZE      = 2048;  // px² per cascade — 2×2048² ≈ half the texels of the old single 4096² map
+NCZ.SHADOW_CAM_NEAR      = 1;     // per-cascade shadow camera near clip (template — CSM clones light.shadow per cascade)
+NCZ.SHADOW_CAM_FAR       = 30000; // per-cascade shadow camera far clip — must span the cascade frustum's depth in light space + the light margin (orthographic ⇒ a large range costs no precision)
+NCZ.SHADOW_LIGHT_MARGIN  = 1000;  // CET units the cascade's shadow camera sits behind its frustum bbox — headroom so tall casters' tops aren't clipped
+NCZ.SHADOW_BIAS          = -0.0005; // base depth bias — CSM scales it ×(cascade+1) so the looser far cascades get proportionally more
+NCZ.SHADOW_NORMAL_BIAS   =  0.01;  // offset along the surface normal — prevents acne on sloped faces
+// Orthographic-proxy depth window. Our schema camera's native near is negative
+// (geometry can sit behind it during low showcase flyovers — see CAMERA_NEAR),
+// which would collapse CSM's view-Z-based cascade selection into one bucket. We
+// feed CSM a proxy ortho camera whose near/far hug the visible ground:
+//   near = camDist − groundHalfDepth ,  far = camDist + groundHalfDepth
+// camDist ≈ orbit radius; groundHalfDepth ≈ visibleHalf·sin(tilt) + slack.
+NCZ.SHADOW_PROXY_DEPTH_SLACK = 1500; // CET units of headroom around the visible-ground depth band (covers building heights / terrain relief; keeps every caster's depth inside linearDepth ∈ [0,1])
 
 // Lighting — directional sun + ambient
 NCZ.AMBIENT_INTENSITY  = 0.35;   // ambient light share; sun gets (1 - ambient) when at full elevation

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -2027,13 +2027,16 @@ const ThreeScene = (() => {
     // orthographic camera, OrbitControls keeps this ≈ the orbit radius
     // regardless of zoom or tilt — a stable ~CAMERA_HEIGHT value.
     const camDist     = camera.position.distanceTo(controls.target);
-    // How far the visible ground strip spreads along the view axis: at tilt θ a
-    // strip of half-width `visibleHalf` reaches ≈ visibleHalf·sinθ deeper. Slack
-    // covers building heights / terrain relief so no caster's depth lands
-    // outside the proxy's near/far window (which would drop it from cascade 0).
-    const tilt        = controls.getPolarAngle?.() ?? 0;   // 0 = top-down, grows toward CAMERA_MAX_TILT
-    const visibleHalf = Math.max(camera.right, camera.top) / camera.zoom;
-    const groundHalfDepth = visibleHalf * Math.sin(tilt) + NCZ.SHADOW_PROXY_DEPTH_SLACK;
+    // How far the visible ground spreads along the view axis. The screen-vertical
+    // half-extent (camera.top/zoom, in world units) maps to ±(that)·tan(tilt) of
+    // view-depth on the ground: at top-down (tilt 0) the whole visible ground is
+    // a single depth (only the slack matters); at our ~70° max tilt it spreads
+    // ~2.75× the screen-vertical extent. Clamp tan well above CAMERA_MAX_TILT so
+    // it can't blow up. Slack covers building heights / terrain relief so no
+    // caster's depth lands outside the proxy window (→ dropped from all cascades).
+    const tilt       = controls.getPolarAngle?.() ?? 0;   // 0 = top-down, grows toward CAMERA_MAX_TILT
+    const screenHalf = camera.top / camera.zoom;           // world units, screen-vertical half-extent at the current zoom
+    const groundHalfDepth = screenHalf * Math.tan(Math.min(tilt, Math.PI * 0.45)) + NCZ.SHADOW_PROXY_DEPTH_SLACK;
     // Proxy: schema camera's view + XY frustum, but a sane positive near/far band.
     _csmCamera.left   = camera.left;
     _csmCamera.right  = camera.right;

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -367,8 +367,8 @@ const ThreeScene = (() => {
     _dirLight.shadow.camera.near = NCZ.SHADOW_CAM_NEAR;
     _dirLight.shadow.camera.far  = NCZ.SHADOW_CAM_FAR; // orthographic ⇒ a wide range costs no precision
     _dirLight.shadow.camera.name = 'sun-shadow-cam';
-    _dirLight.shadow.bias        = NCZ.SHADOW_BIAS;       // 0 — native depth32float + reverse-Z + a tight map need no cushion
-    _dirLight.shadow.normalBias  = NCZ.SHADOW_NORMAL_BIAS; // 0 — ditto
+    _dirLight.shadow.bias        = NCZ.SHADOW_BIAS;        // 0 — native depth32float + reverse-Z need no depth cushion
+    // normalBias is set per-frame by updateShadowCamera (scaled with the footprint).
     _dirLight.shadow.intensity   = _shadowsOn ? 1 : 0;
     _dirLight.target.name = 'sun-target';
     // Position the light + target are set by updateShadowCamera (it centres the
@@ -1988,7 +1988,10 @@ const ThreeScene = (() => {
       const tilt = controls.getPolarAngle?.() ?? 0;
       const D = (2 * camera.top / camera.zoom) / Math.max(0.25, Math.cos(tilt)); // 0.25 ≈ cos 76°, past CAMERA_MAX_TILT
       half = Math.min(0.5 * Math.hypot(W, D), NCZ.SHADOW_MAX_DISTANCE) + NCZ.SHADOW_GROUND_MARGIN;
-      center = controls.target;
+      // Pin the centre to the ground plane (Y = 0): controls.target can drift
+      // off Y=0 with screen-space panning at a tilt, which would slide the
+      // footprint off the terrain. The terrain is at Y≈0 — centre on it.
+      center = _shadowScratchV.set(controls.target.x, 0, controls.target.z);
     } else {
       // External camera (showcase fly cam) — square at the shadow draw distance,
       // centred where the camera's forward ray meets the ground (Y = 0).
@@ -2004,6 +2007,11 @@ const ThreeScene = (() => {
     shadowCam.near = NCZ.SHADOW_CAM_NEAR;
     shadowCam.far  = NCZ.SHADOW_CAM_FAR;
     shadowCam.updateProjectionMatrix();
+    // Normal-bias the receiver samples by a few shadow texels' worth of world
+    // units — scaled with the footprint so it's the same texel offset at every
+    // zoom (a constant world bias is too small zoomed out → grazing-sun acne
+    // ["the wave" on flat terrain/water], too large zoomed in → shadows detach).
+    _dirLight.shadow.normalBias = NCZ.SHADOW_NORMAL_BIAS_TEXELS * (2 * half / NCZ.SHADOW_MAP_SIZE);
 
     // Keep the sun light SUN_DIST up the sun ray from the footprint centre.
     // Orthographic ⇒ only the direction matters for shading; the distance just

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -31,11 +31,40 @@ import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { Line2 } from 'three/addons/lines/webgpu/Line2.js';
 import { LineGeometry } from 'three/addons/lines/LineGeometry.js';
 import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
+import { CSMShadowNode } from 'three/addons/csm/CSMShadowNode.js';
 import Stats from 'three/addons/libs/stats.module.js';
 
 window.NCZ = window.NCZ || {};
 
 const SUN_DIR = new THREE.Vector3(-1, 1.5, -1).normalize();
+
+/**
+ * CSMShadowNode that drives its cascade splits from a caller-supplied proxy
+ * camera instead of the camera the scene is rendered with.
+ *
+ * Why a proxy: our schema OrthographicCamera uses a *negative* near plane —
+ * geometry can sit behind it during low showcase flyovers (see NCZ.CAMERA_NEAR).
+ * CSM picks a fragment's cascade from its view-space depth mapped to [0,1] via
+ * `camera.near`/`camera.far`; a negative near makes that mapping collapse so
+ * every fragment lands in the same cascade. The proxy camera (set up in
+ * three-scene.js) shares the schema camera's view and XY frustum but carries a
+ * sane positive near/far window that hugs the visible ground, so the split is
+ * meaningful at all tilts.
+ *
+ * `_init` is the one hook CSMShadowNode runs lazily on the first render to bind
+ * its camera; overriding it to bind the proxy is the only change needed —
+ * everything downstream (updateFrustums, updateBefore, the TSL
+ * `reference('camera.near', …)`) reads `this.camera`, which is now the proxy.
+ */
+class ProxyCSMShadowNode extends CSMShadowNode {
+  constructor(light, proxyCamera, data) {
+    super(light, data);
+    this._proxyCamera = proxyCamera;
+  }
+  _init(builder) {
+    super._init({ camera: this._proxyCamera, renderer: builder.renderer });
+  }
+}
 
 const ThreeScene = (() => {
   let renderer, camera, scene, controls;
@@ -47,6 +76,8 @@ const ThreeScene = (() => {
   let loadStepsDone  = 0;
   let _dirLight      = null; // stored so setSunPosition can update it live
   let _ambLight      = null;
+  let _csm           = null; // ProxyCSMShadowNode — owns the per-cascade shadow cameras
+  let _csmCamera     = null; // orthographic proxy fed to CSM (see updateShadowCascades)
   let _shadowsOn     = true;  // shadows on by default; checkbox reflects this via poll
   let _sunSphere     = null; // visible sun disc — shown during showcase only
   let _sunAz = Math.PI * 0.25, _sunEl = Math.PI * 0.35; // last setSunPosition args
@@ -305,6 +336,11 @@ const ThreeScene = (() => {
     renderer.setSize(container.clientWidth, container.clientHeight, false);
     renderer.shadowMap.enabled = true;
     renderer.shadowMap.type    = THREE.PCFSoftShadowMap;
+    // Render-on-demand already decides *whether* a frame renders; this decides
+    // whether the shadow cascades re-render within a frame. updateShadowCascades()
+    // (camera moved) and setSunPosition() (sun moved) raise needsUpdate; renders
+    // that change nothing geometric (theme tweens, pin hover) skip the shadow pass.
+    renderer.shadowMap.autoUpdate = false;
     // Take the canvas out of document flow so its pixel-buffer dimensions
     // can never push or displace surrounding layout elements.
     // inset:0 stretches it to fill #map-3d on all four sides — no explicit
@@ -342,25 +378,47 @@ const ThreeScene = (() => {
     _dirLight.name = 'sun';
     _dirLight.position.copy(SUN_DIR).multiplyScalar(NCZ.SUN_DIST);
 
-    // Shadow map: 4096² covers the ~14 000-unit world at ~3.4 units/texel.
-    // Frustum centred on Night City (NCZ.WORLD_CX, 0, -NCZ.WORLD_CY).
-    _dirLight.castShadow                    = _shadowsOn;
+    // Cascaded shadow maps. _dirLight.shadow holds the *template* CSM clones
+    // per cascade (mapSize, near/far, bias); CSM sizes/positions each cascade's
+    // shadow camera itself from the proxy camera's frustum (see
+    // updateShadowCascades). castShadow stays on permanently — the "shadows"
+    // layer toggle flips shadow *intensity* via setShadowsEnabled rather than
+    // this flag, because toggling castShadow on a live light tears its depth
+    // texture down mid-frame and crashes WebGPURenderer.
+    _dirLight.castShadow            = true;
     _dirLight.shadow.mapSize.set(NCZ.SHADOW_MAP_SIZE, NCZ.SHADOW_MAP_SIZE);
-    _dirLight.shadow.camera.left            = -NCZ.SHADOW_FRUSTUM;
-    _dirLight.shadow.camera.right           =  NCZ.SHADOW_FRUSTUM;
-    _dirLight.shadow.camera.top             =  NCZ.SHADOW_FRUSTUM;
-    _dirLight.shadow.camera.bottom          = -NCZ.SHADOW_FRUSTUM;
-    _dirLight.shadow.camera.near            = NCZ.SHADOW_CAM_NEAR;
-    _dirLight.shadow.camera.far             = NCZ.SHADOW_CAM_FAR;
-    _dirLight.shadow.bias                   = NCZ.SHADOW_BIAS;
-    _dirLight.shadow.normalBias             = NCZ.SHADOW_NORMAL_BIAS;
+    _dirLight.shadow.camera.near    = NCZ.SHADOW_CAM_NEAR;
+    _dirLight.shadow.camera.far     = NCZ.SHADOW_CAM_FAR;
+    _dirLight.shadow.bias           = NCZ.SHADOW_BIAS;
+    _dirLight.shadow.normalBias     = NCZ.SHADOW_NORMAL_BIAS;
+    _dirLight.shadow.intensity      = _shadowsOn ? 1 : 0;
 
-    // Centre the shadow frustum on Night City, not the world origin
+    // Centre the (placeholder) light target on Night City; CSM repositions the
+    // per-cascade lights each render, but the template's direction comes from here.
     _dirLight.target.position.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
     _dirLight.target.name = 'sun-target';
 
     scene.add(_dirLight);
     scene.add(_dirLight.target);
+
+    // Orthographic proxy that drives CSM's cascade splits (see ProxyCSMShadowNode).
+    // Its left/right/top/bottom/zoom/transform mirror the schema camera; its
+    // near/far are recomputed by updateShadowCascades to hug the visible ground.
+    // Synced for real once OrbitControls exists (just below) and on every change.
+    _csmCamera = new THREE.OrthographicCamera();
+    _csmCamera.name = 'csm-proxy-camera';
+    _csm = new ProxyCSMShadowNode(_dirLight, _csmCamera, {
+      cascades:    NCZ.SHADOW_CASCADES,
+      mode:        'practical',          // logarithmic-ish near split, uniform-ish far
+      lightMargin: NCZ.SHADOW_LIGHT_MARGIN,
+      // Cap the shadowed depth at the city's scale. Matters for the showcase
+      // flyCamera (FLYOVER_CAM_FAR is 120 km — without this the cascades would
+      // span 120 km and dissolve into nothing); the ortho proxy's far is already
+      // well under this so it's unaffected.
+      maxFar:      NCZ.SHADOW_CAM_FAR,
+    });
+    _dirLight.shadow.shadowNode = _csm;
+
     _ambLight = new THREE.AmbientLight(0xffffff, NCZ.AMBIENT_INTENSITY);
     _ambLight.name = 'ambient-light';
     scene.add(_ambLight);
@@ -396,10 +454,11 @@ const ThreeScene = (() => {
     controls.target.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
     controls.update();
     updateFrustumUniforms();   // seed frustum planes for the first cull dispatch
+    updateShadowCascades();    // seed the CSM proxy camera from the initial pose
     controls.addEventListener('change', () => {
       updateDistrictZoom();
       if (metroZoomUniform) metroZoomUniform.value = camera.zoom;
-      updateShadowFrustum();
+      updateShadowCascades();
       updateFrustumUniforms();   // Phase 2B: refresh the 6 cull-frustum planes
       updateScaleBar();
       requestRender();
@@ -480,6 +539,7 @@ const ThreeScene = (() => {
     camera.left   = -frustumH * aspect;
     camera.right  =  frustumH * aspect;
     camera.updateProjectionMatrix();
+    updateShadowCascades();   // CSM proxy frustum follows the schema camera's aspect
     // flyCamera resize is handled in flyover.js
     // Line2NodeMaterial pulls viewport size from a TSL screen node at
     // shader-execution time, so the legacy resolution-set loop is no longer
@@ -627,7 +687,7 @@ const ThreeScene = (() => {
       fitCameraToBox(box);
 
       stepProgress(); // terrain done
-      updateShadowFrustum(); // set initial frustum for current zoom
+      updateShadowCascades(); // re-fit the CSM cascades now the camera is sized to terrain
       setLoadingText('Loading roads & buildings...');
 
       // Trigger the sun slider so app.js applies the correct initial sun position.
@@ -1445,6 +1505,13 @@ const ThreeScene = (() => {
   // (e.g. from a still-running color tween) doesn't resurrect the loop.
   function startRenderLoop() {
     _suppressed = false;
+    // The showcase flyover points CSM at its own PerspectiveCamera (renderFrame
+    // below); when it hands control back, return CSM to the schema camera's
+    // ortho proxy and re-fit the cascades before the next schema frame.
+    if (_csm && _csm.camera && _csm.camera !== _csmCamera) {
+      _csm.camera = _csmCamera;
+      updateShadowCascades();
+    }
     requestRender();
   }
 
@@ -1595,8 +1662,12 @@ const ThreeScene = (() => {
                           ? !!_rendererInitParams?.antialias
                           : !!(renderer.getContextAttributes?.() && renderer.getContextAttributes().antialias),
         backend:        renderer.isWebGPURenderer ? 'WebGPU' : 'WebGL2',
-        shadowsEnabled: renderer.shadowMap.enabled,
+        // _shadowsOn is the user-facing state; renderer.shadowMap.enabled stays
+        // true permanently (the toggle flips shadow intensity, not the pass).
+        shadowsEnabled: _shadowsOn,
         shadowMapType:  shadowTypeNames[renderer.shadowMap.type] || String(renderer.shadowMap.type),
+        shadowCascades: NCZ.SHADOW_CASCADES,
+        shadowMapSize:  NCZ.SHADOW_MAP_SIZE,
       } : null,
       display: {
         windowSize:       `${window.innerWidth}x${window.innerHeight}`,
@@ -1649,7 +1720,10 @@ const ThreeScene = (() => {
     if (dump.rendererSettings) {
       const r = dump.rendererSettings;
       lines.push('');
-      lines.push(`Renderer:      ${r.backend} / DPR ${r.pixelRatio} / AA ${r.antialias ? 'on' : 'off'} / Shadows ${r.shadowsEnabled ? r.shadowMapType : 'off'}`);
+      const shadowText = r.shadowsEnabled
+        ? `${r.shadowMapType} / CSM ${r.shadowCascades}×${r.shadowMapSize}²`
+        : 'off';
+      lines.push(`Renderer:      ${r.backend} / DPR ${r.pixelRatio} / AA ${r.antialias ? 'on' : 'off'} / Shadows ${shadowText}`);
     }
     lines.push(`Display:       ${dump.display.windowSize} window, ${dump.display.screenSize} screen, ${dump.display.devicePixelRatio} DPR`);
     lines.push(`Effective px:  ${dump.display.effectivePixels.toLocaleString()}`);
@@ -1692,7 +1766,18 @@ const ThreeScene = (() => {
   // Called by flyover.js — kept minimal to avoid exposing internals.
 
   function renderFrame(cam) {
-    if (renderer && scene) renderer.render(scene, cam);
+    if (!renderer || !scene) return;
+    // The showcase flyover renders through its own PerspectiveCamera (sane
+    // positive near/far ⇒ CSM can track it directly, no proxy). Point CSM at it
+    // and re-fit the cascades each frame it moves; startRenderLoop restores the
+    // schema camera's ortho proxy when the flyover ends. Guarded on _csm.camera
+    // so we don't run before CSM's lazy _init has bound a camera.
+    if (_csm && _csm.camera && cam !== camera) {
+      if (_csm.camera !== cam) _csm.camera = cam;
+      _csm.updateFrustums();
+      renderer.shadowMap.needsUpdate = true;
+    }
+    renderer.render(scene, cam);
   }
 
   function setControlsEnabled(enabled) {
@@ -1872,28 +1957,20 @@ const ThreeScene = (() => {
     const el = altitudeRad;
     const az = azimuthRad;
 
-    // Scale position so the shadow camera sits well above the scene.
-    // At sunrise/sunset el is small — we floor the Y component so the
-    // shadow camera never dips below the terrain.
+    // Only the *direction* of _dirLight matters now — CSM reads it from
+    // (target − position) and positions the per-cascade shadow cameras itself
+    // (no more degenerate "infinitely long shadow at sunrise" frustum to dodge).
+    // The Math.max(0.1, …) floor keeps the direction from going perfectly
+    // horizontal at the horizon, which would make CSM's lookAt() degenerate;
+    // sun *intensity* already fades near the horizon so the artefact is muted.
     const SHADOW_DIST = NCZ.SUN_DIST;
     _dirLight.position.set(
       -Math.cos(el) * Math.sin(az)  * SHADOW_DIST,
        Math.max(0.1, Math.sin(el))  * SHADOW_DIST,
        Math.cos(el) * Math.cos(az)  * SHADOW_DIST,
     );
-
-    // (Phase 2A — 2026-05-10): the original WebGL build toggled `castShadow`
-    // off when the sun dropped below NCZ.SHADOW_MIN_ELEV° to avoid infinitely
-    // long degenerate shadows at sunrise/sunset. Under WebGPURenderer that
-    // toggle crashes the next frame with `Cannot read properties of null
-    // (reading 'depthTexture')` — the shadow map is torn down but the
-    // per-object update path still references it. Until Phase 3's CSM
-    // (which adapts the shadow frustum to camera/sun automatically), we
-    // keep `castShadow` static at the user's preference and accept the
-    // brief degenerate-shadow artefact at horizon transitions. Light
-    // intensity already drops near the horizon (line below) so the visual
-    // impact is muted.
-    _dirLight.castShadow = _shadowsOn;
+    // Sun moved ⇒ the shadow cascades must re-render (shadowMap.autoUpdate is off).
+    if (renderer) renderer.shadowMap.needsUpdate = true;
 
     // Colour: warm orange at horizon → neutral white above ~NCZ.SUN_COLOR_ELEV°.
     // setRGB writes linear-light values directly (ColorManagement does NOT convert
@@ -1937,48 +2014,70 @@ const ThreeScene = (() => {
     requestRender();
   }
 
-  function updateShadowFrustum() {
-    if (!_dirLight || !controls) return;
-    // Scale frustum to cover the visible ground area plus margin.
-    // At high tilt angles the visible ground extends further back — account for this
-    // by scaling with 1/cos(tilt), which grows from 1 (top-down) to ~3 (70° tilt).
+  // Re-fit the CSM cascades to the current schema-camera pose. CSM positions
+  // and sizes each cascade's shadow camera itself; this just keeps its proxy
+  // camera (see ProxyCSMShadowNode) mirroring the schema camera's view and XY
+  // frustum, with a near/far window that hugs the visible ground so the
+  // view-Z-based cascade split actually subdivides the geometry instead of
+  // bucketing it all into one cascade. Called on every camera change, on resize,
+  // once after terrain loads, and from startRenderLoop (after a flyover).
+  function updateShadowCascades() {
+    if (!_csm || !_csmCamera || !camera || !controls) return;
+    // Distance from the camera plane to the orbit target on the ground. With an
+    // orthographic camera, OrbitControls keeps this ≈ the orbit radius
+    // regardless of zoom or tilt — a stable ~CAMERA_HEIGHT value.
+    const camDist     = camera.position.distanceTo(controls.target);
+    // How far the visible ground strip spreads along the view axis: at tilt θ a
+    // strip of half-width `visibleHalf` reaches ≈ visibleHalf·sinθ deeper. Slack
+    // covers building heights / terrain relief so no caster's depth lands
+    // outside the proxy's near/far window (which would drop it from cascade 0).
+    const tilt        = controls.getPolarAngle?.() ?? 0;   // 0 = top-down, grows toward CAMERA_MAX_TILT
     const visibleHalf = Math.max(camera.right, camera.top) / camera.zoom;
-    const tilt = controls.getPolarAngle?.() ?? 0;
-    // 1/cos(tilt) accounts for ground depth at angle; extra 2× margin for the asymmetric
-    // forward/back distribution around controls.target when tilted
-    const tiltFactor = Math.max(1, 1 / Math.max(0.2, Math.cos(tilt)));
-    const frustum = Math.max(NCZ.SHADOW_FRUSTUM_MIN, visibleHalf * 3.0 * tiltFactor);
-    _dirLight.shadow.camera.left   = -frustum;
-    _dirLight.shadow.camera.right  =  frustum;
-    _dirLight.shadow.camera.top    =  frustum;
-    _dirLight.shadow.camera.bottom = -frustum;
-    _dirLight.shadow.camera.updateProjectionMatrix();
-
-    // Scale bias with frustum — smaller frustum = higher resolution = less bias needed.
-    // Prevents peter panning (shadow detached from base) at high zoom.
-    const biasScale = Math.min(1, frustum / NCZ.SHADOW_FRUSTUM);
-    _dirLight.shadow.bias       = NCZ.SHADOW_BIAS       * biasScale;
-    _dirLight.shadow.normalBias = NCZ.SHADOW_NORMAL_BIAS * biasScale;
-
-    // Track camera target so shadow stays centred on the visible area when panning.
-    // Move both light position and target by the same delta to preserve sun direction.
-    const ct = controls.target;
-    const delta = new THREE.Vector3().subVectors(ct, _dirLight.target.position);
-    if (delta.lengthSq() > 0.01) {
-      _dirLight.position.add(delta);
-      _dirLight.target.position.copy(ct);
-      _dirLight.target.updateMatrixWorld();
+    const groundHalfDepth = visibleHalf * Math.sin(tilt) + NCZ.SHADOW_PROXY_DEPTH_SLACK;
+    // Proxy: schema camera's view + XY frustum, but a sane positive near/far band.
+    _csmCamera.left   = camera.left;
+    _csmCamera.right  = camera.right;
+    _csmCamera.top    = camera.top;
+    _csmCamera.bottom = camera.bottom;
+    _csmCamera.zoom   = camera.zoom;
+    _csmCamera.near   = Math.max(1, camDist - groundHalfDepth);
+    _csmCamera.far    = camDist + groundHalfDepth;
+    _csmCamera.updateProjectionMatrix();
+    _csmCamera.position.copy(camera.position);
+    _csmCamera.quaternion.copy(camera.quaternion);   // controls.update() refreshed this; matrixWorld below
+    _csmCamera.updateMatrixWorld();
+    // updateFrustums recomputes the cascade splits + per-cascade shadow-camera
+    // bounds from the proxy. Skip until CSM's lazy _init has bound a camera and
+    // created the cascade lights — the first render does that via
+    // ProxyCSMShadowNode._init (which calls updateFrustums itself).
+    if (_csm.camera) {
+      if (_csm.lights.length && !_csm.lights[0].name) {
+        _csm.lights.forEach((l, i) => {
+          l.name        = `csm-cascade-${i}`;
+          l.target.name = `csm-cascade-${i}-target`;
+        });
+      }
+      _csm.updateFrustums();
     }
+    // Always flag a shadow re-render — shadowMap.autoUpdate is off, so any
+    // camera move (or this seeding call) needs to be reflected in the cascades.
+    if (renderer) renderer.shadowMap.needsUpdate = true;
   }
 
   function setShadowsEnabled(enabled) {
     _shadowsOn = enabled;
-    // No elevation floor — see the comment in setSunPosition. Toggling
-    // `castShadow` mid-render under WebGPURenderer nulls the shadow's
-    // depthTexture and crashes the next object update.
-    if (_dirLight) {
-      _dirLight.castShadow = _shadowsOn;
-    }
+    const intensity = enabled ? 1 : 0;
+    // Toggle shadow *intensity* rather than the light's castShadow flag or
+    // renderer.shadowMap.enabled — both tear shadow depth textures down
+    // mid-frame and crash WebGPURenderer ("Cannot read properties of null
+    // (reading 'depthTexture')"). intensity 0 keeps the textures alive but
+    // contributes no darkening; ShadowNode reads it via a live `reference` node,
+    // so the change applies on the next render with no recompile. Set both the
+    // template (so a not-yet-_init'd CSM clones the right value) and any live
+    // cascade lights. NB: the shadow pass still runs at intensity 0 — this is a
+    // visual switch, not a perf one (the deferred mobile-perf pass owns that).
+    if (_dirLight) _dirLight.shadow.intensity = intensity;
+    if (_csm) for (const l of _csm.lights) l.shadow.intensity = intensity;
     requestRender();
   }
 

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -389,6 +389,7 @@ const ThreeScene = (() => {
     _dirLight.shadow.mapSize.set(NCZ.SHADOW_MAP_SIZE, NCZ.SHADOW_MAP_SIZE);
     _dirLight.shadow.camera.near    = NCZ.SHADOW_CAM_NEAR;
     _dirLight.shadow.camera.far     = NCZ.SHADOW_CAM_FAR;
+    _dirLight.shadow.camera.name    = 'sun-shadow-cam-template'; // CSM clones this per cascade; not rendered directly
     _dirLight.shadow.bias           = NCZ.SHADOW_BIAS;
     _dirLight.shadow.normalBias     = NCZ.SHADOW_NORMAL_BIAS;
     _dirLight.shadow.intensity      = _shadowsOn ? 1 : 0;
@@ -2056,8 +2057,9 @@ const ThreeScene = (() => {
     if (_csm.camera) {
       if (_csm.lights.length && !_csm.lights[0].name) {
         _csm.lights.forEach((l, i) => {
-          l.name        = `csm-cascade-${i}`;
-          l.target.name = `csm-cascade-${i}-target`;
+          l.name        = `csm-cascade-${i}-light`;       // placeholder DirectionalLight CSM repositions per cascade
+          l.target.name = `csm-cascade-${i}-target`;       // its lookAt target (sun direction)
+          if (l.shadow?.camera) l.shadow.camera.name = `csm-cascade-${i}-shadow-cam`; // ortho cam that renders this cascade's depth map
         });
       }
       _csm.updateFrustums();

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -31,40 +31,18 @@ import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { Line2 } from 'three/addons/lines/webgpu/Line2.js';
 import { LineGeometry } from 'three/addons/lines/LineGeometry.js';
 import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
-import { CSMShadowNode } from 'three/addons/csm/CSMShadowNode.js';
 import Stats from 'three/addons/libs/stats.module.js';
 
 window.NCZ = window.NCZ || {};
 
+// Default sun direction (unit, points from the ground toward the sun) until the
+// real SunCalc-driven position arrives via setSunPosition.
 const SUN_DIR = new THREE.Vector3(-1, 1.5, -1).normalize();
-
-/**
- * CSMShadowNode that drives its cascade splits from a caller-supplied proxy
- * camera instead of the camera the scene is rendered with.
- *
- * Why a proxy: our schema OrthographicCamera uses a *negative* near plane —
- * geometry can sit behind it during low showcase flyovers (see NCZ.CAMERA_NEAR).
- * CSM picks a fragment's cascade from its view-space depth mapped to [0,1] via
- * `camera.near`/`camera.far`; a negative near makes that mapping collapse so
- * every fragment lands in the same cascade. The proxy camera (set up in
- * three-scene.js) shares the schema camera's view and XY frustum but carries a
- * sane positive near/far window that hugs the visible ground, so the split is
- * meaningful at all tilts.
- *
- * `_init` is the one hook CSMShadowNode runs lazily on the first render to bind
- * its camera; overriding it to bind the proxy is the only change needed —
- * everything downstream (updateFrustums, updateBefore, the TSL
- * `reference('camera.near', …)`) reads `this.camera`, which is now the proxy.
- */
-class ProxyCSMShadowNode extends CSMShadowNode {
-  constructor(light, proxyCamera, data) {
-    super(light, data);
-    this._proxyCamera = proxyCamera;
-  }
-  _init(builder) {
-    super._init({ camera: this._proxyCamera, renderer: builder.renderer });
-  }
-}
+const _GROUND_NORMAL = new THREE.Vector3(0, 1, 0);
+// Hemisphere-fill sky colour, lerped by sun elevation: hazy cool daylight when
+// high, warm hazy when low (the real sky scatters orange at golden hour too).
+const SKY_NOON    = new THREE.Color(0x8a96a6);
+const SKY_HORIZON = new THREE.Color(0xc9a878);
 
 const ThreeScene = (() => {
   let renderer, camera, scene, controls;
@@ -74,10 +52,11 @@ const ThreeScene = (() => {
   let loadingFillEl  = null;
   let loadStepsTotal = 0;
   let loadStepsDone  = 0;
-  let _dirLight      = null; // stored so setSunPosition can update it live
-  let _ambLight      = null;
-  let _csm           = null; // ProxyCSMShadowNode — owns the per-cascade shadow cameras
-  let _csmCamera     = null; // orthographic proxy fed to CSM (see updateShadowCascades)
+  let _dirLight      = null; // the sun (DirectionalLight + single fitted shadow camera)
+  let _hemiLight     = null; // sky/ground fill (replaces a flat AmbientLight)
+  let _sunDir        = SUN_DIR.clone(); // unit, ground→sun; updated by setSunPosition, consumed by updateShadowCamera
+  let _shadowGroundCenter = new THREE.Vector3(); // world point the shadow camera is centred on (the visible-ground centre)
+  let _shadowScratchV = new THREE.Vector3();     // reused by updateShadowCamera so it doesn't allocate per camera move
   let _shadowsOn     = true;  // shadows on by default; checkbox reflects this via poll
   let _sunSphere     = null; // visible sun disc — shown during showcase only
   let _sunAz = Math.PI * 0.25, _sunEl = Math.PI * 0.35; // last setSunPosition args
@@ -337,7 +316,7 @@ const ThreeScene = (() => {
     renderer.shadowMap.enabled = true;
     renderer.shadowMap.type    = THREE.PCFSoftShadowMap;
     // Render-on-demand already decides *whether* a frame renders; this decides
-    // whether the shadow cascades re-render within a frame. updateShadowCascades()
+    // whether the shadow map re-renders within a frame. updateShadowCamera()
     // (camera moved) and setSunPosition() (sun moved) raise needsUpdate; renders
     // that change nothing geometric (theme tweens, pin hover) skip the shadow pass.
     renderer.shadowMap.autoUpdate = false;
@@ -372,57 +351,41 @@ const ThreeScene = (() => {
     camera.up.set(0, 1, 0);  // Standard Three.js up vector
     camera.updateProjectionMatrix();
 
-    // Lighting — direction set to current real sun position via SunCalc if available,
-    // otherwise falls back to the default NW hillshade direction.
+    // ── Lighting: outdoor model — directional sun + hemisphere fill ──
+    // The sun: a DirectionalLight whose direction tracks the real Morro Bay sun
+    // (SunCalc, via setSunPosition; default NW hillshade until then). One shadow
+    // map, an OrthographicCamera fitted each move to exactly the visible-ground
+    // footprint (updateShadowCamera) — no cascades: for a top-down ortho camera
+    // there's no perspective near/far disparity to split, so a single tight map
+    // beats CSM and is far simpler. castShadow stays on permanently; the
+    // "shadows" layer toggle flips shadow *intensity* (toggling castShadow on a
+    // live light tears its depth texture down mid-frame and crashes WebGPURenderer).
     _dirLight = new THREE.DirectionalLight(0xffffff, 1.0 - NCZ.AMBIENT_INTENSITY);
     _dirLight.name = 'sun';
-    _dirLight.position.copy(SUN_DIR).multiplyScalar(NCZ.SUN_DIST);
-
-    // Cascaded shadow maps. _dirLight.shadow holds the *template* CSM clones
-    // per cascade (mapSize, near/far, bias); CSM sizes/positions each cascade's
-    // shadow camera itself from the proxy camera's frustum (see
-    // updateShadowCascades). castShadow stays on permanently — the "shadows"
-    // layer toggle flips shadow *intensity* via setShadowsEnabled rather than
-    // this flag, because toggling castShadow on a live light tears its depth
-    // texture down mid-frame and crashes WebGPURenderer.
-    _dirLight.castShadow            = true;
+    _dirLight.castShadow         = true;
     _dirLight.shadow.mapSize.set(NCZ.SHADOW_MAP_SIZE, NCZ.SHADOW_MAP_SIZE);
-    _dirLight.shadow.camera.near    = NCZ.SHADOW_CAM_NEAR;
-    _dirLight.shadow.camera.far     = NCZ.SHADOW_CAM_FAR;
-    _dirLight.shadow.camera.name    = 'sun-shadow-cam-template'; // CSM clones this per cascade; not rendered directly
-    _dirLight.shadow.bias           = NCZ.SHADOW_BIAS;
-    _dirLight.shadow.normalBias     = NCZ.SHADOW_NORMAL_BIAS;
-    _dirLight.shadow.intensity      = _shadowsOn ? 1 : 0;
-
-    // Centre the (placeholder) light target on Night City; CSM repositions the
-    // per-cascade lights each render, but the template's direction comes from here.
-    _dirLight.target.position.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
+    _dirLight.shadow.camera.near = NCZ.SHADOW_CAM_NEAR;
+    _dirLight.shadow.camera.far  = NCZ.SHADOW_CAM_FAR; // orthographic ⇒ a wide range costs no precision
+    _dirLight.shadow.camera.name = 'sun-shadow-cam';
+    _dirLight.shadow.bias        = NCZ.SHADOW_BIAS;       // 0 — native depth32float + reverse-Z + a tight map need no cushion
+    _dirLight.shadow.normalBias  = NCZ.SHADOW_NORMAL_BIAS; // 0 — ditto
+    _dirLight.shadow.intensity   = _shadowsOn ? 1 : 0;
     _dirLight.target.name = 'sun-target';
-
+    // Position the light + target are set by updateShadowCamera (it centres the
+    // shadow on the visible ground); seed them at the world centre so the first
+    // frame before that runs isn't degenerate.
+    _dirLight.target.position.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
+    _dirLight.position.copy(_dirLight.target.position).addScaledVector(_sunDir, NCZ.SUN_DIST);
     scene.add(_dirLight);
     scene.add(_dirLight.target);
 
-    // Orthographic proxy that drives CSM's cascade splits (see ProxyCSMShadowNode).
-    // Its left/right/top/bottom/zoom/transform mirror the schema camera; its
-    // near/far are recomputed by updateShadowCascades to hug the visible ground.
-    // Synced for real once OrbitControls exists (just below) and on every change.
-    _csmCamera = new THREE.OrthographicCamera();
-    _csmCamera.name = 'csm-proxy-camera';
-    _csm = new ProxyCSMShadowNode(_dirLight, _csmCamera, {
-      cascades:    NCZ.SHADOW_CASCADES,
-      mode:        'practical',          // logarithmic-ish near split, uniform-ish far
-      lightMargin: NCZ.SHADOW_LIGHT_MARGIN,
-      // Cap the shadowed depth at the city's scale. Matters for the showcase
-      // flyCamera (FLYOVER_CAM_FAR is 120 km — without this the cascades would
-      // span 120 km and dissolve into nothing); the ortho proxy's far is already
-      // well under this so it's unaffected.
-      maxFar:      NCZ.SHADOW_CAM_FAR,
-    });
-    _dirLight.shadow.shadowNode = _csm;
-
-    _ambLight = new THREE.AmbientLight(0xffffff, NCZ.AMBIENT_INTENSITY);
-    _ambLight.name = 'ambient-light';
-    scene.add(_ambLight);
+    // Hemisphere fill — sky-colour from above (hazy cool daylight), darker
+    // ground-colour bounce from below. Reads more like an outdoor scene than a
+    // flat AmbientLight: building tops catch the sky, sides get a 50/50 mix →
+    // subtle face-to-face contrast for free. Intensity tracks the day in setSunPosition.
+    _hemiLight = new THREE.HemisphereLight(0x8a96a6, 0x1c2128, NCZ.AMBIENT_INTENSITY);
+    _hemiLight.name = 'sky-fill';
+    scene.add(_hemiLight);
     // Sun position is applied by app.js via the slider once terrain has loaded.
 
     // Visible sun sphere — hidden by default, shown during showcase only.
@@ -455,11 +418,11 @@ const ThreeScene = (() => {
     controls.target.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
     controls.update();
     updateFrustumUniforms();   // seed frustum planes for the first cull dispatch
-    updateShadowCascades();    // seed the CSM proxy camera from the initial pose
+    updateShadowCamera();      // seed the shadow camera from the initial pose
     controls.addEventListener('change', () => {
       updateDistrictZoom();
       if (metroZoomUniform) metroZoomUniform.value = camera.zoom;
-      updateShadowCascades();
+      updateShadowCamera();
       updateFrustumUniforms();   // Phase 2B: refresh the 6 cull-frustum planes
       updateScaleBar();
       requestRender();
@@ -540,7 +503,7 @@ const ThreeScene = (() => {
     camera.left   = -frustumH * aspect;
     camera.right  =  frustumH * aspect;
     camera.updateProjectionMatrix();
-    updateShadowCascades();   // CSM proxy frustum follows the schema camera's aspect
+    updateShadowCamera();   // shadow camera follows the schema camera's aspect
     // flyCamera resize is handled in flyover.js
     // Line2NodeMaterial pulls viewport size from a TSL screen node at
     // shader-execution time, so the legacy resolution-set loop is no longer
@@ -688,7 +651,7 @@ const ThreeScene = (() => {
       fitCameraToBox(box);
 
       stepProgress(); // terrain done
-      updateShadowCascades(); // re-fit the CSM cascades now the camera is sized to terrain
+      updateShadowCamera(); // re-fit the shadow camera now the schema camera is sized to terrain
       setLoadingText('Loading roads & buildings...');
 
       // Trigger the sun slider so app.js applies the correct initial sun position.
@@ -1506,13 +1469,10 @@ const ThreeScene = (() => {
   // (e.g. from a still-running color tween) doesn't resurrect the loop.
   function startRenderLoop() {
     _suppressed = false;
-    // The showcase flyover points CSM at its own PerspectiveCamera (renderFrame
-    // below); when it hands control back, return CSM to the schema camera's
-    // ortho proxy and re-fit the cascades before the next schema frame.
-    if (_csm && _csm.camera && _csm.camera !== _csmCamera) {
-      _csm.camera = _csmCamera;
-      updateShadowCascades();
-    }
+    // The showcase flyover fits the shadow camera to its own PerspectiveCamera
+    // (renderFrame below); when it hands control back, re-fit to the schema
+    // camera's view before the next schema frame.
+    updateShadowCamera();
     requestRender();
   }
 
@@ -1667,7 +1627,6 @@ const ThreeScene = (() => {
         // true permanently (the toggle flips shadow intensity, not the pass).
         shadowsEnabled: _shadowsOn,
         shadowMapType:  shadowTypeNames[renderer.shadowMap.type] || String(renderer.shadowMap.type),
-        shadowCascades: NCZ.SHADOW_CASCADES,
         shadowMapSize:  NCZ.SHADOW_MAP_SIZE,
       } : null,
       display: {
@@ -1721,9 +1680,7 @@ const ThreeScene = (() => {
     if (dump.rendererSettings) {
       const r = dump.rendererSettings;
       lines.push('');
-      const shadowText = r.shadowsEnabled
-        ? `${r.shadowMapType} / CSM ${r.shadowCascades}×${r.shadowMapSize}²`
-        : 'off';
+      const shadowText = r.shadowsEnabled ? `${r.shadowMapType} / ${r.shadowMapSize}²` : 'off';
       lines.push(`Renderer:      ${r.backend} / DPR ${r.pixelRatio} / AA ${r.antialias ? 'on' : 'off'} / Shadows ${shadowText}`);
     }
     lines.push(`Display:       ${dump.display.windowSize} window, ${dump.display.screenSize} screen, ${dump.display.devicePixelRatio} DPR`);
@@ -1768,16 +1725,10 @@ const ThreeScene = (() => {
 
   function renderFrame(cam) {
     if (!renderer || !scene) return;
-    // The showcase flyover renders through its own PerspectiveCamera (sane
-    // positive near/far ⇒ CSM can track it directly, no proxy). Point CSM at it
-    // and re-fit the cascades each frame it moves; startRenderLoop restores the
-    // schema camera's ortho proxy when the flyover ends. Guarded on _csm.camera
-    // so we don't run before CSM's lazy _init has bound a camera.
-    if (_csm && _csm.camera && cam !== camera) {
-      if (_csm.camera !== cam) _csm.camera = cam;
-      _csm.updateFrustums();
-      renderer.shadowMap.needsUpdate = true;
-    }
+    // The showcase flyover renders through its own PerspectiveCamera — re-fit
+    // the shadow camera to *its* view each frame (it moves continuously).
+    // startRenderLoop re-fits to the schema camera when the flyover ends.
+    if (cam && cam !== camera) updateShadowCamera(cam);
     renderer.render(scene, cam);
   }
 
@@ -1952,26 +1903,21 @@ const ThreeScene = (() => {
   // GLB space axes: East = +X, South = +Z, West = -X, North = -Z, Up = +Y
   // So az=0 (south) → Z+; az=π/2 (west) → X-; az=-π/2 (east) → X+
   function setSunPosition(azimuthRad, altitudeRad) {
-    if (!_dirLight || !_ambLight) return;
+    if (!_dirLight || !_hemiLight) return;
     _sunAz = azimuthRad;
     _sunEl = altitudeRad;
     const el = altitudeRad;
     const az = azimuthRad;
 
-    // Only the *direction* of _dirLight matters now — CSM reads it from
-    // (target − position) and positions the per-cascade shadow cameras itself
-    // (no more degenerate "infinitely long shadow at sunrise" frustum to dodge).
-    // The Math.max(0.1, …) floor keeps the direction from going perfectly
-    // horizontal at the horizon, which would make CSM's lookAt() degenerate;
-    // sun *intensity* already fades near the horizon so the artefact is muted.
-    const SHADOW_DIST = NCZ.SUN_DIST;
-    _dirLight.position.set(
-      -Math.cos(el) * Math.sin(az)  * SHADOW_DIST,
-       Math.max(0.1, Math.sin(el))  * SHADOW_DIST,
-       Math.cos(el) * Math.cos(az)  * SHADOW_DIST,
-    );
-    // Sun moved ⇒ the shadow cascades must re-render (shadowMap.autoUpdate is off).
-    if (renderer) renderer.shadowMap.needsUpdate = true;
+    // Sun direction (unit, ground→sun). Floor the Y at ~6° elevation so the
+    // shadow camera's lookAt never goes degenerate-horizontal; the visible sun
+    // sphere below uses the *unclamped* elevation so it still sets at the horizon.
+    _sunDir.set(-Math.cos(el) * Math.sin(az), Math.max(0.1, Math.sin(el)), Math.cos(el) * Math.cos(az)).normalize();
+    // Re-orient the light around its current target (updateShadowCamera owns the
+    // target = visible-ground centre; here we just keep the light up the sun ray
+    // from it). Orthographic ⇒ only the direction matters for shading.
+    _dirLight.position.copy(_dirLight.target.position).addScaledVector(_sunDir, NCZ.SUN_DIST);
+    if (renderer) renderer.shadowMap.needsUpdate = true;   // sun moved ⇒ re-render the shadow map
 
     // Colour: warm orange at horizon → neutral white above ~NCZ.SUN_COLOR_ELEV°.
     // setRGB writes linear-light values directly (ColorManagement does NOT convert
@@ -1983,10 +1929,13 @@ const ThreeScene = (() => {
 
     // Intensity: dims near the horizon, full above ~NCZ.SUN_INTENSITY_ELEV°
     const intensity = NCZ.SUN_INTENSITY_MIN + (1 - NCZ.SUN_INTENSITY_MIN) * Math.min(1, Math.max(0, elevDeg / NCZ.SUN_INTENSITY_ELEV));
-    _dirLight.intensity = (1 - NCZ.AMBIENT_INTENSITY) * intensity;
-    _ambLight.intensity =      NCZ.AMBIENT_INTENSITY  * Math.max(NCZ.SUN_AMBIENT_MIN, intensity);
+    _dirLight.intensity   = (1 - NCZ.AMBIENT_INTENSITY) * intensity;
+    // Hemisphere fill: track the day's brightness, and warm the sky toward
+    // sunset so the whole scene shifts warm (the real sky scatters orange too).
+    _hemiLight.intensity  = NCZ.AMBIENT_INTENSITY * Math.max(NCZ.SUN_AMBIENT_MIN, intensity);
+    _hemiLight.color.lerpColors(SKY_HORIZON, SKY_NOON, t);
 
-    // Building materials use MeshLambertMaterial — scene lights update automatically.
+    // Building materials use MeshLambertNodeMaterial — scene lights update automatically.
 
     // Move and recolour the visible sun sphere.
     // Centred on Night City (WORLD_CX, 0, -WORLD_CY) so it hangs over the map.
@@ -2015,74 +1964,67 @@ const ThreeScene = (() => {
     requestRender();
   }
 
-  // Re-fit the CSM cascades to the current schema-camera pose. CSM positions
-  // and sizes each cascade's shadow camera itself; this just keeps its proxy
-  // camera (see ProxyCSMShadowNode) mirroring the schema camera's view and XY
-  // frustum, with a near/far window that hugs the visible ground so the
-  // view-Z-based cascade split actually subdivides the geometry instead of
-  // bucketing it all into one cascade. Called on every camera change, on resize,
-  // once after terrain loads, and from startRenderLoop (after a flyover).
-  function updateShadowCascades() {
-    if (!_csm || !_csmCamera || !camera || !controls) return;
-    // Distance from the camera plane to the orbit target on the ground. With an
-    // orthographic camera, OrbitControls keeps this ≈ the orbit radius
-    // regardless of zoom or tilt — a stable ~CAMERA_HEIGHT value.
-    const camDist     = camera.position.distanceTo(controls.target);
-    // How far the visible ground spreads along the view axis. The screen-vertical
-    // half-extent (camera.top/zoom, in world units) maps to ±(that)·tan(tilt) of
-    // view-depth on the ground: at top-down (tilt 0) the whole visible ground is
-    // a single depth (only the slack matters); at our ~70° max tilt it spreads
-    // ~2.75× the screen-vertical extent. Clamp tan well above CAMERA_MAX_TILT so
-    // it can't blow up. Slack covers building heights / terrain relief so no
-    // caster's depth lands outside the proxy window (→ dropped from all cascades).
-    const tilt       = controls.getPolarAngle?.() ?? 0;   // 0 = top-down, grows toward CAMERA_MAX_TILT
-    const screenHalf = camera.top / camera.zoom;           // world units, screen-vertical half-extent at the current zoom
-    const groundHalfDepth = screenHalf * Math.tan(Math.min(tilt, Math.PI * 0.45)) + NCZ.SHADOW_PROXY_DEPTH_SLACK;
-    // Proxy: schema camera's view + XY frustum, but a sane positive near/far band.
-    _csmCamera.left   = camera.left;
-    _csmCamera.right  = camera.right;
-    _csmCamera.top    = camera.top;
-    _csmCamera.bottom = camera.bottom;
-    _csmCamera.zoom   = camera.zoom;
-    _csmCamera.near   = Math.max(1, camDist - groundHalfDepth);
-    _csmCamera.far    = camDist + groundHalfDepth;
-    _csmCamera.updateProjectionMatrix();
-    _csmCamera.position.copy(camera.position);
-    _csmCamera.quaternion.copy(camera.quaternion);   // controls.update() refreshed this; matrixWorld below
-    _csmCamera.updateMatrixWorld();
-    // updateFrustums recomputes the cascade splits + per-cascade shadow-camera
-    // bounds from the proxy. Skip until CSM's lazy _init has bound a camera and
-    // created the cascade lights — the first render does that via
-    // ProxyCSMShadowNode._init (which calls updateFrustums itself).
-    if (_csm.camera) {
-      if (_csm.lights.length && !_csm.lights[0].name) {
-        _csm.lights.forEach((l, i) => {
-          l.name        = `csm-cascade-${i}-light`;       // placeholder DirectionalLight CSM repositions per cascade
-          l.target.name = `csm-cascade-${i}-target`;       // its lookAt target (sun direction)
-          if (l.shadow?.camera) l.shadow.camera.name = `csm-cascade-${i}-shadow-cam`; // ortho cam that renders this cascade's depth map
-        });
-      }
-      _csm.updateFrustums();
+  // Re-fit the single shadow camera (the OrthographicCamera that renders the
+  // sun's depth map) to exactly the visible-ground footprint of `renderCam`,
+  // capped at SHADOW_MAX_DISTANCE so it can't balloon at the zoomed-out + tilted
+  // extreme. Re-centres the sun light + its target on that footprint so the
+  // shadow tracks what you see. Called on every camera change, on resize, after
+  // terrain loads, on flyover frames (renderCam = the fly cam), and from
+  // startRenderLoop. No cascades — our schema camera is orthographic (uniform
+  // pixels-per-world-unit), so there's no perspective near/far disparity for
+  // cascades to exploit; one tight map is both simpler and sharper here.
+  function updateShadowCamera(renderCam = camera) {
+    if (!_dirLight || !renderCam) return;
+    const shadowCam = _dirLight.shadow.camera;
+
+    let half, center;
+    if (renderCam === camera && controls) {
+      // Schema orthographic camera — analytic fit. The visible ground is a W×D
+      // rectangle: W = the screen-horizontal world extent; D = the screen-vertical
+      // extent stretched by 1/cos(tilt) (a tilted view sees a longer strip of
+      // ground). A square of side = that rectangle's diagonal contains it from any
+      // sun azimuth. Cap so it can't reach the horizon at the zoomed-out extreme.
+      const W = 2 * camera.right / camera.zoom;
+      const tilt = controls.getPolarAngle?.() ?? 0;
+      const D = (2 * camera.top / camera.zoom) / Math.max(0.25, Math.cos(tilt)); // 0.25 ≈ cos 76°, past CAMERA_MAX_TILT
+      half = Math.min(0.5 * Math.hypot(W, D), NCZ.SHADOW_MAX_DISTANCE) + NCZ.SHADOW_GROUND_MARGIN;
+      center = controls.target;
+    } else {
+      // External camera (showcase fly cam) — square at the shadow draw distance,
+      // centred where the camera's forward ray meets the ground (Y = 0).
+      half = NCZ.SHADOW_MAX_DISTANCE + NCZ.SHADOW_GROUND_MARGIN;
+      const dir   = _shadowScratchV.set(0, 0, -1).applyQuaternion(renderCam.quaternion);
+      const denom = dir.dot(_GROUND_NORMAL);
+      const tHit  = Math.abs(denom) > 1e-4 ? Math.max(0, -renderCam.position.y / denom) : 0;
+      center = _shadowGroundCenter.copy(renderCam.position).addScaledVector(dir, tHit);
     }
-    // Always flag a shadow re-render — shadowMap.autoUpdate is off, so any
-    // camera move (or this seeding call) needs to be reflected in the cascades.
-    if (renderer) renderer.shadowMap.needsUpdate = true;
+
+    shadowCam.left = -half; shadowCam.right = half;
+    shadowCam.top  =  half; shadowCam.bottom = -half;
+    shadowCam.near = NCZ.SHADOW_CAM_NEAR;
+    shadowCam.far  = NCZ.SHADOW_CAM_FAR;
+    shadowCam.updateProjectionMatrix();
+
+    // Keep the sun light SUN_DIST up the sun ray from the footprint centre.
+    // Orthographic ⇒ only the direction matters for shading; the distance just
+    // places the shadow camera comfortably above the footprint so nothing clips.
+    // Three copies these into the shadow camera during the shadow pass.
+    _dirLight.target.position.copy(center);
+    _dirLight.position.copy(center).addScaledVector(_sunDir, NCZ.SUN_DIST);
+
+    if (renderer) renderer.shadowMap.needsUpdate = true;  // shadowMap.autoUpdate is off
   }
 
   function setShadowsEnabled(enabled) {
     _shadowsOn = enabled;
-    const intensity = enabled ? 1 : 0;
-    // Toggle shadow *intensity* rather than the light's castShadow flag or
-    // renderer.shadowMap.enabled — both tear shadow depth textures down
-    // mid-frame and crash WebGPURenderer ("Cannot read properties of null
-    // (reading 'depthTexture')"). intensity 0 keeps the textures alive but
-    // contributes no darkening; ShadowNode reads it via a live `reference` node,
-    // so the change applies on the next render with no recompile. Set both the
-    // template (so a not-yet-_init'd CSM clones the right value) and any live
-    // cascade lights. NB: the shadow pass still runs at intensity 0 — this is a
-    // visual switch, not a perf one (the deferred mobile-perf pass owns that).
-    if (_dirLight) _dirLight.shadow.intensity = intensity;
-    if (_csm) for (const l of _csm.lights) l.shadow.intensity = intensity;
+    // Toggle shadow *intensity*, not castShadow or renderer.shadowMap.enabled —
+    // either of those tears the shadow depth texture down mid-frame and crashes
+    // WebGPURenderer ("Cannot read properties of null (reading 'depthTexture')").
+    // intensity 0 keeps the texture alive but contributes no darkening; ShadowNode
+    // reads it via a live `reference` node, so it applies next render with no
+    // recompile. (The shadow pass still runs at intensity 0 — a visual switch,
+    // not a perf one; disabling the pass safely under WebGPU is deferred.)
+    if (_dirLight) _dirLight.shadow.intensity = enabled ? 1 : 0;
     requestRender();
   }
 


### PR DESCRIPTION
**WebGPU migration — Phase 3.** Replaces the WebGL-era shadow + lighting setup with an outdoor-style model designed for our camera shape.

> Note: started as CSMShadowNode (`webgpu_shadowmap_csm` pattern) — see the commit history — but cascaded shadow maps front-load resolution by exploiting *perspective* foreshortening, and our schema camera is **orthographic** (uniform pixels-per-world-unit). CSM there only split the texel budget for no gain and ballooned into coarse blocky terrain self-shadow ("shadow boxes") at zoomed-out + max tilt. Pivoted to a **single shadow map fitted to the visible-ground footprint** — the [`shadowMapping` WebGPU sample](https://github.com/webgpu/webgpu-samples/tree/main/sample/shadowMapping) pattern, which is what Three's plain `DirectionalLightShadow` does internally. Simpler *and* sharper here. (Branch name is now a misnomer; the squash-merge commit won't be.)

## Shadows — one fitted `depth32float` map

- `updateShadowCamera(renderCam = camera)` fits a single `OrthographicCamera` each move to exactly the visible-ground footprint: a `W×D` rectangle (`W` = screen-horizontal world extent, `D` = screen-vertical extent / `cos(tilt)` — a tilted view sees a longer strip), shadow camera = a square of side = that rectangle's diagonal (covers it from any sun azimuth), capped at `SHADOW_MAX_DISTANCE`, + `SHADOW_GROUND_MARGIN`. Re-centres the sun light + its target on the footprint so the shadow tracks the view. For the showcase fly cam: a fixed-distance square centred where the cam's forward ray meets `Y=0`.
- `renderer.shadowMap.autoUpdate = false`; `updateShadowCamera()` (camera/resize/post-terrain/post-flyover) and `setSunPosition()` (sun moved) raise `needsUpdate`. Renders that change nothing geometric skip the shadow pass. 1× geometry per frame (no cascade re-renders).
- `SHADOW_BIAS` / `SHADOW_NORMAL_BIAS` = **0** — native `depth32float` + reverse-Z + a tight map need no cushion (verified: no acne, no peter-panning). The `-0.0005` / `0.01` values were for the WebGL RGBA8-packed depth path. Left as re-arm knobs.
- The negative `CAMERA_NEAR` is a non-issue now — it only mattered for CSM's view-Z-based cascade selection; a single-map shadow lookup doesn't care. No proxy camera.
- `setSunPosition` no longer positions the light; it tracks a `_sunDir` unit vector. `updateShadowCamera` places the light `SUN_DIST` up the sun ray from the footprint centre (orthographic ⇒ only the *direction* matters for shading; the distance just keeps the shadow camera above so nothing clips). Avoids the sun-drag-while-panned desync a reset-to-world-centre would have with a tight map.
- "shadows" layer toggle → `_dirLight.shadow.intensity` (live `reference` node, no teardown — toggling `castShadow` or `renderer.shadowMap.enabled` crashes WebGPURenderer with the `depthTexture` null). Resolves the Phase 2A workaround. NB: the shadow pass still runs at intensity 0 (visual switch, not a perf one — disabling the pass safely under WebGPU is deferred).

## Lighting — "lit like it's outside"

- `AmbientLight` → **`HemisphereLight`**: hazy cool sky-colour from above, dark ground-colour bounce from below. Building tops catch the sky, vertical faces get a 50/50 mix → subtle face-to-face contrast for free. The sky tint warms toward sunset; intensity tracks the day (same ramp as the sun's colour/intensity).
- Sun arc unchanged: SunCalc → Morro Bay (35.37°N, −120.85°W), summer solstice → azimuth/altitude → light direction; the time-of-day slider + showcase flyover animate through it. (SunCalc / lighting were already renderer-agnostic — the genuinely WebGL→WebGPU part was the shadow's *storage*, which Phase 1 got for free.)

## Constants (`constants.js`)

Removed `SHADOW_CASCADES`, `SHADOW_PROXY_DEPTH_SLACK`, `SHADOW_LIGHT_MARGIN`. Added `SHADOW_GROUND_MARGIN` (600). `SHADOW_MAP_SIZE` 2048→4096 (single map). `SHADOW_MAX_DISTANCE` → 12000 (cap on the footprint half-side; clean unshadowed falloff past it; never bites at normal zooms). `SHADOW_CAM_FAR` 30000→40000, `SUN_DIST` 8000→22000 (so the whole footprint stays in front of the shadow camera even at a low sun). `SHADOW_BIAS`/`SHADOW_NORMAL_BIAS` stay 0.

## Net

~70 fewer lines than the CSM version. No cascade machinery, no proxy camera, no cascade-coarseness boxes, 1× shadow-pass cost (no perf risk). Trade vs CSM: at extreme tilt the near ground is uniformly coarser than CSM's near cascade would be — but uniform (no artifact), and at that view individual building shadows are sub-pixel anyway.

## Still needs interactive verification

- [ ] Shadow quality vs current `dev` at the 5 canonical viewpoints (esp. #1 downtown, #3 far Watson); the "shadow boxes" should be gone.
- [ ] The hemisphere fill reads well across themes / through the day.
- [ ] Shadow-pass cost on the Radeon 840M (single 4096² map + 1× geometry — should be ≈ the old WebGL build, no CSM N× multiplier).
- [ ] `shadowMap.autoUpdate = false` / `needsUpdate` honoured by `WebGPURenderer`.
- [ ] Flyover: shadows track the fly cam; on/off toggle doesn't crash.
- [ ] WebGL2 fallback (`forceWebGL: true`) — no CSM addon now, so this should "just work".

## Known residual (follow-up, post-migration)

Off-screen building shadows: Phase 2B compute-culls buildings to the *camera* frustum, so the shadow pass (same culled set) misses casters just outside the view → shadows pop in at screen edges on pan. Fix = a shadow-cascade-aware union frustum for the cull (or a separate un-culled shadow-caster pass) — easier to reason about now with one shadow frustum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)