### PR TITLE
feat(3d): align schematic camera to game — ortho → perspective FOV 25°

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ The 3D scene renders through `WebGPURenderer` (automatic WebGL2 fallback). Nativ
 
 New constants in [`constants.js`](assets/js/constants.js): `NCZ.STENCIL_WATER` (2), `NCZ.STENCIL_OCCLUDER` (1), `NCZ.WATER_OPACITY` (1.0); plus a reworked `SHADOW_*` set for the single fitted shadow map (`SHADOW_MAP_SIZE`, `SHADOW_MAX_DISTANCE`, `SHADOW_GROUND_MARGIN`, `SHADOW_NORMAL_BIAS_TEXELS`) and `SUN_DIST`.
 
+#### Three.js-Parity: schema camera (orthographic → perspective)
+
+- Schema camera is now `PerspectiveCamera` at **FOV 25°** matching the game's TopDown view. Values mirror TweakDB `WorldMap.TopDownCameraSettingsDefault` (zoom min/default/max = 800 / 3000 / 15000 CET units). Replaces the prior `OrthographicCamera` — chosen originally without reference to the game's actual setup. See [`docs/data/worldmap_tweakdb_tree.json`](docs/data/worldmap_tweakdb_tree.json) for the full record dump.
+- Downstream perspective-aware refactors: shadow camera footprint via a 4-corner ray-cast against `Y=0` (handles tilt without an analytic `1/cos` stretch); scale bar, district→subdistrict label switch, and pin cluster threshold all driven by camera-to-target distance; `flyTo` lands at `SCHEMA_FLY_TO_DISTANCE = 1250` (TweakDB `zoomToZoomValue`).
+- **Pan envelope** now uses the game's canonical `cursorBoundary` (X[−5500..6050], Y[−7300..5000] in CET → Z[−5000..7300] in Three.js) instead of the wider terrain GLB extent. **`resetCamera`** restores the first-load `fitCameraToBox` view (whole-map fit) instead of dropping to default distance.
+- **Showcase exit** dips the 3D container's opacity for ~150 ms across the camera swap (schema 25° ↔ flyover 55° FOV) so the perspective change reads as an intentional transition rather than a hard cut.
+- **Metro LOD** mutex tier switch (B wide → G thin → R dotted) driven by schema camera-to-target distance, replacing the legacy `camera.zoom` reading. Thresholds at `MED = 7000` and `NEAR = 2500` (CET wu) align with the WorldMap zoom-ladder rather than the metro material's `VisibilityDistance*` values — the latter don't map onto a camera-to-target metric since our `zoomMax = 15000 < 18000`. Constants page documents the deviation.
+- Follow-ups queued: **CSM shadows** (the "no cascades because schema is ortho" rationale dissolved with this change); cluster-radius re-tune for the new screen-space behaviour; `pitchRelativeToZoom` lean-back curve from TweakDB; **Line2 near-plane clipping** under perspective (district outline segments whose endpoints cross the camera near plane stretch as straight rays across the viewport — pre-existing latent bug, only visible under perspective).
+
 #### Three.js-Parity: shadow accuracy
 
 - Off-screen buildings now cast shadows into the visible area. The Phase 2B GPU compute cull tests each building instance against the union of the camera frustum and the sun's shadow-camera frustum (12 planes via boolean OR) instead of the camera alone — so a caster just outside the view still makes it into the indirect-draw buffer.

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -183,27 +183,40 @@ NCZ.DISTRICT_LINE_OPACITY   = 0.85;
 // no-op for everyone at DPR ≤ 1.5, so most desktops see zero change.
 NCZ.MAX_DEVICE_PIXEL_RATIO = 1.5;
 
-// Camera — orthographic projection, positioned above world centre looking straight down
-NCZ.CAMERA_NEAR     = -20000;           // near plane behind the camera (orthographic — not a clip distance)
-NCZ.CAMERA_FAR      =  20000;           // far plane in front; sized for max-tilt + max-pan worst case (~23k) with margin
-NCZ.CAMERA_HEIGHT   =  10000;           // Y position above world centre (CET units)
+// Camera — perspective projection, positioned above world centre looking straight down.
+// Source: TweakDB WorldMap.TopDownCameraSettingsDefault — see docs/data/worldmap_tweakdb_tree.json.
+// The schema camera matches the game's TopDown view (FOV 25°, distance in CET / world units).
+NCZ.SCHEMA_CAMERA_FOV              = 25;     // degrees — game canonical (TopDownCameraSettingsDefault.fovMin/Max)
+NCZ.SCHEMA_CAMERA_NEAR             = 10;     // CET units — perspective near clip; must be > 0
+NCZ.SCHEMA_CAMERA_FAR              = 50000;  // CET units — far clip; covers shadow camera + sun sphere
+NCZ.SCHEMA_CAMERA_DEFAULT_DISTANCE = 3000;   // CET units — opening distance (TweakDB zoomDefault)
+NCZ.SCHEMA_CAMERA_MIN_DISTANCE     = 800;    // CET units — zoom-in limit  (TweakDB zoomMin)
+NCZ.SCHEMA_CAMERA_MAX_DISTANCE     = 15000;  // CET units — zoom-out limit (TweakDB zoomMax)
+NCZ.SCHEMA_FLY_TO_DISTANCE         = 1250;   // CET units — fly-to-pin target distance (TweakDB zoomToZoomValue)
 
-// Camera controls (OrbitControls) — source: TweakDB WorldMap.FreeCameraSettingsDefault
+// Pan envelope — clamps controls.target so the camera can't roam off the map.
+// Source: TweakDB WorldMap.DefaultSettings.cursorBoundary{Min,Max}.
+// CET → Three.js: X stays as-is; CET Y maps to Three Z with a sign flip
+// (GLB_Z = -CET_Y), so CET Y range (-7300..5000) becomes Three Z (-5000..7300).
+NCZ.PAN_BOUND_MIN_X =  -5500;  // CET / Three X — TweakDB cursorBoundaryMin.X
+NCZ.PAN_BOUND_MAX_X =   6050;  // CET / Three X — TweakDB cursorBoundaryMax.X
+NCZ.PAN_BOUND_MIN_Z =  -5000;  // Three Z — derived from -cursorBoundaryMax.Y
+NCZ.PAN_BOUND_MAX_Z =   7300;  // Three Z — derived from -cursorBoundaryMin.Y
+
+// Camera controls (OrbitControls)
 NCZ.CAMERA_MIN_TILT     = 0;              // min polar angle (Three.js default: 0)           — 0 = perfectly top-down
 NCZ.CAMERA_MAX_TILT     = Math.PI * 0.39; // max polar angle (Three.js default: Math.PI)     — ~70° tilt from top-down
 NCZ.CAMERA_DAMPING      = 0.05;           // dampingFactor   (Three.js default: 0.05)        — higher = more inertia/lag
-NCZ.CAMERA_ZOOM_MIN     = 2.0;            // minZoom         (Three.js default: 0)           — zoom-out limit; small = small map
-NCZ.CAMERA_ZOOM_MAX     = 50.0;           // maxZoom         (Three.js default: Infinity)    — zoom-in limit; large = close up
 NCZ.CAMERA_ZOOM_SPEED   = 2.0;            // zoomSpeed       (Three.js default: 1.0)         — scroll wheel rate; increase if too slow
 NCZ.CAMERA_PAN_SPEED    = 1.0;            // panSpeed        (Three.js default: 1.0)         — left-drag pan rate
 NCZ.CAMERA_ROTATE_SPEED = 0.6;            // rotateSpeed     (Three.js default: 1.0)         — right-drag tilt rate; lower = more precise
 
 // Shadow map — one OrthographicCamera fitted each frame to exactly the visible-
 // ground footprint (updateShadowCamera in three-scene.js), rendered into a
-// single depth32float texture (the WebGPU `shadowMapping` pattern). No cascades:
-// our schema camera is orthographic (uniform pixels-per-world-unit), so there's
-// no perspective near/far disparity for cascaded maps to exploit — one tight map
-// is simpler and, for this camera, sharper.
+// single depth32float texture (the WebGPU `shadowMapping` pattern). Single map
+// for now; a CSM revisit is queued — the original "no cascades because schema
+// is ortho" rationale no longer holds since the schema camera moved to perspective
+// (FOV 25°, TweakDB-aligned), see [[align-schematic-camera-to-game]].
 NCZ.SHADOW_MAP_SIZE      = 4096;  // px² — ~3 u/texel at a whole-city zoom; razor-sharp zoomed in (the footprint shrinks with zoom)
 NCZ.SHADOW_MAX_DISTANCE  = 12000; // CET units — cap on the footprint half-side. Keeps the shadow reasonably sharp at the zoomed-out + max-tilt extreme (where the visible ground would otherwise run ~20 km wide); ground past the cap is a clean unshadowed falloff. Never bites at normal zooms.
 NCZ.SHADOW_GROUND_MARGIN =   600; // CET units the footprint extends past the visible ground — covers building heights / terrain relief + a sliver of just-off-screen casters. Wider off-screen-caster coverage waits on the union-frustum cull (a follow-up).
@@ -236,15 +249,35 @@ NCZ.BUILDING_EDGE_INTENSITY =  0.05;  // max mix weight — keeps effect subtle;
 NCZ.BUILDING_TEX_FLOOR      =   0.3;  // minimum _m.dds brightness — prevents faces going pitch-black
 NCZ.BUILDING_TEX_RANGE      =   0.7;  // brightness range above the floor (floor + range = max)
 
-// Three.js orthographic camera.zoom threshold for district→subdistrict label switch
-NCZ.SUBDISTRICT_ZOOM_3D = 2.5;
+// Camera distance threshold for district→subdistrict label switch.
+// Source: TweakDB WorldMap.ZoomLevelSubDistricts.zoom = 7000.
+// Below this distance the camera is "zoomed in enough" to show subdistricts.
+NCZ.SUBDISTRICT_DISTANCE_3D = 7000;
 
 // Metro LOD zoom thresholds — vertex COLOR_0 channels are mutually exclusive tiers:
 // B = wide solid line (far zoom only,    zoom < LOD_MED)   — VisibilityDistanceBold=30000
 // G = thin solid line (medium zoom only, LOD_MED < zoom < LOD_NEAR) — VisibilityDistanceRegular=18000
 // R = dotted line     (close zoom only,  zoom > LOD_NEAR)  — VisibilityDistanceDashed=5000
