### PR TITLE
feat(3d): procedural terrain grid (terrain/water/cliffs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Three.js-Parity: procedural terrain grid
+
+- Terrain, water and cliffs now carry the game's "graph-paper" grid — a procedural three-tier anti-aliased line grid (cells 80 / 8 / 400 wu) on world XZ, decoded from the game's `3d_map_terrain` pixel shader.
+- New theme variable `--scene-grid` colours the grid lines per theme; surface base colours are unchanged. New `NCZ.TERRAIN_GRID_*` constants in [`constants.js`](assets/js/constants.js).
+
 #### Three.js-Parity: cluster panel UX cleanup (E12)
 
 - Picking a mod from the cluster panel now flies to the pin and **keeps the panel open** as a comparison list (was: closed on click). The picked pin stays full-opacity, the rest of its cluster dims; re-clicking the active cluster bubble (before a pin is picked) toggles the panel closed; empty-canvas click closes the panel in 3D too (2D parity).

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -128,6 +128,7 @@ html.theme-night-corp {
     --scene-cliffs:          #2e4a62;
     --scene-buildings:       #8aacbf;
     --scene-buildings-edge:  #00f0ff;
+    --scene-grid:            #5b86a8;
 
     /* Overlay colors (roads/metro for SCHEMA, districts for both) */
     --overlay-road-color:        #485c70;
@@ -170,6 +171,7 @@ html.theme-arasaka {
     --scene-cliffs:          #3a2e2e;
     --scene-buildings:       #a08888;
     --scene-buildings-edge:  #ff5050;
+    --scene-grid:            #8a5a5a;
 
     /* Overlay colors */
     --overlay-road-color:        #4a3838;
@@ -212,6 +214,7 @@ html.theme-militech {
     --scene-cliffs:          #384030;
     --scene-buildings:       #8a9070;
     --scene-buildings-edge:  #ffd040;
+    --scene-grid:            #6f7c55;
 
     /* Overlay colors */
     --overlay-road-color:        #485248;
@@ -254,6 +257,7 @@ html.theme-aldecaldos {
     --scene-cliffs:          #3a3428;
     --scene-buildings:       #9a9080;
     --scene-buildings-edge:  #ff8050;
+    --scene-grid:            #847349;
 
     /* Overlay colors */
     --overlay-road-color:        #4a4238;
@@ -296,6 +300,7 @@ html.theme-synthwave {
     --scene-cliffs:          #140828;
     --scene-buildings:       #6040a0;
     --scene-buildings-edge:  #00d4ff;
+    --scene-grid:            #6a3aa0;
 
     /* Overlay colors — road borders are cyan for neon grid feel */
     --overlay-road-color:        #18102a;

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -249,6 +249,17 @@ NCZ.BUILDING_EDGE_INTENSITY =  0.05;  // max mix weight — keeps effect subtle;
 NCZ.BUILDING_TEX_FLOOR      =   0.3;  // minimum _m.dds brightness — prevents faces going pitch-black
 NCZ.BUILDING_TEX_RANGE      =   0.7;  // brightness range above the floor (floor + range = max)
 
+// Terrain "graph-paper" grid — decoded from the game's 3d_map_terrain pixel
+// shader (PIX DXIL capture; see wiki/sources/terrain-grid-shader.md). Three
+// nested anti-aliased line grids on world XZ, combined into one line factor.
+// Every value below is the game's exact decoded value — the "game:" note in
+// each comment keeps the original recoverable if a value is later tuned.
+NCZ.TERRAIN_GRID_CELLS       = [80, 8, 400]; // world-unit cell sizes, main/fine/major — game: [80, 8, 400]
+NCZ.TERRAIN_GRID_LINE_N      = [20, 2, 75];  // line-width factors, line ≈ cell/N wide — game: [20, 2, 75]
+NCZ.TERRAIN_GRID_FINE_OFFSET = 1423.6;       // phase offset on the fine grid — game: 1423.6
+NCZ.TERRAIN_GRID_MAIN_WEIGHT = 0.65;         // main-grid contribution, before the fine grid is subtracted — game: 0.65
+NCZ.TERRAIN_GRID_MAJOR_BOOST = 50;           // major-line emphasis: (1 + BOOST·major) multiplies the result — game: 50
+
 // District / subdistrict outline visibility thresholds in CET camera-to-target
 // distance. Three-state, matching the game's WorldMap.ZoomLevel* TweakDB records:
 //   d ≥ DISTRICT_DISTANCE_3D            → main district outlines visible

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -15,10 +15,12 @@
 import * as THREE from 'three';
 import {
   attribute, uniform, texture, positionWorld, positionLocal, normalLocal,
-  transformNormal, transformNormalToView, uv, vec2, vec4, float, materialColor,
+  transformNormal, transformNormalToView, uv, vec2, vec4, float, mix, smoothstep, materialColor,
   instancedArray, instanceIndex,
   // Phase 2B compute culling
   Fn, If, storage, struct, atomicStore, atomicAdd, uint,
+  // Terrain grid shader
+  dFdx, dFdy,
 } from 'three/tsl';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
@@ -235,13 +237,73 @@ const ThreeScene = (() => {
 
   // Derive edge highlight colour from the building base colour.
 
+  // ── Terrain "graph-paper" grid ─────────────────────────────────────────────
+  // Decoded from the game's 3d_map_terrain pixel shader (PIX DXIL capture —
+  // see wiki/sources/terrain-grid-shader.md). In-game, terrain, water AND
+  // cliffs all use that one material template, so every hillshade material
+  // below carries the grid.
+
+  // Continuous anti-aliased grid-line coverage. The game's original formula
+  // (round() + min(frac()·N,1), integrated over the pixel footprint) has hard
+  // step discontinuities — coverage JUMPS as the camera moves, and the game
+  // hides the resulting shimmer with TAA, which our scene does not have. This
+  // replacement is continuous so it antialiases itself, no TAA needed:
+  //   • triangle-wave distance to the nearest line centre — no jumps,
+  //   • smoothstep ramp across the pixel footprint,
+  //   • minification compensation — once a line is thinner than a pixel it is
+  //     drawn at footprint width and dimmed proportionally, so it fades out
+  //     smoothly instead of aliasing.
+  // N is the line-width factor — a line spans ≈ cell/N. The +0.5 places the
+  // lines where the game's formula put them (same grid, no flicker).
+  const gridCoverage = Fn(([c, N]) => {
+    const w         = dFdx(c).abs().max(dFdy(c).abs());                  // pixel footprint per axis
+    const halfWidth = float(0.5).div(N);                                 // line half-width (cell fraction)
+    const dist      = float(0.5).sub(c.add(0.5).fract().sub(0.5).abs()); // 0 on a line, 0.5 mid-cell
+    const eff       = w.max(halfWidth);                                  // never thinner than a pixel
+    const cov       = float(1).sub(smoothstep(eff.sub(w), eff.add(w), dist))
+                              .mul(halfWidth.div(eff));                  // dim sub-pixel lines → fade
+    return cov.x.max(cov.y).clamp(0, 1);   // a line in X or Y
+  });
+
+  // Three nested grids on world XZ (cells 80 / 8 / 400 wu) combined into one
+  // line factor: main grid, minus the fine grid, with major lines boosted.
+  function terrainGridFactor() {
+    const P = positionWorld.xz;
+    const [cellA, cellB, cellC] = NCZ.TERRAIN_GRID_CELLS;
+    const [nA, nB, nC]          = NCZ.TERRAIN_GRID_LINE_N;
+    const a = gridCoverage(P.div(cellA), nA);
+    const b = gridCoverage(P.div(cellB).add(NCZ.TERRAIN_GRID_FINE_OFFSET), nB);
+    const c = gridCoverage(P.div(cellC), nC);
+    return a.mul(NCZ.TERRAIN_GRID_MAIN_WEIGHT).sub(b)
+            .mul(c.mul(NCZ.TERRAIN_GRID_MAJOR_BOOST).add(1))
+            .clamp(0, 1);
+  }
+
+  // Hillshade material for terrain / water / cliffs. `colorNode` lerps the
+  // theme base colour → theme grid colour by the procedural grid factor, so
+  // each surface keeps its existing per-theme colour and the grid rides on
+  // top. Where there's no grid line the factor is 0 and the colorNode is
+  // exactly `materialColor` — the fill is identical to the plain material.
+  //
+  // Use the `mix()` FUNCTION, never the `.mix()` node method here: the
+  // method does not evaluate as `mix(receiver, b, t)` — `materialColor.mix(
+  // uGrid, 0)` rendered the grid colour, not the base colour, washing the
+  // whole surface even at factor 0. The `mix(a, b, t)` function is correct
+  // (verified: `mix(materialColor, uGrid, 0) === materialColor`).
+  //
+  // Base colour stays in `material.color` (read via `materialColor`); only
+  // the grid line colour is a `uniform()` on userData.tslUniforms.
   function makeHillshadeMaterial(colorVar, fallback, extra = {}) {
-    return new THREE.MeshLambertNodeMaterial({
+    const mat = new THREE.MeshLambertNodeMaterial({
       color: readThemeColor(colorVar, fallback),
       flatShading: true,
       side: THREE.DoubleSide,
       ...extra,
     });
+    const uGrid = uniform(readThemeColor('--scene-grid', '#6d8ab0'));
+    mat.userData.tslUniforms = { uGrid };
+    mat.colorNode = mix(materialColor, uGrid, terrainGridFactor());
+    return mat;
   }
 
 
@@ -2292,9 +2354,18 @@ const ThreeScene = (() => {
 
     scene.background = readThemeColor('--primary', '#0a192f');
 
-    if (terrainMat) terrainMat.color.copy(readThemeColor('--scene-terrain',      '#566c88'));
-    if (waterMat)   waterMat.color.copy(readThemeColor('--scene-water',           '#2a3f57'));
-    if (cliffsMat)  cliffsMat.color.copy(readThemeColor('--scene-cliffs',         '#566c88'));
+    // Terrain/water/cliffs: base colour is material.color; the grid line
+    // colour is the shared uGrid uniform stashed on each material.
+    const gridColour = readThemeColor('--scene-grid', '#6d8ab0');
+    const setHillshade = (m, baseVar, baseFallback) => {
+      if (!m) return;
+      m.color.copy(readThemeColor(baseVar, baseFallback));
+      const u = m.userData.tslUniforms;
+      if (u) u.uGrid.value.copy(gridColour);
+    };
+    setHillshade(terrainMat, '--scene-terrain', '#566c88');
+    setHillshade(waterMat,   '--scene-water',   '#2a3f57');
+    setHillshade(cliffsMat,  '--scene-cliffs',  '#566c88');
     if (roadsMat)         roadsMat.color.copy(readThemeColor('--overlay-road-color',         '#504b41'));
     if (normalRoadsMat)   normalRoadsMat.color.copy(readThemeColor('--overlay-road-color',    '#504b41'));
     if (bordersMat)       bordersMat.color.copy(readThemeColor('--overlay-road-border-color', '#1ec3c8'));
@@ -2329,6 +2400,10 @@ const ThreeScene = (() => {
       lerp:  (f, t, a) => m?.color.lerpColors(f, t, a),
       ...extra,
     });
+    // The grid line colour is one uniform shared by all three hillshade mats.
+    const eachGridUniform = (op) => [terrainMat, waterMat, cliffsMat].forEach(m => {
+      const u = m?.userData.tslUniforms; if (u) op(u.uGrid.value);
+    });
     return [
       { key: 'bg', cssVar: '--primary', fallback: '#0a192f',
         get:   () => scene?.background?.clone() ?? null,
@@ -2338,6 +2413,11 @@ const ThreeScene = (() => {
       { key: 'terrain',  cssVar: '--scene-terrain',  fallback: '#566c88', ...mat(terrainMat) },
       { key: 'water',    cssVar: '--scene-water',    fallback: '#2a3f57', ...mat(waterMat) },
       { key: 'cliffs',   cssVar: '--scene-cliffs',   fallback: '#566c88', ...mat(cliffsMat) },
+      { key: 'grid',     cssVar: '--scene-grid',     fallback: '#6d8ab0',
+        get:   () => terrainMat?.userData.tslUniforms?.uGrid.value.clone() ?? null,
+        reset: c  => { if (c) eachGridUniform(v => v.copy(c)); },
+        lerp:  (f, t, a) => { if (f && t) eachGridUniform(v => v.lerpColors(f, t, a)); },
+      },
       { key: 'roads',    cssVar: '--overlay-road-color', fallback: '#504b41',
         get:   () => roadsMat?.color.clone() ?? null,
         reset: c  => { roadsMat?.color.copy(c); normalRoadsMat?.color.copy(c); },

--- a/scripts/terrain_grid_spike.html
+++ b/scripts/terrain_grid_spike.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CP2077 3D-Map Terrain Grid — decoded shader</title>
+<!--
+  Standalone calibration demo for the in-game world-map terrain grid.
+  The grid is procedural: decoded 2026-05-20 from a PIX GPU capture of
+  Cyberpunk 2077 (pixel shader hash 8538a550680120453ca108b5628a9b1f).
+  See wiki/sources/terrain-grid-shader.md for the full DXIL decode.
+
+  This runs the EXACT decoded algorithm on a flat plane spanning the
+  terrain's world bounds (+/-8000). Lighting is omitted (flat plane);
+  the grid pattern, colours and edge-fade are the calibration target.
+  Load an in-game screenshot via the panel to compare side-by-side.
+-->
+<style>
+  html,body{margin:0;height:100%;background:#05080f;overflow:hidden;
+            font-family:'Segoe UI',Tahoma,sans-serif;}
+  #c{position:fixed;inset:0;display:block;}
+  #overlay{position:fixed;inset:0;width:100%;height:100%;object-fit:contain;
+           pointer-events:none;opacity:0;}
+  #panel{position:fixed;top:10px;left:10px;width:264px;max-height:95vh;
+         overflow:auto;background:rgba(10,16,28,.93);border:1px solid #1e3a4a;
+         border-radius:6px;padding:10px 12px;color:#cfe;font-size:12px;
+         box-shadow:0 4px 18px rgba(0,0,0,.5);}
+  #panel h1{font-size:13px;margin:0 0 2px;color:#5ef6ff;}
+  #panel h2{font-size:10px;margin:11px 0 4px;color:#7fdac0;
+            text-transform:uppercase;letter-spacing:.6px;}
+  .row{display:flex;align-items:center;gap:7px;margin:4px 0;}
+  .row label{flex:0 0 92px;color:#aebed0;}
+  .row input[type=range]{flex:1;min-width:0;}
+  .row input[type=color]{flex:1;height:20px;padding:0;border:0;background:none;}
+  .row input[type=file]{flex:1;min-width:0;font-size:10px;color:#aebed0;}
+  .row .val{flex:0 0 44px;text-align:right;color:#fff;
+            font-variant-numeric:tabular-nums;}
+  button{background:#15485a;color:#dff;border:1px solid #2a8f9a;
+         border-radius:4px;padding:5px 8px;cursor:pointer;width:100%;margin-top:9px;}
+  button:hover{background:#1d6377;}
+  .note{color:#6b7d92;font-size:10px;margin-top:8px;line-height:1.45;}
+  code{color:#9fe;}
+</style>
+</head>
+<body>
+<canvas id="c"></canvas>
+<img id="overlay" alt="">
+<div id="panel">
+  <h1>3D-Map Terrain Grid</h1>
+  <div class="note">Decoded from PIX capture — shader <code>8538a550…</code>.
+    Defaults are the exact game values. Drag to orbit, scroll to zoom.</div>
+  <div id="controls"></div>
+</div>
+
+<script type="importmap">
+{ "imports": {
+  "three": "https://cdn.jsdelivr.net/npm/three@0.170.0/build/three.module.js",
+  "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.170.0/examples/jsm/"
+}}
+</script>
+<script type="module">
+import * as THREE from 'three';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+
+/* ── decoded game defaults ───────────────────────────────────────────────
+   Three nested grids on world XZ. Cell sizes are 1/scale from the DXIL:
+   layer A scale 0.0125 → 80 wu,  B 0.125 → 8 wu,  C 0.0025 → 400 wu.
+   N = line-width factor (line ≈ cell/N wide). Colours from cbuffer cb4. */
+const GAME = {
+  cellA: 80,  nA: 20,  enA: true,
+  cellB: 8,   nB: 2,   offB: 1423.6, enB: true,
+  cellC: 400, nC: 75,  enC: true,
+  baseColor: '#566c88',          // BaseColorScale  rgb(86,108,136)
+  linesColor:'#6d8ab0',          // LinesColor      rgb(109,138,176)
+  darkEdge: 4500,                // DarkEdgeWidth
+  bright: 1.0,                   // Brightness
+};
+const state = { ...GAME };
+
+/* ── three.js scene ──────────────────────────────────────────────────── */
+const canvas = document.getElementById('c');
+const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+renderer.setClearColor(0x05080f);
+
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(35, innerWidth/innerHeight, 10, 300000);
+camera.position.set(6000, 22000, 15000);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.target.set(0, 0, 0);
+controls.minDistance = 2000;
+controls.maxDistance = 120000;
+
+const uniforms = {
+  uBaseColor:    { value: new THREE.Color(state.baseColor) },
+  uLinesColor:   { value: new THREE.Color(state.linesColor) },
+  uDarkEdgeWidth:{ value: state.darkEdge },
+  uBrightness:   { value: state.bright },
+  uCellSize:     { value: new THREE.Vector3(state.cellA, state.cellB, state.cellC) },
+  uLineN:        { value: new THREE.Vector3(state.nA, state.nB, state.nC) },
+  uLayerBOffset: { value: state.offB },
+  uLayerEnable:  { value: new THREE.Vector3(1, 1, 1) },
+  uMapHalf:      { value: 8000 },
+};
+
+const vertexShader = /* glsl */`
+  out vec2 vWorldXZ;
+  void main() {
+    vec4 wp = modelMatrix * vec4(position, 1.0);
+    vWorldXZ = wp.xz;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+/* Faithful port of the decoded pixel shader. gridCoverage() is the
+   analytic anti-aliased grid-line integral: round(c) + min(frac(c)*N,1)
+   is the antiderivative of the line pulse train, evaluated across the
+   pixel footprint c ± fwidth/2. */
+const fragmentShader = /* glsl */`
+  in vec2 vWorldXZ;
+  out vec4 outColor;
+  uniform vec3  uBaseColor, uLinesColor, uCellSize, uLineN, uLayerEnable;
+  uniform float uDarkEdgeWidth, uBrightness, uLayerBOffset, uMapHalf;
+
+  float gridCoverage(vec2 c, float N) {
+    vec2 w   = max(abs(dFdx(c)), abs(dFdy(c)));   // pixel footprint
+    vec2 up  = c + w * 0.5;
+    vec2 dn  = c - w * 0.5;
+    vec2 Fup = round(up) + min(fract(up) * N, 1.0);
+    vec2 Fdn = round(dn) + min(fract(dn) * N, 1.0);
+    vec2 cov = (Fup - Fdn) / (w * N);
+    return clamp(max(cov.x, cov.y), 0.0, 1.0);    // line in X or Y
+  }
+
+  void main() {
+    vec2 P = vWorldXZ;
+    float A = gridCoverage(P / uCellSize.x, uLineN.x) * uLayerEnable.x;
+    float B = gridCoverage(P / uCellSize.y + uLayerBOffset, uLineN.y) * uLayerEnable.y;
+    float C = gridCoverage(P / uCellSize.z, uLineN.z) * uLayerEnable.z;
+
+    float g = clamp((1.0 + 50.0 * C) * (0.65 * A - B), 0.0, 1.0);
+    vec3 col = mix(uBaseColor, uLinesColor, g) * uBrightness;
+
+    float edge = clamp((uMapHalf - max(abs(P.x), abs(P.y))) / uDarkEdgeWidth, 0.0, 1.0);
+    edge = edge * edge * (3.0 - 2.0 * edge);      // smoothstep
+    outColor = vec4(max(col * edge, 0.0), 1.0);
+  }
+`;
+
+const material = new THREE.ShaderMaterial({
+  uniforms, vertexShader, fragmentShader,
+  glslVersion: THREE.GLSL3, side: THREE.DoubleSide,
+});
+
+const plane = new THREE.PlaneGeometry(16000, 16000);
+plane.rotateX(-Math.PI / 2);                       // lie flat in world XZ
+scene.add(new THREE.Mesh(plane, material));
+
+function syncUniforms() {
+  uniforms.uBaseColor.value.set(state.baseColor);
+  uniforms.uLinesColor.value.set(state.linesColor);
+  uniforms.uDarkEdgeWidth.value = state.darkEdge;
+  uniforms.uBrightness.value = state.bright;
+  uniforms.uCellSize.value.set(state.cellA, state.cellB, state.cellC);
+  uniforms.uLineN.value.set(state.nA, state.nB, state.nC);
+  uniforms.uLayerBOffset.value = state.offB;
+  uniforms.uLayerEnable.value.set(+state.enA, +state.enB, +state.enC);
+}
+
+/* ── control panel ───────────────────────────────────────────────────── */
+const CONFIG = [
+  { sec: 'Layer A — 80-unit grid' },
+  { k:'cellA', label:'cell size', min:5, max:400, step:1 },
+  { k:'nA',    label:'line N',    min:1, max:120, step:1 },
+  { k:'enA',   label:'enabled',   chk:true },
+  { sec: 'Layer B — 8-unit grid' },
+  { k:'cellB', label:'cell size', min:1, max:200, step:1 },
+  { k:'nB',    label:'line N',    min:1, max:60,  step:0.5 },
+  { k:'offB',  label:'phase',     min:0, max:2000,step:0.1 },
+  { k:'enB',   label:'enabled',   chk:true },
+  { sec: 'Layer C — 400-unit grid' },
+  { k:'cellC', label:'cell size', min:50, max:1600, step:5 },
+  { k:'nC',    label:'line N',    min:1,  max:200,  step:1 },
+  { k:'enC',   label:'enabled',   chk:true },
+  { sec: 'Appearance' },
+  { k:'baseColor',  label:'terrain fill', color:true },
+  { k:'linesColor', label:'grid lines',   color:true },
+  { k:'darkEdge',   label:'edge fade',    min:0, max:8000, step:50 },
+  { k:'bright',     label:'brightness',   min:0, max:3,    step:0.05 },
+];
+
+const host = document.getElementById('controls');
+const refs = {};
+
+for (const item of CONFIG) {
+  if (item.sec) {
+    const h = document.createElement('h2');
+    h.textContent = item.sec;
+    host.appendChild(h);
+    continue;
+  }
+  const row = document.createElement('div');
+  row.className = 'row';
+  const lab = document.createElement('label');
+  lab.textContent = item.label;
+  row.appendChild(lab);
+
+  if (item.color) {
+    const inp = document.createElement('input');
+    inp.type = 'color'; inp.value = state[item.k];
+    inp.oninput = () => { state[item.k] = inp.value; syncUniforms(); };
+    row.appendChild(inp);
+  } else if (item.chk) {
+    const inp = document.createElement('input');
+    inp.type = 'checkbox'; inp.checked = state[item.k];
+    inp.style.flex = '1';
+    inp.onchange = () => { state[item.k] = inp.checked; syncUniforms(); };
+    row.appendChild(inp);
+  } else {
+    const inp = document.createElement('input');
+    inp.type = 'range';
+    inp.min = item.min; inp.max = item.max; inp.step = item.step;
+    inp.value = state[item.k];
+    const val = document.createElement('span');
+    val.className = 'val'; val.textContent = state[item.k];
+    inp.oninput = () => {
+      state[item.k] = parseFloat(inp.value);
+      val.textContent = state[item.k];
+      syncUniforms();
+    };
+    row.appendChild(inp); row.appendChild(val);
+    refs[item.k] = { inp, val };
+  }
+  host.appendChild(row);
+}
+
+// reset button
+const reset = document.createElement('button');
+reset.textContent = 'Reset to game values';
+reset.onclick = () => {
+  Object.assign(state, GAME);
+  for (const item of CONFIG) {
+    if (item.sec) continue;
+    if (refs[item.k]) {
+      refs[item.k].inp.value = state[item.k];
+      refs[item.k].val.textContent = state[item.k];
+    }
+  }
+  // re-sync color/checkbox inputs
+  host.querySelectorAll('input[type=color]').forEach((inp, i) => {
+    inp.value = i === 0 ? state.baseColor : state.linesColor;
+  });
+  host.querySelectorAll('input[type=checkbox]').forEach((inp, i) => {
+    inp.checked = [state.enA, state.enB, state.enC][i];
+  });
+  syncUniforms();
+};
+host.appendChild(reset);
+
+// compare-with-screenshot section
+const cmp = document.createElement('h2');
+cmp.textContent = 'Compare with screenshot';
+host.appendChild(cmp);
+
+const overlay = document.getElementById('overlay');
+const fileRow = document.createElement('div');
+fileRow.className = 'row';
+const fileLab = document.createElement('label');
+fileLab.textContent = 'load image';
+const fileInp = document.createElement('input');
+fileInp.type = 'file'; fileInp.accept = 'image/*';
+fileInp.onchange = () => {
+  if (fileInp.files[0]) overlay.src = URL.createObjectURL(fileInp.files[0]);
+};
+fileRow.appendChild(fileLab); fileRow.appendChild(fileInp);
+host.appendChild(fileRow);
+
+const opRow = document.createElement('div');
+opRow.className = 'row';
+const opLab = document.createElement('label');
+opLab.textContent = 'overlay opacity';
+const opInp = document.createElement('input');
+opInp.type = 'range'; opInp.min = 0; opInp.max = 1; opInp.step = 0.02; opInp.value = 0;
+opInp.oninput = () => { overlay.style.opacity = opInp.value; };
+opRow.appendChild(opLab); opRow.appendChild(opInp);
+host.appendChild(opRow);
+
+const note = document.createElement('div');
+note.className = 'note';
+note.textContent = 'Lighting is omitted — this is a flat plane; the real ' +
+  'terrain normals drive the in-game shading. Grid pattern, colours and ' +
+  'edge-fade match 1:1.';
+host.appendChild(note);
+
+/* ── render loop ─────────────────────────────────────────────────────── */
+addEventListener('resize', () => {
+  camera.aspect = innerWidth / innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(innerWidth, innerHeight);
+});
+renderer.setSize(innerWidth, innerHeight);
+
+renderer.setAnimationLoop(() => {
+  controls.update();
+  renderer.render(scene, camera);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds the in-game world-map "graph-paper" grid to the 3D scene's terrain, water and cliffs.

The grid was reverse-engineered from the game's `3d_map_terrain` pixel shader via a PIX GPU capture (DXIL decode — full write-up in the wiki source page `terrain-grid-shader`). In-game, terrain/water/cliffs all share that one material template, so all three carry the grid here too.

## How it works

- **Three nested anti-aliased line grids** on world XZ — cell sizes 80 / 8 / 400 wu (main / fine / major) — combined into one line factor (`0.65·A − B`, major lines boosted ×50). New `NCZ.TERRAIN_GRID_*` constants carry the decoded values, each annotated with its game value.
- **Theme-coloured** — new `--scene-grid` CSS variable, one per theme. `colorNode = mix(base, grid, factor)`; where there's no line the factor is 0, so the surface fill is byte-identical to before the grid (verified by pixel sampling: `[14,27,40]` terrain, `[8,18,29]` water — unchanged from `dev`).
- Flows through the existing theme-switch + flyover colour-tween machinery (new `grid` colour binding).

## Two notable departures, both deliberate

1. **Continuous grid maths, not the game's exact formula.** The game's `round()`/`fract()`-based line function has step discontinuities — coverage *jumps* as the camera moves. The game hides the shimmer with TAA; this scene has none, so it flickered badly. Replaced with a continuous formulation (triangle-wave distance + `smoothstep` + minification fade) that self-antialiases. Verified flicker-free and visually matching the in-game map.
2. **`mix()` function, not the `.mix()` node method.** The TSL `.mix()` method does not evaluate as `mix(receiver, b, t)` — it silently mis-orders operands and washed the whole surface ~2.4× brighter. Diagnosed by instrumentation; documented in the wiki learning `tsl-mix-method-misorders-operands`.

## Not included

- `scripts/terrain_grid_spike.html` — standalone calibration demo of the decoded shader (sibling of the `webgpu_*_spike.html` reference spikes). Committed as reference; not wired into the app.
- The building-edge highlight has a related shimmer (no in-shader AA at all) — tracked separately, not touched here.

## Testing

Driven live in the WebGPU 3D scene: fill matches `dev` exactly, grid renders, theme-switch recolours it, no console errors. Flicker confirmed resolved by the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
