### PR TITLE
fix(3d): camera gestures over pins/clusters — Leaflet-style no-pointer-capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Three.js-Parity: camera gestures over pins/clusters/popups
+
+- `OrbitControls` now attaches to `#map-3d` (parent of canvas + CSS2D overlay) instead of `renderer.domElement`, with `setPointerCapture` / `releasePointerCapture` overridden to no-ops on that element. Copies Leaflet's `Draggable` pattern (drag handler at the container, no pointer capture) so pan/zoom gestures pass through pins and cluster bubbles to the camera while the per-element `click` handlers stay intact.
+- Drag-vs-click discrimination via a `_dragSuppressClick` flag in `three-markers.js` (set when the container-level `pointerdown→pointerup` distance exceeds `PIN_3D_DRAG_THRESHOLD_PX`). Popup card stops `pointerdown` propagation so internal interactions don't arm phantom drags.
+
 #### Three.js-Parity: district outline visibility + camera ergonomics
 
 Three changes, all matching game behaviour more closely than what shipped in #653:

--- a/assets/js/three-markers.js
+++ b/assets/js/three-markers.js
@@ -59,6 +59,13 @@ const ThreeMarkers = (() => {
                                     // whose contents the cluster panel is showing
   const _projectVec = new THREE.Vector3();
 
+  // Set by the container pointerup handler when the gesture exceeded
+  // PIN_3D_DRAG_THRESHOLD_PX; read by per-pin and per-cluster click
+  // handlers. Lives at IIFE scope because click events fire AFTER
+  // pointerup, on element listeners, and need to see the flag set during
+  // the just-finished gesture. Reset on every pointerdown. See attach().
+  let _dragSuppressClick = false;
+
   // Render-on-demand bridge. ThreeScene's loop only re-renders (and re-runs
   // our render() in turn) when explicitly asked. Anything that mutates pin
   // visibility, position, popup state, or cluster layout without moving the
@@ -162,23 +169,42 @@ const ThreeMarkers = (() => {
     tooltipObj.renderOrder = 999;
     scene.add(tooltipObj);
 
-    // Click outside any pin closes the popup, matching Leaflet — but only on
-    // a *true* click. Releasing an OrbitControls drag fires a click event too;
-    // tracking pointerdown→pointerup distance lets us ignore drags.
+    // Drag-vs-click discrimination — Leaflet pattern.
+    //
+    // OrbitControls is attached to the container (see three-scene.js), and
+    // its setPointerCapture is monkey-patched to a no-op there so the
+    // natural click flow survives — mousedown on a pin → mouseup on a pin
+    // → click event fires on the pin. But a click ALSO fires if the user
+    // pans the camera then releases over a pin (mousedown=pin, mouseup=pin
+    // even with movement in between). Leaflet handles this by tracking
+    // drag distance at the container level and suppressing the next click
+    // when it exceeds the tolerance threshold.
+    //
+    // _dragSuppressClick is set in the pointerup handler below when the
+    // pointerdown→pointerup distance exceeds PIN_3D_DRAG_THRESHOLD_PX, and
+    // read by the per-pin and per-cluster click handlers (in buildPins
+    // and getOrCreateClusterObj). The flag is reset on every pointerdown
+    // so a subsequent true click after the suppressed one still works.
     let pointerDown = null;
     container.addEventListener('pointerdown', (e) => {
       pointerDown = { x: e.clientX, y: e.clientY };
+      _dragSuppressClick = false;
     });
     container.addEventListener('pointerup', (e) => {
       const start = pointerDown;
       pointerDown = null;
-      if (!start || !popup) return;
+      if (!start) return;
       const dist = Math.hypot(e.clientX - start.x, e.clientY - start.y);
-      if (dist > NCZ.PIN_3D_DRAG_THRESHOLD_PX) return;  // was a drag, not a click
+      if (dist > NCZ.PIN_3D_DRAG_THRESHOLD_PX) {
+        _dragSuppressClick = true;       // suppress the synthesised click
+        return;
+      }
+      // True click on empty space (canvas) closes any open popup, matching
+      // Leaflet's behaviour. Pin and cluster clicks are handled by their
+      // own element listeners — guard so this doesn't double-act on them.
+      if (!popup) return;
       if (e.target.closest('.three-popup')) return;
       if (e.target.closest('.three-marker')) return;
-      // Cluster click opens the cluster panel; matches Leaflet's behaviour
-      // where clicking a cluster does NOT close an already-open popup.
       if (e.target.closest('.marker-cluster')) return;
       closePopup();
     });
@@ -227,6 +253,11 @@ const ThreeMarkers = (() => {
       el.style.pointerEvents = 'auto';
       el.style.cursor = 'pointer';
       el.addEventListener('click', (e) => {
+        // Leaflet pattern: a drag that ended on the pin still fires a click
+        // event. _dragSuppressClick is set by the container-level pointerup
+        // when the gesture moved beyond PIN_3D_DRAG_THRESHOLD_PX, so we
+        // ignore those — only true clicks open the popup.
+        if (_dragSuppressClick) return;
         e.stopPropagation();
         // Toggle behaviour to match Leaflet: clicking the already-selected
         // pin deselects it. Sidebar item clicks (focusMod) deliberately
@@ -475,6 +506,8 @@ const ThreeMarkers = (() => {
     obj.name = `cluster-pool-${_clusterPool.length}`;
     obj.layers.set(NCZ.LAYER_PINS);
     root.addEventListener('click', (e) => {
+      // Drag-then-release-on-cluster also fires a click; suppress per Leaflet.
+      if (_dragSuppressClick) return;
       e.stopPropagation();
       // userData.modIds is set by recomputeClusters each time the bubble is
       // assigned to a group; pass to whatever handler app.js registered.
@@ -517,6 +550,18 @@ const ThreeMarkers = (() => {
     card.className = `three-popup ncz-dynamic-popup ncz-popup-top popup-${catStyle.class}`;
     card.innerHTML = html;
     anchor.appendChild(card);
+
+    // The popup card has pointer-events:auto so its buttons/links are
+    // interactive. Because OrbitControls is now wired to the container
+    // (see three-scene.js), every pointerdown that bubbles up to it
+    // arms a potential drag — a tiny mouse jiggle inside the popup would
+    // pan the camera. Stop pointer events at the card boundary so the
+    // popup behaves like a self-contained widget, exactly as the 2D
+    // Leaflet popup shields the map drag handler from its own clicks.
+    // Wheel left intentionally bubbling — we don't have scrollable
+    // popup content today, and forwarding wheel-to-zoom while a popup
+    // is open matches Leaflet behaviour.
+    card.addEventListener('pointerdown', (e) => e.stopPropagation());
 
     // Clipboard copy handler — same behaviour as Leaflet popup
     const copyBtn = card.querySelector('.ui-popup-action-link-copy-link');

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -481,8 +481,30 @@ const ThreeScene = (() => {
     _sunSphere.visible = false;
     scene.add(_sunSphere);
 
-    // OrbitControls — left=pan, right=tilt, middle=zoom
-    controls = new OrbitControls(camera, renderer.domElement);
+    // OrbitControls — left=pan, right=tilt, middle=zoom.
+    //
+    // Attached to `container` (#map-3d), not `renderer.domElement` (the
+    // canvas), so pointer events bubbling up from the CSS2D pin/cluster
+    // overlay reach the controls — mirroring Leaflet's pattern where the
+    // map's drag handler lives on the container element above the marker
+    // layer. Combined with the pointer-capture defeat below, this lets
+    // OrbitControls see drag/zoom gestures that start on a pin while the
+    // pin's own `click` event still fires naturally on mouseup. See
+    // wiki/learnings about the prior synthetic-event approach failing
+    // because pointer capture redirected pointerup off the pin.
+    const _orbitDom = renderer.domElement.parentElement;
+    controls = new OrbitControls(camera, _orbitDom);
+    // Defeat OrbitControls' setPointerCapture — Leaflet doesn't use pointer
+    // capture for its map drag, and that's exactly the property that
+    // preserves click event dispatch on child markers. Without this
+    // override, `pointerup` would retarget to the container and the
+    // browser would fire `click` on the lowest common ancestor (the
+    // container) instead of on the pin. No-op'ing both methods is a
+    // single-line patch; the only behavioural trade-off is that a drag
+    // pointer leaving the container during a gesture goes silent — the
+    // container fills the viewport so this is a near-impossible case.
+    _orbitDom.setPointerCapture     = () => {};
+    _orbitDom.releasePointerCapture = () => {};
     controls.mouseButtons = {
       LEFT:   THREE.MOUSE.PAN,
       MIDDLE: THREE.MOUSE.DOLLY,


### PR DESCRIPTION
Closes project item **E9 — Camera gestures blocked when cursor is over pins/clusters/popups** (Three.js Parity stream, High priority).

## Summary

- `OrbitControls` now attaches to `#map-3d` (parent of canvas + CSS2D overlay) instead of `renderer.domElement`, with `setPointerCapture` / `releasePointerCapture` overridden to no-ops on that element. Matches Leaflet's `Draggable` pattern: drag handler at the container, no pointer capture, click events stay on their natural targets.
- Drag-vs-click discrimination via a `_dragSuppressClick` flag in `three-markers.js`, set at the container level when `pointerdown`→`pointerup` distance exceeds `PIN_3D_DRAG_THRESHOLD_PX`. Per-pin and per-cluster click handlers consult the flag.
- Popup card stops `pointerdown` propagation so its internal interactions don't arm phantom OrbitControls drags.

## Why this works (and the prior attempt didn't)

OrbitControls r170 line 1122 calls `this.domElement.setPointerCapture(event.pointerId)` on `pointerdown`. In Chrome/Firefox, pointer capture redirects the synthesised `click` event off CSS2D pin/cluster DOM, so the per-element click handlers go silently dead. The previous attempt forwarded synthetic events to the canvas — same redirect, same failure.

Leaflet (`src/dom/Draggable.js`) demonstrates the alternative: drag handler bound to the map container, `pointermove`/`pointerup` on the same target, **no `setPointerCapture`**. Click discrimination is purely a movement-threshold check (`clickTolerance: 3` px in Leaflet, `PIN_3D_DRAG_THRESHOLD_PX = 4` here). Because no capture happens, marker `click` events fire on the marker regardless of how the drag handler did or didn't react.

The fix copies that pattern: move OrbitControls one level up (so pin pointerdowns reach it by bubbling) and neutralise the one line that breaks DOM-child click flow.

## Trade-off accepted

Without pointer capture, if the cursor leaves the container mid-drag, `pointermove`/`pointerup` stop firing — the drag freezes silently. Leaflet has the same trade-off and accepts it because the container fills the visible map. `#map-3d` does too (canvas is `inset: 0` inside it; the container spans the viewport), so this only triggers on leaving the browser window — at which point `pointercancel` fires and OrbitControls resets cleanly.

## Test plan

- [ ] Pan map by dragging on empty canvas
- [ ] Pan map by dragging starting over a pin (camera moves, no popup)
- [ ] Click a pin (popup opens, no drag)
- [ ] Drag-pan ending on a pin (camera moved, no popup opened — `_dragSuppressClick` did its job)
- [ ] Click an already-open pin (popup closes — toggle)
- [ ] Click a cluster bubble (cluster panel opens)
- [ ] Click empty space with popup open (popup closes)
- [ ] Click "Copy link" / "Nexus" / SLM links inside the popup (links fire, no map drag)
- [ ] Wheel-zoom over a pin / cluster / popup (camera zooms)
- [ ] Right-click drag-tilt ending over a pin (no contextmenu)
- [ ] Tooltip on pin hover (`:hover` CSS still drives the scale + the tooltip appears)
- [ ] Touch: tap pin opens popup; pinch zoom works

## Files changed

- `assets/js/three-scene.js` — OrbitControls' `domElement` and pointer-capture defeat
- `assets/js/three-markers.js` — `_dragSuppressClick` flag + container-level pointerdown/pointerup + popup-card `pointerdown` stopPropagation
- `CHANGELOG.md` — terse subsection under Three.js-Parity

## Companion wiki

- New learning page: `wiki/learnings/orbitcontrols-pointer-capture-defeats-child-clicks.md` (synced to Obsidian) — full What/Fix/Trade-off/Prevention writeup, citing Leaflet's `Draggable` source.
- New user-memory feedback entry: "for any 3D-view UX with a 2D-view equivalent, read Leaflet's source first" — captures the redirect that collapsed a planned 150–200 LOC NDC-space hit-test redesign into a ~30 LOC patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)