### PR TITLE
fix(3d/2d): cluster panel UX cleanup — flyTo + sticky panel, force-individual, no spiderfy (E12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Three.js-Parity: cluster panel UX cleanup (E12)
+
+- Picking a mod from the cluster panel now flies to the pin and **keeps the panel open** as a comparison list (was: closed on click). The picked pin stays full-opacity, the rest of its cluster dims; re-clicking the active cluster bubble (before a pin is picked) toggles the panel closed; empty-canvas click closes the panel in 3D too (2D parity).
+- The cluster is **guaranteed to dissolve** on pick via force-individual (2D pulls the markers out of `markerClusterGroup`; 3D excludes them from the distance clusterer) instead of depending on zoom/spacing. **Spiderfy removed entirely** — `focusMarker` no longer uses `zoomToShowLayer`; a clustered-but-focused pin is kept visible by force-individual instead.
+- `?mod=` deep-link is now written eagerly on focus (not on popup open) so cross-view camera/popup restore works for clustered pins; 2D popup-open deferred to flyTo settle to kill the ghost/vibrating double-popup.
+
 #### Three.js-Parity: camera gestures over pins/clusters/popups
 
 - `OrbitControls` now attaches to `#map-3d` (parent of canvas + CSS2D overlay) instead of `renderer.domElement`, with `setPointerCapture` / `releasePointerCapture` overridden to no-ops on that element. Copies Leaflet's `Draggable` pattern (drag handler at the container, no pointer capture) so pan/zoom gestures pass through pins and cluster bubbles to the camera while the per-element `click` handlers stay intact.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -894,6 +894,32 @@ async function initMap() {
   let focusedMarker = null;
   let isZoomTransitioning = false;
   let focusedRestoreFrame = null;
+  // The single non-panel marker currently pulled out of the cluster group
+  // for focus (Discover / sidebar / deep-link). The 2D analogue of 3D's
+  // "popupModId is excluded from the clusterer" rule — replaces spiderfy as
+  // the way a clustered-but-focused pin stays visible. Panel-set markers are
+  // owned by applyPanelPinFocus instead; this is only for the lone-pin paths.
+  let soloFocusMarker = null;
+
+  // ?mod= deep-link sync. Mirrors NCZ.ThreeMarkers.syncUrlForMod so the two
+  // views stay coherent. Called EAGERLY when focus is initiated (not only
+  // from popupopen) — the popup now opens deferred (on flyTo's moveend), so
+  // waiting for popupopen left a window where switching views lost the
+  // pin (the "shared camera/popup broken on clustered pins" bug: clustered
+  // pins go through the deferred path, unclustered ones opened synchronously).
+  function setModUrlParam(mod) {
+    if (!mod) return;
+    const isNum = /^\d+$/.test(String(mod.nexus_id));
+    const lid = isNum ? String(mod.nexus_id) : mod.id;
+    const url = new URL(window.location.href);
+    url.searchParams.set(NCZ.URL_PARAM_MOD, lid);
+    history.replaceState(null, "", url.toString());
+  }
+  function clearModUrlParam() {
+    const url = new URL(window.location.href);
+    url.searchParams.delete(NCZ.URL_PARAM_MOD);
+    history.replaceState(null, "", url.toString());
+  }
 
   function repositionActivePopup() {
     if (!activePopup) return;
@@ -909,32 +935,23 @@ async function initMap() {
     });
   }
 
