### PR TITLE
refactor(3d): extract stencil/water magic numbers to constants.js

### DIFF
--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -250,13 +250,9 @@ NCZ.METRO_LOD_ZOOM_NEAR = 20.0;  // B→R transition zoom threshold
 // Water (rendered in the transparent pass — see three-scene.js loadTerrain) writes
 // stencil=STENCIL_WATER where it's the visible surface; terrain/cliffs/buildings over-stamp
 // stencil=STENCIL_OCCLUDER where THEY are; the SeeThrough road pass renders where
-// stencil==STENCIL_WATER AND the fragment is below WATER_LEVEL_Y (i.e. genuinely under water —
-// so a road bridging the bay, whose deck is above the waterline, stays normal-styled rather
-// than going cyan). Road geometry world-Y spans roughly -27.5 (the tunnel deck) to +229.5
-// (elevated highways), so the waterline (≈ -1) cleanly separates "submerged" from "surface".
+// stencil==STENCIL_WATER (with depthTest off, so it draws on top of the water).
 NCZ.STENCIL_WATER    = 2;     // stencil ref written by the water mesh / tested by the SeeThrough roads
 NCZ.STENCIL_OCCLUDER = 1;     // stencil ref written by terrain / cliffs / buildings (visible-surface over-stamp)
-NCZ.WATER_LEVEL_Y    = -1;    // world Y of the 3dmap_water.glb sea-level sheet; SeeThrough road fragments below this are "under water"
 NCZ.WATER_OPACITY    = 1.0;   // water material opacity — water is in the transparent pass (so its stencil write is depth-limited to the visible bay) but renders visually opaque at 1.0; lower to make the ocean see-through
 
 // 3D pin layer (NCZ.ThreeMarkers) — visual + UX tunables for CSS2DObject markers

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -246,6 +246,19 @@ NCZ.SUBDISTRICT_ZOOM_3D = 2.5;
 NCZ.METRO_LOD_ZOOM_MED  = 8.0;   // G→B transition zoom threshold
 NCZ.METRO_LOD_ZOOM_NEAR = 20.0;  // B→R transition zoom threshold
 
+// SeeThrough roads — the Pacifica tunnel: a road visible *through* the open bay water.
+// Water (rendered in the transparent pass — see three-scene.js loadTerrain) writes
+// stencil=STENCIL_WATER where it's the visible surface; terrain/cliffs/buildings over-stamp
+// stencil=STENCIL_OCCLUDER where THEY are; the SeeThrough road pass renders where
+// stencil==STENCIL_WATER AND the fragment is below WATER_LEVEL_Y (i.e. genuinely under water —
+// so a road bridging the bay, whose deck is above the waterline, stays normal-styled rather
+// than going cyan). Road geometry world-Y spans roughly -27.5 (the tunnel deck) to +229.5
+// (elevated highways), so the waterline (≈ -1) cleanly separates "submerged" from "surface".
+NCZ.STENCIL_WATER    = 2;     // stencil ref written by the water mesh / tested by the SeeThrough roads
+NCZ.STENCIL_OCCLUDER = 1;     // stencil ref written by terrain / cliffs / buildings (visible-surface over-stamp)
+NCZ.WATER_LEVEL_Y    = -1;    // world Y of the 3dmap_water.glb sea-level sheet; SeeThrough road fragments below this are "under water"
+NCZ.WATER_OPACITY    = 1.0;   // water material opacity — water is in the transparent pass (so its stencil write is depth-limited to the visible bay) but renders visually opaque at 1.0; lower to make the ocean see-through
+
 // 3D pin layer (NCZ.ThreeMarkers) — visual + UX tunables for CSS2DObject markers
 // Used ONLY by pin/popup rendering. Mod data Z is read raw everywhere else.
 NCZ.PIN_3D_GROUND_OFFSET            =  5;  // CET metres above player CET Z — purely cosmetic lift so the diamond reads above the surface, not embedded

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -603,27 +603,32 @@ const ThreeScene = (() => {
         loadGLB('3dmap_cliffs.glb'),
       ]);
 