-NCZ.METRO_LOD_ZOOM_MED  = 8.0;   // G→B transition zoom threshold
-NCZ.METRO_LOD_ZOOM_NEAR = 20.0;  // B→R transition zoom threshold
+// Metro LOD thresholds — schema camera-to-target distance (CET units).
+// Mutually-exclusive tiers (one renders at a time, in-game look):
+//   B (wide solid) when distance > MED
+//   G (thin solid) when NEAR < distance < MED
+//   R (dotted)     when distance < NEAR
+//
+// Canonical material values (3dmap_metro.Material.json) are
+// VisibilityDistanceRegular = 18000 and VisibilityDistanceDashed = 5000.
+// They don't apply directly to our metric: schema camera-to-target distance
+// maxes at SCHEMA_CAMERA_MAX_DISTANCE = 15000 wu, so MED = 18000 would mean
+// the B tier never appears in our camera range. The game's compiled shader
+// almost certainly applies these via a metric we can't see (possibly view-
+// space depth with tilt, or a scale factor we don't have).
+//
+// These values align with the WorldMap zoom-ladder instead — same TweakDB
+// source-of-truth, different mapping: when subdistricts appear
+// (`ZoomLevelSubDistricts.zoom = 7000`), metro changes B → G; when full
+// mappins appear (`ZoomLevelAllMappins.zoom = 2500`), metro changes G → R.
+NCZ.METRO_LOD_DISTANCE_MED  = 7000;   // G↔B boundary — aligns with subdistrict-visible zoom
+NCZ.METRO_LOD_DISTANCE_NEAR = 2500;   // R↔G boundary — aligns with all-mappins-visible zoom
 
 // SeeThrough roads — the Pacifica tunnel: a road visible *through* the open bay water.
 // Water (rendered in the transparent pass — see three-scene.js loadTerrain) writes
@@ -261,7 +294,7 @@ NCZ.PIN_3D_GROUND_OFFSET            =  5;  // CET metres above player CET Z — 
 NCZ.PIN_3D_DRAG_THRESHOLD_PX        =  4;  // pixels of pointerdown→pointerup movement before a click is treated as a drag (and thus does not close the popup)
 NCZ.PIN_3D_POPUP_FLIP_PADDING_PX    = 24;  // pixels of clearance above the viewport top before the popup flips from above-pin to below-pin placement
 NCZ.PIN_3D_FLY_DURATION_MS          = 700; // total tween time for sidebar click → camera fly-to-pin
-NCZ.PIN_3D_FLY_ZOOM                 = 15;  // target camera.zoom at the end of the fly — close enough to read pin context, not max-zoom
+// Fly-to-pin target distance lives in SCHEMA_FLY_TO_DISTANCE (TweakDB zoomToZoomValue = 1250)
 NCZ.PIN_3D_CLUSTER_RADIUS_PX        = 40;  // screen-pixel radius for grouping pins into a cluster — matches Leaflet's maxClusterRadius
 NCZ.PIN_3D_PAN_EDGE_FRACTION        = 0.5; // viewport-relative pan padding — at the bound, the world edge sits at screen-center (matches Leaflet's `panEdgeFraction`). Smaller = tighter bound.
 NCZ.PIN_3D_SCALE_TARGET_PX          = 100; // ideal scale-bar width in pixels — the actual bar rounds to a "nice" length (1, 2, 5 × 10ⁿ metres) closest to this width

