### PR TITLE
docs(dev-guide): correct main→dev sync cadence + add CHANGELOG resolution rule

### DIFF
--- a/docs/dev-branch-maintainer-guide.md
+++ b/docs/dev-branch-maintainer-guide.md
@@ -91,7 +91,9 @@ git merge origin/main --no-edit         # Merge main's changes
 git push origin dev
 ```
 
-Do this **at minimum weekly** and **always before starting a new phase**. Merge conflicts are usually limited to `CHANGELOG.md` (which has `[Unreleased]` entries on dev that don't exist on main) and are trivial to resolve.
+Do this **ad-hoc, whenever `main` has changes `dev` needs** — a Leaflet/satellite-view bugfix, new location JSONs, tooling, or docs. There is **no fixed cadence**: no weekly schedule, no per-phase requirement. Sync on demand.
+
+Merge conflicts are **almost always limited to `CHANGELOG.md`**, and the conflict is structural: `dev` carries a long-lived `[Unreleased]` block (the 3D-map changelog) that `main` doesn't have, while `main` accumulates released `[0.3.x]` sections `dev` doesn't have. **Resolve by union, in order:** keep dev's entire `[Unreleased]` body, then place main's released `[0.3.x]` sections immediately below it (above the previously-newest released version). Drop neither side — a correct resolution just removes the `<<<<<<<` / `=======` / `>>>>>>>` markers with both blocks intact.
 
 ## Phase status
 


### PR DESCRIPTION
## Why

`docs/dev-branch-maintainer-guide.md` is a dev-only doc. Two accuracy problems in the **Keeping dev in sync with main** section:

1. **False cadence** — it said the sync should be done *"at minimum weekly and always before starting a new phase."* There is no weekly cadence; the sync is ad-hoc, done when `main` has changes `dev` needs (confirmed with @spuddeh). The stale claim actively misled a reader (it led me to describe a "weekly sync" the maintainer doesn't do).
2. **No resolution guidance** — it said the `CHANGELOG.md` conflict is *"trivial to resolve"* without saying how. That conflict is structural and recurs on every ad-hoc sync; re-deriving the resolution each time is error-prone.

## What

Scoped to the one section (the broader '7-phase migration' framing / phase-status staleness is intentionally **not** touched — separate, bigger, needs current-state input):

- Cadence corrected to **ad-hoc, on demand** with the real triggers (Leaflet bugfix, new location JSONs, tooling, docs).
- Added the **union-in-order** CHANGELOG resolution rule: keep dev's entire `[Unreleased]` body, slot main's released `[0.3.x]` sections immediately below it, drop neither side.

This is exactly the resolution just used in the `4fd717a` main→dev sync (parser fix + monitor + new location), so the doc now matches established practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)