### PR TITLE
fix(auto-discovery): resilient NCZoning BBCode parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Auto-discovery — resilient BBCode parsing**: `parseNcZoningBlock()` now strips all BBCode tags and anchors on the `NCZoning:` sentinel instead of requiring an intact `[code]…[/code]` wrapper. Blocks that lost their `[code]` tags or picked up stray `[spoiler]`/`[size]`/`[font]`/`[color]` styling (e.g. from a copy-paste round-trip) now parse correctly.
+
 ## [0.3.2] - 2026-04-09
 
 ### 16k WebP Tile Layer

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -136,13 +136,18 @@ NCZ.pickDirectionAndPosition = function (anchorPoint, size, mapSize, config) {
  * Parse the NCZoning: metadata block from a Nexus mod description.
  * Returns a parsed object, or null if no valid block is present.
  *
- * Resilient to blocks that have lost their [code] wrapper or picked up
- * stray BBCode styling ([spoiler]/[size]/[font]/[color], often per-line)
- * — e.g. from a copy-paste round-trip (Discord → Nexus) or the author
- * manually reformatting. We strip every BBCode tag first, so a clean
- * [code] block and a styled/unwrapped one normalize to the same plain
- * text, then anchor on the `NCZoning:` sentinel line and read the
- * key=value lines that follow it.
+ * Resilient to however the author actually pasted the block:
+ *  - lost [code] wrapper or stray styling ([spoiler]/[size]/[font]/
+ *    [color], often per-line) from a copy-paste round-trip
+ *  - the sentinel glued to the end of a sentence (e.g. `...Making!
+ *    [code]NCZoning:` — stripping [code] fuses it onto the prose)
+ *  - a false-positive "NCZoning:" mention earlier in the description
+ *
+ * Strategy: strip all BBCode, then treat `NCZoning:` as a token that
+ * can appear anywhere (not a whole line). Every occurrence is tried as
+ * a candidate; the first one whose following lines yield valid coords +
+ * category wins, so the coords/category validation — not the sentinel's
+ * position — is what disambiguates the real block from prose.
  */
 NCZ.parseNcZoningBlock = function (description, validTagNames) {
   if (!description) return null;
@@ -154,60 +159,62 @@ NCZ.parseNcZoningBlock = function (description, validTagNames) {
     .replace(/<br\s*\/?>/gi, "\n")
     .replace(/\[\/?[a-z][^\]]*\]/gi, "");
 
-  const lines = text.split("\n").map((l) => l.trim());
-  const start = lines.findIndex((l) => /^NCZoning\s*:$/i.test(l));
-  if (start === -1) return null;
-
-  // Read recognized key=value lines after the sentinel. Blank lines (left
-  // behind by stripped per-line tags) are skipped; once we've collected at
-  // least one field, the first unrecognized non-empty line ends the block
-  // so trailing description prose isn't mis-parsed.
   const RECOGNIZED = new Set(["coords", "category", "tags", "yaw", "credits", "authors"]);
-  const data = {};
-  for (let i = start + 1; i < lines.length; i++) {
-    const line = lines[i];
-    if (!line) continue;
-    const eqIdx = line.indexOf("=");
-    const key = eqIdx === -1 ? "" : line.slice(0, eqIdx).trim().toLowerCase();
-    if (!RECOGNIZED.has(key)) {
-      if (Object.keys(data).length) break;
-      continue;
-    }
-    const value = line.slice(eqIdx + 1).trim();
-    if (value && !(key in data)) data[key] = value;
-  }
-
-  // coords is required — two or three comma-separated numbers [X, Y] or [X, Y, Z]
-  if (!data.coords) return null;
-  const coordParts = data.coords.split(",").map((s) => parseFloat(s.trim()));
-  // Prevent invalid input: reject < 2 values (missing Y or both), > 3 values (extra fields), or NaN (failed parse)
-  if (coordParts.length < 2 || coordParts.length > 3 || coordParts.some(isNaN)) return null;
-
-  // category is required
   const validCategories = ["location-overhaul", "new-location", "other"];
-  if (!data.category || !validCategories.includes(data.category)) return null;
 
-  // tags: filter to known tags only — unknown tags silently dropped
-  const tags = data.tags
-    ? data.tags.split(",").map((t) => t.trim()).filter((t) => validTagNames.has(t))
-    : [];
+  // Turn a collected key=value map into the public parsed object, or
+  // null if required fields are missing/invalid (also the signal to try
+  // the next NCZoning: candidate).
+  const finalize = (data) => {
+    if (!data.coords) return null;
+    // coords: two or three comma-separated numbers [X, Y] or [X, Y, Z].
+    // Reject < 2 (missing Y/both), > 3 (extra fields), or NaN (bad parse).
+    const coordParts = data.coords.split(",").map((s) => parseFloat(s.trim()));
+    if (coordParts.length < 2 || coordParts.length > 3 || coordParts.some(isNaN)) return null;
+    if (!data.category || !validCategories.includes(data.category)) return null;
 
-  // additional authors beyond Nexus uploader
-  const additionalAuthors = data.authors
-    ? data.authors.split(",").map((a) => a.trim()).filter(Boolean)
-    : [];
-
-  // yaw is optional
-  const yaw = data.yaw && !isNaN(parseFloat(data.yaw)) ? parseFloat(data.yaw) : null;
-
-  return {
-    coordinates: coordParts,
-    category: data.category,
-    tags,
-    credits: data.credits || null,
-    additionalAuthors,
-    yaw,
+    return {
+      coordinates: coordParts,
+      category: data.category,
+      // tags: filter to known tags only — unknown tags silently dropped
+      tags: data.tags
+        ? data.tags.split(",").map((t) => t.trim()).filter((t) => validTagNames.has(t))
+        : [],
+      credits: data.credits || null,
+      // additional authors beyond the Nexus uploader
+      additionalAuthors: data.authors
+        ? data.authors.split(",").map((a) => a.trim()).filter(Boolean)
+        : [],
+      yaw: data.yaw && !isNaN(parseFloat(data.yaw)) ? parseFloat(data.yaw) : null,
+    };
   };
+
+  // `NCZoning:` is a token, not a line — authors paste it inline after
+  // prose. [ \t]* (not \s*) tolerates `NCZoning :` without swallowing the
+  // newline that separates it from the first field.
+  const sentinel = /NCZoning[ \t]*:/gi;
+  let m;
+  while ((m = sentinel.exec(text)) !== null) {
+    const data = {};
+    // Read the lines that follow this candidate. Blank lines (left behind
+    // by stripped per-line tags) are skipped; the first non-blank line
+    // that isn't a recognized key=value ends the block, so neither the
+    // glued-on prose before the sentinel nor description text after the
+    // fields is mis-parsed.
+    for (const raw of text.slice(m.index + m[0].length).split("\n")) {
+      const line = raw.trim();
+      if (!line) continue;
+      const eqIdx = line.indexOf("=");
+      const key = eqIdx === -1 ? "" : line.slice(0, eqIdx).trim().toLowerCase();
+      if (!RECOGNIZED.has(key)) break;
+      const value = line.slice(eqIdx + 1).trim();
+      if (value && !(key in data)) data[key] = value;
+    }
+    const parsed = finalize(data);
+    if (parsed) return parsed;
+    // Not a valid block (false-positive mention) — try the next occurrence.
+  }
+  return null;
 };
 
 // Returns true when a mod was updated on Nexus within the recent window.

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -133,29 +133,48 @@ NCZ.pickDirectionAndPosition = function (anchorPoint, size, mapSize, config) {
 };
 
 /**
- * Parse the [code]NCZoning:...[/code] metadata block from a Nexus mod description.
- * Returns a parsed object or null if the block is missing/invalid.
+ * Parse the NCZoning: metadata block from a Nexus mod description.
+ * Returns a parsed object, or null if no valid block is present.
+ *
+ * Resilient to blocks that have lost their [code] wrapper or picked up
+ * stray BBCode styling ([spoiler]/[size]/[font]/[color], often per-line)
+ * — e.g. from a copy-paste round-trip (Discord → Nexus) or the author
+ * manually reformatting. We strip every BBCode tag first, so a clean
+ * [code] block and a styled/unwrapped one normalize to the same plain
+ * text, then anchor on the `NCZoning:` sentinel line and read the
+ * key=value lines that follow it.
  */
 NCZ.parseNcZoningBlock = function (description, validTagNames) {
   if (!description) return null;
 
-  // Normalize HTML line breaks from Nexus API to actual newlines
-  let text = description.replace(/<br\s*\/?>/gi, "\n");
+  // Normalize HTML line breaks, then strip every BBCode [tag]/[/tag].
+  // This subsumes the old [spoiler] unwrap and the [code] requirement —
+  // both become tag noise that disappears, leaving plain key=value text.
+  const text = description
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/\[\/?[a-z][^\]]*\]/gi, "");
 
-  // Strip outer [spoiler]...[/spoiler] wrapper if present
-  text = text.replace(/\[spoiler\]([\s\S]*?)\[\/spoiler\]/gi, "$1");
+  const lines = text.split("\n").map((l) => l.trim());
+  const start = lines.findIndex((l) => /^NCZoning\s*:$/i.test(l));
+  if (start === -1) return null;
 
-  // Extract [code]NCZoning:\n...[/code] block
-  const match = text.match(/\[code\]\s*NCZoning:\s*\n([\s\S]*?)\[\/code\]/i);
-  if (!match) return null;
-
+  // Read recognized key=value lines after the sentinel. Blank lines (left
+  // behind by stripped per-line tags) are skipped; once we've collected at
+  // least one field, the first unrecognized non-empty line ends the block
+  // so trailing description prose isn't mis-parsed.
+  const RECOGNIZED = new Set(["coords", "category", "tags", "yaw", "credits", "authors"]);
   const data = {};
-  for (const line of match[1].split("\n")) {
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line) continue;
     const eqIdx = line.indexOf("=");
-    if (eqIdx === -1) continue;
-    const key = line.slice(0, eqIdx).trim().toLowerCase();
+    const key = eqIdx === -1 ? "" : line.slice(0, eqIdx).trim().toLowerCase();
+    if (!RECOGNIZED.has(key)) {
+      if (Object.keys(data).length) break;
+      continue;
+    }
     const value = line.slice(eqIdx + 1).trim();
-    if (key && value) data[key] = value;
+    if (value && !(key in data)) data[key] = value;
   }
 
   // coords is required — two or three comma-separated numbers [X, Y] or [X, Y, Z]