+  // Safety net only: re-open the focused popup if it closed while the marker
+  // is an un-clustered singleton. Spiderfy was removed entirely (per product
+  // decision) — focused/selected markers are now kept visible by pulling
+  // them OUT of the cluster group (soloFocusMarker / applyPanelPinFocus), so
+  // a focused marker is never hidden inside a bubble and never needs
+  // spiderfying. For force-individual markers this whole function early-
+  // returns at the hasLayer check (they're not in the group); it survives
+  // only for any legacy clustered-focus edge.
   function restoreFocusedPopupIfVisible() {
     if (!focusedMarker) return;
+    if (panelSelectedModId !== null) return;
     if (!markerClusterGroup.hasLayer(focusedMarker)) return;
     const visibleParent = markerClusterGroup.getVisibleParent(focusedMarker);
     if (!visibleParent) return;
-
-    if (visibleParent === focusedMarker) {
-      if (!focusedMarker.isPopupOpen()) {
-        focusedMarker.openPopup();
-      }
-      return;
+    if (visibleParent === focusedMarker && !focusedMarker.isPopupOpen()) {
+      focusedMarker.openPopup();
     }
-
-    // Keep focused markers visible even when they are clustered by re-spiderfying
-    // their current cluster once zoom animations have settled.
-    if (typeof visibleParent.spiderfy !== "function" || markerClusterGroup._inZoomAnimation) return;
-    if (markerClusterGroup._spiderfied === visibleParent) return;
-
-    const targetCluster = visibleParent;
-    const targetMarker = focusedMarker;
-    markerClusterGroup.once("spiderfied", (event) => {
-      if (event.cluster !== targetCluster) return;
-      if (focusedMarker !== targetMarker) return;
-      scheduleFocusedPopupRestore();
-    });
-    targetCluster.spiderfy();
   }
 
   function scheduleFocusedPopupRestore() {
@@ -951,13 +968,7 @@ async function initMap() {
     const popupSource = e.popup?._source;
     if (popupSource?.modData) {
       focusedMarker = popupSource;
-      // URL sync: reflect the open pin in the address bar
-      const mod = popupSource.modData;
-      const isNum = /^\d+$/.test(String(mod.nexus_id));
-      const lid = isNum ? String(mod.nexus_id) : mod.id;
-      const url = new URL(window.location.href);
-      url.searchParams.set(NCZ.URL_PARAM_MOD, lid);
-      history.replaceState(null, "", url.toString());
+      setModUrlParam(popupSource.modData);
     }
     repositionActivePopup();
     scheduleActivePopupReposition();
@@ -993,9 +1004,7 @@ async function initMap() {
       Boolean(markerClusterGroup._inZoomAnimation);
     // URL sync: clear the mod param when popup closes (unless zoom-related)
     if (popupSource?.modData && !isZoomRelatedClose) {
-      const url = new URL(window.location.href);
-      url.searchParams.delete(NCZ.URL_PARAM_MOD);
-      history.replaceState(null, "", url.toString());
+      clearModUrlParam();
     }
     if (
       focusedMarker &&
@@ -1005,6 +1014,17 @@ async function initMap() {
     ) {
       // Manual close on a visible marker clears focused state.
       focusedMarker = null;
+    }
+    // Genuine dismissal of the soloed lone-pin's popup → let it re-cluster.
+    // Skipped on zoom-driven closes (transient) and when the marker belongs
+    // to an open panel set (clearPanelPinFocus owns that restore).
+    if (
+      soloFocusMarker &&
+      popupSource === soloFocusMarker &&
+      !isZoomRelatedClose &&
+      !panelClusterModIds?.has(soloFocusMarker.modData.id)
+    ) {
+      setSoloFocusMarker(null);
     }
     if (popupRepositionFrame !== null) {
       cancelAnimationFrame(popupRepositionFrame);
@@ -1171,6 +1191,22 @@ async function initMap() {
   // breaks up the cluster the panel was opened for.
   let panelClusterModIds = null;
 
+  // The panel mod the user last clicked. null = panel just opened, no pin
+  // chosen yet (cluster still on screen). Once set, the panel becomes a
+  // static comparison list: successor tracking is suppressed (the cluster
+  // it followed has been flown into and dissolved) and the cluster bubble's
+  // toggle-close no longer applies (there's no bubble to re-click). Drives
+  // the "selected pin prominent, rest dimmed" emphasis.
+  let panelSelectedModId = null;
+
+  // True only while pin emphasis is actually applied (a panel item was
+  // clicked). Lets clearPanelPinFocus() short-circuit when there's nothing
+  // to undo — important because populateClusterPanel() calls it on EVERY
+  // (re)populate, including the high-frequency successor-tracking path
+  // during camera moves. Without this, each successor recompute would do a
+  // full marker sweep + a synchronous 3D recomputeClusters for no reason.
+  let panelPinFocusApplied = false;
+
   // Adds .marker-cluster-active to the SAT cluster bubble whose modIds best
   // match panelClusterModIds. Called after each Leaflet cluster recompute
   // (zoomend / animationend / filter) because Leaflet recreates DOM elements.
@@ -1201,20 +1237,173 @@ async function initMap() {
     }
   }
 
+  // True iff `set` contains exactly the IDs in `list`. Used by both cluster
+  // bubble click handlers (2D + 3D) to detect "user clicked the cluster
+  // whose contents are already in the panel" → toggle-close instead of
+  // re-populate. Cheap O(n) — cluster sizes are bounded by markercluster's
+  // disable-clustering-at-zoom threshold.
+  function isSameModSet(set, list) {
+    if (!set || set.size !== list.length) return false;
+    for (const id of list) if (!set.has(id)) return false;
+    return true;
+  }
+
+  // "Top pin, rest fade": after a panel item is clicked the cluster has
+  // dissolved (focusMarker/focusMod flew in past the cluster radius), so the
+  // member pins are individually visible. Dim every panel pin except the
+  // selected one. 2D uses Leaflet's marker.setOpacity (survives the marker
+  // DOM being recreated on zoom) + a zIndexOffset so the chosen pin sits
+  // above its now-faded neighbours; 3D delegates to ThreeMarkers, which sets
+  // the inner .marker-pin opacity (the only mechanism that survives
+  // CSS2DRenderer's per-frame inline restyling). Two mechanisms, one
+  // behaviour — the divergence is forced by the two views' DOM lifecycles,
+  // not parallel styling.
+  function applyPanelPinFocus() {
+    if (!panelClusterModIds) return;
+    for (const id of panelClusterModIds) {
+      const marker = allMarkers.find((m) => m.modData.id === id);
+      if (!marker) continue;
+      // 2D force-individual: Leaflet.markercluster has no per-marker
+      // "don't cluster" flag — the idiomatic way to keep specific markers
+      // always visible is to pull them out of the cluster group and add
+      // them straight to the map. Idempotent: only move if still grouped.
+      if (markerClusterGroup.hasLayer(marker)) {
+        markerClusterGroup.removeLayer(marker);
+        marker.addTo(map);
+      }
+      const selected = id === panelSelectedModId;
+      marker.setOpacity(selected ? 1 : 0.3);
+      marker.setZIndexOffset(selected ? 1000 : 0);
+    }
+    const ids = [...panelClusterModIds];
+    NCZ.ThreeMarkers?.setPanelPinFocus?.(ids, panelSelectedModId);
+    // 3D equivalent: exclude the whole set from the distance-based clusterer
+    // so dissolution doesn't depend on how tightly the mods are packed.
+    NCZ.ThreeMarkers?.setForcedIndividualIds?.(new Set(ids));
+    panelPinFocusApplied = true;
+  }
+
+  // Restore every panel pin to full opacity / default stacking. Must run
+  // before panelClusterModIds is cleared (it drives the 2D iteration).
+  // No-ops unless emphasis was actually applied — keeps the per-populate
+  // call cheap and breaks the populateClusterPanel→clear→setForced→recompute
+  // re-entry in the common (no pin picked) case.
+  function clearPanelPinFocus() {
+    if (!panelPinFocusApplied) return;
+    if (panelClusterModIds) {
+      for (const id of panelClusterModIds) {
+        const marker = allMarkers.find((m) => m.modData.id === id);
+        if (!marker) continue;
+        marker.setOpacity(1);
+        marker.setZIndexOffset(0);
+        // Return the marker to the cluster group so it re-clusters normally.
+        // Only if we actually pulled it out (standalone on the map and not
+        // in the group) — guards the cluster-mode-then-close path where no
+        // marker was ever moved.
+        if (map.hasLayer(marker) && !markerClusterGroup.hasLayer(marker)) {
+          map.removeLayer(marker);
+          markerClusterGroup.addLayer(marker);
+        }
+      }
+    }
+    NCZ.ThreeMarkers?.setPanelPinFocus?.(null, null);
+    NCZ.ThreeMarkers?.setForcedIndividualIds?.(null);
+    panelPinFocusApplied = false;
+  }
+
   // Hide and reset cluster menu state
   function hideClusterPanel() {
     clusterModList.innerHTML = "";
     clusterPanelCount.textContent = "";
     clusterPanel.classList.add("cluster-panel-closed");
+    clearPanelPinFocus();          // restore pin opacity/stacking first
     panelClusterModIds = null;
+    panelSelectedModId = null;
     // Clear the active mark on whichever bubble was highlighted.
     refreshActiveSatClusterMark();
     NCZ.ThreeMarkers?.setActiveClusterMods?.(null);
   }
 
-  function focusMarker(marker) {
+  // Shared 2D focus motion.
+  //
+  // 1. Close any popup that's already open FIRST. A lingering popup from the
+  //    previously-selected pin would otherwise stay visible through the
+  //    0.6s flyTo, repositioned every animation frame by the custom dynamic-
+  //    popup placer → the "ghost / vibrating, faded double-popup". Nothing
+  //    visible during the fly = no vibration.
+  // 2. Sync ?mod= EAGERLY (not from popupopen). The popup is opened deferred
+  //    on moveend, so a view switch during the fly would otherwise see no
+  //    ?mod= and fail to restore — that's the "shared camera/popup broken
+  //    on clustered pins" report (clustered pins route through this deferred
+  //    path; unclustered ones open synchronously and were unaffected).
+  // 3. Open the popup only once the flyTo settles. `opened` + the
+  //    `focusedMarker === marker` guard handle rapid re-clicks (flyTo B
+  //    interrupts flyTo A → A's moveend still fires, but focus moved on).
+  // targetZoom never zooms OUT — keep the user's zoom if already close.
+  // (6/8 is a building-detail zoom; tune here if it feels too near/far.)
+  function flyToMarkerAndOpen(marker) {
+    map.closePopup();
     focusedMarker = marker;
-    markerClusterGroup.zoomToShowLayer(marker, () => marker.openPopup());
+    setModUrlParam(marker.modData);
+    const targetZoom = Math.max(map.getZoom(), 6);
+    let opened = false;
+    const openOnce = () => {
+      if (opened) return;
+      opened = true;
+      if (focusedMarker === marker) marker.openPopup();
+    };
+    map.once("moveend", openOnce);
+    map.flyTo(marker.getLatLng(), targetZoom, { duration: 0.6 });
+  }
+
+  // Pull `marker` out of the cluster group so a clustered-but-focused pin is
+  // visible without spiderfy. Returns the previously soloed marker to the
+  // group first — unless it belongs to an active panel set, which
+  // applyPanelPinFocus / clearPanelPinFocus own. This is the lone-pin path
+  // (Discover / sidebar / deep-link); the panel path force-individuals the
+  // whole set separately.
+  // IMPORTANT ordering: reassign `soloFocusMarker` to the new marker FIRST,
+  // operate on a local `prev`. `map.removeLayer(prev)` synchronously closes
+  // prev's popup → the popupclose handler's solo-release branch fires
+  // re-entrantly; if `soloFocusMarker` still pointed at `prev` there, that
+  // branch would call setSoloFocusMarker(null) mid-call and the line below
+  // would `markerClusterGroup.addLayer(null)` — prev removed from the map
+  // and never re-added = the "Discover removes the pin when clicked again"
+  // bug. Reassigning first makes `popupSource === soloFocusMarker` false in
+  // the re-entrant check, so it no-ops; using the `prev` local makes the
+  // re-add robust regardless.
+  function setSoloFocusMarker(marker) {
+    const prev = soloFocusMarker;
+    soloFocusMarker = marker || null;
+    if (prev && prev !== marker) {
+      const ownedByPanel = panelClusterModIds?.has(prev.modData.id);
+      if (
+        !ownedByPanel &&
+        map.hasLayer(prev) &&
+        !markerClusterGroup.hasLayer(prev)
+      ) {
+        map.removeLayer(prev);
+        markerClusterGroup.addLayer(prev);
+      }
+    }
+    if (marker && markerClusterGroup.hasLayer(marker)) {
+      markerClusterGroup.removeLayer(marker);
+      marker.addTo(map);
+    }
+  }
+
+  // Lone-pin focus (Discover / sidebar / deep-link). Force the marker
+  // individual (no clustering, no spiderfy), then fly + open.
+  function focusMarker(marker) {
+    setSoloFocusMarker(marker);
+    flyToMarkerAndOpen(marker);
+  }
+
+  // Panel-item focus. The marker is already individual (applyPanelPinFocus
+  // pulled the whole panel set out of the cluster group before this runs),
+  // so just fly + open — no solo bookkeeping needed.
+  function flyToPanelMarker(marker) {
+    flyToMarkerAndOpen(marker);
   }
 
   function focusRandomVisibleMarker() {
@@ -1256,10 +1445,19 @@ async function initMap() {
 
   // Populates the cluster panel with a sorted list of mods. View-agnostic —
   // both the Leaflet clusterclick handler and ThreeMarkers cluster clicks
-  // call this. onItemClick receives the mod object; the active view decides
-  // how to focus it (focusMarker for SAT, NCZ.ThreeMarkers.focusMod for SCHEMA).
+  // call this. onItemClick receives the mod object; the active view flies to
+  // it (focusMarker for SAT, NCZ.ThreeMarkers.focusMod for SCHEMA) — the fly
+  // dissolves the cluster but the panel stays open as a comparison list, so
+  // the user can click each member in turn. The clicked pin is kept at full
+  // opacity and the rest dim (applyPanelPinFocus).
   function populateClusterPanel(modsList, opts = {}) {
     const { onItemClick, nexusThumbs = {} } = opts;
+
+    // New cluster context → drop any prior pin emphasis and selection.
+    // Runs before panelClusterModIds is reassigned (below) so the old set
+    // is the one un-dimmed.
+    clearPanelPinFocus();
+    panelSelectedModId = null;
 
     clusterModList.innerHTML = "";
     clusterPanelCount.textContent = `(${modsList.length})`;
@@ -1320,6 +1518,15 @@ async function initMap() {
         }
 
         button.addEventListener("click", () => {
+          // Order matters: select → force-individual → fly.
+          // applyPanelPinFocus must run BEFORE the fly so the whole panel
+          // set is already pulled out of the cluster group (2D) / excluded
+          // from the clusterer (3D); otherwise the bubble persists through
+          // the fly (the original recording bug). The panel stays open on
+          // desktop; mobile still closes it (full-screen panel + fly +
+          // popup at once is too much there).
+          panelSelectedModId = mod.id;
+          applyPanelPinFocus();
           onItemClick?.(mod);
           if (window.innerWidth < NCZ.MOBILE_BREAKPOINT) hideClusterPanel();
         });
@@ -1440,17 +1647,34 @@ async function initMap() {
         .slice()
         .sort((left, right) => NCZ.sortModsByUpdated(left.modData, right.modData));
       const childMods = childMarkers.map((m) => m.modData);
+      // Toggle-close: re-clicking the cluster whose contents the panel shows
+      // closes it — but only before a pin was picked. Once a pin is selected
+      // the cluster has dissolved (flown into), so this path can't be hit
+      // for that cluster anyway; the guard makes the intent explicit.
+      if (
+        panelSelectedModId === null &&
+        isSameModSet(panelClusterModIds, childMods.map((m) => m.id))
+      ) {
+        hideClusterPanel();
+        return;
+      }
       populateClusterPanel(childMods, {
         nexusThumbs,
         onItemClick: (mod) => {
           const marker = childMarkers.find((m) => m.modData.id === mod.id);
-          if (marker) focusMarker(marker);
+          if (marker) flyToPanelMarker(marker);
         },
       });
     });
 
     // 3D (ThreeMarkers) cluster click → cluster panel
     NCZ.ThreeMarkers?.setClusterClickHandler?.((modIds) => {
+      // Toggle-close on the active cluster, before a pin is picked (parity
+      // with 2D — see that handler for the rationale).
+      if (panelSelectedModId === null && isSameModSet(panelClusterModIds, modIds)) {
+        hideClusterPanel();
+        return;
+      }
       const idSet = new Set(modIds);
       const childMods = mods
         .filter((m) => idSet.has(m.id))
@@ -1461,6 +1685,11 @@ async function initMap() {
       });
     });
 
+    // 3D empty-canvas click → close the cluster panel. Parity with the 2D
+    // `map.on("click", hideClusterPanel)` below: clicking empty space (not a
+    // pin / cluster / popup) dismisses the panel in both views.
+    NCZ.ThreeMarkers?.setEmptyClickHandler?.(hideClusterPanel);
+
     // 3D map-aware panel: when 3D clusters recompute (camera moved/zoomed/
     // tilted), follow the cluster the panel was opened for. Find the
     // "successor" — the current cluster with the most overlap with the
@@ -1469,6 +1698,10 @@ async function initMap() {
     // best successor has fewer than 2 mods (no longer a real cluster).
     NCZ.ThreeMarkers?.setClustersChangedHandler?.((clusterSets) => {
       if (!panelClusterModIds || panelClusterModIds.size === 0) return;
+      // Once a pin is picked the panel is a static comparison list — the
+      // flyTo already dissolved the cluster it tracked, so don't let the
+      // recompute close or rewrite the panel out from under the user.
+      if (panelSelectedModId !== null) return;
       // Skip while SAT is active — SAT panel state is independent.
       if (mapEl.style.display !== "none") return;
 
@@ -1517,6 +1750,9 @@ async function initMap() {
     // sync with Leaflet's automatic cluster recomputation.
     function recomputeSatClusterPanel() {
       if (!panelClusterModIds || panelClusterModIds.size === 0) return;
+      // Pin picked → static comparison list; the panel set is force-
+      // individual now, so don't auto-close or rewrite the panel.
+      if (panelSelectedModId !== null) return;
       // Skip while SCHEMA is active — SCHEMA panel state is independent.
       if (mapEl.style.display === "none") return;
 
@@ -1576,7 +1812,7 @@ async function initMap() {
         nexusThumbs,
         onItemClick: (mod) => {
           const m = childMarkers.find((cm) => cm.modData.id === mod.id);
-          if (m) focusMarker(m);
+          if (m) flyToPanelMarker(m);
         },
       });
     }
@@ -1585,7 +1821,7 @@ async function initMap() {
     // recomputed at the new zoom level).
     map.on("zoomend", recomputeSatClusterPanel);
     // markercluster fires animationend after cluster animations settle —
-    // covers spiderfy/unspiderfy and zoom-driven cluster regrouping.
+    // covers zoom-driven cluster regrouping (spiderfy is no longer used).
     markerClusterGroup.on("animationend", recomputeSatClusterPanel);
 
     sortedMods.forEach((mod) => {
@@ -1907,9 +2143,14 @@ async function initMap() {
       if (clearTagFiltersBtn) clearTagFiltersBtn.hidden = activeTags.length === 0;
       if (clearAuthorFiltersBtn) clearAuthorFiltersBtn.hidden = activeAuthors.length === 0;
 
+      // Close any open cluster panel FIRST. hideClusterPanel →
+      // clearPanelPinFocus returns any force-individual (comparison-mode)
+      // markers from the map back into the cluster group before we wipe it,
+      // so they can't orphan on the map or survive a filter that excludes
+      // them. Order matters: this must precede clearLayers().
+      hideClusterPanel();
       // Clear current cluster group
       markerClusterGroup.clearLayers();
-      hideClusterPanel();
       const visibleMarkers = [];
 
       // Compute which mods pass all filters (view-agnostic)

--- a/assets/js/three-markers.js
+++ b/assets/js/three-markers.js
@@ -9,7 +9,9 @@
  * The shared "interface" both views satisfy:
  *   setMods(mods, nexusThumbs, tagsDict) — build pins from data
  *   applyFilters(visibleIdSet)           — toggle which pins render
- *   focusMod(modId)                       — open popup for a mod
+ *   focusMod(modId)                       — fly to mod, then open popup
+ *   setPanelPinFocus(modIds, selectedId)  — dim a cluster's pins, keep the
+ *                                           selected one at full opacity
  *   closePopup()                          — programmatic close
  *
  * Rendering uses CSS2DRenderer so each pin is a real DOM node — DOM events,
@@ -55,8 +57,13 @@ const ThreeMarkers = (() => {
   let _recomputeFrame = null;
   let _onClusterClick = null;       // cluster-click callback (set by app.js)
   let _onClustersChanged = null;    // recompute-fired callback (set by app.js)
+  let _onEmptyClick = null;         // empty-canvas click (set by app.js) —
+                                    // parity with Leaflet map.on('click')
   let _activeClusterMods = null;    // Set<modId> | null — mods of the cluster
                                     // whose contents the cluster panel is showing
+  let _forcedIndividualIds = null;  // Set<modId> | null — pins that must never
+                                    // be absorbed into a bubble (panel
+                                    // comparison mode expands the whole set)
   const _projectVec = new THREE.Vector3();
 
   // Set by the container pointerup handler when the gesture exceeded
@@ -199,14 +206,18 @@ const ThreeMarkers = (() => {
         _dragSuppressClick = true;       // suppress the synthesised click
         return;
       }
-      // True click on empty space (canvas) closes any open popup, matching
-      // Leaflet's behaviour. Pin and cluster clicks are handled by their
-      // own element listeners — guard so this doesn't double-act on them.
-      if (!popup) return;
+      // True click on empty space (canvas). Pin and cluster clicks are
+      // handled by their own element listeners — guard so this doesn't
+      // double-act on them.
       if (e.target.closest('.three-popup')) return;
       if (e.target.closest('.three-marker')) return;
       if (e.target.closest('.marker-cluster')) return;
-      closePopup();
+      // Close any open popup AND dismiss the cluster panel. The panel close
+      // is routed through app.js (it owns the panel) so this matches
+      // Leaflet's `map.on('click', hideClusterPanel)` — empty-space click
+      // closes the panel in both views.
+      if (popup) closePopup();
+      _onEmptyClick?.();
     });
 
     // Build pins from any data that arrived before attach.
@@ -366,7 +377,14 @@ const ThreeMarkers = (() => {
     });
   }
 
-  function recomputeClusters() {
+  // `notify` (default true): fire _onClustersChanged so app.js can follow
+  // the cluster the panel tracks. Programmatic recomputes triggered FROM
+  // within panel code (setForcedIndividualIds / openPopup / closePopup) pass
+  // notify:false — otherwise the notification re-enters populateClusterPanel
+  // → clearPanelPinFocus → setForcedIndividualIds → recomputeClusters →
+  // _onClustersChanged → … (infinite recursion / stack overflow). Only
+  // genuine camera/filter-driven recomputes should rebuild the panel.
+  function recomputeClusters({ notify = true } = {}) {
     if (!_clusterLayer || !_schemaCamera || !container || !controls) return;
     const w = container.clientWidth;
     if (!w) return;
@@ -389,6 +407,17 @@ const ThreeMarkers = (() => {
     const points = [];
     for (const [id, pin] of pins) {
       if (!_filterVisibleIds.has(id)) continue;
+      // Forced-individual pins bypass grouping entirely so they always
+      // render as a standalone diamond: the open popup's pin (so flyTo /
+      // Discover / deep-link never leave it hidden under a still-tight
+      // bubble) plus, in panel comparison mode, the whole expanded cluster
+      // (so "click a pin → see all the pins" is guaranteed, not dependent
+      // on how tightly the mods are packed). 2D's equivalent is the
+      // restoreFocusedPopupIfVisible spiderfy path in app.js.
+      if (id === popupModId || _forcedIndividualIds?.has(id)) {
+        pin.visible = true;
+        continue;
+      }
       points.push({ id, pin, x: pin.position.x, z: pin.position.z, used: false });
     }
 
@@ -451,7 +480,7 @@ const ThreeMarkers = (() => {
     // Notify app.js so it can dismiss a stale cluster panel (one that was
     // opened for a cluster whose membership no longer matches any current
     // cluster after this recompute).
-    if (_onClustersChanged) {
+    if (notify && _onClustersChanged) {
       const sets = [];
       for (let i = 0; i < poolIdx; i++) {
         sets.push(_clusterPool[i].userData.modIds || []);
@@ -490,6 +519,18 @@ const ThreeMarkers = (() => {
     _activeClusterMods = modSet || null;
     refreshActiveClusterMark();
     _redraw();
+  }
+
+  // Pins that must never be clustered while this set is active. app.js sets
+  // it to the panel's mod set in comparison mode so the whole cluster
+  // expands into individual diamonds (the user can then compare them);
+  // (null) restores normal clustering. Synchronous recompute so the
+  // expand/collapse is immediate, not deferred to the next camera move.
+  function setForcedIndividualIds(idSet) {
+    _forcedIndividualIds = idSet && idSet.size ? idSet : null;
+    // notify:false — this is called from app.js panel code; re-notifying
+    // would recurse back into populateClusterPanel.
+    recomputeClusters({ notify: false });
   }
 
   function getOrCreateClusterObj(idx) {
@@ -591,6 +632,12 @@ const ThreeMarkers = (() => {
     if (pin) popup.position.copy(pin.position);
     pinsLayer.add(popup);
     popupModId = mod.id;
+    // Re-cluster so the just-focused pin pops out of any bubble it was
+    // hidden in. flyTo's last recompute fires mid-tween (before openPopup,
+    // the onComplete callback, sets popupModId), so without this the pin
+    // stays clustered after Discover / deep-link / a tight panel pick.
+    // notify:false — popup open must not re-trigger the panel-rebuild path.
+    recomputeClusters({ notify: false });
     syncUrlForMod(mod);
     _redraw();
   }
@@ -602,6 +649,11 @@ const ThreeMarkers = (() => {
     popup = null;
     popupModId = null;
     if (!silent) clearUrlMod();
+    // Re-cluster so the pin can rejoin a bubble now that it's no longer
+    // focused. Skip when silent — that path is buildPins (which recomputes
+    // itself) or openPopup's internal close (it recomputes after reopening).
+    // notify:false — popup close must not re-trigger the panel-rebuild path.
+    if (!silent) recomputeClusters({ notify: false });
     _redraw();
   }
 
@@ -623,12 +675,46 @@ const ThreeMarkers = (() => {
   function focusMod(modId) {
     const pin = pins.get(modId);
     if (!pin) return;
+    // Sync ?mod= EAGERLY. openPopup (which also syncs) runs deferred as the
+    // flyTo onComplete (~0.7s); a view switch during the fly would otherwise
+    // see no ?mod= and fail to restore the pin in the other view — the
+    // "shared camera/popup broken on clustered pins" report (clustered pins
+    // reach the popup via this deferred focusMod path; unclustered pins call
+    // openPopup synchronously and were unaffected).
+    syncUrlForMod(pin.userData.modData);
     // If we don't have controls (called before attach somehow), just open.
     if (!controls) {
       openPopup(pin.userData.modData);
       return;
     }
     flyTo(pin, () => openPopup(pin.userData.modData));
+  }
+
+  // Cluster-panel emphasis: once the user picks a pin from the panel the
+  // cluster has dissolved (flyTo zoomed in past the cluster radius), so all
+  // its pins are individually visible. Dim every pin in `modIds` except
+  // `selectedId`, which stays at full opacity — the "top pin, rest fade"
+  // effect. Opacity is set on the inner `.marker-pin` so the existing
+  // `transition: all` (style.css) animates the fade. Passing
+  // (null, null) restores every pin (panel closed / view switched).
+  // CSS2DRenderer only writes transform/display/zIndex inline, never
+  // opacity, so this style survives every render frame.
+  function setPanelPinFocus(modIds, selectedId) {
+    pins.forEach((pin) => {
+      const pinEl = pin.element?.querySelector('.marker-pin');
+      if (pinEl) pinEl.style.opacity = '';
+    });
+    if (modIds) {
+      for (const id of modIds) {
+        const pinEl = pins.get(id)?.element?.querySelector('.marker-pin');
+        if (pinEl) pinEl.style.opacity = id === selectedId ? '' : '0.3';
+      }
+    }
+    _redraw();
+  }
+
+  function setEmptyClickHandler(fn) {
+    _onEmptyClick = fn;
   }
 
   // Smooth ease-in-out so the camera doesn't jolt at start or stop.
@@ -781,6 +867,9 @@ const ThreeMarkers = (() => {
     applyFilters,
     getVisibleModIds,
     focusMod,
+    setPanelPinFocus,
+    setForcedIndividualIds,
+    setEmptyClickHandler,
     setPulse,
     setClusterClickHandler,
     setClustersChangedHandler,


### PR DESCRIPTION
Closes project item **E12 — Cluster panel UX cleanup**.

## Behaviour

| Action | Before | After |
|---|---|---|
| Click a mod in the cluster panel | Panel closed, popup floated to hidden pin | Camera flies to the pin, **panel stays open** as a comparison list; picked pin full-opacity, rest of cluster dims |
| Click another panel mod | Reopen panel each time | Emphasis moves, single clean popup |
| Re-click the active cluster bubble (no pin picked yet) | Nothing | Toggle-closes the panel |
| Empty-canvas click | 2D closed panel, 3D didn't | Both close the panel |
| Cluster dissolution on pick | Depended on zoom/spacing — tight clusters never dissolved | **Guaranteed** via force-individual |

## Design

Shared policy / separate mechanism. `populateClusterPanel`, the panel state (`panelClusterModIds` / `panelSelectedModId` / `panelPinFocusApplied`), popup HTML and the `onItemClick` abstraction live once in `app.js`; the per-view focus/fly/force-individual is bridged through the `NCZ.ThreeMarkers` callback interface (`setClusterClickHandler`, `setClustersChangedHandler`, `setEmptyClickHandler`, `setPanelPinFocus`, `setForcedIndividualIds`).

**Force-individual** replaces spiderfy as the single concept for "a focused/selected pin must stay visible while clustered":
- 2D: pull the marker(s) out of `markerClusterGroup` and add directly to the map (Leaflet-idiomatic — there is no per-marker no-cluster flag). Panel set via `applyPanelPinFocus`; lone pins (Discover / sidebar / deep-link) via `soloFocusMarker`.
- 3D: exclude the ids from the distance clusterer (`setForcedIndividualIds` + the open popup's `popupModId`), recompute on popup open/close.

**Spiderfy removed entirely** — both the explicit `cluster.spiderfy()` and the implicit `zoomToShowLayer` spiderfy path. It leaked on view-swap and Discover and conflicted with force-individual.

`?mod=` is the cross-view sync bus — both engines write it (`setModUrlParam` / `syncUrlForMod`) and read it on `onViewSwitched`. Now written **eagerly on focus** (not on popup open), since the popup now opens deferred.

## Bugs found & fixed during iterative testing (with screen recordings)

1. **Cluster didn't dissolve (both views).** Clustering is distance-based with no notion of selection; tight clusters stayed grouped at fly-to zoom. → force-individual.
2. **`Maximum call stack size exceeded` (3D).** Synchronous observer recursion: `populateClusterPanel → clearPanelPinFocus → setForcedIndividualIds → recomputeClusters → _onClustersChanged → populateClusterPanel → …`. → `recomputeClusters({notify})` (panel-internal recomputes pass `notify:false`) + `panelPinFocusApplied` short-circuit.
3. **Ghost / vibrating double-popup (2D).** Previous pin's popup stayed open through the 0.6 s flyTo, repositioned every frame by the dynamic-popup placer. → `map.closePopup()` before the fly; open deferred to `moveend`.
4. **Discover deleted the pin on re-click (2D).** `setSoloFocusMarker` did `map.removeLayer(prev)` while `soloFocusMarker` still pointed at `prev`; the synchronous `popupclose` re-entered `setSoloFocusMarker(null)`, so the next line ran `markerClusterGroup.addLayer(null)` — pin removed, never re-added. → reassign `soloFocusMarker` first, operate on a local `prev`.
5. **Cross-view sync broken for clustered pins.** Deferring popup-open also deferred the `?mod=` write; switching views in that window lost the pin. Unclustered pins opened synchronously (unaffected). → eager `?mod=`.

## Scope

`assets/js/app.js`, `assets/js/three-markers.js`, `CHANGELOG.md`. Untouched paths (Discover/sidebar/deep-link fly, filters) regression-tested. Verified via three OBS recordings across the iteration; 3D reported bug-free, 2D ghost/Discover/cross-view all confirmed fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)