### PR TITLE
feat(ci): scheduled auto-discovery health monitor → Discord

### DIFF
--- a/.github/workflows/monitor-auto-discovery.yml
+++ b/.github/workflows/monitor-auto-discovery.yml
@@ -1,0 +1,31 @@
+name: Monitor Auto-Discovery Health
+
+# Auto-discovered pins are parsed client-side from live Nexus descriptions
+# that authors add at any time, and a parse failure is silent (a console
+# log nobody reads). This runs the REAL production parser
+# (assets/js/utils.js) against live Nexus data on a schedule and pings
+# Discord only when a tagged mod is missing from the map — so a broken or
+# incomplete block is caught within a day instead of when an author complains.
+
+on:
+  schedule:
+    - cron: '0 9 * * *'   # Daily at 09:00 UTC
+  workflow_dispatch:        # Manual trigger (for testing / on demand)
+
+permissions:
+  contents: read
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Scan NCZoning-tagged mods and alert on parse failures
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: node scripts/monitor_auto_discovery.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-05-16
+
 ### Added
 
-- **Auto-discovery health monitor**: scheduled GitHub Action runs the real `parseNcZoningBlock()` against all live NCZoning-tagged Nexus mods daily and posts a Discord alert listing any that are missing from the map — split into "malformed block" (author fix needed) vs "tagged, no block". Catches silent parse failures within a day instead of when an author complains.
+- **Auto-discovery health monitor**: scheduled GitHub Action runs the real `parseNcZoningBlock()` against all live NCZoning-tagged Nexus mods daily and posts a Discord alert listing any that are missing from the map — split into "malformed block" (author fix needed) vs "tagged, no block". Catches silent parse failures within a day instead of when an author complains. Local/dry runs (no webhook) print the payload for review instead of sending.
 
 ## [0.3.4] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Auto-discovery health monitor**: scheduled GitHub Action runs the real `parseNcZoningBlock()` against all live NCZoning-tagged Nexus mods daily and posts a Discord alert listing any that are missing from the map — split into "malformed block" (author fix needed) vs "tagged, no block". Catches silent parse failures within a day instead of when an author complains.
+
 ## [0.3.4] - 2026-05-16
 
 ### Fixed