--- a/assets/js/flyover.js
+++ b/assets/js/flyover.js
@@ -439,51 +439,84 @@ const Flyover = (() => {
     flyoverLoop();
   }
 
+  // Short fade-out/in across the camera swap. The showcase camera renders at
+  // FOV 55° and the schema camera at 25°; cutting from one to the other is a
+  // jarring perspective snap. Dipping the 3D container's opacity for a moment
+  // bridges them — feels like an intentional transition, not a glitch.
+  const EXIT_FADE_MS = 150;
+
   function stopFlyover() {
     if (!flyActive) return;
     flyActive = false;
     if (flyFrameId !== null) { cancelAnimationFrame(flyFrameId); flyFrameId = null; }
-    // Restore clusters before swapping the camera back, so the recompute
-    // triggered by setActiveCamera(null) sees the cluster layer visible
-    // again and rebuilds the clustered state cleanly.
-    NCZ.ThreeMarkers?.setUnclusteredMode?.(false);
-    // Hand the marker overlay back to the schema camera so pins project against
-    // the orthographic view again. setActiveCamera(null) also re-runs cluster
-    // recompute so cluster math resyncs (the cluster recompute is suppressed
-    // while a non-schema camera is active).
-    NCZ.ThreeMarkers?.setActiveCamera?.(null);
-    clearLayerReveal();
-    if (_audio) {
-      _audio.pause();
-      _audio.currentTime = 0;
-      if (_onAudioEnded) { _audio.removeEventListener('ended', _onAudioEnded); _onAudioEnded = null; }
-    }
-    hideStartScreen();
-    resetFade();
-    NCZ.ThreeScene.setControlsEnabled(true);
-    NCZ.ThreeScene.startRenderLoop();
-    NCZ.ThreeScene.setSunSphereVisible?.(false);
 
-    // Restore whichever theme the user had before showcase started
-    if (_savedTheme) { applyThemeSmooth(_savedTheme); _savedTheme = null; }
+    const canvas    = NCZ.ThreeScene.getCanvasElement?.();
+    const container = canvas?.parentElement || null;
 
-    _runOpts = null;
-
-    // Restore all overlay checkboxes + sun slider to exactly what they were.
-    // Dispatching the native events ensures the app.js handlers run —
-    // layer visibility, shadow state, and UI all stay in sync.
-    if (_savedState) {
-      _savedState.overlays.forEach(({ cb, checked }) => {
-        cb.checked = checked;
-        cb.dispatchEvent(new Event('change'));
-      });
-      const slider = document.getElementById('scene-sun-slider');
-      if (slider && _savedState.sunSlider !== null) {
-        slider.value = _savedState.sunSlider;
-        slider.dispatchEvent(new Event('input'));
+    const doRestore = () => {
+      // Restore clusters before swapping the camera back, so the recompute
+      // triggered by setActiveCamera(null) sees the cluster layer visible
+      // again and rebuilds the clustered state cleanly.
+      NCZ.ThreeMarkers?.setUnclusteredMode?.(false);
+      // Hand the marker overlay back to the schema camera so pins project
+      // against the perspective FOV-25° view again. setActiveCamera(null)
+      // also re-runs cluster recompute (suppressed while a non-schema camera
+      // is active).
+      NCZ.ThreeMarkers?.setActiveCamera?.(null);
+      clearLayerReveal();
+      if (_audio) {
+        _audio.pause();
+        _audio.currentTime = 0;
+        if (_onAudioEnded) { _audio.removeEventListener('ended', _onAudioEnded); _onAudioEnded = null; }
       }
-      _savedState = null;
+      hideStartScreen();
+      resetFade();
+      NCZ.ThreeScene.setControlsEnabled(true);
+      NCZ.ThreeScene.startRenderLoop();
+      NCZ.ThreeScene.setSunSphereVisible?.(false);
+
+      // Restore whichever theme the user had before showcase started
+      if (_savedTheme) { applyThemeSmooth(_savedTheme); _savedTheme = null; }
+
+      _runOpts = null;
+
+      // Restore all overlay checkboxes + sun slider to exactly what they were.
+      // Dispatching the native events ensures the app.js handlers run —
+      // layer visibility, shadow state, and UI all stay in sync.
+      if (_savedState) {
+        _savedState.overlays.forEach(({ cb, checked }) => {
+          cb.checked = checked;
+          cb.dispatchEvent(new Event('change'));
+        });
+        const slider = document.getElementById('scene-sun-slider');
+        if (slider && _savedState.sunSlider !== null) {
+          slider.value = _savedState.sunSlider;
+          slider.dispatchEvent(new Event('input'));
+        }
+        _savedState = null;
+      }
+    };
+
+    if (!container || document.hidden) {
+      doRestore();
+      return;
     }
+
+    container.style.transition = `opacity ${EXIT_FADE_MS}ms ease-out`;
+    container.style.opacity = '0';
+    setTimeout(() => {
+      doRestore();
+      // Two-rAF gate so the swap's first render lands while we're still at
+      // opacity 0, then we fade back up. requestAnimationFrame alone races
+      // some browsers' commit timing.
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        container.style.opacity = '1';
+      }));
+      setTimeout(() => {
+        container.style.transition = '';
+        container.style.opacity = '';
+      }, EXIT_FADE_MS + 50);
+    }, EXIT_FADE_MS);
   }
 
   function flyoverLoop() {

--- a/assets/js/three-markers.js
+++ b/assets/js/three-markers.js
@@ -23,12 +23,12 @@ window.NCZ = window.NCZ || {};
 
 const ThreeMarkers = (() => {
   let scene = null;
-  // Two camera references: the schema OrthographicCamera captured at attach
-  // time, and an optional override active during the showcase flyover (the
-  // PerspectiveCamera owned by flyover.js). Cluster math + fly-to-pin tween
-  // assume orthographic fields and always use _schemaCamera; the popup
-  // projection and the render call use whichever is active so pins follow
-  // the cinematic camera during the showcase.
+  // Two camera references: the schema PerspectiveCamera captured at attach
+  // time, and an optional override active during the showcase flyover (a
+  // separate PerspectiveCamera with a wider FOV owned by flyover.js). Cluster
+  // math + fly-to-pin tween are distance-based and always run against
+  // _schemaCamera; the popup projection and the render call use whichever
+  // camera is active so pins follow the cinematic camera during the showcase.
   let _schemaCamera = null;
   let _activeCamera = null;
   const getCam = () => _activeCamera || _schemaCamera;
@@ -314,19 +314,20 @@ const ThreeMarkers = (() => {
   // while the user explores — no reshuffle on rotation. (Aki's UX call,
   // applied 2026-05-02. Earlier screen-space approach in git history if
   // you ever want to revisit.)
-  let _lastZoomForCluster = null;
+  let _lastDistanceForCluster = null;
 
   function scheduleRecomputeClusters() {
-    // Skip if zoom hasn't changed (pan/tilt only) — world clusters don't
-    // move. Filter changes call recomputeClusters() synchronously and
-    // bypass this guard.
-    // Cluster math reads orthographic-only fields (zoom, right, left) so it
-    // can only run against the schema camera. During the showcase the active
-    // camera is the perspective fly camera — bail out and let clusters keep
-    // their last-recomputed positions for the duration of the cinematic.
+    // Skip if camera-to-target distance hasn't changed (pan/tilt only) —
+    // world clusters don't move. Filter changes call recomputeClusters()
+    // synchronously and bypass this guard.
+    // During the showcase the active camera is the perspective fly camera —
+    // bail out and let clusters keep their last-recomputed positions for the
+    // duration of the cinematic.
     if (_activeCamera) return;
-    if (_lastZoomForCluster === _schemaCamera.zoom) return;
-    _lastZoomForCluster = _schemaCamera.zoom;
+    if (!controls) return;
+    const distance = _schemaCamera.position.distanceTo(controls.target);
+    if (_lastDistanceForCluster === distance) return;
+    _lastDistanceForCluster = distance;
     if (_recomputeFrame !== null) return;
     _recomputeFrame = requestAnimationFrame(() => {
       _recomputeFrame = null;
@@ -335,15 +336,20 @@ const ThreeMarkers = (() => {
   }
 
   function recomputeClusters() {
-    if (!_clusterLayer || !_schemaCamera || !container) return;
+    if (!_clusterLayer || !_schemaCamera || !container || !controls) return;
     const w = container.clientWidth;
     if (!w) return;
 
-    // Convert "PIN_3D_CLUSTER_RADIUS_PX equivalent at current zoom" into world
-    // units. At zoom=2 this is roughly the same radius the screen-space
-    // version used at top-down view; as the user zooms in, the world radius
-    // shrinks proportionally so clusters dissolve at the same rate as Leaflet's.
-    const worldPerPixel = (_schemaCamera.right - _schemaCamera.left) / (_schemaCamera.zoom * w);
+    // Convert "PIN_3D_CLUSTER_RADIUS_PX equivalent at current camera distance"
+    // into world units. Perspective worldPerPixel at the *centre of screen*
+    // (the OrbitControls target, on Y=0): visible width = 2 × distance ×
+    // tan(FOV/2) × aspect; worldPerPixel = that / canvasWidth. As the user
+    // zooms in (smaller distance), the world radius shrinks proportionally,
+    // so clusters dissolve at the same rate as Leaflet's screen-space ones.
+    const distance = _schemaCamera.position.distanceTo(controls.target);
+    const halfFovY = (_schemaCamera.fov * Math.PI) / 360;
+    const visibleWidth = 2 * distance * Math.tan(halfFovY) * _schemaCamera.aspect;
+    const worldPerPixel = visibleWidth / w;
     const radiusWorld = NCZ.PIN_3D_CLUSTER_RADIUS_PX * worldPerPixel;
     const radiusSq = radiusWorld * radiusWorld;
 
@@ -585,9 +591,12 @@ const ThreeMarkers = (() => {
     return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
   }
 
-  // Tween OrbitControls' target (XZ only — keep camera height) + camera.position
-  // by the same delta (preserving the spherical offset) + camera.zoom. Runs in
-  // the render loop via updateFlyTween().
+  // Tween OrbitControls' target + camera.position toward the pin. For a
+  // perspective camera the "zoom level" at the end of the fly is a fixed
+  // *distance* (SCHEMA_FLY_TO_DISTANCE — the game's TweakDB zoomToZoomValue):
+  // end position = endTarget + currentDirection × that distance, so the camera
+  // approach angle is preserved but always lands at the same close zoom.
+  // Runs in the render loop via updateFlyTween().
   function flyTo(pin, onComplete) {
     const startTarget = controls.target.clone();
     // Target the pin's full world position INCLUDING height. With a tilted
@@ -596,15 +605,13 @@ const ThreeMarkers = (() => {
     // screen centre regardless of tilt or pin elevation.
     const endTarget = pin.position.clone();
 
-    const offset = _schemaCamera.position.clone().sub(startTarget); // preserved
     const startCameraPos = _schemaCamera.position.clone();
-    const endCameraPos   = endTarget.clone().add(offset);
+    const offsetDir = startCameraPos.clone().sub(startTarget).normalize();
+    const endCameraPos = endTarget.clone().addScaledVector(offsetDir, NCZ.SCHEMA_FLY_TO_DISTANCE);
 
     _flyTween = {
       startTarget, endTarget,
       startCameraPos, endCameraPos,
-      startZoom: _schemaCamera.zoom,
-      endZoom:   NCZ.PIN_3D_FLY_ZOOM,
       elapsed: 0,
       duration: NCZ.PIN_3D_FLY_DURATION_MS,
       onComplete,
@@ -626,7 +633,6 @@ const ThreeMarkers = (() => {
 
     controls.target.lerpVectors(_flyTween.startTarget, _flyTween.endTarget, e);
     _schemaCamera.position.lerpVectors(_flyTween.startCameraPos, _flyTween.endCameraPos, e);
-    _schemaCamera.zoom = _flyTween.startZoom + (_flyTween.endZoom - _flyTween.startZoom) * e;
     _schemaCamera.updateProjectionMatrix();
 
     if (u >= 1) {
@@ -673,9 +679,9 @@ const ThreeMarkers = (() => {
   // Swap the CSS2DRenderer's projection camera for the duration of the
   // showcase. Passing a camera (typically the flyover PerspectiveCamera)
   // makes pins, clusters, popup and tooltip track that camera's view; passing
-  // null reverts to the schema OrthographicCamera. On revert we trigger a
-  // cluster recompute so the orthographic-only math resyncs against the
-  // current zoom (which may have changed during the showcase).
+  // null reverts to the schema PerspectiveCamera. On revert we trigger a
+  // cluster recompute so the distance-based math resyncs against the current
+  // camera distance (which may have changed during the showcase).
   function setActiveCamera(cam) {
     _activeCamera = cam || null;
     if (!cam) recomputeClusters();

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -2,8 +2,9 @@
  * NC Zoning Board — Three.js Scene
  * Namespace: NCZ.ThreeScene
  *
- * Manages the WebGL renderer, orthographic camera, OrbitControls,
- * GLB loading (tiered), lighting, and render loop for the schematic 3D view.
+ * Manages the WebGPU renderer, perspective schema camera (FOV 25°, TweakDB-
+ * aligned to the game's TopDown view), OrbitControls, GLB loading (tiered),
+ * lighting, and render loop for the schematic 3D view.
  *
  * Camera/coordinate notes (derived from render_terrain_3d.html):
  *   GLB space: X = CET_X, Y = height, Z = -CET_Y
@@ -57,6 +58,37 @@ const ThreeScene = (() => {
   let _sunDir        = SUN_DIR.clone(); // unit, ground→sun; updated by setSunPosition, consumed by updateShadowCamera
   let _shadowGroundCenter = new THREE.Vector3(); // world point the shadow camera is centred on (the visible-ground centre)
   let _shadowScratchV = new THREE.Vector3();     // reused by updateShadowCamera so it doesn't allocate per camera move
+  // Reusable scratch state for visible-ground-rect ray casts (perspective camera)
+  const _groundRectCorner = new THREE.Vector3();
+  const _groundRectMin    = new THREE.Vector3();
+  const _groundRectMax    = new THREE.Vector3();
+  const _GROUND_RECT_NDC  = [[-1, -1], [1, -1], [1, 1], [-1, 1]];
+
+  // Cast rays from the camera through the four NDC corners and intersect with
+  // the ground plane (Y=0). The XZ AABB of those four hits is the bounding rect
+  // of what the camera sees on the ground — used by pan bounds, scale bar, and
+  // the shadow camera footprint. Works for any camera type (orthographic via
+  // unproject's projection-matrix inversion, perspective likewise).
+  // Mutates and returns _groundRectMin / _groundRectMax.
+  function _computeVisibleGroundRect(cam) {
+    _groundRectMin.set( Infinity, 0,  Infinity);
+    _groundRectMax.set(-Infinity, 0, -Infinity);
+    for (const [nx, ny] of _GROUND_RECT_NDC) {
+      _groundRectCorner.set(nx, ny, 0.5).unproject(cam);
+      const dx = _groundRectCorner.x - cam.position.x;
+      const dy = _groundRectCorner.y - cam.position.y;
+      const dz = _groundRectCorner.z - cam.position.z;
+      if (Math.abs(dy) < 1e-6) continue;           // ray parallel to ground
+      const t = -cam.position.y / dy;
+      if (t <= 0) continue;                         // ground is behind camera
+      const gx = cam.position.x + t * dx;
+      const gz = cam.position.z + t * dz;
+      if (gx < _groundRectMin.x) _groundRectMin.x = gx;
+      if (gx > _groundRectMax.x) _groundRectMax.x = gx;
+      if (gz < _groundRectMin.z) _groundRectMin.z = gz;
+      if (gz > _groundRectMax.z) _groundRectMax.z = gz;
+    }
+  }
   let _shadowsOn     = true;  // shadows on by default; checkbox reflects this via poll
   let _sunSphere     = null; // visible sun disc — shown during showcase only
   let _sunAz = Math.PI * 0.25, _sunEl = Math.PI * 0.35; // last setSunPosition args
@@ -72,7 +104,7 @@ const ThreeScene = (() => {
   let normalRoadsMat  = null;  // Normal depth-tested pass
   let normalBordersMat= null;  // Normal depth-tested pass
   let metroMat        = null;
-  let metroZoomUniform = null; // TSL uniform() node — mutated from controls 'change'
+  let metroDistanceUniform = null; // TSL uniform() — schema camera-to-target distance; drives metro LOD tier discard (mutex)
   // Captured at WebGPURenderer construction so dumpDebugInfo can introspect
   // the antialias flag — WebGPURenderer has no getContextAttributes() to read it
   // back from, unlike WebGLRenderer.
@@ -383,31 +415,30 @@ const ThreeScene = (() => {
     scene.name = 'main-scene';
     scene.background = readThemeColor('--primary', '#0a192f');
 
-    // Orthographic camera — frustum updated after terrain loads
+    // Perspective camera matching the game's TopDown view — FOV 25°, distance in
+    // CET / world units (see SCHEMA_CAMERA_* in constants.js; values mirror
+    // WorldMap.TopDownCameraSettingsDefault in TweakDB). Z = -WORLD_CY because
+    // GLB_Z = -CET_Y.
     const aspect = container.clientWidth / container.clientHeight;
-    const frustumH = NCZ.WORLD_H / 2;
-    camera = new THREE.OrthographicCamera(
-      -frustumH * aspect, frustumH * aspect,
-       frustumH, -frustumH,
-      NCZ.CAMERA_NEAR, NCZ.CAMERA_FAR
+    camera = new THREE.PerspectiveCamera(
+      NCZ.SCHEMA_CAMERA_FOV, aspect, NCZ.SCHEMA_CAMERA_NEAR, NCZ.SCHEMA_CAMERA_FAR,
     );
     camera.name = 'schema-camera';
-    // Positioned above world centre, looking straight down.
-    // Z = -WORLD_CY because GLB_Z = -CET_Y.
-    camera.position.set(NCZ.WORLD_CX, NCZ.CAMERA_HEIGHT, -NCZ.WORLD_CY);
+    camera.position.set(NCZ.WORLD_CX, NCZ.SCHEMA_CAMERA_DEFAULT_DISTANCE, -NCZ.WORLD_CY);
     camera.lookAt(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
-    camera.up.set(0, 1, 0);  // Standard Three.js up vector
+    camera.up.set(0, 1, 0);
     camera.updateProjectionMatrix();
 
     // ── Lighting: outdoor model — directional sun + hemisphere fill ──
     // The sun: a DirectionalLight whose direction tracks the real Morro Bay sun
     // (SunCalc, via setSunPosition; default NW hillshade until then). One shadow
     // map, an OrthographicCamera fitted each move to exactly the visible-ground
-    // footprint (updateShadowCamera) — no cascades: for a top-down ortho camera
-    // there's no perspective near/far disparity to split, so a single tight map
-    // beats CSM and is far simpler. castShadow stays on permanently; the
-    // "shadows" layer toggle flips shadow *intensity* (toggling castShadow on a
-    // live light tears its depth texture down mid-frame and crashes WebGPURenderer).
+    // footprint (updateShadowCamera) — single map for now; a CSM revisit is
+    // queued (see [[align-schematic-camera-to-game]] — the original "no cascades
+    // because schema is ortho" rationale dissolved when the schema camera moved
+    // to perspective). castShadow stays on permanently; the "shadows" layer
+    // toggle flips shadow *intensity* (toggling castShadow on a live light
+    // tears its depth texture down mid-frame and crashes WebGPURenderer).
     _dirLight = new THREE.DirectionalLight(0xffffff, 1.0 - NCZ.AMBIENT_INTENSITY);
     _dirLight.name = 'sun';
     _dirLight.castShadow         = true;
@@ -456,8 +487,8 @@ const ThreeScene = (() => {
     controls.minPolarAngle  = NCZ.CAMERA_MIN_TILT;
     controls.maxPolarAngle  = NCZ.CAMERA_MAX_TILT;
     controls.dampingFactor  = NCZ.CAMERA_DAMPING;
-    controls.minZoom        = NCZ.CAMERA_ZOOM_MIN;
-    controls.maxZoom        = NCZ.CAMERA_ZOOM_MAX;
+    controls.minDistance    = NCZ.SCHEMA_CAMERA_MIN_DISTANCE;
+    controls.maxDistance    = NCZ.SCHEMA_CAMERA_MAX_DISTANCE;
     controls.zoomSpeed      = NCZ.CAMERA_ZOOM_SPEED;
     controls.panSpeed       = NCZ.CAMERA_PAN_SPEED;
     controls.rotateSpeed    = NCZ.CAMERA_ROTATE_SPEED;
@@ -469,7 +500,7 @@ const ThreeScene = (() => {
     updateShadowCamera();      // seed the shadow camera from the initial pose
     controls.addEventListener('change', () => {
       updateDistrictZoom();
-      if (metroZoomUniform) metroZoomUniform.value = camera.zoom;
+      if (metroDistanceUniform) metroDistanceUniform.value = camera.position.distanceTo(controls.target);
       updateShadowCamera();
       updateFrustumUniforms();   // Phase 2B: refresh the 6 cull-frustum planes
       updateScaleBar();
@@ -500,17 +531,22 @@ const ThreeScene = (() => {
     // tilt; that was reverted in favour of this stable simpler bound. A
     // proper tilt-aware fix is a future improvement (see E5/E6 discussion).
     controls.addEventListener('change', () => {
-      if (!_terrainBox) return;  // terrain not loaded yet — no bound to clamp against
       const t = controls.target;
       const f = NCZ.PIN_3D_PAN_EDGE_FRACTION;
-      const Vx = (camera.right - camera.left) / camera.zoom;
-      const Vz = (camera.top - camera.bottom) / camera.zoom;
+      // Pan envelope = TweakDB WorldMap.DefaultSettings.cursorBoundary (the
+      // game's own pan limits — tighter than the terrain GLB extent because
+      // the playable area sits in the northern half of the world). Allow the
+      // target to drift toward an edge by (f - 0.5) × visible-rect-size so
+      // edge content can still be centred.
+      _computeVisibleGroundRect(camera);
+      const Vx = _groundRectMax.x - _groundRectMin.x;
+      const Vz = _groundRectMax.z - _groundRectMin.z;
       const offsetX = (f - 0.5) * Vx;
       const offsetZ = (f - 0.5) * Vz;
-      const xMin = _terrainBox.min.x - offsetX;
-      const xMax = _terrainBox.max.x + offsetX;
-      const zMin = _terrainBox.min.z - offsetZ;
-      const zMax = _terrainBox.max.z + offsetZ;
+      const xMin = NCZ.PAN_BOUND_MIN_X - offsetX;
+      const xMax = NCZ.PAN_BOUND_MAX_X + offsetX;
+      const zMin = NCZ.PAN_BOUND_MIN_Z - offsetZ;
+      const zMax = NCZ.PAN_BOUND_MAX_Z + offsetZ;
       let dx = 0, dz = 0;
       if (t.x < xMin) dx = xMin - t.x;
       else if (t.x > xMax) dx = xMax - t.x;
@@ -546,10 +582,7 @@ const ThreeScene = (() => {
     const w = container.clientWidth;
     const h = container.clientHeight;
     renderer.setSize(w, h, false); // updateStyle:false — CSS width/height stay at 100%
-    const aspect = w / h;
-    const frustumH = (camera.top - camera.bottom) / 2;
-    camera.left   = -frustumH * aspect;
-    camera.right  =  frustumH * aspect;
+    camera.aspect = w / h;
     camera.updateProjectionMatrix();
     updateShadowCamera();   // shadow camera follows the schema camera's aspect
     // flyCamera resize is handled in flyover.js
@@ -598,8 +631,11 @@ const ThreeScene = (() => {
   }
 
   function updateDistrictZoom() {
-    if (!_districtOuter || !_districtSub) return;
-    const zoomedIn = camera.zoom > NCZ.SUBDISTRICT_ZOOM_3D;
+    if (!_districtOuter || !_districtSub || !controls) return;
+    // Distance from camera to target = distance-to-ground (target sits on Y=0).
+    // Smaller distance = more zoomed in; subdistricts replace districts under the threshold.
+    const distance = camera.position.distanceTo(controls.target);
+    const zoomedIn = distance < NCZ.SUBDISTRICT_DISTANCE_3D;
     _districtOuter.visible = !zoomedIn;
     _districtSub.visible   =  zoomedIn;
   }
@@ -610,18 +646,21 @@ const ThreeScene = (() => {
   // a horizontal bar of that pixel width, label it. CET unit ≈ metre, so no
   // unit conversion needed beyond CET_UNITS_PER_METER (default 1).
   //
-  // Computed from camera frustum width: metres-per-pixel along the screen-X
-  // axis = (camera.right - camera.left) / camera.zoom / canvas_pixel_width.
-  // Screen-X is parallel to the ground regardless of tilt (camera right
-  // vector stays in the world XZ plane for our orthographic top-down + tilt
-  // setup), so the bar reads true even when the camera is tilted.
+  // Perspective worldPerPixel along screen-X at the *centre of screen* (where
+  // the OrbitControls target sits on Y=0): visible width = 2 × distance ×
+  // tan(FOV/2) × aspect; worldPerPixel = that / canvasWidth. Screen-X is
+  // parallel to the ground regardless of tilt, so the bar still reads true
+  // when tilted (camera right vector stays in the world XZ plane).
   function updateScaleBar() {
-    if (!camera || !renderer) return;
+    if (!camera || !renderer || !controls) return;
     const el = document.querySelector('#scene-scale .leaflet-control-scale-line');
     if (!el) return;
     const canvasWidth = renderer.domElement.clientWidth;
     if (!canvasWidth) return;
-    const worldPerPixel = (camera.right - camera.left) / (camera.zoom * canvasWidth);
+    const distance = camera.position.distanceTo(controls.target);
+    const halfFovY = (camera.fov * Math.PI) / 360;
+    const visibleWidth = 2 * distance * Math.tan(halfFovY) * camera.aspect;
+    const worldPerPixel = visibleWidth / canvasWidth;
     const metresPerPixel = worldPerPixel / NCZ.CET_UNITS_PER_METER;
     const idealMetres = NCZ.PIN_3D_SCALE_TARGET_PX * metresPerPixel;
     if (!isFinite(idealMetres) || idealMetres <= 0) return;
@@ -805,19 +844,26 @@ const ThreeScene = (() => {
         blending: THREE.AdditiveBlending,
         depthWrite: false,
       });
-      metroZoomUniform        = uniform(camera.zoom);
-      const uMetroLODMed_node  = uniform(NCZ.METRO_LOD_ZOOM_MED);
-      const uMetroLODNear_node = uniform(NCZ.METRO_LOD_ZOOM_NEAR);
+      // Mutually-exclusive LOD tiers driven by a single CPU uniform (schema
+      // camera-to-target distance). One tier renders at a time across the whole
+      // metro mesh, replacing rather than overlaying as the user zooms. Matches
+      // the in-game "wide → thin → dashed" transition.
+      //   B (wide solid) when distance > MED
+      //   G (thin solid) when NEAR < distance < MED
+      //   R (dotted)     when distance < NEAR
+      metroDistanceUniform     = uniform(NCZ.SCHEMA_CAMERA_DEFAULT_DISTANCE);
+      const uMetroLODMed_node  = uniform(NCZ.METRO_LOD_DISTANCE_MED);
+      const uMetroLODNear_node = uniform(NCZ.METRO_LOD_DISTANCE_NEAR);
       const lodColor = attribute('color');
       const discardCondition =
-        lodColor.b.greaterThan(0.5).and(metroZoomUniform.greaterThan(uMetroLODMed_node))
+        lodColor.b.greaterThan(0.5).and(metroDistanceUniform.lessThan(uMetroLODMed_node))
           .or(
             lodColor.g.greaterThan(0.5).and(
-              metroZoomUniform.lessThan(uMetroLODMed_node).or(metroZoomUniform.greaterThan(uMetroLODNear_node))
+              metroDistanceUniform.greaterThan(uMetroLODMed_node).or(metroDistanceUniform.lessThan(uMetroLODNear_node))
             )
           )
           .or(
-            lodColor.r.greaterThan(0.5).and(metroZoomUniform.lessThan(uMetroLODNear_node))
+            lodColor.r.greaterThan(0.5).and(metroDistanceUniform.greaterThan(uMetroLODNear_node))
           );
       metroMat.maskNode = discardCondition.not();
 
@@ -1385,17 +1431,17 @@ const ThreeScene = (() => {
   function fitCameraToBox(box) {
     const size   = box.getSize(new THREE.Vector3());
     const center = box.getCenter(new THREE.Vector3());
-    const maxDim = Math.max(size.x, size.z);
     const aspect = renderer.domElement.clientWidth / renderer.domElement.clientHeight;
-
-    camera.left   = -maxDim * aspect / 2;
-    camera.right  =  maxDim * aspect / 2;
-    camera.top    =  maxDim / 2;
-    camera.bottom = -maxDim / 2;
-    camera.updateProjectionMatrix();
+    // Distance needed to fit the larger of width / height into the perspective
+    // frustum, accounting for aspect on the horizontal axis. tan(FOV/2) × distance
+    // = halfHeight; horizontal frustum half-width = halfHeight × aspect.
+    const halfFovY = (NCZ.SCHEMA_CAMERA_FOV * Math.PI) / 360;
+    const distForHeight = (size.z / 2) / Math.tan(halfFovY);
+    const distForWidth  = (size.x / 2) / (Math.tan(halfFovY) * aspect);
+    const distance = Math.max(distForHeight, distForWidth);
 
     controls.target.set(center.x, 0, center.z);
-    camera.position.set(center.x, NCZ.CAMERA_HEIGHT, center.z);
+    camera.position.set(center.x, distance, center.z);
     camera.lookAt(center.x, 0, center.z);
     controls.update();
   }
@@ -1575,7 +1621,9 @@ const ThreeScene = (() => {
     // until the user moved the camera (firing the controls 'change' reset).
     updateShadowCamera();
     updateFrustumUniforms();
-    if (metroZoomUniform && camera) metroZoomUniform.value = camera.zoom;
+    if (metroDistanceUniform && camera && controls) {
+      metroDistanceUniform.value = camera.position.distanceTo(controls.target);
+    }
     requestRender();
   }
 
@@ -1873,15 +1921,12 @@ const ThreeScene = (() => {
     if (cam && cam !== camera) {
       updateShadowCamera(cam);   // also refreshes the union-cull's shadow frustum
       updateFrustumUniforms(cam); // and the camera-frustum half
-      // Metro LOD: pin to the R-tier (dashed close-zoom variant) for the
-      // whole showcase. Calibrating a perspective-altitude → ortho-zoom
-      // mapping that hits the existing METRO_LOD_ZOOM_MED / _NEAR thresholds
-      // cleanly across every waypoint isn't worth the tuning effort —
-      // dashed reads well from any cinematic angle and avoids tier
-      // transitions mid-flight. Any value > METRO_LOD_ZOOM_NEAR makes the
-      // discard expression keep only R; +1 stays well clear of float wobble.
-      if (metroZoomUniform && cam.isPerspectiveCamera) {
-        metroZoomUniform.value = NCZ.METRO_LOD_ZOOM_NEAR + 1;
+      // Metro LOD: pin to the R-tier (dotted close-zoom variant) for the whole
+      // showcase. Dashed reads well from any cinematic angle and avoids tier
+      // transitions mid-flight. Any distance < METRO_LOD_DISTANCE_NEAR forces
+      // the discard expression to keep only R; 0 is the unambiguous floor.
+      if (metroDistanceUniform && cam.isPerspectiveCamera) {
+        metroDistanceUniform.value = 0;
       }
       for (const c of _cullComputes) {
         renderer.compute(c.reset);
@@ -1904,21 +1949,20 @@ const ThreeScene = (() => {
 
   function resetCamera() {
     if (!controls) return;
-    const aspect = renderer.domElement.clientWidth / renderer.domElement.clientHeight;
-    const frustumH = NCZ.WORLD_H / 2;
-    camera.left   = -frustumH * aspect;
-    camera.right  =  frustumH * aspect;
-    camera.top    =  frustumH;
-    camera.bottom = -frustumH;
-    camera.updateProjectionMatrix();
 
-    // Reset to top-down view: target at sea level, camera directly above
-    controls.target.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
-    camera.position.set(NCZ.WORLD_CX, NCZ.CAMERA_HEIGHT, -NCZ.WORLD_CY);
-    camera.lookAt(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
+    // Match the first-load view: fit the camera to the terrain box (same code
+    // path init runs after terrain loads), capped at maxDistance by OrbitControls
+    // on the controls.update() below. Falls back to the default distance pose if
+    // terrain hasn't loaded yet (early reset before assets ready).
+    if (_terrainBox) {
+      fitCameraToBox(_terrainBox);
+    } else {
+      controls.target.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
+      camera.position.set(NCZ.WORLD_CX, NCZ.SCHEMA_CAMERA_DEFAULT_DISTANCE, -NCZ.WORLD_CY);
+      camera.lookAt(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
+    }
     camera.up.set(0, 1, 0);
 
-    // Reset OrbitControls state (polar angle = π/2 for top-down)
     controls.autoRotate = false;
     controls.autoRotateSpeed = 0;
     controls.update();
@@ -2129,23 +2173,23 @@ const ThreeScene = (() => {
   // extreme. Re-centres the sun light + its target on that footprint so the
   // shadow tracks what you see. Called on every camera change, on resize, after
   // terrain loads, on flyover frames (renderCam = the fly cam), and from
-  // startRenderLoop. No cascades — our schema camera is orthographic (uniform
-  // pixels-per-world-unit), so there's no perspective near/far disparity for
-  // cascades to exploit; one tight map is both simpler and sharper here.
+  // startRenderLoop. Single map for now; CSM is a queued follow-up
+  // (see [[align-schematic-camera-to-game]] for the rationale shift).
   function updateShadowCamera(renderCam = camera) {
     if (!_dirLight || !renderCam) return;
     const shadowCam = _dirLight.shadow.camera;
 
     let half, center;
     if (renderCam === camera && controls) {
-      // Schema orthographic camera — analytic fit. The visible ground is a W×D
-      // rectangle: W = the screen-horizontal world extent; D = the screen-vertical
-      // extent stretched by 1/cos(tilt) (a tilted view sees a longer strip of
-      // ground). A square of side = that rectangle's diagonal contains it from any
-      // sun azimuth. Cap so it can't reach the horizon at the zoomed-out extreme.
-      const W = 2 * camera.right / camera.zoom;
-      const tilt = controls.getPolarAngle?.() ?? 0;
-      const D = (2 * camera.top / camera.zoom) / Math.max(0.25, Math.cos(tilt)); // 0.25 ≈ cos 76°, past CAMERA_MAX_TILT
+      // Schema perspective camera — fit a square to the visible ground rect
+      // (computed by ray-casting from camera through the four NDC corners and
+      // intersecting Y=0). The rect handles tilt and aspect naturally — no
+      // analytic 1/cos(tilt) stretch needed. A square of side = rect diagonal
+      // contains it from any sun azimuth; cap so it can't reach the horizon at
+      // the zoomed-out extreme.
+      _computeVisibleGroundRect(camera);
+      const W = _groundRectMax.x - _groundRectMin.x;
+      const D = _groundRectMax.z - _groundRectMin.z;
       half = Math.min(0.5 * Math.hypot(W, D), NCZ.SHADOW_MAX_DISTANCE) + NCZ.SHADOW_GROUND_MARGIN;
       // Pin the centre to the ground plane (Y = 0): controls.target can drift
       // off Y=0 with screen-space panning at a tilt, which would slide the
@@ -2214,7 +2258,6 @@ const ThreeScene = (() => {
     return {
       target:    controls.target.toArray(),
       position:  camera.position.toArray(),
-      zoom:      camera.zoom,
       polar:     controls.getPolarAngle(),
       azimuth:   controls.getAzimuthalAngle(),
       sunAz:     _sunAz,
@@ -2227,7 +2270,6 @@ const ThreeScene = (() => {
     if (!controls || !camera) return;
     controls.target.fromArray(s.target);
     camera.position.fromArray(s.position);
-    camera.zoom = s.zoom;
     controls.update();
     camera.updateProjectionMatrix();
     if (s.sunAz !== undefined) setSunPosition(s.sunAz, s.sunEl);

--- a/docs/data/worldmap_tweakdb_tree.json
+++ b/docs/data/worldmap_tweakdb_tree.json
@@ -1,0 +1,2610 @@
+{
+  "_prefix": "WorldMap.",
+  "_seedCount": 64,
+  "_recordCount": 110,
+  "_byNamespace": {
+    "WorldMap": 64,
+    "Mappins": 46
+  },
+  "_refsBroken": [],
+  "_recordIds": [
+    "Mappins.ApartmentToPurchaseVariant",
+    "Mappins.CarForPurchaseVariant",
+    "Mappins.CustomPositionVariant",
+    "Mappins.DefaultQuestVariant",
+    "Mappins.DelamainTaxiDestinationVariant",
+    "Mappins.DelamainTaxiVariant",
+    "Mappins.DogtownGateVariant",
+    "Mappins.MotorcycleForPurchaseVariant",
+    "Mappins.MotorcycleVariant",
+    "Mappins.NCPDGigVariant",
+    "Mappins.PointOfInterest_ApartmentVariant",
+    "Mappins.PointOfInterest_BountyHuntVariant",
+    "Mappins.PointOfInterest_ClientInDistressVariant",
+    "Mappins.PointOfInterest_ConvoyVariant",
+    "Mappins.PointOfInterest_ExclamationMarkVariant",
+    "Mappins.PointOfInterest_FastTravelVariant",
+    "Mappins.PointOfInterest_FixerVariant",
+    "Mappins.PointOfInterest_GangWatchVariant",
+    "Mappins.PointOfInterest_HiddenStashVariant",
+    "Mappins.PointOfInterest_HuntForPsychoVariant",
+    "Mappins.PointOfInterest_MinorActivityVariant",
+    "Mappins.PointOfInterest_NCARTVariant",
+    "Mappins.PointOfInterest_OutpostVariant",
+    "Mappins.PointOfInterest_RacingVariant",
+    "Mappins.PointOfInterest_RetrievingVariant",
+    "Mappins.PointOfInterest_SabotageVariant",
+    "Mappins.PointOfInterest_ServicePointBarVariant",
+    "Mappins.PointOfInterest_ServicePointClothesVariant",
+    "Mappins.PointOfInterest_ServicePointDropPoint",
+    "Mappins.PointOfInterest_ServicePointFoodVariant",
+    "Mappins.PointOfInterest_ServicePointGunsVariant",
+    "Mappins.PointOfInterest_ServicePointJunkVariant",
+    "Mappins.PointOfInterest_ServicePointMedsVariant",
+    "Mappins.PointOfInterest_ServicePointMeleeTrainerVariant",
+    "Mappins.PointOfInterest_ServicePointNetTrainerVariant",
+    "Mappins.PointOfInterest_ServicePointProstituteVariant",
+    "Mappins.PointOfInterest_ServicePointRipperdocVariant",
+    "Mappins.PointOfInterest_TarotVariant",
+    "Mappins.PointOfInterest_ThieveryVariant",
+    "Mappins.QuestGiverVariant",
+    "Mappins.RelicDeviceBasicVariant",
+    "Mappins.RelicDeviceSpecialVariant",
+    "Mappins.ServicePointBlackMarketVariant",
+    "Mappins.VehicleVariant",
+    "Mappins.WorldEncounterVariant",
+    "Mappins.Zzz09_CourierSandboxActivityVariant",
+    "WorldMap.AllServicePointsFilterGroup",
+    "WorldMap.ApartmentToPurchaseFilter",
+    "WorldMap.ApartmentToPurchaseFilterGroup",
+    "WorldMap.ApartmentToPurchaseMappinsGroup",
+    "WorldMap.AutofixerFilter",
+    "WorldMap.AutofixerFilterGroup",
+    "WorldMap.BaseZoomLevel",
+    "WorldMap.CommonFilter",
+    "WorldMap.CommonFilterGroup",
+    "WorldMap.CourierFilter",
+    "WorldMap.CourierFilterGroup",
+    "WorldMap.CustomFilter",
+    "WorldMap.CustomFilterGroup",
+    "WorldMap.CyberPsychoFilterGroup",
+    "WorldMap.DefaultSettings",
+    "WorldMap.DogtownGateFilter",
+    "WorldMap.DogtownGateFilterGroup",
+    "WorldMap.DropPointFilter",
+    "WorldMap.DropPointFilterGroup",
+    "WorldMap.ExplorationFilter",
+    "WorldMap.ExplorationFilterGroup",
+    "WorldMap.FastTravelFilter",
+    "WorldMap.FastTravelFilterGroup",
+    "WorldMap.FastTravelMappinsGroup",
+    "WorldMap.FreeCameraSettingsDefault",
+    "WorldMap.GigsFilter",
+    "WorldMap.JobsFilterGroup",
+    "WorldMap.MainQuestFilterGroup",
+    "WorldMap.NoFilter",
+    "WorldMap.NoFilterGroup",
+    "WorldMap.PlayerMappinsGroup",
+    "WorldMap.PsychoFilter",
+    "WorldMap.QuestFilter",
+    "WorldMap.QuestFilterGroup",
+    "WorldMap.QuestMappinsGroup",
+    "WorldMap.RelicDeviceFilter",
+    "WorldMap.RelicDeviceFilterGroup",
+    "WorldMap.RipperdocFilter",
+    "WorldMap.RipperdocFilterGroup",
+    "WorldMap.SandboxActivitesMappinsGroup",
+    "WorldMap.SecondaryQuestMappinsGroup",
+    "WorldMap.ServicePointFilter",
+    "WorldMap.ServicePointFilterGroup",
+    "WorldMap.ServicePointMappinsGroup",
+    "WorldMap.StoryFilter",
+    "WorldMap.StoryFilterGroup",
+    "WorldMap.StoryMappinsGroup",
+    "WorldMap.TarotFilter",
+    "WorldMap.TarotFilterGroup",
+    "WorldMap.TopDownCameraSettingsDefault",
+    "WorldMap.VehicleForPurchaseMappinsGroup",
+    "WorldMap.VehicleForSaleFilter",
+    "WorldMap.VendorFilter",
+    "WorldMap.VendorFilterGroup",
+    "WorldMap.WorldEncounterFilter",
+    "WorldMap.WorldEncounterFilterGroup",
+    "WorldMap.WorldMapCustomFiltersList",
+    "WorldMap.WorldMapQuickFiltersList",
+    "WorldMap.ZoomLevelAllMappins",
+    "WorldMap.ZoomLevelDistricts",
+    "WorldMap.ZoomLevelExtraMappins",
+    "WorldMap.ZoomLevelImportant",
+    "WorldMap.ZoomLevelSubDistricts",
+    "WorldMap.ZoomLevelVendors"
+  ],
+  "records": {
+    "WorldMap.WorldMapCustomFiltersList": {
+      "$type": "gamedataWorldMapFiltersList_Record",
+      "list": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.MainQuestFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.QuestFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CyberPsychoFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.StoryFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.FastTravelFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.RipperdocFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.VendorFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.AutofixerFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.DropPointFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.ApartmentToPurchaseFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.TarotFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CommonFilterGroup"
+        }
+      ]
+    },
+    "WorldMap.FastTravelFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "FastTravel"
+      }
+    },
+    "WorldMap.ZoomLevelAllMappins": {
+      "$type": "gamedataWorldMapZoomLevel_Record",
+      "canChangeFilters": 1,
+      "fov": 25,
+      "iconScale": 1,
+      "mappinFilterGroups": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.MainQuestFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CommonFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.QuestFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CyberPsychoFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CourierFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.WorldEncounterFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.RipperdocFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.FastTravelFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.DropPointFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.ApartmentToPurchaseFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.TarotFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.DogtownGateFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.RelicDeviceFilterGroup"
+        }
+      ],
+      "panSpeed": 1400,
+      "rotation": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": 0,
+        "Yaw": -85
+      },
+      "showDistricts": 0,
+      "showSubDistricts": 0,
+      "zoom": 2500
+    },
+    "WorldMap.SandboxActivitesMappinsGroup": {
+      "$type": "gamedataMappinsGroup_Record",
+      "groupName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "SandboxActivites"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.Zzz09_CourierSandboxActivityVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.WorldEncounterVariant"
+        }
+      ],
+      "widgetState": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Gigs"
+      }
+    },
+    "WorldMap.CustomFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Settings-Video-QualitySetting-Custom"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.CustomFilter"
+      },
+      "mappins": [],
+      "shouldCollectMappins": 0
+    },
+    "WorldMap.CommonFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Menus-WorldMap-Filter-YourProperty"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.CommonFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.CustomPositionVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.DelamainTaxiVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.DelamainTaxiDestinationVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.VehicleVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.MotorcycleVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ApartmentVariant"
+        }
+      ],
+      "shouldCollectMappins": 0
+    },
+    "WorldMap.CustomFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "CustomFilter"
+      }
+    },
+    "WorldMap.ZoomLevelImportant": {
+      "$type": "gamedataWorldMapZoomLevel_Record",
+      "canChangeFilters": 1,
+      "fov": 25,
+      "iconScale": 1,
+      "mappinFilterGroups": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.MainQuestFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CommonFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.QuestFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CyberPsychoFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CourierFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.WorldEncounterFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.ApartmentToPurchaseFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.TarotFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.DogtownGateFilterGroup"
+        }
+      ],
+      "panSpeed": 1400,
+      "rotation": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": 0,
+        "Yaw": -85
+      },
+      "showDistricts": 0,
+      "showSubDistricts": 0,
+      "zoom": 4500
+    },
+    "WorldMap.AllServicePointsFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Menus-WorldMap-Filter-ServicePoint"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.ServicePointFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.CustomPositionVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.DelamainTaxiVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.DelamainTaxiDestinationVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.VehicleVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.MotorcycleVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ApartmentVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointRipperdocVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointClothesVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointFoodVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointJunkVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointMedsVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointNetTrainerVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointGunsVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.ServicePointBlackMarketVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointMeleeTrainerVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointBarVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointProstituteVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointDropPoint"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_FastTravelVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_NCARTVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.CarForPurchaseVariant"
+        }
+      ],
+      "shouldCollectMappins": 0
+    },
+    "WorldMap.MainQuestFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Menus-WorldMap-Filter-Jobs"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.QuestFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ExclamationMarkVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.DefaultQuestVariant"
+        }
+      ],
+      "shouldCollectMappins": 0
+    },
+    "WorldMap.StoryMappinsGroup": {
+      "$type": "gamedataMappinsGroup_Record",
+      "groupName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Story"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_MinorActivityVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_GangWatchVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_OutpostVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_HiddenStashVariant"
+        }
+      ],
+      "widgetState": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Story"
+      }
+    },
+    "WorldMap.TarotFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "TarotFilter"
+      }
+    },
+    "WorldMap.WorldEncounterFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-MappinTypes-WorldEncounter"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.WorldEncounterFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.WorldEncounterVariant"
+        }
+      ],
+      "shouldCollectMappins": 0
+    },
+    "WorldMap.RipperdocFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Menus-WorldMap-Filter-Ripperdoc"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.RipperdocFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointRipperdocVariant"
+        }
+      ],
+      "shouldCollectMappins": 1
+    },
+    "WorldMap.NoFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Menus-WorldMap-Filter-Dynamic"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.NoFilter"
+      },
+      "mappins": [],
+      "shouldCollectMappins": 0
+    },
+    "WorldMap.QuestFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Quests-Labels-StreetStories"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.GigsFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_FixerVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.QuestGiverVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.WorldEncounterVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.Zzz09_CourierSandboxActivityVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_BountyHuntVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_RetrievingVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ThieveryVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_SabotageVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ClientInDistressVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ConvoyVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_RacingVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.NCPDGigVariant"
+        }
+      ],
+      "shouldCollectMappins": 0
+    },
+    "WorldMap.ZoomLevelSubDistricts": {
+      "$type": "gamedataWorldMapZoomLevel_Record",
+      "canChangeFilters": 1,
+      "fov": 25,
+      "iconScale": 1,
+      "mappinFilterGroups": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.MainQuestFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CommonFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.QuestFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CyberPsychoFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CourierFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.WorldEncounterFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.DogtownGateFilterGroup"
+        }
+      ],
+      "panSpeed": 3000,
+      "rotation": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": 0,
+        "Yaw": -85
+      },
+      "showDistricts": 0,
+      "showSubDistricts": 1,
+      "zoom": 7000
+    },
+    "WorldMap.JobsFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Menus-WorldMap-Filter-Jobs"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.GigsFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ExclamationMarkVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.DefaultQuestVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_FixerVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.QuestGiverVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_BountyHuntVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_RetrievingVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ThieveryVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_SabotageVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ClientInDistressVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ConvoyVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_HuntForPsychoVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_RacingVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.NCPDGigVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.WorldEncounterVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.Zzz09_CourierSandboxActivityVariant"
+        }
+      ],
+      "shouldCollectMappins": 0
+    },
+    "WorldMap.RipperdocFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "RipperdocFilter"
+      }
+    },
+    "WorldMap.RelicDeviceFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Gameplay-Devices-DisplayNames-CorporateCoreDataHolder"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.AutofixerFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.RelicDeviceBasicVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.RelicDeviceSpecialVariant"
+        }
+      ],
+      "shouldCollectMappins": 1
+    },
+    "WorldMap.CommonFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "CommonFilter"
+      }
+    },
+    "WorldMap.PlayerMappinsGroup": {
+      "$type": "gamedataMappinsGroup_Record",
+      "groupName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Player"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_FixerVariant"
+        }
+      ],
+      "widgetState": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Gigs"
+      }
+    },
+    "WorldMap.AutofixerFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Menus-WorldMap-Filter-Autofixer"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.AutofixerFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.CarForPurchaseVariant"
+        }
+      ],
+      "shouldCollectMappins": 1
+    },
+    "WorldMap.WorldEncounterFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Outpost"
+      }
+    },
+    "WorldMap.ApartmentToPurchaseFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-MappinTypes-ApartmentToPurchase"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.ApartmentToPurchaseFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.ApartmentToPurchaseVariant"
+        }
+      ],
+      "shouldCollectMappins": 0
+    },
+    "WorldMap.ExplorationFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Story-base-journal-codex-tutorials-Exploration_groupName"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.ExplorationFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointProstituteVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.WorldEncounterVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.RelicDeviceBasicVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.RelicDeviceSpecialVariant"
+        }
+      ],
+      "shouldCollectMappins": 1
+    },
+    "WorldMap.FreeCameraSettingsDefault": {
+      "$type": "gamedataWorldMapFreeCameraSettings_Record",
+      "fovMax": 25,
+      "fovMin": 25,
+      "iconScaleMax": 1,
+      "iconScaleMin": 1,
+      "mousePanStrength": 0.00139999995,
+      "mouseRotateStrength": 0.00079999998,
+      "mouseZoomSpeedMax": 4000,
+      "mouseZoomSpeedMin": 200,
+      "panSpeedMax": 3500,
+      "panSpeedMin": 250,
+      "pitchRelativeToZoom": 0,
+      "rotationDefault": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": 0,
+        "Yaw": -45
+      },
+      "rotationMax": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": 360,
+        "Yaw": -30
+      },
+      "rotationMin": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": -360,
+        "Yaw": -85
+      },
+      "rotationSpeed": {
+        "$type": "EulerAngles",
+        "Pitch": 75,
+        "Roll": 95,
+        "Yaw": 75
+      },
+      "zoomDefault": 3000,
+      "zoomDefaultInFastTravel": 5000,
+      "zoomMax": 10500,
+      "zoomMin": 800,
+      "zoomSpeed": 25,
+      "zoomSpeedMax": 20000,
+      "zoomSpeedMin": 1500
+    },
+    "WorldMap.DropPointFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-MappinTypes-Dropbox"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.DropPointFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointDropPoint"
+        }
+      ],
+      "shouldCollectMappins": 0
+    },
+    "WorldMap.DogtownGateFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "DogtownGateFilter"
+      }
+    },
+    "WorldMap.StoryFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Story"
+      }
+    },
+    "WorldMap.ExplorationFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ExplorationFilter"
+      }
+    },
+    "WorldMap.ServicePointMappinsGroup": {
+      "$type": "gamedataMappinsGroup_Record",
+      "groupName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePoint"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.CustomPositionVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.DelamainTaxiVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.DelamainTaxiDestinationVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.VehicleVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.MotorcycleVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ApartmentVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointRipperdocVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointClothesVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointFoodVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointJunkVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointMedsVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointNetTrainerVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointGunsVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.ServicePointBlackMarketVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointMeleeTrainerVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointBarVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointProstituteVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointDropPoint"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.RelicDeviceBasicVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.RelicDeviceSpecialVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.DogtownGateVariant"
+        }
+      ],
+      "widgetState": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePoint"
+      }
+    },
+    "WorldMap.ZoomLevelVendors": {
+      "$type": "gamedataWorldMapZoomLevel_Record",
+      "canChangeFilters": 1,
+      "fov": 25,
+      "iconScale": 1,
+      "mappinFilterGroups": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.MainQuestFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CommonFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.QuestFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CyberPsychoFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CourierFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.WorldEncounterFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.RipperdocFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.ApartmentToPurchaseFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.TarotFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.DogtownGateFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.RelicDeviceFilterGroup"
+        }
+      ],
+      "panSpeed": 1400,
+      "rotation": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": 0,
+        "Yaw": -85
+      },
+      "showDistricts": 0,
+      "showSubDistricts": 0,
+      "zoom": 3500
+    },
+    "WorldMap.QuestMappinsGroup": {
+      "$type": "gamedataMappinsGroup_Record",
+      "groupName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Quest"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.DefaultQuestVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ExclamationMarkVariant"
+        }
+      ],
+      "widgetState": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Quest"
+      }
+    },
+    "WorldMap.ZoomLevelDistricts": {
+      "$type": "gamedataWorldMapZoomLevel_Record",
+      "canChangeFilters": 1,
+      "fov": 25,
+      "iconScale": 1,
+      "mappinFilterGroups": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CommonFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.MainQuestFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.DogtownGateFilterGroup"
+        }
+      ],
+      "panSpeed": 3500,
+      "rotation": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": 0,
+        "Yaw": -85
+      },
+      "showDistricts": 1,
+      "showSubDistricts": 0,
+      "zoom": 11000
+    },
+    "WorldMap.CourierFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-MappinTypes-CourierTitleDiscovered"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.CourierFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.Zzz09_CourierSandboxActivityVariant"
+        }
+      ],
+      "shouldCollectMappins": 0
+    },
+    "WorldMap.DropPointFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "DropPoint"
+      }
+    },
+    "WorldMap.ZoomLevelExtraMappins": {
+      "$type": "gamedataWorldMapZoomLevel_Record",
+      "canChangeFilters": 1,
+      "fov": 25,
+      "iconScale": 1,
+      "mappinFilterGroups": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.MainQuestFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CommonFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.QuestFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CyberPsychoFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CourierFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.WorldEncounterFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.RipperdocFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.AutofixerFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.FastTravelFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.VendorFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.DropPointFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.ExplorationFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.ApartmentToPurchaseFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.TarotFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.DogtownGateFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.RelicDeviceFilterGroup"
+        }
+      ],
+      "panSpeed": 1400,
+      "rotation": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": 0,
+        "Yaw": -85
+      },
+      "showDistricts": 0,
+      "showSubDistricts": 0,
+      "zoom": 1000
+    },
+    "WorldMap.RelicDeviceFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "RelicDeviceFilter"
+      }
+    },
+    "WorldMap.ApartmentToPurchaseFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ApartmentToPurchaseFilter"
+      }
+    },
+    "WorldMap.AutofixerFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "AutofixerFilter"
+      }
+    },
+    "WorldMap.ApartmentToPurchaseMappinsGroup": {
+      "$type": "gamedataMappinsGroup_Record",
+      "groupName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ApartmentToPurchase"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.ApartmentToPurchaseVariant"
+        }
+      ],
+      "widgetState": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Gigs"
+      }
+    },
+    "WorldMap.GigsFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Gigs"
+      }
+    },
+    "WorldMap.DefaultSettings": {
+      "$type": "gamedataWorldMapSettings_Record",
+      "cameraModeTransitionTime": 0.349999994,
+      "cursorBoundaryMax": {
+        "$type": "Vector2",
+        "X": 6050,
+        "Y": 5000
+      },
+      "cursorBoundaryMin": {
+        "$type": "Vector2",
+        "X": -5500,
+        "Y": -7300
+      },
+      "enableGroupTransitionAnimations": 1,
+      "freeCamera": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.FreeCameraSettingsDefault"
+      },
+      "mouseZoomTransitionTime": 0.100000001,
+      "NCPDEventsVisibilityRange": 100,
+      "topDownCamera": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.TopDownCameraSettingsDefault"
+      },
+      "zoomLevels": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.ZoomLevelDistricts"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.ZoomLevelSubDistricts"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.ZoomLevelImportant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.ZoomLevelVendors"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.ZoomLevelAllMappins"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.ZoomLevelExtraMappins"
+        }
+      ],
+      "zoomToEnabledAtMinimumZoom": 2000,
+      "zoomToZoomValue": 1250,
+      "zoomTransitionTime": 0.25
+    },
+    "WorldMap.SecondaryQuestMappinsGroup": {
+      "$type": "gamedataMappinsGroup_Record",
+      "groupName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "SecondaryQuest"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.QuestGiverVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_BountyHuntVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_RetrievingVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ThieveryVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_SabotageVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ClientInDistressVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ConvoyVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_HuntForPsychoVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_RacingVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.NCPDGigVariant"
+        }
+      ],
+      "widgetState": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Gigs"
+      }
+    },
+    "WorldMap.VehicleForSaleFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "VehicleForSaleFilter"
+      }
+    },
+    "WorldMap.VendorFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Menus-WorldMap-Filter-Vendor"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.VendorFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointClothesVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointFoodVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointJunkVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointMedsVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointNetTrainerVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointGunsVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.ServicePointBlackMarketVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointMeleeTrainerVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointBarVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointProstituteVariant"
+        }
+      ],
+      "shouldCollectMappins": 1
+    },
+    "WorldMap.BaseZoomLevel": {
+      "$type": "gamedataWorldMapZoomLevel_Record",
+      "canChangeFilters": 1,
+      "fov": 25,
+      "iconScale": 1,
+      "mappinFilterGroups": [],
+      "panSpeed": 1,
+      "rotation": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": 0,
+        "Yaw": -85
+      },
+      "showDistricts": 0,
+      "showSubDistricts": 0,
+      "zoom": 1
+    },
+    "WorldMap.CourierFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Courier"
+      }
+    },
+    "WorldMap.VendorFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "VendorFilter"
+      }
+    },
+    "WorldMap.TarotFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-PanelNames-TAROT"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.TarotFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_TarotVariant"
+        }
+      ],
+      "shouldCollectMappins": 1,
+      "numberOfHitsForAdditionalAttack": {
+        "$type": "TweakDBID",
+        "$value": {
+          "$type": "TweakDBID",
+          "$storage": "uint64",
+          "$value": "0"
+        }
+      }
+    },
+    "WorldMap.PsychoFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "PsychoFilter"
+      },
+      "tireLateralSlipEffectsMul": {
+        "$type": "CName",
+        "$value": {
+          "$type": "CName",
+          "$storage": "string",
+          "$value": "None"
+        }
+      }
+    },
+    "WorldMap.TopDownCameraSettingsDefault": {
+      "$type": "gamedataWorldMapFreeCameraSettings_Record",
+      "fovMax": 25,
+      "fovMin": 25,
+      "iconScaleMax": 1,
+      "iconScaleMin": 1,
+      "mousePanStrength": 0.00139999995,
+      "mouseRotateStrength": 0.00079999998,
+      "mouseZoomSpeedMax": 4000,
+      "mouseZoomSpeedMin": 200,
+      "panSpeedMax": 3500,
+      "panSpeedMin": 250,
+      "pitchRelativeToZoom": 1,
+      "rotationDefault": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": 0,
+        "Yaw": 45
+      },
+      "rotationMax": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": 0,
+        "Yaw": -89
+      },
+      "rotationMin": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": 0,
+        "Yaw": -75
+      },
+      "rotationSpeed": {
+        "$type": "EulerAngles",
+        "Pitch": 0,
+        "Roll": 0,
+        "Yaw": 0
+      },
+      "zoomDefault": 3000,
+      "zoomDefaultInFastTravel": 5000,
+      "zoomMax": 15000,
+      "zoomMin": 800,
+      "zoomSpeed": 25,
+      "zoomSpeedMax": 20000,
+      "zoomSpeedMin": 1500
+    },
+    "WorldMap.NoFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "NoFilter"
+      }
+    },
+    "WorldMap.WorldMapQuickFiltersList": {
+      "$type": "gamedataWorldMapFiltersList_Record",
+      "list": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.NoFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.JobsFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.AllServicePointsFilterGroup"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "WorldMap.CustomFilterGroup"
+        }
+      ]
+    },
+    "WorldMap.FastTravelMappinsGroup": {
+      "$type": "gamedataMappinsGroup_Record",
+      "groupName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "FastTravel"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_TarotVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_FastTravelVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_NCARTVariant"
+        }
+      ],
+      "widgetState": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "FastTravel"
+      }
+    },
+    "WorldMap.VehicleForPurchaseMappinsGroup": {
+      "$type": "gamedataMappinsGroup_Record",
+      "groupName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "VehicleForPurchase"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.CarForPurchaseVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.MotorcycleForPurchaseVariant"
+        }
+      ],
+      "widgetState": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePoint"
+      }
+    },
+    "WorldMap.ServicePointFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePoint"
+      }
+    },
+    "WorldMap.QuestFilter": {
+      "$type": "gamedataWorldMapFilter_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Quest"
+      }
+    },
+    "WorldMap.DogtownGateFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Menus-WorldMap-Filter-DogtownGate"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.DogtownGateFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.DogtownGateVariant"
+        }
+      ],
+      "shouldCollectMappins": 1
+    },
+    "WorldMap.FastTravelFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Menus-WorldMap-Filter-FastTravel"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.FastTravelFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_FastTravelVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_NCARTVariant"
+        }
+      ],
+      "shouldCollectMappins": 0
+    },
+    "WorldMap.CyberPsychoFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-MappinTypes-HuntforPsycho"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.PsychoFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_HuntForPsychoVariant"
+        }
+      ],
+      "shouldCollectMappins": 0
+    },
+    "WorldMap.StoryFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Menus-WorldMap-Filter-NcpdScanner"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.StoryFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_MinorActivityVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_GangWatchVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_HiddenStashVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_OutpostVariant"
+        }
+      ],
+      "shouldCollectMappins": 1
+    },
+    "WorldMap.ServicePointFilterGroup": {
+      "$type": "gamedataMappinUIFilterGroup_Record",
+      "filterName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "UI-Menus-WorldMap-Filter-ServicePoint"
+      },
+      "filterType": {
+        "$type": "TweakDBID",
+        "$storage": "string",
+        "$value": "WorldMap.ServicePointFilter"
+      },
+      "mappins": [
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointClothesVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointRipperdocVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointNetTrainerVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointGunsVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.ServicePointBlackMarketVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointMeleeTrainerVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointMedsVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointFoodVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointBarVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointProstituteVariant"
+        },
+        {
+          "$type": "TweakDBID",
+          "$storage": "string",
+          "$value": "Mappins.PointOfInterest_ServicePointJunkVariant"
+        }
+      ],
+      "shouldCollectMappins": 1
+    },
+    "Mappins.Zzz09_CourierSandboxActivityVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz09_CourierSandboxActivityVariant"
+      }
+    },
+    "Mappins.WorldEncounterVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz12_WorldEncounterVariant"
+      }
+    },
+    "Mappins.CustomPositionVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "CustomPositionVariant"
+      }
+    },
+    "Mappins.DelamainTaxiVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz19_DelamainTaxiVariant"
+      }
+    },
+    "Mappins.DelamainTaxiDestinationVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz20_DelamainTaxiDestinationVariant"
+      }
+    },
+    "Mappins.VehicleVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "VehicleVariant"
+      }
+    },
+    "Mappins.MotorcycleVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz03_MotorcycleVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ApartmentVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ApartmentVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ServicePointRipperdocVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePointRipperdocVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ServicePointClothesVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePointClothesVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ServicePointFoodVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePointFoodVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ServicePointJunkVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePointJunkVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ServicePointMedsVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePointMedsVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ServicePointNetTrainerVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePointNetTrainerVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ServicePointGunsVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePointGunsVariant"
+      }
+    },
+    "Mappins.ServicePointBlackMarketVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz14_ServicePointBlackMarketVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ServicePointMeleeTrainerVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePointMeleeTrainerVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ServicePointBarVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePointBarVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ServicePointProstituteVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePointProstituteVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ServicePointDropPoint": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ServicePointDropPointVariant"
+      }
+    },
+    "Mappins.PointOfInterest_FastTravelVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "FastTravelVariant"
+      }
+    },
+    "Mappins.PointOfInterest_NCARTVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz17_NCARTVariant"
+      }
+    },
+    "Mappins.CarForPurchaseVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz01_CarForPurchaseVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ExclamationMarkVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ExclamationMarkVariant"
+      }
+    },
+    "Mappins.DefaultQuestVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "DefaultQuestVariant"
+      }
+    },
+    "Mappins.PointOfInterest_MinorActivityVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "MinorActivityVariant"
+      }
+    },
+    "Mappins.PointOfInterest_GangWatchVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "GangWatchVariant"
+      }
+    },
+    "Mappins.PointOfInterest_OutpostVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "OutpostVariant"
+      }
+    },
+    "Mappins.PointOfInterest_HiddenStashVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "HiddenStashVariant"
+      }
+    },
+    "Mappins.PointOfInterest_FixerVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "FixerVariant"
+      }
+    },
+    "Mappins.QuestGiverVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "QuestGiverVariant"
+      }
+    },
+    "Mappins.PointOfInterest_BountyHuntVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "BountyHuntVariant"
+      }
+    },
+    "Mappins.PointOfInterest_RetrievingVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "RetrievingVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ThieveryVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ThieveryVariant"
+      }
+    },
+    "Mappins.PointOfInterest_SabotageVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "SabotageVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ClientInDistressVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ClientInDistressVariant"
+      }
+    },
+    "Mappins.PointOfInterest_ConvoyVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "ConvoyVariant"
+      }
+    },
+    "Mappins.PointOfInterest_RacingVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz18_RacingVariant"
+      }
+    },
+    "Mappins.NCPDGigVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz06_NCPDGigVariant"
+      }
+    },
+    "Mappins.PointOfInterest_HuntForPsychoVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "HuntForPsychoVariant"
+      }
+    },
+    "Mappins.RelicDeviceBasicVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz16_RelicDeviceBasicVariant"
+      }
+    },
+    "Mappins.RelicDeviceSpecialVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz16_RelicDeviceSpecialVariant"
+      }
+    },
+    "Mappins.ApartmentToPurchaseVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz05_ApartmentToPurchaseVariant"
+      }
+    },
+    "Mappins.DogtownGateVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz13_DogtownGateVariant"
+      }
+    },
+    "Mappins.PointOfInterest_TarotVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "TarotVariant"
+      }
+    },
+    "Mappins.MotorcycleForPurchaseVariant": {
+      "$type": "gamedataMappinVariant_Record",
+      "enumComment": "",
+      "enumName": {
+        "$type": "CName",
+        "$storage": "string",
+        "$value": "Zzz02_MotorcycleForPurchaseVariant"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Schema camera migrates from `OrthographicCamera` to `PerspectiveCamera` at **FOV 25°**, matching the game's `WorldMap.TopDownCameraSettingsDefault` TweakDB record (zoom min/default/max = 800 / 3000 / 15000 CET units). The original ortho choice was made without reference to the game's actual configuration — corrected after `WorldMap.*` TweakDB extraction.
- Full extraction of every `WorldMap.*` record (64 records + 46 transitive `Mappins.*`) via a new `dump_worldmap_tree.wscript` for WolvenKit. Frozen dataset committed at [`docs/data/worldmap_tweakdb_tree.json`](docs/data/worldmap_tweakdb_tree.json) for permanent reference.
- All downstream perspective-aware math wired in one PR: shadow camera footprint via 4-corner ray-cast against Y=0, pan bounds to canonical `cursorBoundary`, scale bar / district label switch / pin cluster threshold / metro LOD / flyTo / reset / fitCameraToBox all converted to camera-to-target distance. Showcase exit gets a brief opacity dip to bridge the 25° ↔ 55° FOV swap.

## Test plan

- [ ] Pan + zoom: feels natural, distance limits (800–15000 wu) honoured, pan bounds tighter than before (game's `cursorBoundary` — X[−5500..6050], Y[−7300..5000] CET)
- [ ] **Resize**: camera aspect updates correctly under window resize
- [ ] **Tilt to max polar angle**: visible-ground rect ray-cast doesn't degenerate; shadow camera footprint still tight
- [ ] **Reset view** button (`resetCamera`): lands at the same whole-map view as first page load (not a closer default-distance pose)
- [ ] **flyTo a pin** from the sidebar: ends at distance 1250 wu (canonical `zoomToZoomValue`), camera angle preserved
- [ ] **District/subdistrict label switch**: subdistricts replace districts at camera distance ≈ 7000 wu (TweakDB `ZoomLevelSubDistricts.zoom`)
- [ ] **Metro LOD**: at max zoom out shows B (wide solid); mid zoom shows G (thin solid); close zoom shows R (dotted); no overlap
- [ ] **Showcase entry/exit**: schematic camera state preserved across the cinematic; exit fade hides the FOV change
- [ ] **Showcase metro LOD**: pinned to R tier (dotted) throughout

## Known follow-ups (separate PRs)

- **CSM shadows** — the "no cascades because schema is ortho" rationale from [PR #647](https://github.com/spuddeh/nc-zoning-board/pull/647) dissolved with this change; see `wiki/learnings/pr647-csm-pivot-rested-on-ortho-assumption.md`
- **Line2 near-plane clipping** — district outline segments whose endpoints cross the camera near plane (10 wu) stretch as rays across the viewport at close zoom; pre-existing latent bug only visible under perspective. Three fix candidates documented in the decision page.
- **Pin cluster radius re-tune** — more pins merge under the narrower 25° FOV view
- **`pitchRelativeToZoom`** lean-back curve from TweakDB
- **Leaflet zoom thresholds** aligned with canonical WU values (independent of 3D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)