### PR TITLE
fix(3d): district outline 3-state visibility + ground-plane pan + dedup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Three.js-Parity: district outline visibility + camera ergonomics
+
+Three changes, all matching game behaviour more closely than what shipped in #653:
+
+- **Three-state district outline visibility** mirroring TweakDB `WorldMap.ZoomLevel*` `showDistricts` / `showSubDistricts` flags: districts visible at d ≥ 11000, subdistricts at 7000 ≤ d < 11000, **neither** below 7000. The "always-visible" group (Dogtown / Morro Rock main outlines, Casino subdistrict) is now tied to the outline-tier-visible rule too — vanishes with subs at close zoom. Closes the long-standing "colored rays across the viewport at close zoom" bug as a side effect: the rays originated in `Line2NodeMaterial`'s screen-space line shader hitting some failure mode under perspective + reverse-Z (issue [#654](https://github.com/spuddeh/nc-zoning-board/issues/654)), but they only ever appeared when subdistrict outlines were rendered at d < 7000 — exactly the zoom band the game itself leaves empty. Matching the game's visibility eliminates the bug surface entirely.
+- **Ground-plane panning** (`controls.screenSpacePanning = false`) replaces the OrbitControls default. Under perspective, the default screen-space pan has a world-Y component whenever the camera is tilted — left-drag panning at high tilt slowly lifts `controls.target` off the ground, the orbit pivot moves up, and the camera itself appears to climb as you pan. Orthographic hid this; perspective surfaced it. Ground-plane panning constrains the target to Y=0 implicitly and makes vertical-drag move at the same rate as horizontal-drag at any tilt.
+- **Polygon vertex dedup at load** (epsilon = 0.1 wu) in `buildLine` defends against zero-length edges in `data/subdistricts.json` — the Shapely `difference()` / `unary_union()` pipeline in `scripts/regenerate_subdistricts.py` rounds output coordinates to 2 decimal places, which can collapse points produced 0.001 wu apart into identical coordinates. Catches the 8 degenerate vertices currently present in 4 badlands/pacifica subdistricts. Not the root cause of the rays (verified by testing), kept as defensive code.
+
+Issue #654 still tracks the underlying `Line2NodeMaterial` × `reversedDepthBuffer` interaction (the actual shader path causing the rays — root cause likely the screen-space line shader producing NaN/Inf direction vectors for some near-camera projection edge case). The visibility-rule fix puts that bug out of the user's typical zoom range without solving the shader bug itself.
+
 #### Renderer: WebGL → WebGPU
 
 The 3D scene renders through `WebGPURenderer` (automatic WebGL2 fallback). Native engine features replace the old WebGL workarounds; visuals are parity-or-better at the five canonical viewpoints.

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -249,10 +249,17 @@ NCZ.BUILDING_EDGE_INTENSITY =  0.05;  // max mix weight — keeps effect subtle;
 NCZ.BUILDING_TEX_FLOOR      =   0.3;  // minimum _m.dds brightness — prevents faces going pitch-black
 NCZ.BUILDING_TEX_RANGE      =   0.7;  // brightness range above the floor (floor + range = max)
 