--- a/scripts/monitor_auto_discovery.js
+++ b/scripts/monitor_auto_discovery.js
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * Auto-discovery health monitor.
+ *
+ * Why this exists and not a unit test: auto-discovered pins are parsed
+ * client-side from *live* Nexus descriptions that authors add at any
+ * time, and a parse failure is silent (a console.log nobody reads). A
+ * fixture test only catches us regressing a *known* case on a parser
+ * edit; it cannot catch a new author pasting a format we've never seen.
+ * So this runs on a schedule against live data, importing the **real
+ * production parser** (`assets/js/utils.js` → `parseNcZoningBlock`) so
+ * it can never drift from what users actually experience.
+ *
+ * Run: node scripts/monitor_auto_discovery.js
+ * Posts a Discord embed (DISCORD_WEBHOOK_URL) only when ≥1 NCZoning-
+ * tagged mod fails to parse and isn't covered by a manual registry
+ * entry. Exit 0 on a clean run OR detected-bad-mods (it's a report,
+ * not a gate); exit 1 only on an infrastructure error.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.join(__dirname, "..");
+const NEXUS_MOD_URL = (id) => `https://www.nexusmods.com/cyberpunk2077/mods/${id}`;
+
+// --- Load the real production parser (drift-proof by construction) -----------
+function loadParser() {
+  const src = fs.readFileSync(path.join(ROOT, "assets/js/utils.js"), "utf8");
+  const NCZ = {};
+  // utils.js assigns onto a bare `NCZ`; parseNcZoningBlock is self-contained
+  // (regex + the validTagNames Set), so no other NCZ members are needed.
+  new Function("NCZ", src)(NCZ);
+  if (typeof NCZ.parseNcZoningBlock !== "function") {
+    throw new Error("parseNcZoningBlock not found after loading assets/js/utils.js");
+  }
+  return NCZ.parseNcZoningBlock;
+}
+
+// --- Pull stable Nexus constants from constants.js source (no eval) ----------
+function loadNexusConstants() {
+  const src = fs.readFileSync(path.join(ROOT, "assets/js/constants.js"), "utf8");
+  const num = (name, fallback) => {
+    const m = src.match(new RegExp(`NCZ\\.${name}\\s*=\\s*(\\d+)`));
+    return m ? Number(m[1]) : fallback;
+  };
+  const str = (name, fallback) => {
+    const m = src.match(new RegExp(`NCZ\\.${name}\\s*=\\s*["']([^"']+)["']`));
+    return m ? m[1] : fallback;
+  };
+  return {
+    endpoint: str("NEXUS_GQL_ENDPOINT", "https://api.nexusmods.com/v2/graphql"),
+    gameId: num("NEXUS_GAME_ID", 3333),
+    batchSize: num("NEXUS_BATCH_SIZE", 50),
+  };
+}
+
+// --- Valid tag names (data/tags.json is a flat { id: description } object) ---
+function loadValidTagNames() {
+  const tags = JSON.parse(fs.readFileSync(path.join(ROOT, "data/tags.json"), "utf8"));
+  return new Set(Object.keys(tags));
+}
+
+// --- Manually-registered numeric nexus_ids (mirror services.js precedence) ---
+// A tagged mod that's also in the manual registry intentionally may have no
+// parseable block — manual data wins — so excluding it avoids false alarms.
+function loadManualNexusIds() {
+  const dir = path.join(ROOT, "data/locations");
+  const ids = new Set();
+  for (const file of fs.readdirSync(dir)) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const mod = JSON.parse(fs.readFileSync(path.join(dir, file), "utf8"));
+      if (/^\d+$/.test(String(mod.nexus_id))) ids.add(String(mod.nexus_id));
+    } catch {
+      /* a malformed location file is validate-mods.yml's problem, not ours */
+    }
+  }
+  return ids;
+}
+
+// --- Fetch every NCZoning-tagged mod (same query/pagination as services.js) --
+async function fetchTaggedMods({ endpoint, gameId, batchSize }) {
+  const query = `
+    query NCZoningMods($filter: ModsFilter!, $count: Int!, $offset: Int!) {
+      mods(filter: $filter, count: $count, offset: $offset) {
+        nodes { modId name description }
+        totalCount
+      }
+    }`;
+  const out = [];
+  let offset = 0;
+  let total = Infinity;
+  while (offset < total) {
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query,
+        variables: {
+          filter: {
+            gameId: [{ value: String(gameId) }],
+            tag: [{ value: "NCZoning" }],
+          },
+          count: batchSize,
+          offset,
+        },
+      }),
+    });
+    if (!res.ok) throw new Error(`Nexus API HTTP ${res.status}`);
+    const json = await res.json();
+    if (json.errors) throw new Error(`Nexus API errors: ${JSON.stringify(json.errors)}`);
+    const page = json?.data?.mods;
+    if (!page) throw new Error("Nexus API: no mods page in response");
+    total = page.totalCount ?? 0;
+    const nodes = page.nodes || [];
+    out.push(...nodes);
+    if (nodes.length === 0 || nodes.length < batchSize) break;
+    offset += nodes.length;
+  }
+  return out;
+}
+
+async function postDiscord(failures, total) {
+  const url = process.env.DISCORD_WEBHOOK_URL;
+  if (!url) {
+    console.log("DISCORD_WEBHOOK_URL not set — skipping notification (local run).");
+    return;
+  }
+  const MAX_PER_GROUP = 12;
+  const fmt = (group) => {
+    const lines = group
+      .slice(0, MAX_PER_GROUP)
+      .map((f) => `• [${f.name || "Unknown"}](${NEXUS_MOD_URL(f.modId)}) — \`${f.modId}\``);
+    if (group.length > MAX_PER_GROUP) lines.push(`…and ${group.length - MAX_PER_GROUP} more.`);
+    return lines.join("\n");
+  };
+
+  // Two distinct signals — keep them separate so the alert is actionable:
+  // a broken block needs the author to fix it; a missing block may just be
+  // a speculative/mistaken tag or an author who never finished setup.
+  const malformed = failures.filter((f) => f.attemptedBlock);
+  const noBlock = failures.filter((f) => !f.attemptedBlock);
+
+  const fields = [];
+  if (malformed.length) {
+    fields.push({
+      name: `🔧 Malformed block — ${malformed.length} (author tried, parse failed)`,
+      value: fmt(malformed),
+    });
+  }
+  if (noBlock.length) {
+    fields.push({
+      name: `🏷️ Tagged, no block — ${noBlock.length} (no NCZoning: in description)`,
+      value: fmt(noBlock),
+    });
+  }
+
+  const body = {
+    embeds: [
+      {
+        title: `⚠️ Auto-discovery: ${failures.length} NCZoning mod(s) missing from the map`,
+        description:
+          `Tagged **NCZoning** on Nexus but not appearing as live pins. ` +
+          `Malformed blocks need an author fix; no-block tags may be ` +
+          `mistaken or incomplete.`,
+        color: 15105570, // amber/orange — warning, not error
+        fields,
+        footer: { text: `NC Zoning Board • ${total} tagged mods scanned` },
+      },
+    ],
+  };
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`Discord webhook HTTP ${res.status}: ${await res.text()}`);
+  }
+  console.log(`Posted Discord alert for ${failures.length} unparseable mod(s).`);
+}
+
+(async () => {
+  try {
+    const parse = loadParser();
+    const consts = loadNexusConstants();
+    const validTagNames = loadValidTagNames();
+    const manualIds = loadManualNexusIds();
+
+    const mods = await fetchTaggedMods(consts);
+    console.log(`Scanned ${mods.length} NCZoning-tagged mods (${manualIds.size} manual ids excluded).`);
+
+    const failures = [];
+    for (const mod of mods) {
+      const id = String(mod.modId);
+      if (manualIds.has(id)) continue; // manual registry covers it
+      if (!parse(mod.description, validTagNames)) {
+        // A `NCZoning` mention means the author attempted a block that
+        // failed to parse (actionable: fix it) vs. no block at all
+        // (a bare/mistaken tag).
+        const attemptedBlock = /NCZoning/i.test(mod.description || "");
+        failures.push({ modId: id, name: mod.name, attemptedBlock });
+      }
+    }
+
+    if (failures.length === 0) {
+      console.log("✅ All non-manual tagged mods parse cleanly.");
+    } else {
+      const malformed = failures.filter((f) => f.attemptedBlock);
+      const noBlock = failures.filter((f) => !f.attemptedBlock);
+      console.log(
+        `❌ ${failures.length} missing (${malformed.length} malformed block, ${noBlock.length} no block):`,
+      );
+      for (const f of failures) {
+        console.log(`   - ${f.modId}  [${f.attemptedBlock ? "malformed" : "no-block "}]  ${f.name}`);
+      }
+      await postDiscord(failures, mods.length);
+    }
+    process.exit(0); // report, not a gate
+  } catch (err) {
+    console.error("Monitor failed (infrastructure error):", err.message);
+    process.exit(1);
+  }
+})();