-      // SeeThrough-roads stencil chain (Pacifica tunnel — a road under visible open water).
-      //   • Water writes stencil=2 where it's the visible surface. The water GLB is a flat
-      //     sea-level sheet (world Y ≈ -1) the whole terrain (Y -99..+879) pokes through, so
-      //     for stencilZPass to land only on "pixels where you see water" (the open bay = where
-      //     the terrain dips below -1), water must be depth-tested against the FULLY-rendered
-      //     opaque scene. `transparent: true` (opacity stays 1.0 — still visually opaque) moves
-      //     water out of the opaque list into the transparent pass, which is unconditionally
-      //     drawn after every opaque object — so its depth test sees terrain/cliffs/buildings
-      //     already in the depth buffer and fails over all of them, confining stencil=2 to the
-      //     bay. (Plain renderOrder doesn't push water past the terrain in the opaque sort under
-      //     WebGPURenderer — cause unclear; the transparent pass sidesteps the sort entirely.)
-      //     renderOrder stays 0, so water still draws before the SeeThrough roads (renderOrder 1).
-      //   • Terrain, cliffs and buildings over-stamp stencil=1 where THEY are the visible surface
-      //     (depth-tested, ZPass:Replace) — so SeeThrough roads (stencilFunc:Equal,2) don't draw
-      //     through them. This is safe vs the tunnel because water (transparent pass) re-writes
-      //     stencil=2 over the bay AFTER the terrain seabed wrote stencil=1 there in the opaque pass.
-      const stencilOverstamp = { stencilWrite: true, stencilRef: 1, stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp };
+      // SeeThrough-roads stencil chain (Pacifica tunnel — a road visible *through* the open bay).
+      //   • Water writes stencil=STENCIL_WATER where it's the visible surface. The water GLB is a
+      //     flat sea-level sheet (world Y ≈ WATER_LEVEL_Y) the whole terrain (Y -99..+879) pokes
+      //     through, so for stencilZPass to land only on "pixels where you see water" (the open
+      //     bay = where the terrain dips below the waterline), water must be depth-tested against
+      //     the FULLY-rendered opaque scene. `transparent: true` (opacity = WATER_OPACITY, 1.0 by
+      //     default — still visually opaque) moves water out of the opaque list into the transparent
+      //     pass, which is unconditionally drawn after every opaque object — so its depth test sees
+      //     terrain/cliffs/buildings already in the depth buffer and fails over all of them,
+      //     confining stencil=STENCIL_WATER to the bay. (Plain renderOrder doesn't push water past
+      //     the terrain in the opaque sort under WebGPURenderer — cause unclear; the transparent
+      //     pass sidesteps the sort entirely.) renderOrder stays 0, so water still draws before the
+      //     SeeThrough roads (renderOrder 1).
+      //   • Terrain, cliffs and buildings over-stamp stencil=STENCIL_OCCLUDER where THEY are the
+      //     visible surface (depth-tested, ZPass:Replace) — so SeeThrough roads don't draw through
+      //     them. Safe vs the tunnel because water (transparent pass) re-writes stencil=STENCIL_WATER
+      //     over the bay AFTER the terrain seabed wrote stencil=STENCIL_OCCLUDER there in the opaque pass.
+      //   • The SeeThrough road pass itself additionally masks to fragments below WATER_LEVEL_Y
+      //     (see loadRoadsMetro) so it's confined to genuinely-submerged road — the tunnel and its
+      //     ramps as they dip under — rather than every road wherever stencil==STENCIL_WATER (which
+      //     would also catch a bridge deck over the bay).
+      const stencilOverstamp = { stencilWrite: true, stencilRef: NCZ.STENCIL_OCCLUDER, stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp };
       terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88', stencilOverstamp);
       waterMat   = makeHillshadeMaterial('--scene-water',   '#2a3f57', {
-        transparent: true,
-        stencilWrite: true, stencilRef: 2,
+        transparent: true, opacity: NCZ.WATER_OPACITY,
+        stencilWrite: true, stencilRef: NCZ.STENCIL_WATER,
         stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
       });
       cliffsMat  = makeHillshadeMaterial('--scene-cliffs',  '#566c88', stencilOverstamp);