--- a/docs/nczoning-auto-discovery.md
+++ b/docs/nczoning-auto-discovery.md
@@ -84,11 +84,11 @@ The Nexus uploader is always included as the first author automatically. Use `au
 
 ### Parsing rules
 
-- The block must start with `NCZoning:` on the first line inside `[code]`
+- The parser anchors on a line that reads `NCZoning:` on its own, then reads the `key=value` lines that follow it
 - `coords` and `category` are required — mods missing either are skipped entirely
 - `coords` accepts either 2 values (`X,Y` — legacy format) or 3 values (`X,Y,Z` — new format). For new submissions, Z is required
 - `tags` that don't exist in the tag registry are silently dropped (the mod still appears)
-- The `[spoiler]` wrapper is stripped before parsing — both formats work identically
+- All BBCode formatting is stripped before parsing, so the block still works if it loses its `[code]` wrapper or picks up stray styling (`[spoiler]`, `[size]`, `[font]`, `[color]`) — e.g. from a copy-paste round-trip. The `[code]` wrapper is still recommended for readability; the generator emits it
 
 ### Transition Note
 

--- a/docs/nczoning-auto-discovery.md
+++ b/docs/nczoning-auto-discovery.md
@@ -84,7 +84,7 @@ The Nexus uploader is always included as the first author automatically. Use `au
 
 ### Parsing rules
 