-// Camera distance threshold for district→subdistrict label switch.
-// Source: TweakDB WorldMap.ZoomLevelSubDistricts.zoom = 7000.
-// Below this distance the camera is "zoomed in enough" to show subdistricts.
-NCZ.SUBDISTRICT_DISTANCE_3D = 7000;
+// District / subdistrict outline visibility thresholds in CET camera-to-target
+// distance. Three-state, matching the game's WorldMap.ZoomLevel* TweakDB records:
+//   d ≥ DISTRICT_DISTANCE_3D            → main district outlines visible
+//   SUBDISTRICT_DISTANCE_3D ≤ d < DISTRICT_DISTANCE_3D → subdistrict outlines visible
+//   d < SUBDISTRICT_DISTANCE_3D          → neither (mappin tiers only)
+// Sources: WorldMap.ZoomLevelDistricts.zoom = 11000 (showDistricts = 1),
+// WorldMap.ZoomLevelSubDistricts.zoom = 7000 (showSubDistricts = 1). All
+// closer zoom-level records (Important / Vendors / AllMappins / ExtraMappins)
+// have both flags false — i.e. neither outline tier is shown below 7000.
+NCZ.DISTRICT_DISTANCE_3D    = 11000;
+NCZ.SUBDISTRICT_DISTANCE_3D =  7000;
 
 // Metro LOD zoom thresholds — vertex COLOR_0 channels are mutually exclusive tiers:
 // B = wide solid line (far zoom only,    zoom < LOD_MED)   — VisibilityDistanceBold=30000

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -493,7 +493,18 @@ const ThreeScene = (() => {
     controls.panSpeed       = NCZ.CAMERA_PAN_SPEED;
     controls.rotateSpeed    = NCZ.CAMERA_ROTATE_SPEED;
     controls.enableDamping  = true;
-    controls.screenSpacePanning = true;
+    // Ground-plane panning, not screen-space. Under perspective, screen-space
+    // panning (the OrbitControls default) has a world-Y component whenever
+    // the camera is tilted — left-drag at high tilt lifts controls.target off
+    // the ground, the orbit pivot moves up, and subsequent rotates/zooms
+    // behave around a lifted point so the camera itself appears to climb as
+    // you pan. With screenSpacePanning=false, panning is constrained to the
+    // plane orthogonal to the camera up vector (world XZ), so target stays
+    // at Y=0 implicitly and vertical drag at high tilt moves the target
+    // forward/back along the camera look direction at the same rate as
+    // horizontal drag moves it left/right. Ortho hid the drift; perspective
+    // surfaces it. See controls 'change' handler — no y-clamp needed.
+    controls.screenSpacePanning = false;
     controls.target.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
     controls.update();
     updateFrustumUniforms();   // seed frustum planes for the first cull dispatch
@@ -609,8 +620,9 @@ const ThreeScene = (() => {
   };
 
   // Sub-groups inside layers.districts (parent group controls overall visibility):
-  let _districtOuter = null; // districts with subs — visible when zoomed OUT
-  let _districtSub   = null; // canonical subdistricts — visible when zoomed IN
+  let _districtOuter  = null; // districts with subs — visible at the districts zoom band (d ≥ 11000)
+  let _districtSub    = null; // canonical subdistricts — visible at the subs band (7000 ≤ d < 11000)
+  let _districtAlways = null; // no-sub districts (Dogtown / Morro Rock) + non-canonical subs (Casino) — visible whenever EITHER outline tier is
 
   function setLayerVisibility(name, visible) {
     if (name === 'districts') {
@@ -632,12 +644,19 @@ const ThreeScene = (() => {
 
   function updateDistrictZoom() {
     if (!_districtOuter || !_districtSub || !controls) return;
+    // Three-state visibility, matching WorldMap.ZoomLevel* records:
+    //   d ≥ 11000: main district outlines (ZoomLevelDistricts.showDistricts = 1)
+    //   7000 ≤ d < 11000: subdistrict outlines (ZoomLevelSubDistricts.showSubDistricts = 1)
+    //   d < 7000: neither (every closer zoom-level record has both flags false)
+    // The game hides outlines entirely at close zoom — only mappins remain.
+    // alwaysGroup (no-sub districts + non-canonical subs) follows the same
+    // outline-tier-visible rule: shown whenever EITHER district or subdistrict
+    // tier would render, hidden together with them below 7000.
     // Distance from camera to target = distance-to-ground (target sits on Y=0).
-    // Smaller distance = more zoomed in; subdistricts replace districts under the threshold.
     const distance = camera.position.distanceTo(controls.target);
-    const zoomedIn = distance < NCZ.SUBDISTRICT_DISTANCE_3D;
-    _districtOuter.visible = !zoomedIn;
-    _districtSub.visible   =  zoomedIn;
+    _districtOuter.visible = distance >= NCZ.DISTRICT_DISTANCE_3D;
+    _districtSub.visible   = distance >= NCZ.SUBDISTRICT_DISTANCE_3D && distance < NCZ.DISTRICT_DISTANCE_3D;
+    if (_districtAlways) _districtAlways.visible = distance >= NCZ.SUBDISTRICT_DISTANCE_3D;
   }
 
   // ── Scale bar ───────────────────────────────────────────────────────
@@ -981,8 +1000,9 @@ const ThreeScene = (() => {
       subGroup.visible  = false;
       outerGroup.visible = true;
 
-      _districtOuter = outerGroup;
-      _districtSub   = subGroup;
+      _districtOuter  = outerGroup;
+      _districtSub    = subGroup;
+      _districtAlways = alwaysGroup;
       layers.districts = parent;
       scene.add(parent);
       requestRender();
@@ -1400,13 +1420,59 @@ const ThreeScene = (() => {
   // District line materials — stored so resolution can be updated on resize
   const districtLineMaterials = [];
 
+  // Drop consecutive ring vertices within ε CET units of each other. The
+  // cleanup script (scripts/regenerate_subdistricts.py) runs Shapely boolean
+  // ops on subdistrict polygons and rounds the output to 2 decimal places —
+  // when two operation-produced vertices land within 0.01 wu of each other,
+  // rounding collapses them to identical coordinates, leaving a zero-length
+  // edge in the ring. Line2NodeMaterial's screen-space line shader divides by
+  // `length(ndcEnd - ndcStart)` to get the segment direction; degenerate
+  // (or sub-pixel after projection) edges produce NaN/Inf direction vectors,
+  // which render as long colored rays across the viewport at close zoom.
+  //
+  // ε = 0.1 wu catches only the literally-degenerate cases observed in
+  // data/subdistricts.json (0.000, 0.010, 0.020 wu edges in badlands subs);
+  // legit polygon corners with closely-spaced vertices (smallest seen ≥ 0.347
+  // wu) are preserved. Bump ε if the rays survive at this threshold.
+  function dedupRing(ring, epsilon = 0.1) {
+    if (ring.length < 2) return ring;
+    const eps2 = epsilon * epsilon;
+    const out = [ring[0]];
+    for (let i = 1; i < ring.length; i++) {
+      const prev = out[out.length - 1];
+      const cur = ring[i];
+      const dx = cur[0] - prev[0];
+      const dy = cur[1] - prev[1];
+      if (dx * dx + dy * dy > eps2) out.push(cur);
+    }
+    // Drop the implicit closing edge if first ≈ last too
+    if (out.length >= 2) {
+      const first = out[0], last = out[out.length - 1];
+      const dx = first[0] - last[0];
+      const dy = first[1] - last[1];
+      if (dx * dx + dy * dy <= eps2) out.pop();
+    }
+    return out;
+  }
+
   // Build a Line2 (fat line) from CET [x, y] ring points.
   // depthTest:false means lines always render over terrain, matching the game's UI overlay approach.
   function buildLine(ring, color, lineWidth) {
+    const cleaned = dedupRing(ring);
+    if (cleaned.length < 3) {
+      // Degenerate polygon after dedup — can't draw a meaningful ring. Build
+      // an empty Line2 so the caller's group structure is preserved.
+      const empty = new LineGeometry();
+      empty.setPositions([]);
+      const placeholderMat = new THREE.Line2NodeMaterial({ color, linewidth: lineWidth, depthTest: false, transparent: true, opacity: 0 });
+      districtLineMaterials.push(placeholderMat);
+      return new Line2(empty, placeholderMat);
+    }
+
     const positions = [];
-    for (const pt of ring) positions.push(pt[0], 0, -pt[1]);
+    for (const pt of cleaned) positions.push(pt[0], 0, -pt[1]);
     // Close the ring
-    if (ring.length > 0) positions.push(ring[0][0], 0, -ring[0][1]);
+    positions.push(cleaned[0][0], 0, -cleaned[0][1]);
 
     const geometry = new LineGeometry();
     geometry.setPositions(positions);


### PR DESCRIPTION
## Summary

Three small fixes, all matching game behaviour more closely than what shipped in [#653](https://github.com/spuddeh/nc-zoning-board/pull/653):

- **3-state district outline visibility** from TweakDB `WorldMap.ZoomLevel*` `showDistricts` / `showSubDistricts` flags. Districts at d ≥ 11000, subdistricts at 7000 ≤ d < 11000, **neither** below 7000. The "always-visible" group (Dogtown / Morro Rock main outlines, Casino subdistrict) is tied to the outline-tier-visible rule too — vanishes with subs at close zoom. Addresses the user-visible symptom of [#654](https://github.com/spuddeh/nc-zoning-board/issues/654) (the "colored rays across the viewport at close zoom" bug) as a side effect.
- **Ground-plane panning** (`controls.screenSpacePanning = false`) — replaces OrbitControls' default screen-space pan, which has a world-Y component at tilt that slowly lifts the orbit target off the ground. Camera now stays at consistent height when panning. Vertical-drag also matches horizontal-drag speed at any tilt.
- **Vertex dedup at load** (ε = 0.1 wu) in `buildLine`, defensive against zero-length edges produced by Shapely + `round(2)` rounding in `scripts/regenerate_subdistricts.py`. Catches 8 degenerate vertices in 4 badlands/pacifica subdistricts. Polygons visually identical (max edge dropped was 0.020 wu).

## About the rays bug (#654)

This PR closes the *user-visible* rays bug but does **not** fix the underlying shader interaction. Investigation summary:

- **Initial hypothesis (Three.js trimSegment under reverse-Z)**: mathematically correct that the bug exists, but verified by testing not to be the actual trigger for our rays. CPU-side near-plane clipping workaround was tried and didn't help.
- **Second hypothesis (zero-length polygon edges)**: real artifacts (4 subs have them), dedup landed defensively, but verified by testing not to be the rays trigger either.
- **Actual fix**: matching the game's visibility rule — districts/subdistricts hide entirely below d = 7000. The rays only ever appeared in the zoom band the game itself leaves empty, so matching parity removes the bug surface without solving the underlying shader bug.

The Line2NodeMaterial × reverse-Z latent bug (#654 upstream [#33570](https://github.com/mrdoob/three.js/issues/33570)) is still real but out of typical user zoom range. Recommend keeping #654 open at lower priority for future investigation.

## Test plan

- [ ] **Close zoom** (camera distance < 7000): no district or subdistrict outlines visible. Just mappins. Rays gone.
- [ ] **Mid zoom** (7000 ≤ d < 11000): subdistrict outlines visible. Districts hidden.
- [ ] **Far zoom** (d ≥ 11000): district outlines visible. Subdistricts hidden.
- [ ] **Always-group** (Dogtown / Morro Rock / Casino): visible at d ≥ 7000, hidden below.
- [ ] **Pan at tilt**: vertical drag moves the target at the same speed as horizontal drag. Camera height stays constant.
- [ ] **Polygon shapes**: subdistrict outlines look identical to before (dedup is non-destructive at ε = 0.1).

## What's next

Separate parity PRs queued (data already extracted):

- District / subdistrict **names** (`LocKey#10945–10951` etc.) and **icons** (`ico_district_<name>_large` from `district_icons.inkatlas`)
- **Segmented block outline rendering** matching game's `inkLinePatternWidget` (10 × 10 blocks, 10-unit spacing, `rotateWithSegment`, opacity 0.05 default, tint from district UiState inkstyle)
- **Hover-brighten** fade matching `3dmap_highlight_on.effect` (0.25 s `customParameter0` 0.05 → 1.0)

All three driven by extracted assets in `D:\Modding\CP2077 Mods\MyMods\map_data_export\source\raw\base\gameplay\gui\fullscreen\world_map\` + the `Districts.*` TweakDB dump that landed alongside this PR's investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