@@ -773,18 +778,23 @@ const ThreeScene = (() => {
         return group;
       }
 
-      // SeeThrough pass: depthTest:false + stencil=EQUAL(2) → only renders where water is above road
-      // Pacifica tunnel: water writes stencil=2 → tunnel visible ✓
-      // Mountain roads: terrain has no stencil=2 → hidden ✓
-      // Buildings: stencil=1 ≠ 2 → hidden ✓
+      // SeeThrough pass — renders where stencil==STENCIL_WATER (i.e. water is the visible surface
+      // at this pixel — see the stencil-chain comment in loadTerrain) AND the fragment is below
+      // WATER_LEVEL_Y (genuinely submerged), with depthTest:false so it draws on top of the water:
+      //   Pacifica tunnel (deck ≈ Y-27.5, ramps dip under the waterline): stencil==WATER + Y < -1 → visible ✓
+      //   Surface roads / bridges over the bay (deck Y ≥ ~0): Y ≥ -1 → masked out → render normal-styled ✓
+      //   Mountain roads / city roads: terrain over-stamps stencil=OCCLUDER ≠ WATER → hidden ✓
       const stBase = {
         transparent: true, depthTest: false, depthWrite: false,
         stencilWrite: true, stencilWriteMask: 0x00,
-        stencilFunc: THREE.EqualStencilFunc, stencilRef: 2, stencilFuncMask: 0xff,
+        stencilFunc: THREE.EqualStencilFunc, stencilRef: NCZ.STENCIL_WATER, stencilFuncMask: 0xff,
         stencilFail: THREE.KeepStencilOp, stencilZFail: THREE.KeepStencilOp, stencilZPass: THREE.KeepStencilOp,
       };
       roadsMat   = new THREE.MeshBasicNodeMaterial({ ...stBase, color: roadColor,   opacity: 0.8 });
       bordersMat = new THREE.MeshBasicNodeMaterial({ ...stBase, color: borderColor, opacity: 0.6, blending: THREE.AdditiveBlending });
+      // Keep-mask: render the SeeThrough copy only where the road fragment is below the waterline.
+      roadsMat.maskNode   = positionWorld.y.lessThan(NCZ.WATER_LEVEL_Y);
+      bordersMat.maskNode = positionWorld.y.lessThan(NCZ.WATER_LEVEL_Y);
 
       applyMaterial(metroScene, metroMat);
 
@@ -796,18 +806,6 @@ const ThreeScene = (() => {
       nameSubtree(stBorders, 'road-border-st');
       stRoads.traverse(o => { if (o.isMesh) o.renderOrder = 1; });
       stBorders.traverse(o => { if (o.isMesh) o.renderOrder = 1; });
-
-      // Phase 4 follow-up diagnostic — per-mesh world-Y extents of the road geometry,
-      // to choose the "this fragment is underwater" threshold for a maskNode that
-      // confines the SeeThrough effect to the actual tunnel (vs bridges over the bay).
-      // (Remove once the threshold is picked.)
-      {
-        const _b = new THREE.Box3();
-        let _i = 0;
-        roadsScene.traverse(c => { if (c.isMesh) { _b.setFromObject(c); console.log(`[NCZ Phase4f] road mesh ${_i++} "${c.name}" Y ${_b.min.y.toFixed(1)}..${_b.max.y.toFixed(1)}`); } });
-        _b.setFromObject(roadsScene);   console.log(`[NCZ Phase4f] ALL roads Y   ${_b.min.y.toFixed(1)}..${_b.max.y.toFixed(1)}`);
-        _b.setFromObject(bordersScene); console.log(`[NCZ Phase4f] ALL borders Y ${_b.min.y.toFixed(1)}..${_b.max.y.toFixed(1)}`);
-      }
 
       const roadsGroup = new THREE.Group();
       roadsGroup.name = 'roads';
@@ -1150,9 +1148,9 @@ const ThreeScene = (() => {
 
         group.add(mesh);
         buildingMeshes.push(mesh);
-        // Write stencil=1 so SeeThrough roads are blocked where buildings are
+        // Over-stamp stencil=STENCIL_OCCLUDER so SeeThrough roads are blocked where buildings are visible
         mat.stencilWrite = true;
-        mat.stencilRef   = 1;
+        mat.stencilRef   = NCZ.STENCIL_OCCLUDER;
         mat.stencilFunc  = THREE.AlwaysStencilFunc;
         mat.stencilZPass = THREE.ReplaceStencilOp;
         mat.needsUpdate  = true;

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -605,25 +605,20 @@ const ThreeScene = (() => {
 
       // SeeThrough-roads stencil chain (Pacifica tunnel — a road visible *through* the open bay).
       //   • Water writes stencil=STENCIL_WATER where it's the visible surface. The water GLB is a
-      //     flat sea-level sheet (world Y ≈ WATER_LEVEL_Y) the whole terrain (Y -99..+879) pokes
-      //     through, so for stencilZPass to land only on "pixels where you see water" (the open
-      //     bay = where the terrain dips below the waterline), water must be depth-tested against
-      //     the FULLY-rendered opaque scene. `transparent: true` (opacity = WATER_OPACITY, 1.0 by
-      //     default — still visually opaque) moves water out of the opaque list into the transparent
-      //     pass, which is unconditionally drawn after every opaque object — so its depth test sees
-      //     terrain/cliffs/buildings already in the depth buffer and fails over all of them,
-      //     confining stencil=STENCIL_WATER to the bay. (Plain renderOrder doesn't push water past
-      //     the terrain in the opaque sort under WebGPURenderer — cause unclear; the transparent
-      //     pass sidesteps the sort entirely.) renderOrder stays 0, so water still draws before the
-      //     SeeThrough roads (renderOrder 1).
+      //     flat sea-level sheet (world Y ≈ -1) the whole terrain (Y -99..+879) pokes through, so
+      //     for stencilZPass to land only on "pixels where you see water" (the open bay = where the
+      //     terrain dips below sea level), water must be depth-tested against the FULLY-rendered
+      //     opaque scene. `transparent: true` (opacity = WATER_OPACITY, 1.0 by default — still
+      //     visually opaque) moves water out of the opaque list into the transparent pass, which is
+      //     unconditionally drawn after every opaque object — so its depth test sees terrain/cliffs/
+      //     buildings already in the depth buffer and fails over all of them, confining
+      //     stencil=STENCIL_WATER to the bay. (Plain renderOrder doesn't push water past the terrain
+      //     in the opaque sort under WebGPURenderer — cause unclear; the transparent pass sidesteps
+      //     the sort entirely.) renderOrder stays 0, so water still draws before the SeeThrough roads.
       //   • Terrain, cliffs and buildings over-stamp stencil=STENCIL_OCCLUDER where THEY are the
       //     visible surface (depth-tested, ZPass:Replace) — so SeeThrough roads don't draw through
       //     them. Safe vs the tunnel because water (transparent pass) re-writes stencil=STENCIL_WATER
       //     over the bay AFTER the terrain seabed wrote stencil=STENCIL_OCCLUDER there in the opaque pass.
-      //   • The SeeThrough road pass itself additionally masks to fragments below WATER_LEVEL_Y
-      //     (see loadRoadsMetro) so it's confined to genuinely-submerged road — the tunnel and its
-      //     ramps as they dip under — rather than every road wherever stencil==STENCIL_WATER (which
-      //     would also catch a bridge deck over the bay).
       const stencilOverstamp = { stencilWrite: true, stencilRef: NCZ.STENCIL_OCCLUDER, stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp };
       terrainMat = makeHillshadeMaterial('--scene-terrain', '#566c88', stencilOverstamp);
       waterMat   = makeHillshadeMaterial('--scene-water',   '#2a3f57', {
@@ -778,12 +773,16 @@ const ThreeScene = (() => {
         return group;
       }
 
-      // SeeThrough pass — renders where stencil==STENCIL_WATER (i.e. water is the visible surface
-      // at this pixel — see the stencil-chain comment in loadTerrain) AND the fragment is below
-      // WATER_LEVEL_Y (genuinely submerged), with depthTest:false so it draws on top of the water:
-      //   Pacifica tunnel (deck ≈ Y-27.5, ramps dip under the waterline): stencil==WATER + Y < -1 → visible ✓
-      //   Surface roads / bridges over the bay (deck Y ≥ ~0): Y ≥ -1 → masked out → render normal-styled ✓
-      //   Mountain roads / city roads: terrain over-stamps stencil=OCCLUDER ≠ WATER → hidden ✓
+      // SeeThrough pass: depthTest:false + stencil=EQUAL(STENCIL_WATER) → only renders where water
+      // is the visible surface at this pixel — i.e. the open bay (see the stencil-chain comment in
+      // loadTerrain). Pacifica tunnel: water writes stencil=STENCIL_WATER → the tunnel road + border
+      // (below the water) draw on top of it = visible through the water ✓.  Mountain / city roads:
+      // terrain/cliffs/buildings over-stamp stencil=STENCIL_OCCLUDER ≠ STENCIL_WATER → hidden ✓.
+      // (A road *bridging* the bay still gets a SeeThrough copy where stencil==STENCIL_WATER — its
+      // road is the same blue as the surface copy so no visible change, and its border's extra
+      // additive cyan reads as a slightly brighter edge over the bay. Tried masking that out by
+      // world-Y < waterline; it just dimmed the bay-area road borders for no real gain, so it's
+      // intentionally left as-is.)
       const stBase = {
         transparent: true, depthTest: false, depthWrite: false,
         stencilWrite: true, stencilWriteMask: 0x00,
@@ -792,9 +791,6 @@ const ThreeScene = (() => {
       };
       roadsMat   = new THREE.MeshBasicNodeMaterial({ ...stBase, color: roadColor,   opacity: 0.8 });
       bordersMat = new THREE.MeshBasicNodeMaterial({ ...stBase, color: borderColor, opacity: 0.6, blending: THREE.AdditiveBlending });
-      // Keep-mask: render the SeeThrough copy only where the road fragment is below the waterline.
-      roadsMat.maskNode   = positionWorld.y.lessThan(NCZ.WATER_LEVEL_Y);
-      bordersMat.maskNode = positionWorld.y.lessThan(NCZ.WATER_LEVEL_Y);
 
       applyMaterial(metroScene, metroMat);
 

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -797,6 +797,18 @@ const ThreeScene = (() => {
       stRoads.traverse(o => { if (o.isMesh) o.renderOrder = 1; });
       stBorders.traverse(o => { if (o.isMesh) o.renderOrder = 1; });
 
+      // Phase 4 follow-up diagnostic — per-mesh world-Y extents of the road geometry,
+      // to choose the "this fragment is underwater" threshold for a maskNode that
+      // confines the SeeThrough effect to the actual tunnel (vs bridges over the bay).
+      // (Remove once the threshold is picked.)
+      {
+        const _b = new THREE.Box3();
+        let _i = 0;
+        roadsScene.traverse(c => { if (c.isMesh) { _b.setFromObject(c); console.log(`[NCZ Phase4f] road mesh ${_i++} "${c.name}" Y ${_b.min.y.toFixed(1)}..${_b.max.y.toFixed(1)}`); } });
+        _b.setFromObject(roadsScene);   console.log(`[NCZ Phase4f] ALL roads Y   ${_b.min.y.toFixed(1)}..${_b.max.y.toFixed(1)}`);
+        _b.setFromObject(bordersScene); console.log(`[NCZ Phase4f] ALL borders Y ${_b.min.y.toFixed(1)}..${_b.max.y.toFixed(1)}`);
+      }
+
       const roadsGroup = new THREE.Group();
       roadsGroup.name = 'roads';
       roadsGroup.add(roadsScene, bordersScene, stRoads, stBorders);


### PR DESCRIPTION
Follow-up to Phase 4 ([PR #648](https://github.com/spuddeh/nc-zoning-board/pull/648)). Pure refactor — **no behaviour change vs `dev`** (the scene should look identical).

## What's here

Magic numbers around the SeeThrough-roads stencil chain → named constants in `constants.js`, and `three-scene.js` updated to use them:

- `NCZ.STENCIL_WATER = 2` — stencil ref written by the water mesh / tested by the SeeThrough roads.
- `NCZ.STENCIL_OCCLUDER = 1` — stencil ref written by terrain / cliffs / buildings (the visible-surface over-stamp that keeps SeeThrough roads off land).
- `NCZ.WATER_OPACITY = 1.0` — water material opacity, now set *explicitly* (water is in the transparent pass so its stencil write is depth-limited to the visible bay, but it renders visually opaque at 1.0; a tuning knob in case we ever want see-through ocean).

## What was tried and dropped

An earlier commit on this branch added a `maskNode` (`positionWorld.y.lessThan(WATER_LEVEL_Y)`) to the SeeThrough road/border materials, to confine the SeeThrough effect to genuinely-submerged road (so a bridge over the bay wouldn't get the SeeThrough treatment). It had no upside — the Pacifica tunnel works off the water-stencil + SeeThrough pass regardless — and one downside: it discarded the SeeThrough *border* clone over bridge decks, and that clone's additive cyan was contributing to the brightness of the bay-area road borders, so they dimmed. Reverted; `NCZ.WATER_LEVEL_Y` (only used by it) dropped too. The "bridge shows the SeeThrough style" residual is intentionally left as-is (it's just a slightly brighter border edge over the bay — harmless, arguably nice).

The diagnostic logging from the first commit on this branch is also removed.

## Test plan

- [ ] Scene looks identical to `dev` — Pacifica tunnel still visible through the water at all angles; bay-area road borders back to their normal brightness; water renders solid.
- [ ] No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)