-- The parser anchors on a line that reads `NCZoning:` on its own, then reads the `key=value` lines that follow it
+- The parser finds the `NCZoning:` marker (it can sit inline — even glued to the end of a sentence) and reads the `key=value` lines that follow it; if `NCZoning:` also appears in your prose, the real block is still found as long as its `coords`/`category` are valid
 - `coords` and `category` are required — mods missing either are skipped entirely
 - `coords` accepts either 2 values (`X,Y` — legacy format) or 3 values (`X,Y,Z` — new format). For new submissions, Z is required
 - `tags` that don't exist in the tag registry are silently dropped (the mod still appears)


### PR DESCRIPTION
## Problem

Mod **29664** (*kabuki tech terrarium - apartment*) was tagged `NCZoning` on Nexus with a valid metadata block, but auto-discovery silently skipped it:

```
NCZoning: skipping mod 29664 — no valid [NCZoning] block found
```

`NCZ.parseNcZoningBlock()` required an intact `[code]NCZoning:…[/code]` wrapper via:

```js
/\[code\]\s*NCZoning:\s*\n([\s\S]*?)\[\/code\]/i
```

The author's block had **no `[code]` tag at all** — it was wrapped per-line in `[spoiler][size=2][font=Monaco, Menlo, Consolas, monospace]…[/font][/size]`. This happens from a copy-paste round-trip (generated block posted to Discord → author copies it back out) or the author manually reformatting. The data itself was correct; only the delimiter contract was broken, so the regex returned `null`.

## Fix

`parseNcZoningBlock()` is now **content-anchored** instead of delimiter-coupled:

1. Strip every BBCode `[tag]`/`[/tag]` (subsumes the old `[spoiler]` unwrap and the `[code]` requirement).
2. Anchor on the `NCZoning:` sentinel line.
3. Read recognized `key=value` lines after it. The `RECOGNIZED` allowlist (`coords`/`category`/`tags`/`yaw`/`credits`/`authors`) doubles as the block terminator, so trailing description prose containing stray `=` (e.g. `version=2.0`) can't poison the result.

A clean `[code]` block and an editor-mangled one normalize to identical plain text.

## Verification

Ran the real mod 29664 description plus regressions through the patched function:

| Case | Result |
| --- | --- |
| mod 29664 (was failing) | ✅ `coords=[1159.6091,1273.2751,67.5941]`, `category=new-location`, `tags=[apartment,kitsch,photos,streetkid]`, `yaw=81.1547` |
| well-formed `[code]` block | ✅ all fields incl. credits/authors/yaw — no regression |
| legacy `[spoiler]`+`[code]`, 2-value coords | ✅ no regression |
| prose with `=` after block | ✅ terminates correctly, no over-collection |
| no block | ✅ `null` |

`docs/nczoning-auto-discovery.md` parsing-rules section and `CHANGELOG.md` updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)