### PR TITLE
fix(3d): correct building _m surface modulation to decoded game value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Three.js-Parity: building surface modulation
+
+- Building `_m` surface modulation corrected to the game's decoded value — `0.4 + 0.5·m` (was a guessed `0.3 + 0.7·m`). Decoded from the same `3d_map_cubes.mt` shader capture; the shader's vertical-AO term ships disabled, so it collapses to a flat floor + range.
+
 #### Three.js-Parity: building edge highlight
 
 - Building edge highlight rewritten to the game's actual algorithm, decoded from the `3d_map_cubes.mt` gbuffer shader (PIX capture): `saturate(pow(max(|1-2u|,|1-2v|), EdgeSharpnessPower))` mixed into the albedo. Real per-district constants (`EdgeThickness`/`EdgeSharpnessPower`) replace the previous guessed values.

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -246,8 +246,13 @@ NCZ.DDS_ALPHA_THRESH  = 655;      // 0.01 × UINT16_MAX — position alpha below
 // Per-district EdgeThickness / EdgeSharpnessPower live in DISTRICT_META
 // (three-scene.js) alongside the other per-district game constants.
 NCZ.BUILDING_EDGE_CAMDIST_K =  0.002; // game's camera-distance widening coefficient: k = camDist × this × EdgeThickness
-NCZ.BUILDING_TEX_FLOOR      =   0.3;  // minimum _m.dds brightness — prevents faces going pitch-black
-NCZ.BUILDING_TEX_RANGE      =   0.7;  // brightness range above the floor (floor + range = max)
+// _m surface modulation, decoded from the 3d_map_cubes.mt gbuffer shader
+// (PIX capture; see wiki/sources/building-edge-shader.md). Game formula:
+//   surface = 0.5·(0.05 + 0.75·ao + m)   →   ao = 1 (the vertical-AO term is
+// gated by DebugScaleOffset, which ships at a default that disables it)
+//   →   surface = 0.5·(0.8 + m) = 0.4 + 0.5·m
+NCZ.BUILDING_TEX_FLOOR      =   0.4;  // _m.dds brightness floor — game 0.5·0.8
+NCZ.BUILDING_TEX_RANGE      =   0.5;  // brightness range above the floor — game 0.5·m
 
 // Terrain "graph-paper" grid — decoded from the game's 3d_map_terrain pixel
 // shader (PIX DXIL capture; see wiki/sources/terrain-grid-shader.md). Three

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -1606,7 +1606,10 @@ const ThreeScene = (() => {
       wzNeg.sub(uOffset.y).sub(uTransMin.y).div(uTransMax.y.sub(uTransMin.y))
     );
 
-    // (1) Diffuse modulation — sample _m, scale base colour
+    // (1) Diffuse modulation — sample _m, scale base colour. The game's
+    // gbuffer shader applies `surface = 0.4 + 0.5·m` to the albedo (decoded —
+    // wiki/sources/building-edge-shader.md; the shader's vertical-AO term is
+    // disabled by the default DebugScaleOffset, so it collapses to floor+range).
     const mVal = texture(mTex, planarUv.clamp(0, 1)).r;
     const modulation = float(NCZ.BUILDING_TEX_FLOOR).add(mVal.mul(NCZ.BUILDING_TEX_RANGE));
 


### PR DESCRIPTION
## What

The building `_m` surface modulation used eyeballed constants — `mod = 0.3 + 0.7·m` (`BUILDING_TEX_FLOOR` / `BUILDING_TEX_RANGE`). This replaces them with the value decoded from the game shader.

## The decode

From the same `3d_map_cubes.mt` gbuffer PIX capture as the edge highlight, the surface term is:

```
surface = 0.5·(0.05 + 0.75·ao + mProcessed)
mProcessed = m + (1-m)·(1/3)·(1-ao)
ao = saturate(TEXCOORD3.z)
```

Tracing `TEXCOORD3.z` into the vertex shader, it's `lerp(verticalGradient, 1.0, saturate(DebugScaleOffset.x))`. `DebugScaleOffset` defaults to `(1,1,0,0)` and **no district material overrides it** — so `ao = 1`, which collapses the formula:

- `mProcessed = m` (the `(1-ao)` factor zeroes the rest)
- `surface = 0.5·(0.05 + 0.75 + m) = 0.5·(0.8 + m) = **0.4 + 0.5·m**`

So: `BUILDING_TEX_FLOOR` 0.3 → **0.4**, `BUILDING_TEX_RANGE` 0.7 → **0.5**.

## Notable finding

The shader *has* a per-building vertical AO gradient (`1−(1−h)²`, darker at the base) — but it's gated behind `DebugScaleOffset`, a debug knob that ships at a value which **disables** it. Replicating the gradient would be *less* faithful than the retail map, so it's intentionally not implemented. (Documented in `wiki/sources/building-edge-shader.md`.)

## Changes

- `constants.js` — `BUILDING_TEX_FLOOR` 0.3 → 0.4, `BUILDING_TEX_RANGE` 0.7 → 0.5, with the decoded derivation in the comment.
- `three-scene.js` — comment on the `modulation` line citing the decode (code unchanged — same `floor + m·range` form).
- `CHANGELOG.md`.

## Effect

Building dark areas slightly brighter (floor 0.3 → 0.4), bright areas no longer blow to full white (max 1.0 → 0.9). Matches the game's flatter, more even building shading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)