### PR TITLE
feat(3d): SeeThrough-roads stencil port — water in transparent pass (Phase 4)

### DIFF
--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -605,13 +605,26 @@ const ThreeScene = (() => {
 
       terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88');
       // Water writes stencil=2 — SeeThrough roads only render where stencil==2 (Pacifica tunnel).
+      // The water GLB is a sea-level sheet the whole terrain pokes through, so its
+      // stencilZPass write is only correct if it's confined to "pixels where water is
+      // the visible surface" = the open bay. Two things to make that true:
+      //   1. renderOrder so water draws LAST among opaques (terrain/cliffs/buildings/
+      //      landmarks are all at renderOrder 0) — otherwise water writes stencil=2
+      //      before the terrain that should occlude it has even drawn.
+      //   2. depthFunc:LessDepth → under reverse-Z that maps to a STRICT `greater`
+      //      compare (vs the default `greater-equal`). So where the flat city terrain
+      //      is roughly coplanar with the sea-level sheet, water fails the depth test
+      //      and writes nothing; it only passes (and writes stencil=2 + its colour)
+      //      where it's *strictly* in front of everything = the bay floor / open water.
+      //      Cost: the ocean colour stops a sub-pixel sliver short of the shoreline
+      //      (coplanar there too) — invisible at map zoom.
       // ?debug=stencil → instead, render water bright magenta on top of everything
-      // (depthTest off, huge renderOrder) so we can see the water mesh's screen
-      // footprint = the pixels its stencil-2 write would reach. No stencil in that mode.
+      // (depthTest off, huge renderOrder) to see the water mesh's full screen footprint.
       const _debugStencil = new URLSearchParams(window.location.search).get('debug') === 'stencil';
       waterMat   = makeHillshadeMaterial('--scene-water', '#2a3f57', _debugStencil
         ? { color: 0xff00ff, transparent: true, opacity: 0.55, depthTest: false, depthWrite: false }
-        : { stencilWrite: true, stencilRef: 2, stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp });
+        : { stencilWrite: true, stencilRef: 2, stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
+            depthFunc: THREE.LessDepth });
       cliffsMat  = makeHillshadeMaterial('--scene-cliffs',   '#566c88');
       applyMaterial(terrainScene, terrainMat);
       applyMaterial(waterScene,   waterMat);
@@ -619,6 +632,8 @@ const ThreeScene = (() => {
       if (_debugStencil) {
         waterScene.traverse(c => { if (c.isMesh) c.renderOrder = 99999; });
         console.warn('[NCZ] ?debug=stencil active — magenta tint = water mesh screen coverage (stencil disabled in this mode)');
+      } else {
+        waterScene.traverse(c => { if (c.isMesh) c.renderOrder = 2; }); // draw water after every renderOrder-0 opaque (see above)
       }
 
       // Shadow flags — terrain and cliffs cast and receive (hills shadow valleys);

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -604,7 +604,18 @@ const ThreeScene = (() => {
       ]);
 
       terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88');
-      // Water writes stencil=2 — SeeThrough roads only render where stencil==2 (Pacifica tunnel)
+      // Water writes stencil=2 from its color pass; SeeThrough roads only render
+      // where stencil==2 — the Pacifica tunnel (a road under visible open water).
+      // The mask MUST be depth-limited to "pixels where water is the visible
+      // surface": the water GLB is a flat sea-level plane that the terrain pokes
+      // up through, so if water draws BEFORE the terrain/buildings that occlude
+      // it, its stencilZPass writes 2 over the whole screen (land included) and
+      // every SeeThrough road shows through everything. WebGL got this for free
+      // because the front-to-back opaque sort happened to put terrain first;
+      // under WebGPU it doesn't, so water's meshes get an explicit renderOrder
+      // (below) that forces them to draw LAST among opaques — then water's depth
+      // test sees the land/buildings in front of it, depth-fails over them, and
+      // only the genuinely-visible bay (incl. the tunnel inlet) keeps stencil=2.
       waterMat   = makeHillshadeMaterial('--scene-water', '#2a3f57', {
         stencilWrite: true, stencilRef: 2,
         stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
@@ -616,8 +627,10 @@ const ThreeScene = (() => {
 
       // Shadow flags — terrain and cliffs cast and receive (hills shadow valleys);
       // water receives only (no hard shadow edges on flat ocean); buildings skipped.
+      // Water also gets renderOrder=2 so it draws after every renderOrder-0 opaque
+      // (terrain, cliffs, buildings, landmarks) — see the stencil note above.
       terrainScene.traverse(c => { if (c.isMesh) { c.castShadow = true; c.receiveShadow = true; c.frustumCulled = false; } });
-      waterScene.traverse(c =>   { if (c.isMesh) { c.receiveShadow = true; c.frustumCulled = false; } });
+      waterScene.traverse(c =>   { if (c.isMesh) { c.receiveShadow = true; c.frustumCulled = false; c.renderOrder = 2; } });
       cliffsScene.traverse(c =>  { if (c.isMesh) { c.castShadow = true; c.receiveShadow = true; c.frustumCulled = false; } });
 
 

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -603,35 +603,13 @@ const ThreeScene = (() => {
         loadGLB('3dmap_cliffs.glb'),
       ]);
 
-      // SeeThrough-roads stencil chain (Pacifica tunnel). Two writers feed it —
-      // the same pair the WebGL build used (water=2, buildings=1), except water's
-      // "2" now comes from a depth-independent silhouette pass instead of being a
-      // side effect of water's color pass:
-      //  • the water silhouette mask (created below) stamps stencil=2 onto every
-      //    pixel the water mesh covers on screen, with NO depth test — a pure 2D
-      //    coverage mark, not an "is water the frontmost surface here?" test. That
-      //    distinction is the whole fix: under WebGPU's reverse-Z `greater` depth
-      //    compare, water's color-pass depth-test result at coplanar terrain/cliff
-      //    seams flips with the opaque draw order (= camera angle), which made the
-      //    old "water writes stencil from its color pass" intermittent (tunnel
-      //    visible from some rotations only).
-      //  • buildings over-stamp stencil=1 where their *visible* fragments sit
-      //    (depth-tested, ZPass only — see buildBuildingMaterial), so SeeThrough
-      //    roads don't render through a building's camera-facing face.
-      // Terrain/cliffs deliberately DON'T touch the stencil: the terrain mesh's
-      // ocean-floor portion is the frontmost surface at the tunnel-mouth pixels at
-      // the moment terrain draws (water's color mesh hasn't drawn yet), so a
-      // stencil=1 over-stamp there would wipe the mask's 2 before the SeeThrough
-      // road reads it — the WebGL build avoided this by never having terrain write
-      // stencil. (Trade-off: if water mesh extends behind a hill in screen space,
-      // a SeeThrough road there could punch through the hill — not observed at the
-      // canonical viewpoints; revisit with a targeted guard if it shows up.)
-      // SeeThrough roads (depthTest:false, stencilFunc:Equal, ref:2 — set in
-      // loadRoadsMetro) then draw only where stencil is still 2 == water visible,
-      // nothing opaque in front == the underwater tunnel.
       terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88');
-      waterMat   = makeHillshadeMaterial('--scene-water',   '#2a3f57');  // color pass only — the silhouette mask owns the stencil
-      cliffsMat  = makeHillshadeMaterial('--scene-cliffs',  '#566c88');
+      // Water writes stencil=2 — SeeThrough roads only render where stencil==2 (Pacifica tunnel)
+      waterMat   = makeHillshadeMaterial('--scene-water', '#2a3f57', {
+        stencilWrite: true, stencilRef: 2,
+        stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
+      });
+      cliffsMat  = makeHillshadeMaterial('--scene-cliffs',   '#566c88');
       applyMaterial(terrainScene, terrainMat);
       applyMaterial(waterScene,   waterMat);
       applyMaterial(cliffsScene,  cliffsMat);
@@ -654,36 +632,6 @@ const ThreeScene = (() => {
       nameSubtree(terrainScene, 'terrain');
       nameSubtree(waterScene,   'water');
       nameSubtree(cliffsScene,  'cliffs');
-
-      // Water silhouette → stencil=2 (see the stencil-chain comment above).
-      // A colorless clone of the water mesh whose only job is to stamp stencil=2
-      // onto every pixel the water mesh covers. renderOrder -1000 runs it before
-      // the depth-tested writer (buildings at renderOrder 0). Parented under
-      // waterScene so it inherits the "water" layer toggle and is frozen by
-      // freezeStatic(waterScene) below; added after nameSubtree(waterScene) so
-      // the rest of the water subtree keeps its descriptive names; shares
-      // geometry with the original water meshes (Mesh.clone() doesn't deep-copy
-      // geometry).
-      //
-      // depthFunc:Always (rather than depthTest:false) keeps the WebGPU pipeline's
-      // depth-stencil state alive — if `depthTest:false` makes Three's backend
-      // omit that state, the stencil ops go down with it and nothing gets written.
-      // The depth test then always passes ⇒ stencilZPass (Replace,2) always fires;
-      // depthWrite:false keeps it out of the depth buffer.
-      const waterMaskMat = new THREE.MeshBasicNodeMaterial({
-        colorWrite: false,
-        depthWrite: false,
-        depthFunc:  THREE.AlwaysDepth,
-        stencilWrite: true, stencilRef: 2,
-        stencilFunc: THREE.AlwaysStencilFunc,
-        stencilZPass: THREE.ReplaceStencilOp, stencilZFail: THREE.ReplaceStencilOp,
-      });
-      const waterMask = waterScene.clone();
-      applyMaterial(waterMask, waterMaskMat);
-      waterMask.name = 'water-stencil-mask';
-      nameSubtree(waterMask, 'water-mask');
-      waterMask.traverse(c => { if (c.isMesh) { c.renderOrder = -1000; c.castShadow = false; c.receiveShadow = false; c.frustumCulled = false; } });
-      waterScene.add(waterMask);
 
       layers.terrain = terrainScene;
       layers.water   = waterScene;
@@ -1173,6 +1121,12 @@ const ThreeScene = (() => {
 
         group.add(mesh);
         buildingMeshes.push(mesh);
+        // Write stencil=1 so SeeThrough roads are blocked where buildings are
+        mat.stencilWrite = true;
+        mat.stencilRef   = 1;
+        mat.stencilFunc  = THREE.AlwaysStencilFunc;
+        mat.stencilZPass = THREE.ReplaceStencilOp;
+        mat.needsUpdate  = true;
         buildingMaterials.push(mat);
         stepProgress(); // one building district done
         console.log(`[NCZ] Buildings [${meta.name}]: ${validCount.toLocaleString()} instances`);
@@ -1226,14 +1180,6 @@ const ThreeScene = (() => {
   function buildBuildingMaterial(meta, mTex, instanceMatricesBuffer, visibleIndicesBuffer) {
     const mat = new THREE.MeshLambertNodeMaterial({
       color: readThemeColor('--scene-buildings', '#7a8fa0'),
-      // Over-stamp the water silhouette mask (stencil=2) with stencil=1 where a
-      // building's *visible* fragments sit, so SeeThrough roads (test stencil==2)
-      // don't render through buildings. Depth-tested write (ZPass only) ⇒ only the
-      // camera-facing surface counts. Set at construction (WebGPU NodeMaterial
-      // wants pipeline-affecting flags before first render — post-construction
-      // mutation isn't reliably picked up the way WebGL's onBeforeCompile path was).
-      stencilWrite: true, stencilRef: 1,
-      stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
     });
 
     // Per-district uniforms (the equivalents of the WebGL onBeforeCompile uniforms)

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -603,31 +603,35 @@ const ThreeScene = (() => {
         loadGLB('3dmap_cliffs.glb'),
       ]);
 
-      // SeeThrough-roads stencil chain (Pacifica tunnel). Three writers feed it:
+      // SeeThrough-roads stencil chain (Pacifica tunnel). Two writers feed it —
+      // the same pair the WebGL build used (water=2, buildings=1), except water's
+      // "2" now comes from a depth-independent silhouette pass instead of being a
+      // side effect of water's color pass:
       //  • the water silhouette mask (created below) stamps stencil=2 onto every
-      //    pixel the water mesh covers on screen — depth-test DISABLED, so it's a
-      //    pure 2D coverage mark, not an "is water the frontmost surface here?"
-      //    test. That distinction matters: under WebGPU's reverse-Z `greater`
-      //    depth compare, water's color-pass depth-test result at coplanar
-      //    terrain/cliff seams flips with the opaque draw order (= camera angle),
-      //    which is what made the old WebGL-style "water writes stencil as a side
-      //    effect of its color pass" intermittent (tunnel visible from some
-      //    rotations only).
-      //  • terrain and cliffs over-stamp stencil=1 where their *visible* fragments
-      //    sit (depth-tested, ZPass only — so only the frontmost surface counts),
-      //    re-introducing occlusion-awareness: a hill in front of distant water
-      //    carves the mask back to 1 so SeeThrough roads don't punch through it.
-      //  • buildings do the same stencil=1 over-stamp (see buildBuildingMaterial).
+      //    pixel the water mesh covers on screen, with NO depth test — a pure 2D
+      //    coverage mark, not an "is water the frontmost surface here?" test. That
+      //    distinction is the whole fix: under WebGPU's reverse-Z `greater` depth
+      //    compare, water's color-pass depth-test result at coplanar terrain/cliff
+      //    seams flips with the opaque draw order (= camera angle), which made the
+      //    old "water writes stencil from its color pass" intermittent (tunnel
+      //    visible from some rotations only).
+      //  • buildings over-stamp stencil=1 where their *visible* fragments sit
+      //    (depth-tested, ZPass only — see buildBuildingMaterial), so SeeThrough
+      //    roads don't render through a building's camera-facing face.
+      // Terrain/cliffs deliberately DON'T touch the stencil: the terrain mesh's
+      // ocean-floor portion is the frontmost surface at the tunnel-mouth pixels at
+      // the moment terrain draws (water's color mesh hasn't drawn yet), so a
+      // stencil=1 over-stamp there would wipe the mask's 2 before the SeeThrough
+      // road reads it — the WebGL build avoided this by never having terrain write
+      // stencil. (Trade-off: if water mesh extends behind a hill in screen space,
+      // a SeeThrough road there could punch through the hill — not observed at the
+      // canonical viewpoints; revisit with a targeted guard if it shows up.)
       // SeeThrough roads (depthTest:false, stencilFunc:Equal, ref:2 — set in
       // loadRoadsMetro) then draw only where stencil is still 2 == water visible,
       // nothing opaque in front == the underwater tunnel.
-      const stencilOverstamp = {
-        stencilWrite: true, stencilRef: 1,
-        stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
-      };
-      terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88', stencilOverstamp);
-      waterMat   = makeHillshadeMaterial('--scene-water',   '#2a3f57');  // color pass only — the mask owns the stencil
-      cliffsMat  = makeHillshadeMaterial('--scene-cliffs',  '#566c88', stencilOverstamp);
+      terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88');
+      waterMat   = makeHillshadeMaterial('--scene-water',   '#2a3f57');  // color pass only — the silhouette mask owns the stencil
+      cliffsMat  = makeHillshadeMaterial('--scene-cliffs',  '#566c88');
       applyMaterial(terrainScene, terrainMat);
       applyMaterial(waterScene,   waterMat);
       applyMaterial(cliffsScene,  cliffsMat);
@@ -652,16 +656,24 @@ const ThreeScene = (() => {
       nameSubtree(cliffsScene,  'cliffs');
 
       // Water silhouette → stencil=2 (see the stencil-chain comment above).
-      // A colorless, depth-test-disabled clone of the water mesh; renderOrder
-      // -1000 runs it before the depth-tested over-stampers (terrain/cliffs/
-      // buildings at renderOrder 0) so they get the last word on occluded
-      // pixels. Parented under waterScene so it inherits the "water" layer
-      // toggle and is frozen by freezeStatic(waterScene) below. Added after
-      // nameSubtree(waterScene) so its own descriptive names aren't clobbered;
-      // shares geometry with the original water meshes (Mesh.clone() doesn't
-      // deep-copy geometry).
+      // A colorless clone of the water mesh whose only job is to stamp stencil=2
+      // onto every pixel the water mesh covers. renderOrder -1000 runs it before
+      // the depth-tested writer (buildings at renderOrder 0). Parented under
+      // waterScene so it inherits the "water" layer toggle and is frozen by
+      // freezeStatic(waterScene) below; added after nameSubtree(waterScene) so
+      // the rest of the water subtree keeps its descriptive names; shares
+      // geometry with the original water meshes (Mesh.clone() doesn't deep-copy
+      // geometry).
+      //
+      // depthFunc:Always (rather than depthTest:false) keeps the WebGPU pipeline's
+      // depth-stencil state alive — if `depthTest:false` makes Three's backend
+      // omit that state, the stencil ops go down with it and nothing gets written.
+      // The depth test then always passes ⇒ stencilZPass (Replace,2) always fires;
+      // depthWrite:false keeps it out of the depth buffer.
       const waterMaskMat = new THREE.MeshBasicNodeMaterial({
-        colorWrite: false, depthTest: false, depthWrite: false,
+        colorWrite: false,
+        depthWrite: false,
+        depthFunc:  THREE.AlwaysDepth,
         stencilWrite: true, stencilRef: 2,
         stencilFunc: THREE.AlwaysStencilFunc,
         stencilZPass: THREE.ReplaceStencilOp, stencilZFail: THREE.ReplaceStencilOp,

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -604,33 +604,27 @@ const ThreeScene = (() => {
       ]);
 
       terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88');
-      // Water writes stencil=2 from its color pass; SeeThrough roads only render
-      // where stencil==2 — the Pacifica tunnel (a road under visible open water).
-      // The mask MUST be depth-limited to "pixels where water is the visible
-      // surface": the water GLB is a flat sea-level plane that the terrain pokes
-      // up through, so if water draws BEFORE the terrain/buildings that occlude
-      // it, its stencilZPass writes 2 over the whole screen (land included) and
-      // every SeeThrough road shows through everything. WebGL got this for free
-      // because the front-to-back opaque sort happened to put terrain first;
-      // under WebGPU it doesn't, so water's meshes get an explicit renderOrder
-      // (below) that forces them to draw LAST among opaques — then water's depth
-      // test sees the land/buildings in front of it, depth-fails over them, and
-      // only the genuinely-visible bay (incl. the tunnel inlet) keeps stencil=2.
-      waterMat   = makeHillshadeMaterial('--scene-water', '#2a3f57', {
-        stencilWrite: true, stencilRef: 2,
-        stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
-      });
+      // Water writes stencil=2 — SeeThrough roads only render where stencil==2 (Pacifica tunnel).
+      // ?debug=stencil → instead, render water bright magenta on top of everything
+      // (depthTest off, huge renderOrder) so we can see the water mesh's screen
+      // footprint = the pixels its stencil-2 write would reach. No stencil in that mode.
+      const _debugStencil = new URLSearchParams(window.location.search).get('debug') === 'stencil';
+      waterMat   = makeHillshadeMaterial('--scene-water', '#2a3f57', _debugStencil
+        ? { color: 0xff00ff, transparent: true, opacity: 0.55, depthTest: false, depthWrite: false }
+        : { stencilWrite: true, stencilRef: 2, stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp });
       cliffsMat  = makeHillshadeMaterial('--scene-cliffs',   '#566c88');
       applyMaterial(terrainScene, terrainMat);
       applyMaterial(waterScene,   waterMat);
       applyMaterial(cliffsScene,  cliffsMat);
+      if (_debugStencil) {
+        waterScene.traverse(c => { if (c.isMesh) c.renderOrder = 99999; });
+        console.warn('[NCZ] ?debug=stencil active — magenta tint = water mesh screen coverage (stencil disabled in this mode)');
+      }
 
       // Shadow flags — terrain and cliffs cast and receive (hills shadow valleys);
       // water receives only (no hard shadow edges on flat ocean); buildings skipped.
-      // Water also gets renderOrder=2 so it draws after every renderOrder-0 opaque
-      // (terrain, cliffs, buildings, landmarks) — see the stencil note above.
       terrainScene.traverse(c => { if (c.isMesh) { c.castShadow = true; c.receiveShadow = true; c.frustumCulled = false; } });
-      waterScene.traverse(c =>   { if (c.isMesh) { c.receiveShadow = true; c.frustumCulled = false; c.renderOrder = 2; } });
+      waterScene.traverse(c =>   { if (c.isMesh) { c.receiveShadow = true; c.frustumCulled = false; } });
       cliffsScene.traverse(c =>  { if (c.isMesh) { c.castShadow = true; c.receiveShadow = true; c.frustumCulled = false; } });
 
 

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -603,21 +603,31 @@ const ThreeScene = (() => {
         loadGLB('3dmap_cliffs.glb'),
       ]);
 
-      terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88');
-      // Water writes stencil=2 — SeeThrough roads only render where stencil==2 (Pacifica tunnel).
-      // stencilZFail: Replace fixes a WebGPU reverse-Z regression where water's depth-test
-      // result flipped at certain camera rotations (suspected coplanar-fragment edge: WebGL
-      // `lessEqual` accepted coplanar terrain/water meshes; reverse-Z `greater` rejects them),
-      // dropping stencil=2 in patches of the tunnel surface. Writing stencil regardless of the
-      // depth result keeps the mask intact — buildings' Replace→1 still overwrites it where
-      // they sit, so SeeThrough roads still respect building occlusion.
-      waterMat   = makeHillshadeMaterial('--scene-water', '#2a3f57', {
-        stencilWrite: true, stencilRef: 2,
-        stencilFunc: THREE.AlwaysStencilFunc,
-        stencilZPass: THREE.ReplaceStencilOp,
-        stencilZFail: THREE.ReplaceStencilOp,
-      });
-      cliffsMat  = makeHillshadeMaterial('--scene-cliffs',   '#566c88');
+      // SeeThrough-roads stencil chain (Pacifica tunnel). Three writers feed it:
+      //  • the water silhouette mask (created below) stamps stencil=2 onto every
+      //    pixel the water mesh covers on screen — depth-test DISABLED, so it's a
+      //    pure 2D coverage mark, not an "is water the frontmost surface here?"
+      //    test. That distinction matters: under WebGPU's reverse-Z `greater`
+      //    depth compare, water's color-pass depth-test result at coplanar
+      //    terrain/cliff seams flips with the opaque draw order (= camera angle),
+      //    which is what made the old WebGL-style "water writes stencil as a side
+      //    effect of its color pass" intermittent (tunnel visible from some
+      //    rotations only).
+      //  • terrain and cliffs over-stamp stencil=1 where their *visible* fragments
+      //    sit (depth-tested, ZPass only — so only the frontmost surface counts),
+      //    re-introducing occlusion-awareness: a hill in front of distant water
+      //    carves the mask back to 1 so SeeThrough roads don't punch through it.
+      //  • buildings do the same stencil=1 over-stamp (see buildBuildingMaterial).
+      // SeeThrough roads (depthTest:false, stencilFunc:Equal, ref:2 — set in
+      // loadRoadsMetro) then draw only where stencil is still 2 == water visible,
+      // nothing opaque in front == the underwater tunnel.
+      const stencilOverstamp = {
+        stencilWrite: true, stencilRef: 1,
+        stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
+      };
+      terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88', stencilOverstamp);
+      waterMat   = makeHillshadeMaterial('--scene-water',   '#2a3f57');  // color pass only — the mask owns the stencil
+      cliffsMat  = makeHillshadeMaterial('--scene-cliffs',  '#566c88', stencilOverstamp);
       applyMaterial(terrainScene, terrainMat);
       applyMaterial(waterScene,   waterMat);
       applyMaterial(cliffsScene,  cliffsMat);
@@ -640,6 +650,28 @@ const ThreeScene = (() => {
       nameSubtree(terrainScene, 'terrain');
       nameSubtree(waterScene,   'water');
       nameSubtree(cliffsScene,  'cliffs');
+
+      // Water silhouette → stencil=2 (see the stencil-chain comment above).
+      // A colorless, depth-test-disabled clone of the water mesh; renderOrder
+      // -1000 runs it before the depth-tested over-stampers (terrain/cliffs/
+      // buildings at renderOrder 0) so they get the last word on occluded
+      // pixels. Parented under waterScene so it inherits the "water" layer
+      // toggle and is frozen by freezeStatic(waterScene) below. Added after
+      // nameSubtree(waterScene) so its own descriptive names aren't clobbered;
+      // shares geometry with the original water meshes (Mesh.clone() doesn't
+      // deep-copy geometry).
+      const waterMaskMat = new THREE.MeshBasicNodeMaterial({
+        colorWrite: false, depthTest: false, depthWrite: false,
+        stencilWrite: true, stencilRef: 2,
+        stencilFunc: THREE.AlwaysStencilFunc,
+        stencilZPass: THREE.ReplaceStencilOp, stencilZFail: THREE.ReplaceStencilOp,
+      });
+      const waterMask = waterScene.clone();
+      applyMaterial(waterMask, waterMaskMat);
+      waterMask.name = 'water-stencil-mask';
+      nameSubtree(waterMask, 'water-mask');
+      waterMask.traverse(c => { if (c.isMesh) { c.renderOrder = -1000; c.castShadow = false; c.receiveShadow = false; c.frustumCulled = false; } });
+      waterScene.add(waterMask);
 
       layers.terrain = terrainScene;
       layers.water   = waterScene;
@@ -1129,12 +1161,6 @@ const ThreeScene = (() => {
 
         group.add(mesh);
         buildingMeshes.push(mesh);
-        // Write stencil=1 so SeeThrough roads are blocked where buildings are
-        mat.stencilWrite = true;
-        mat.stencilRef   = 1;
-        mat.stencilFunc  = THREE.AlwaysStencilFunc;
-        mat.stencilZPass = THREE.ReplaceStencilOp;
-        mat.needsUpdate  = true;
         buildingMaterials.push(mat);
         stepProgress(); // one building district done
         console.log(`[NCZ] Buildings [${meta.name}]: ${validCount.toLocaleString()} instances`);
@@ -1188,6 +1214,14 @@ const ThreeScene = (() => {
   function buildBuildingMaterial(meta, mTex, instanceMatricesBuffer, visibleIndicesBuffer) {
     const mat = new THREE.MeshLambertNodeMaterial({
       color: readThemeColor('--scene-buildings', '#7a8fa0'),
+      // Over-stamp the water silhouette mask (stencil=2) with stencil=1 where a
+      // building's *visible* fragments sit, so SeeThrough roads (test stencil==2)
+      // don't render through buildings. Depth-tested write (ZPass only) ⇒ only the
+      // camera-facing surface counts. Set at construction (WebGPU NodeMaterial
+      // wants pipeline-affecting flags before first render — post-construction
+      // mutation isn't reliably picked up the way WebGL's onBeforeCompile path was).
+      stencilWrite: true, stencilRef: 1,
+      stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
     });
 
     // Per-district uniforms (the equivalents of the WebGL onBeforeCompile uniforms)

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -603,25 +603,30 @@ const ThreeScene = (() => {
         loadGLB('3dmap_cliffs.glb'),
       ]);
 
-      terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88');
-      // Water writes stencil=2 — SeeThrough roads only render where stencil==2 (Pacifica tunnel).
-      // The water GLB is a flat sea-level sheet (world Y ≈ -1) the whole terrain (Y -99..+879)
-      // pokes through. For the stencilZPass write to land only on "pixels where water is the
-      // visible surface" (the open bay = where the terrain dips below sea level), water must
-      // be depth-tested against the FULLY-rendered opaque scene. `transparent: true` (with
-      // opacity 1.0 — still looks opaque) moves water out of the opaque list into the
-      // transparent pass, which is unconditionally rendered after every opaque object — so its
-      // depth test sees terrain/cliffs/buildings already in the depth buffer and fails over all
-      // of them, confining stencil=2 to the bay. (Plain renderOrder doesn't work here: the
-      // opaque sort key order is groupOrder→renderOrder→z, and something keeps water sorting
-      // before terrain regardless; moving to the transparent pass sidesteps the sort entirely.)
-      // renderOrder stays 0, so water still draws before the SeeThrough roads (renderOrder 1).
-      waterMat   = makeHillshadeMaterial('--scene-water', '#2a3f57', {
-        transparent: true,  // opacity stays 1.0 — visually opaque; this just puts water in the post-opaque pass
+      // SeeThrough-roads stencil chain (Pacifica tunnel — a road under visible open water).
+      //   • Water writes stencil=2 where it's the visible surface. The water GLB is a flat
+      //     sea-level sheet (world Y ≈ -1) the whole terrain (Y -99..+879) pokes through, so
+      //     for stencilZPass to land only on "pixels where you see water" (the open bay = where
+      //     the terrain dips below -1), water must be depth-tested against the FULLY-rendered
+      //     opaque scene. `transparent: true` (opacity stays 1.0 — still visually opaque) moves
+      //     water out of the opaque list into the transparent pass, which is unconditionally
+      //     drawn after every opaque object — so its depth test sees terrain/cliffs/buildings
+      //     already in the depth buffer and fails over all of them, confining stencil=2 to the
+      //     bay. (Plain renderOrder doesn't push water past the terrain in the opaque sort under
+      //     WebGPURenderer — cause unclear; the transparent pass sidesteps the sort entirely.)
+      //     renderOrder stays 0, so water still draws before the SeeThrough roads (renderOrder 1).
+      //   • Terrain, cliffs and buildings over-stamp stencil=1 where THEY are the visible surface
+      //     (depth-tested, ZPass:Replace) — so SeeThrough roads (stencilFunc:Equal,2) don't draw
+      //     through them. This is safe vs the tunnel because water (transparent pass) re-writes
+      //     stencil=2 over the bay AFTER the terrain seabed wrote stencil=1 there in the opaque pass.
+      const stencilOverstamp = { stencilWrite: true, stencilRef: 1, stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp };
+      terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88', stencilOverstamp);
+      waterMat   = makeHillshadeMaterial('--scene-water',   '#2a3f57', {
+        transparent: true,
         stencilWrite: true, stencilRef: 2,
         stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
       });
-      cliffsMat  = makeHillshadeMaterial('--scene-cliffs',   '#566c88');
+      cliffsMat  = makeHillshadeMaterial('--scene-cliffs',  '#566c88', stencilOverstamp);
       applyMaterial(terrainScene, terrainMat);
       applyMaterial(waterScene,   waterMat);
       applyMaterial(cliffsScene,  cliffsMat);

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -664,6 +664,19 @@ const ThreeScene = (() => {
       freezeStatic(cliffsScene);
       requestRender();
 
+      // Phase 4 diagnostic — map mesh world-space extents. Tells us whether the
+      // water sheet sits above / below / coplanar with the terrain, which decides
+      // whether the SeeThrough-stencil bug is geometry alignment or render order.
+      // (Remove once Phase 4 lands.)
+      {
+        const bbT = new THREE.Box3().setFromObject(terrainScene);
+        const bbW = new THREE.Box3().setFromObject(waterScene);
+        const bbC = new THREE.Box3().setFromObject(cliffsScene);
+        const f = v => v.toFixed(0);
+        console.log(`[NCZ Phase4] world Y — terrain ${f(bbT.min.y)}..${f(bbT.max.y)} | water ${f(bbW.min.y)}..${f(bbW.max.y)} | cliffs ${f(bbC.min.y)}..${f(bbC.max.y)}`);
+        console.log(`[NCZ Phase4] world XZ — terrain x[${f(bbT.min.x)}..${f(bbT.max.x)}] z[${f(bbT.min.z)}..${f(bbT.max.z)}] | water x[${f(bbW.min.x)}..${f(bbW.max.x)}] z[${f(bbW.min.z)}..${f(bbW.max.z)}]`);
+      }
+
       // Fit camera frustum to the terrain bounding box. Stored at module
       // scope so the pan-bound listener can clamp against terrain extent
       // (the visible square) instead of the playable-CET-world extent

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -604,10 +604,18 @@ const ThreeScene = (() => {
       ]);
 
       terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88');
-      // Water writes stencil=2 — SeeThrough roads only render where stencil==2 (Pacifica tunnel)
+      // Water writes stencil=2 — SeeThrough roads only render where stencil==2 (Pacifica tunnel).
+      // stencilZFail: Replace fixes a WebGPU reverse-Z regression where water's depth-test
+      // result flipped at certain camera rotations (suspected coplanar-fragment edge: WebGL
+      // `lessEqual` accepted coplanar terrain/water meshes; reverse-Z `greater` rejects them),
+      // dropping stencil=2 in patches of the tunnel surface. Writing stencil regardless of the
+      // depth result keeps the mask intact — buildings' Replace→1 still overwrites it where
+      // they sit, so SeeThrough roads still respect building occlusion.
       waterMat   = makeHillshadeMaterial('--scene-water', '#2a3f57', {
         stencilWrite: true, stencilRef: 2,
-        stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
+        stencilFunc: THREE.AlwaysStencilFunc,
+        stencilZPass: THREE.ReplaceStencilOp,
+        stencilZFail: THREE.ReplaceStencilOp,
       });
       cliffsMat  = makeHillshadeMaterial('--scene-cliffs',   '#566c88');
       applyMaterial(terrainScene, terrainMat);

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -605,36 +605,26 @@ const ThreeScene = (() => {
 
       terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88');
       // Water writes stencil=2 — SeeThrough roads only render where stencil==2 (Pacifica tunnel).
-      // The water GLB is a sea-level sheet the whole terrain pokes through, so its
-      // stencilZPass write is only correct if it's confined to "pixels where water is
-      // the visible surface" = the open bay. Two things to make that true:
-      //   1. renderOrder so water draws LAST among opaques (terrain/cliffs/buildings/
-      //      landmarks are all at renderOrder 0) — otherwise water writes stencil=2
-      //      before the terrain that should occlude it has even drawn.
-      //   2. depthFunc:LessDepth → under reverse-Z that maps to a STRICT `greater`
-      //      compare (vs the default `greater-equal`). So where the flat city terrain
-      //      is roughly coplanar with the sea-level sheet, water fails the depth test
-      //      and writes nothing; it only passes (and writes stencil=2 + its colour)
-      //      where it's *strictly* in front of everything = the bay floor / open water.
-      //      Cost: the ocean colour stops a sub-pixel sliver short of the shoreline
-      //      (coplanar there too) — invisible at map zoom.
-      // ?debug=stencil → instead, render water bright magenta on top of everything
-      // (depthTest off, huge renderOrder) to see the water mesh's full screen footprint.
-      const _debugStencil = new URLSearchParams(window.location.search).get('debug') === 'stencil';
-      waterMat   = makeHillshadeMaterial('--scene-water', '#2a3f57', _debugStencil
-        ? { color: 0xff00ff, transparent: true, opacity: 0.55, depthTest: false, depthWrite: false }
-        : { stencilWrite: true, stencilRef: 2, stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
-            depthFunc: THREE.LessDepth });
+      // The water GLB is a flat sea-level sheet (world Y ≈ -1) the whole terrain (Y -99..+879)
+      // pokes through. For the stencilZPass write to land only on "pixels where water is the
+      // visible surface" (the open bay = where the terrain dips below sea level), water must
+      // be depth-tested against the FULLY-rendered opaque scene. `transparent: true` (with
+      // opacity 1.0 — still looks opaque) moves water out of the opaque list into the
+      // transparent pass, which is unconditionally rendered after every opaque object — so its
+      // depth test sees terrain/cliffs/buildings already in the depth buffer and fails over all
+      // of them, confining stencil=2 to the bay. (Plain renderOrder doesn't work here: the
+      // opaque sort key order is groupOrder→renderOrder→z, and something keeps water sorting
+      // before terrain regardless; moving to the transparent pass sidesteps the sort entirely.)
+      // renderOrder stays 0, so water still draws before the SeeThrough roads (renderOrder 1).
+      waterMat   = makeHillshadeMaterial('--scene-water', '#2a3f57', {
+        transparent: true,  // opacity stays 1.0 — visually opaque; this just puts water in the post-opaque pass
+        stencilWrite: true, stencilRef: 2,
+        stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
+      });
       cliffsMat  = makeHillshadeMaterial('--scene-cliffs',   '#566c88');
       applyMaterial(terrainScene, terrainMat);
       applyMaterial(waterScene,   waterMat);
       applyMaterial(cliffsScene,  cliffsMat);
-      if (_debugStencil) {
-        waterScene.traverse(c => { if (c.isMesh) c.renderOrder = 99999; });
-        console.warn('[NCZ] ?debug=stencil active — magenta tint = water mesh screen coverage (stencil disabled in this mode)');
-      } else {
-        waterScene.traverse(c => { if (c.isMesh) c.renderOrder = 2; }); // draw water after every renderOrder-0 opaque (see above)
-      }
 
       // Shadow flags — terrain and cliffs cast and receive (hills shadow valleys);
       // water receives only (no hard shadow edges on flat ocean); buildings skipped.
@@ -663,19 +653,6 @@ const ThreeScene = (() => {
       freezeStatic(waterScene);
       freezeStatic(cliffsScene);
       requestRender();
-
-      // Phase 4 diagnostic — map mesh world-space extents. Tells us whether the
-      // water sheet sits above / below / coplanar with the terrain, which decides
-      // whether the SeeThrough-stencil bug is geometry alignment or render order.
-      // (Remove once Phase 4 lands.)
-      {
-        const bbT = new THREE.Box3().setFromObject(terrainScene);
-        const bbW = new THREE.Box3().setFromObject(waterScene);
-        const bbC = new THREE.Box3().setFromObject(cliffsScene);
-        const f = v => v.toFixed(0);
-        console.log(`[NCZ Phase4] world Y — terrain ${f(bbT.min.y)}..${f(bbT.max.y)} | water ${f(bbW.min.y)}..${f(bbW.max.y)} | cliffs ${f(bbC.min.y)}..${f(bbC.max.y)}`);
-        console.log(`[NCZ Phase4] world XZ — terrain x[${f(bbT.min.x)}..${f(bbT.max.x)}] z[${f(bbT.min.z)}..${f(bbT.max.z)}] | water x[${f(bbW.min.x)}..${f(bbW.max.x)}] z[${f(bbW.min.z)}..${f(bbW.max.z)}]`);
-      }
 
       // Fit camera frustum to the terrain bounding box. Stored at module
       // scope so the pan-bound listener can clamp against terrain extent


### PR DESCRIPTION
## Summary

Phase 4 of the WebGPU migration — port the SeeThrough-roads stencil chain (the Pacifica tunnel: a road visible *through* the open bay water). Net change vs `dev`: ~25 lines in `assets/js/three-scene.js`. (Branch history includes several abandoned approaches + their reverts + debug scaffolding — all cancel out; squash-merge gives the clean diff.)

## Root cause

`3dmap_water.glb` is a flat sea-level sheet at world Y ≈ −1 that the whole terrain (Y −99..+879) pokes through. Water writes `stencil=2` from its color pass (`stencilZPass: Replace, ref 2`); the SeeThrough roads (`stencilFunc: Equal, ref 2, depthTest: false`) render only where `stencil==2`. For that mask to land **only on pixels where water is the visible surface** (the open bay = where the terrain dips below −1 = where the underwater tunnel road sits), water's depth test has to run against the terrain that occludes it.

Under WebGL that worked because the opaque draw sort happened to put the terrain before water. Under `WebGPURenderer` the opaque sort lands differently — water draws *before* the terrain — so `stencilZPass` fires across the whole screen (against the empty depth buffer), then terrain/buildings draw on top *visually* but never clear the stencil. Net: `stencil==2` nearly everywhere → every SeeThrough road shows through everything; with the buildings layer on, the buildings' existing `stencil=1` over-stamp re-limited it *unevenly*, which presented as the rotation-dependent tunnel. Setting `renderOrder` on the water meshes did **not** push water past the terrain in the opaque list under WebGPURenderer (cause not pinned down) — so the fix sidesteps the opaque sort entirely.

## Fix

- **`transparent: true` on the water material** (opacity stays 1.0 → still renders visually opaque). This moves water out of the opaque list into the transparent pass, which is *unconditionally* drawn after the entire opaque pass — no sort-key / `groupOrder` dependency. Water's depth test then runs against the fully-populated opaque depth buffer (terrain + cliffs + buildings), depth-fails over all of them, and writes `stencil=2` only where it's strictly the visible surface = the bay. `renderOrder` stays 0 so water still draws before the SeeThrough roads (`renderOrder` 1); `depthWrite` stays true so it still occludes the surface tunnel road (only the cyan SeeThrough copy shows through).
- **Terrain + cliffs over-stamp `stencil=1`** (the same pattern buildings already use) — so SeeThrough roads stay off bare land / hills / cliffs even when the buildings layer is toggled off. Safe vs the tunnel because water (transparent pass) re-writes `stencil=2` over the bay *after* the terrain seabed wrote `stencil=1` there in the opaque pass. (This is exactly why an earlier opaque-water version of the over-stamp broke the tunnel — the seabed and water were both opaque and the seabed sometimes drew first; now water always draws last.)

## Verified

- Pacifica tunnel visible through the water at every rotation / tilt / zoom, with the buildings layer on (default) and off.
- SeeThrough roads no longer bleed through terrain / hills / cliffs / buildings.
- Ocean still renders solid (water visually opaque despite `transparent: true`).
- No regression at the other canonical viewpoints.

## Known residual (out of scope)

A road that *bridges the open bay* shows the cyan SeeThrough style over its surface copy — `stencil==2` there means "water visible at this pixel" regardless of whether the road is above or below the water, and the stencil mask can't distinguish the two. Cleanly fixing it would mean isolating the underwater tunnel geometry from the rest of the road network in the GLB (content-pipeline work). Was the same in the WebGL build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)