### PR TITLE
fix(3d): scene-controls no longer pan/zoom the camera

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `OrbitControls` now attaches to `#map-3d` (parent of canvas + CSS2D overlay) instead of `renderer.domElement`, with `setPointerCapture` / `releasePointerCapture` overridden to no-ops on that element. Copies Leaflet's `Draggable` pattern (drag handler at the container, no pointer capture) so pan/zoom gestures pass through pins and cluster bubbles to the camera while the per-element `click` handlers stay intact.
 - Drag-vs-click discrimination via a `_dragSuppressClick` flag in `three-markers.js` (set when the container-level `pointerdown→pointerup` distance exceeds `PIN_3D_DRAG_THRESHOLD_PX`). Popup card stops `pointerdown` propagation so internal interactions don't arm phantom drags.
+- `#scene-controls` (Reset/Showcase buttons, sun slider, tilt) now stops `pointerdown`/`wheel`/`contextmenu` propagation so operating an on-canvas control no longer pans/zooms the camera (the inverse of the pin case — Leaflet's `disableClickPropagation` idiom).
 
 #### Three.js-Parity: district outline visibility + camera ergonomics
 

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -569,6 +569,23 @@ const ThreeScene = (() => {
     // container fills the viewport so this is a near-impossible case.
     _orbitDom.setPointerCapture     = () => {};
     _orbitDom.releasePointerCapture = () => {};
+    // Scene-control UI (#scene-controls — Reset/Showcase buttons, sun slider,
+    // tilt readout) lives *inside* #map-3d, so its gestures bubble up to the
+    // OrbitControls listeners on _orbitDom and pan/zoom/tilt the camera while
+    // you're operating a control (dragging the sun slider moved the map).
+    // This is the inverse of the pin/cluster case above: pins *want* the
+    // gesture to reach the camera (drag-to-pan, click still fires); controls
+    // do NOT. Mirror Leaflet's L.DomEvent.disableClickPropagation /
+    // disableScrollPropagation — stop the gesture-initiating events at the
+    // control container so OrbitControls (the ancestor listener) never sees
+    // them. stopPropagation only (no preventDefault / stopImmediatePropagation)
+    // leaves the controls' own behaviour and click handlers fully intact.
+    const _sceneControls = document.getElementById('scene-controls');
+    if (_sceneControls) {
+      for (const evt of ['pointerdown', 'wheel', 'contextmenu']) {
+        _sceneControls.addEventListener(evt, (e) => e.stopPropagation());
+      }
+    }
     controls.mouseButtons = {
       LEFT:   THREE.MOUSE.PAN,
       MIDDLE: THREE.MOUSE.DOLLY,


### PR DESCRIPTION
## Why

Follow-up to the E9 OrbitControls fix ([[orbitcontrols-pointer-capture-defeats-child-clicks]]). That fix attached OrbitControls to `#map-3d` (parent of canvas + CSS2D overlay) so pin/cluster drags reach the camera while clicks survive. Side effect: `#scene-controls` (Reset/Showcase buttons, sun slider, tilt readout) also lives inside `#map-3d`, so dragging the sun slider — or click-dragging a button — bubbled into OrbitControls and moved the map.

Project item: *"Clicking and dragging on the scene controls moves the map"* (itemId 188497103).

## What

Inverse of the pin case (pins *want* the gesture to reach the camera; controls do not). Mirror Leaflet's `L.DomEvent.disableClickPropagation`/`disableScrollPropagation`: `#scene-controls` now `stopPropagation()`s `pointerdown` / `wheel` / `contextmenu` so the ancestor OrbitControls listeners never see them. `stopPropagation` only — no `preventDefault` / `stopImmediatePropagation` — so the controls' own behaviour and click handlers stay fully intact. Co-located in `three-scene.js` with the pointer-capture defeat it complements (~7 lines).

## Verify

On a PR-preview SCHEMA view:
- Drag the **sun slider** — time changes, camera does **not** pan. ✅
- Click-drag off the **Reset view** / **Showcase** buttons — no camera move; their click still works.
- Scroll the wheel **over** `#scene-controls` — camera does **not** zoom.
- Regression: dragging on the **canvas** and on **pins/clusters** still pans the camera; pin/cluster **clicks** still open popups (E9 behaviour unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)