--- a/scripts/monitor_auto_discovery.js
+++ b/scripts/monitor_auto_discovery.js
@@ -123,10 +123,6 @@ async function fetchTaggedMods({ endpoint, gameId, batchSize }) {
 
 async function postDiscord(failures, total) {
   const url = process.env.DISCORD_WEBHOOK_URL;
-  if (!url) {
-    console.log("DISCORD_WEBHOOK_URL not set — skipping notification (local run).");
-    return;
-  }
   const MAX_PER_GROUP = 12;
   const fmt = (group) => {
     const lines = group
@@ -170,6 +166,14 @@ async function postDiscord(failures, total) {
       },
     ],
   };
+  if (!url) {
+    // No webhook (local run / dry run): print the exact payload that
+    // would be POSTed so the alert can be reviewed without sending it.
+    console.log("\n--- DISCORD_WEBHOOK_URL not set — preview of payload that would be sent ---");
+    console.log(JSON.stringify(body, null, 2));
+    console.log("--- end preview (nothing was sent) ---");
+    return;
+  }
   const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Why

Auto-discovered pins are parsed **client-side from live Nexus descriptions** that authors add at any time, and a parse failure is **silent** — just a `console.log` nobody reads. This session alone, two correctly-tagged mods (29664, 4371) were silently dropped and only found by chance.

A fixture/unit test is the wrong tool here (raised by @spuddeh): it only catches *us regressing a known case* on a parser edit, never a *new author format*, and `validate-mods.yml` only triggers on `data/` PRs so it wouldn't even run on a parser change. The failure mode is silent + the input is unbounded and external → the correct instrument is a **monitor against live data on a schedule**, not a test against frozen fixtures.

## What

- `scripts/monitor_auto_discovery.js` — loads the **real production parser** (`assets/js/utils.js` → `parseNcZoningBlock`, so it can never drift from what users experience), fetches every `NCZoning`-tagged mod from Nexus (same query/pagination as `services.js`), excludes manual-registry `nexus_id`s (manual entries legitimately may have no block), and posts a Discord embed **only** when something is missing from the map.
- `.github/workflows/monitor-auto-discovery.yml` — daily cron (`0 9 * * *`) + `workflow_dispatch`, `contents: read` only, uses the existing `DISCORD_WEBHOOK_URL` secret.
- Report-only: exit 0 on detected-bad-mods (it's a report, not a gate), exit 1 only on infra error.

### Two honest buckets

Failures are split so the alert is actionable:
- 🔧 **Malformed block** — description contains `NCZoning` but didn't parse → author attempted a block, needs a fix.
- 🏷️ **Tagged, no block** — no `NCZoning:` in the description → bare/mistaken tag, different problem.

## Validation

Ran against live Nexus on this branch:

```
Scanned 37 NCZoning-tagged mods (249 manual ids excluded).
❌ 1 missing (0 malformed block, 1 no block):
   - 19605  [no-block ]  H10 Minimal Apartment Clean Up
```

- **0 malformed** confirms the #660 parser fix holds across all 37 live tagged mods.
- Surfaced **19605**, a previously-invisible mistaken/incomplete tag — exactly the class this is built to catch.

Discord post path is exercised only when `DISCORD_WEBHOOK_URL` is set (skipped on local runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)