### PR TITLE
WebGPU migration Phase 5 — cleanup + final validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Renderer: WebGL → WebGPU
+
+The 3D scene renders through `WebGPURenderer` (automatic WebGL2 fallback). Native engine features replace the old WebGL workarounds; visuals are parity-or-better at the five canonical viewpoints.
+
+- **Native depth + lighting** — reverse-Z depth buffer (`reversedDepthBuffer: true`) replaces `logarithmicDepthBuffer` and keeps early-Z; the two `onBeforeCompile` shader patches (building-edge highlight, metro LOD discard) are now TSL node materials; `AmbientLight` → `HemisphereLight` ("lit like it's outside") with one fitted orthographic shadow map tracking the visible-ground footprint (no cascades).
+- **GPU compute frustum culling for buildings** — a compute pass (per camera change) appends the visible building instances to a storage buffer and writes the indirect-draw `instanceCount`; replaces Three's host-side cull, which was a no-op for our cube-at-origin instances. Building instance matrices moved from `InstancedMesh.instanceMatrix` to an `instancedArray` storage buffer.
+- **SeeThrough-roads stencil (Pacifica tunnel)** — ported to material-level stencil flags. `transparent: true` on the water material (opacity 1.0 — still visually opaque) puts it in the always-last transparent pass so its `stencil = 2` write stays depth-confined to the open bay; terrain and cliffs over-stamp `stencil = 1` like buildings.
+- **Debug dump** — `dumpDebugInfo()` branches on `renderer.isWebGPURenderer`; GPU name/vendor read from `GPUDevice.adapterInfo`. New `getCullCounts()` console helper reads the indirect buffer back for visible-vs-total building instances.
+
+New constants in [`constants.js`](assets/js/constants.js): `NCZ.STENCIL_WATER` (2), `NCZ.STENCIL_OCCLUDER` (1), `NCZ.WATER_OPACITY` (1.0); plus a reworked `SHADOW_*` set for the single fitted shadow map (`SHADOW_MAP_SIZE`, `SHADOW_MAX_DISTANCE`, `SHADOW_GROUND_MARGIN`, `SHADOW_NORMAL_BIAS_TEXELS`) and `SUN_DIST`.
+
 #### Render-on-demand
 
 - The 3D scene's rAF loop now runs only when something has actually changed (camera moved, damping in progress, sun/theme/layer/material updated, pins added) instead of unconditionally re-rendering every frame. Idle map views cost zero GPU/CPU; saves battery on every machine and recovers headroom on weaker iGPUs (Intel UHD without Iris Xe was the worst case). Implemented in [`three-scene.js`](assets/js/three-scene.js) via a new `requestRender()` entrypoint hooked into every state-mutating helper, with a `_suppressed` flag that prevents in-flight color tweens from racing the flyover camera.

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -1536,13 +1536,16 @@ const ThreeScene = (() => {
     if (!renderer || !buildingMaterials.length) return null;
     const byDistrict = [];
     let total = 0, visible = 0;
-    for (const mat of buildingMaterials) {
+    // buildingMeshes and buildingMaterials are pushed in lockstep in loadBuildings,
+    // so the index aligns — use it for the district name (`buildings-<district>`).
+    for (let i = 0; i < buildingMaterials.length; i++) {
+      const mat  = buildingMaterials[i];
       const attr = mat.userData.indirectAttribute;
       if (!attr) continue;
       const cap  = mat.userData.instanceMatricesBuffer?.value?.count ?? null;
       const buf  = await renderer.getArrayBufferAsync(attr);
       const instanceCount = new Uint32Array(buf)[1];
-      byDistrict.push({ name: mat.name || '?', instanceCount, capacity: cap });
+      byDistrict.push({ name: buildingMeshes[i]?.name || mat.name || `district-${i}`, instanceCount, capacity: cap });
       if (cap != null) total += cap;
       visible += instanceCount;
     }

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -1395,6 +1395,7 @@ const ThreeScene = (() => {
 
     console.log('[NCZ] Debug mode active. Try:');
     console.log('  NCZ.ThreeScene.getRenderInfo()       → draw calls / tris / textures snapshot');
+    console.log('  NCZ.ThreeScene.getCullCounts()       → await: visible vs total building instances after the compute cull');
     console.log('  NCZ.ThreeScene.setOverrideMaterial(true|false)  → flat-shade everything to test fragment cost');
     console.log('  NCZ.ThreeScene.dumpDebugInfo()       → full diagnostic snapshot (also bound to the "Copy debug info" button)');
   }
@@ -1524,6 +1525,30 @@ const ThreeScene = (() => {
     };
   }
 
+  // Phase 2B cull-effectiveness probe. `renderer.info.render.triangles` is
+  // CPU-computed and never round-trips the indirect buffer's atomic
+  // instanceCount, so it reads 0 under indirect draws — the only way to know
+  // how many building instances actually survive the compute frustum cull is
+  // to read the GPU copy back. `getArrayBufferAsync` maps the storage buffer
+  // to the CPU; index [1] of the 5-uint IndirectDraw struct is instanceCount.
+  // Returns { total, visible, byDistrict: [{ name, instanceCount }] } or null.
+  async function getCullCounts() {
+    if (!renderer || !buildingMaterials.length) return null;
+    const byDistrict = [];
+    let total = 0, visible = 0;
+    for (const mat of buildingMaterials) {
+      const attr = mat.userData.indirectAttribute;
+      if (!attr) continue;
+      const cap  = mat.userData.instanceMatricesBuffer?.value?.count ?? null;
+      const buf  = await renderer.getArrayBufferAsync(attr);
+      const instanceCount = new Uint32Array(buf)[1];
+      byDistrict.push({ name: mat.name || '?', instanceCount, capacity: cap });
+      if (cap != null) total += cap;
+      visible += instanceCount;
+    }
+    return { total: total || null, visible, fraction: total ? visible / total : null, byDistrict };
+  }
+
   // Override-material diagnostic: replaces every material in the scene with a
   // flat MeshBasicMaterial. If FPS jumps when enabled → fragment-bound (shader cost).
   // If FPS stays the same → vertex/CPU-bound (geometry or draw calls).
@@ -1583,7 +1608,13 @@ const ThreeScene = (() => {
     if (renderer) {
       try {
         if (renderer.isWebGPURenderer) {
-          const adapterInfo = renderer.backend?.adapterInfo;
+          // r184's WebGPUBackend keeps the GPUAdapter local to init() — it's not
+          // on `renderer.backend`. The device, however, exposes `adapterInfo`
+          // (spec-stable GPUDevice.adapterInfo). Chrome's anti-fingerprinting
+          // policy blanks `device`/`description` for non-allowlisted origins, but
+          // `vendor` ("nvidia", "amd"…) and `architecture` ("blackwell", "rdna3"…)
+          // still come through — same caveat the WebGL2 path's UNMASKED_* had.
+          const adapterInfo = renderer.backend?.device?.adapterInfo;
           if (adapterInfo) {
             gpu    = adapterInfo.description || adapterInfo.architecture || 'unknown';
             vendor = adapterInfo.vendor || 'unknown';
@@ -2098,7 +2129,7 @@ const ThreeScene = (() => {
     requestRender();
   }
 
-  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, getSunElevation, setSunSphereVisible, getCameraState, setCameraState, getSceneColorVars, getRenderInfo, setOverrideMaterial, setBuildingEdgeIntensity, dumpDebugInfo };
+  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, getSunElevation, setSunSphereVisible, getCameraState, setCameraState, getSceneColorVars, getRenderInfo, getCullCounts, setOverrideMaterial, setBuildingEdgeIntensity, dumpDebugInfo };
 })();
 
 window.NCZ.ThreeScene = ThreeScene;


### PR DESCRIPTION
Final phase of the WebGL→WebGPU migration of the 3D schematic map. Phases 1–4 are already merged on `dev` (PRs #644 / #645 / #646 / #647 / #648, plus the constants refactor #649). This PR wraps it up **on `dev`** — it is **not** a `dev` → `main` release (that's a separate, explicitly-gated decision; `dev` carries other in-flight work).

## What's in this PR

### `three-scene.js`

**`dumpDebugInfo()` — fix the WebGPU GPU-name/vendor path.** It read `renderer.backend?.adapterInfo`, which doesn't exist in three r184: `WebGPUBackend` keeps the `GPUAdapter` local to `init()` and only stores `device`. Now reads `renderer.backend?.device?.adapterInfo` (spec-stable `GPUDevice.adapterInfo`). On non-allowlisted origins Chrome blanks `device`/`description` for fingerprinting, but `vendor` ("nvidia", "amd"…) and `architecture` ("blackwell", "rdna3"…) still come through — same caveat the WebGL2 path's `WEBGL_debug_renderer_info` had.

*Resolves the risk-register item "`adapterInfo` returns empty strings under Electron browsers — test on standalone Chrome/Firefox in Phase 5":* confirmed on standalone Chrome 148 — the strings were always empty because the code was reading a property that doesn't exist, not because of a browser policy.

**New `getCullCounts()`** (exposed on the `ThreeScene` API; listed in the `?debug=1` console hints). `renderer.info.render.triangles` reads `0` under indirect draws — Three computes it CPU-side and never round-trips the indirect buffer's atomic `instanceCount` — so Phase 2B's cull effectiveness was unverifiable. `getCullCounts()` reads each district's `IndirectStorageBufferAttribute` back via `renderer.getArrayBufferAsync()` and returns `{ total, visible, fraction, byDistrict[] }`.

*Resolves the risk-register item "Phase 2B cull-rate measurement is unreliable".*

### `CHANGELOG.md`

New **"Renderer: WebGL → WebGPU"** subsection under `## [Unreleased]` → `### Three.js 3D Schematic Map`, batching Phases 1–4 (native reverse-Z depth + TSL materials + Hemisphere lighting + single fitted shadow map; GPU compute building cull + `instancedArray` storage buffer; SeeThrough-roads stencil with `transparent: true` water) and the new constants (`STENCIL_WATER` / `STENCIL_OCCLUDER` / `WATER_OPACITY` / reworked `SHADOW_*` / `SUN_DIST`). PRs #644–#649 didn't add CHANGELOG entries; this is the single batched entry for the whole migration.

## Validation done

- **dispose() audit** — no leaks from migration churn. The scene is constructed once (`init()` → `load*()`); there's no teardown path and no runtime resource recreation. Theme switching mutates `uniform()` `.value` / `Color` in place; the one cached debug material (`_debugOverrideMat`) is lazily created and reused; building geometry is one shared `BoxGeometry` cloned per district. Live `renderer.info.memory` on `dev`: `geometries: 31`, `textures: 13`, stable across pan/zoom/sun cycling (the documented lazy-upload caveat — subdistrict line geometries upload on first zoom-in — applies but is not a leak).
- **adapterInfo on standalone Chrome** — verified (see above).
- **5-viewpoint visual diff** — formal contact sheet skipped by owner decision; the scene has been eyeballed parity-or-better phase-by-phase.
- **iGPU frame-time check** — deferred by owner decision; Phases 1–4 were each perf-checked on the Intel UHD laptop.

## To verify on this PR's Cloudflare preview before merge

- [ ] `NCZ.ThreeScene.getCullCounts()` returns a sane number at the zoom-0.6 downtown viewpoint (sanity-check the new helper against the preview build)

## Out of scope (tracked as separate Project items)

- `dev` → `main` (explicitly user-gated)
- Shadow-aware union frustum for the building cull (Three.js Parity follow-up)
- Building-edge shimmer
- The SeeThrough-roads underwater `maskNode` (tried in #649's branch, reverted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)