### PR TITLE
fix(3d): showcase cull + metro LOD parity under WebGPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ New constants in [`constants.js`](assets/js/constants.js): `NCZ.STENCIL_WATER` (
 
 - Off-screen buildings now cast shadows into the visible area. The Phase 2B GPU compute cull tests each building instance against the union of the camera frustum and the sun's shadow-camera frustum (12 planes via boolean OR) instead of the camera alone — so a caster just outside the view still makes it into the indirect-draw buffer.
 
+#### Showcase fly-through — WebGPU parity (partial)
+
+- `renderFrame(cam)` now dispatches the Phase 2B cull computes and refreshes the cam-frustum uniforms each cinematic frame. Previously the cull only ran in the schema `renderLoop()` (suppressed during showcase), so the building indirect buffer's `instanceCount` was frozen at whatever the schema cam last culled — buildings popped in/out of the cinematic and most shadows were missing because their casters were never in the buffer.
+- Metro LOD pinned to the R-tier (dashed close-zoom variant) for the whole showcase. The previous tier-switching read `camera.zoom`, which a perspective camera doesn't have; calibrating altitude→tier across all 11 waypoints isn't worth the tuning effort.
+- `startRenderLoop()` snaps the cull-frustum uniforms, shadow camera, and metro pseudo-zoom back to schema-cam values on showcase exit so the first post-cinematic frame draws cleanly.
+- **Still broken (separate PR)**: shadows trail off in the distance during cinematic — the fly cam's perspective view often extends past the fixed-size shadow ortho box. CSM for the showcase camera path is the planned fix.
+
 #### Render-on-demand
 
 - The 3D scene's rAF loop now runs only when something has actually changed (camera moved, damping in progress, sun/theme/layer/material updated, pins added) instead of unconditionally re-rendering every frame. Idle map views cost zero GPU/CPU; saves battery on every machine and recovers headroom on weaker iGPUs (Intel UHD without Iris Xe was the worst case). Implemented in [`three-scene.js`](assets/js/three-scene.js) via a new `requestRender()` entrypoint hooked into every state-mutating helper, with a `_suppressed` flag that prevents in-flight color tweens from racing the flyover camera.

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -116,9 +116,13 @@ const ThreeScene = (() => {
   // Dispatched in pairs from `renderLoop` before `renderer.render`.
   const _cullComputes = [];
 
-  function updateFrustumUniforms() {
-    if (!camera) return;
-    _frustumScratchMat.multiplyMatrices(camera.projectionMatrix, camera.matrixWorldInverse);
+  function updateFrustumUniforms(renderCam = camera) {
+    if (!renderCam) return;
+    // `renderCam` defaults to the schema ortho camera; pass the perspective
+    // `flyCamera` during showcase so the cull tests against what's actually
+    // being rendered. `Frustum.setFromProjectionMatrix` handles both
+    // ortho + perspective projections — the algebra is the same.
+    _frustumScratchMat.multiplyMatrices(renderCam.projectionMatrix, renderCam.matrixWorldInverse);
     // Critical: pass WebGPUCoordinateSystem so the near/far plane extraction
     // uses the WebGPU clip-space convention (depth range [0, 1]). The default
     // is WebGL (depth range [-1, 1]), which extracts a wrong near plane for
@@ -1562,10 +1566,16 @@ const ThreeScene = (() => {
   // (e.g. from a still-running color tween) doesn't resurrect the loop.
   function startRenderLoop() {
     _suppressed = false;
-    // The showcase flyover fits the shadow camera to its own PerspectiveCamera
-    // (renderFrame below); when it hands control back, re-fit to the schema
-    // camera's view before the next schema frame.
+    // The showcase flyover fits the shadow camera, the cull-frustum uniforms,
+    // and the metro LOD pseudo-zoom to its own PerspectiveCamera (renderFrame
+    // below). When it hands control back, snap all three back to the schema
+    // camera's view before the next schema frame — otherwise the cull's first
+    // post-showcase dispatch would test against the flyCamera's last frustum
+    // and the metro LOD would be stuck on the synthetic perspective zoom
+    // until the user moved the camera (firing the controls 'change' reset).
     updateShadowCamera();
+    updateFrustumUniforms();
+    if (metroZoomUniform && camera) metroZoomUniform.value = camera.zoom;
     requestRender();
   }
 
@@ -1851,10 +1861,33 @@ const ThreeScene = (() => {
 
   function renderFrame(cam) {
     if (!renderer || !scene) return;
-    // The showcase flyover renders through its own PerspectiveCamera — re-fit
-    // the shadow camera to *its* view each frame (it moves continuously).
-    // startRenderLoop re-fits to the schema camera when the flyover ends.
-    if (cam && cam !== camera) updateShadowCamera(cam);
+    // The showcase flyover renders through its own PerspectiveCamera —
+    // re-fit the shadow camera AND the cull-frustum uniforms to *its* view
+    // each frame (the schema renderLoop is suppressed during showcase, so
+    // nothing else is keeping these in sync). Then dispatch the per-frame
+    // Phase 2B cull computes the same way renderLoop does — without this,
+    // the indirect buffer's instanceCount is frozen at whatever the schema
+    // cam last culled, so both the shadow pass and the main pass draw a
+    // stale building set (the original symptom: shadows missing under
+    // showcase, and buildings popping as the cinematic moves).
+    if (cam && cam !== camera) {
+      updateShadowCamera(cam);   // also refreshes the union-cull's shadow frustum
+      updateFrustumUniforms(cam); // and the camera-frustum half
+      // Metro LOD: pin to the R-tier (dashed close-zoom variant) for the
+      // whole showcase. Calibrating a perspective-altitude → ortho-zoom
+      // mapping that hits the existing METRO_LOD_ZOOM_MED / _NEAR thresholds
+      // cleanly across every waypoint isn't worth the tuning effort —
+      // dashed reads well from any cinematic angle and avoids tier
+      // transitions mid-flight. Any value > METRO_LOD_ZOOM_NEAR makes the
+      // discard expression keep only R; +1 stays well clear of float wobble.
+      if (metroZoomUniform && cam.isPerspectiveCamera) {
+        metroZoomUniform.value = NCZ.METRO_LOD_ZOOM_NEAR + 1;
+      }
+      for (const c of _cullComputes) {
+        renderer.compute(c.reset);
+        renderer.compute(c.cull);
+      }
+    }
     renderer.render(scene, cam);
   }
 


### PR DESCRIPTION
## Summary

First piece of the showcase WebGPU-parity work. Three surgical edits inside the cinematic render path, all confined to `renderFrame(cam)` and `startRenderLoop()` — schema-cam path is untouched. Refs project item [#186981843 "Showcase fly-through is broken under WebGPU"](https://github.com/users/spuddeh/projects/1) — closes two of the three named symptoms, the third (shadows in the distance) is escalated to a planned CSM follow-up.

## What was broken

The showcase was written for the pre-WebGPU code path. Phase 2B (GPU compute frustum culling) and the Phase 3 single-fitted-shadow-map rewrite each came in *after* the showcase was finalised, and neither was extended to the cinematic render path. Result:

1. **Buildings popped mid-flight.** `renderLoop()` dispatches the cull computes before `renderer.render(scene, camera)`, but the schema loop is `_suppressed` during showcase — only `renderFrame(flyCamera)` runs, and that just refits the shadow camera and renders. The indirect buffer's `instanceCount` stayed frozen at whatever the schema cam last culled, so the cinematic drew a stale building set that didn't match the perspective view.
2. **Shadows were missing in large chunks.** Same root cause — the shadow pass also reads the indirect buffer, so casters that should have been writing into the shadow map weren't even submitted.
3. **Metro LOD was stuck at the schema cam's pre-showcase tier.** `metroZoomUniform.value` is only updated in the controls 'change' handler (controls are disabled during showcase), and `flyCamera.zoom` is meaningless on a perspective camera anyway.

The project item body hypothesised `_dirLight.shadow.intensity` was being flipped or `updateShadowCamera(flyCamera)` wasn't being refit per frame. Both check out — `setShadowsEnabled(true)` is called at start of `startFlyover`, and `renderFrame(cam)` already called `updateShadowCamera(cam)` per the Phase 3 work. The actual cause was the frozen cull output.

## What this PR does

- **`updateFrustumUniforms(renderCam = camera)`** parameterised — defaults to the schema ortho cam, accepts any camera. `THREE.Frustum.setFromProjectionMatrix` handles perspective + ortho identically.
- **`renderFrame(cam)`** now does, in order:
  1. `updateShadowCamera(cam)` (was already there)
  2. `updateFrustumUniforms(cam)` (new — refreshes the cam-frustum half of the union cull)
  3. Pin `metroZoomUniform.value = NCZ.METRO_LOD_ZOOM_NEAR + 1` (new — forces R-tier)
  4. Dispatch all `_cullComputes` reset+cull pairs (new — mirroring `renderLoop()`)
  5. `renderer.render(scene, cam)`
- **`startRenderLoop()`** snaps the cull-frustum uniforms and `metroZoomUniform.value` back to schema-cam values alongside the existing `updateShadowCamera()` reset, so the first post-cinematic frame draws cleanly.

The shadow-frustum half of the union cull doesn't need a new call site — it's refreshed by `updateShadowCamera()` already (PR #651 wired it in).

## What's still broken (separate follow-up)

**Shadows trail off in the distance during cinematic.** The fly cam's perspective view often extends far past the fixed-size shadow ortho box that `updateShadowCamera(flyCam)` builds (12,600-half-side, centred where the cam's forward ray meets ground). Receivers outside the box read whatever the shadow texture's edge sampler returns → typically "lit", hence the trailing-off.

Phase 3's fitted-box pattern is the right answer for a top-down ortho cam (no perspective foreshortening to exploit) but wrong for a perspective cinematic. CSM was rejected for the schema cam in Phase 3 for that exact reason; for the perspective fly cam it's the textbook answer. Planned: bring back `CSMShadowNode` on the perspective cam path only, schema cam keeps the single fitted box.

User-confirmed scope rail (per project item body): showcase-only fix; the normal map render path must stay untouched.

## Files

- [`assets/js/three-scene.js`](assets/js/three-scene.js) — `updateFrustumUniforms` parameterised; `renderFrame` extended with cull dispatch + frustum refresh + metro pin; `startRenderLoop` extended with exit-restore.
- [`CHANGELOG.md`](CHANGELOG.md) — new \"Showcase fly-through — WebGPU parity (partial)\" subsection under `[Unreleased]` → `Three.js 3D Schematic Map`, next to the migration entries.

## Test plan

Confirmed visually on the local dev server:

- [x] Buildings stay drawn for as long as they're in the perspective cam's view — no mid-flight pop.
- [x] Metro draws as dashed lines throughout the showcase.
- [x] Exit to schema cam restores the normal map cleanly (cull, shadow box, metro LOD all back to schema-cam values).
- [ ] (Cloudflare preview) Re-confirm on a clean build, especially the post-cinematic snap-back at the moment Esc / autoplay-end fires.
- [ ] Project item moves to In progress (the third symptom — shadow distance — is the CSM follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)