### PR TITLE
fix(3d): metro LOD crossfade + decoded thresholds + load-flicker fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Three.js-Parity: metro LOD crossfade
+
+- Metro LOD tiers (dotted / thin / wide) now **crossfade** by camera distance instead of hard-switching, decoded from the `3d_map_metro.mt` pixel shader (PIX capture). Real thresholds: tiers change at 2500 / 9000 / 15000 wu (game `VisibilityDistance*` ÷ 2 — the game's metric is `2 × cameraZ`), crossfading over a 150 wu band.
+- Fixed: the metro showed the wrong tier on first load until the camera moved — the distance uniform was seeded from a constant instead of the live camera.
+
 #### Three.js-Parity: building surface modulation
 
 - Building `_m` surface modulation corrected to the game's decoded value — `0.4 + 0.5·m` (was a guessed `0.3 + 0.7·m`). Decoded from the same `3d_map_cubes.mt` shader capture; the shader's vertical-AO term ships disabled, so it collapses to a flat floor + range.

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -277,30 +277,23 @@ NCZ.TERRAIN_GRID_MAJOR_BOOST = 50;           // major-line emphasis: (1 + BOOST�
 NCZ.DISTRICT_DISTANCE_3D    = 11000;
 NCZ.SUBDISTRICT_DISTANCE_3D =  7000;
 
-// Metro LOD zoom thresholds — vertex COLOR_0 channels are mutually exclusive tiers:
-// B = wide solid line (far zoom only,    zoom < LOD_MED)   — VisibilityDistanceBold=30000
-// G = thin solid line (medium zoom only, LOD_MED < zoom < LOD_NEAR) — VisibilityDistanceRegular=18000
-// R = dotted line     (close zoom only,  zoom > LOD_NEAR)  — VisibilityDistanceDashed=5000
-// Metro LOD thresholds — schema camera-to-target distance (CET units).
-// Mutually-exclusive tiers (one renders at a time, in-game look):
-//   B (wide solid) when distance > MED
-//   G (thin solid) when NEAR < distance < MED
-//   R (dotted)     when distance < NEAR
+// Metro LOD — decoded from the game's 3d_map_metro.mt pixel shader (PIX
+// capture; see wiki/sources/metro-lod-shader.md). The metro mesh carries
+// three LOD tiers in COLOR_0, one channel per vertex:
+//   R = dotted (closest)   G = thin solid (medium)   B = wide solid (far)
+// Each tier is fully visible below its distance threshold and crossfades
+// out over METRO_LOD_TRANSITION; past the far threshold the metro hides.
 //
-// Canonical material values (3dmap_metro.Material.json) are
-// VisibilityDistanceRegular = 18000 and VisibilityDistanceDashed = 5000.
-// They don't apply directly to our metric: schema camera-to-target distance
-// maxes at SCHEMA_CAMERA_MAX_DISTANCE = 15000 wu, so MED = 18000 would mean
-// the B tier never appears in our camera range. The game's compiled shader
-// almost certainly applies these via a metric we can't see (possibly view-
-// space depth with tilt, or a scale factor we don't have).
-//
-// These values align with the WorldMap zoom-ladder instead — same TweakDB
-// source-of-truth, different mapping: when subdistricts appear
-// (`ZoomLevelSubDistricts.zoom = 7000`), metro changes B → G; when full
-// mappins appear (`ZoomLevelAllMappins.zoom = 2500`), metro changes G → R.
-NCZ.METRO_LOD_DISTANCE_MED  = 7000;   // G↔B boundary — aligns with subdistrict-visible zoom
-NCZ.METRO_LOD_DISTANCE_NEAR = 2500;   // R↔G boundary — aligns with all-mappins-visible zoom
+// The game drives this off `D = 2 × cameraZ`, comparing against
+// VisibilityDistance{Dashed,Regular,Bold} = 5000 / 18000 / 30000. Our
+// camera-to-target distance is that same metric halved, so the thresholds
+// below are the game values ÷ 2 — FAR (15000) lands exactly on
+// SCHEMA_CAMERA_MAX_DISTANCE, which is why the raw game values looked too
+// large until the `2×` was decoded out of the camera cbuffer.
+NCZ.METRO_LOD_DISTANCE_NEAR = 2500;   // R→G boundary  (game VisibilityDistanceDashed  5000 ÷ 2)
+NCZ.METRO_LOD_DISTANCE_MED  = 9000;   // G→B boundary  (game VisibilityDistanceRegular 18000 ÷ 2)
+NCZ.METRO_LOD_DISTANCE_FAR  = 15000;  // B→hidden      (game VisibilityDistanceBold    30000 ÷ 2)
+NCZ.METRO_LOD_TRANSITION    = 150;    // crossfade band width (game TransitionLength 300 ÷ 2)
 
 // SeeThrough roads — the Pacifica tunnel: a road visible *through* the open bay water.
 // Water (rendered in the transparent pass — see three-scene.js loadTerrain) writes

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -1064,28 +1064,38 @@ const ThreeScene = (() => {
         blending: THREE.AdditiveBlending,
         depthWrite: false,
       });
-      // Mutually-exclusive LOD tiers driven by a single CPU uniform (schema
-      // camera-to-target distance). One tier renders at a time across the whole
-      // metro mesh, replacing rather than overlaying as the user zooms. Matches
-      // the in-game "wide → thin → dashed" transition.
-      //   B (wide solid) when distance > MED
-      //   G (thin solid) when NEAR < distance < MED
-      //   R (dotted)     when distance < NEAR
-      metroDistanceUniform     = uniform(NCZ.SCHEMA_CAMERA_DEFAULT_DISTANCE);
-      const uMetroLODMed_node  = uniform(NCZ.METRO_LOD_DISTANCE_MED);
-      const uMetroLODNear_node = uniform(NCZ.METRO_LOD_DISTANCE_NEAR);
-      const lodColor = attribute('color');
-      const discardCondition =
-        lodColor.b.greaterThan(0.5).and(metroDistanceUniform.lessThan(uMetroLODMed_node))
-          .or(
-            lodColor.g.greaterThan(0.5).and(
-              metroDistanceUniform.greaterThan(uMetroLODMed_node).or(metroDistanceUniform.lessThan(uMetroLODNear_node))
-            )
-          )
-          .or(
-            lodColor.r.greaterThan(0.5).and(metroDistanceUniform.greaterThan(uMetroLODNear_node))
-          );
-      metroMat.maskNode = discardCondition.not();
+      // Metro LOD — decoded from 3d_map_metro.mt's pixel shader (PIX capture;
+      // see wiki/sources/metro-lod-shader.md). The metro mesh carries three
+      // tiers in COLOR_0 (R dotted / G thin / B wide), one channel per vertex.
+      // Each tier is fully on below its distance threshold and crossfades out
+      // over METRO_LOD_TRANSITION — the game dissolves tiers, it doesn't snap.
+      // Driven by one CPU uniform: schema camera-to-target distance, seeded
+      // from the LIVE camera here — a constant seed showed the wrong tier on
+      // the first frame until the first camera move (the load-flicker bug).
+      metroDistanceUniform = uniform(camera.position.distanceTo(controls.target));
+      const uMetroNear = uniform(NCZ.METRO_LOD_DISTANCE_NEAR);
+      const uMetroMed  = uniform(NCZ.METRO_LOD_DISTANCE_MED);
+      const uMetroFar  = uniform(NCZ.METRO_LOD_DISTANCE_FAR);
+      const uMetroW    = uniform(NCZ.METRO_LOD_TRANSITION);
+      const lodColor   = attribute('color');
+      // Per-tier ramp: 1 below `threshold`, ramps to 0 by `threshold + W`.
+      const tierRamp = (threshold) =>
+        threshold.add(uMetroW).sub(metroDistanceUniform).div(uMetroW).clamp(0, 1);
+      const fNear = tierRamp(uMetroNear);
+      const fMed  = tierRamp(uMetroMed);
+      const fFar  = tierRamp(uMetroFar);
+      // Mutually-exclusive tier weights — the game's min(ramp, 1 - prevRamp)
+      // chain, so adjacent tiers crossfade and never both reach full.
+      const nearW = fNear;
+      const midW  = fMed.min(float(1).sub(fNear));
+      const farW  = fFar.min(float(1).sub(fMed));
+      // Each vertex carries exactly one tier in COLOR_0; `max` selects its
+      // weight. The result drives alpha — tiers fade in/out under additive blend.
+      const metroLOD = nearW.mul(lodColor.r)
+        .max(midW.mul(lodColor.g))
+        .max(farW.mul(lodColor.b));
+      metroMat.opacityNode = metroLOD.mul(0.9);            // 0.9 = base metro opacity
+      metroMat.maskNode    = metroLOD.greaterThan(0.001);  // drop fully-faded fragments
 
       function makeSeeThrough(source, mat) {
         const group = new THREE.Group();


### PR DESCRIPTION
## What

Rewrites the metro LOD to the game's decoded behaviour, and fixes the load-flicker bug. Decoded from the `3d_map_metro.mt` pixel shader (PIX capture) — see `wiki/sources/metro-lod-shader.md`.

## The decode

The metro mesh carries three LOD tiers in `COLOR_0` (R dotted / G thin / B wide), one channel per vertex. The PS blends them by camera distance:

```
ramp(T) = saturate((T + W - D) / W)        // 1 below T, fades out by T+W
nearW = ramp(Dashed)
midW  = min(ramp(Regular), 1 - nearW)      // mutually exclusive
farW  = min(ramp(Bold),    1 - midW...)
lod   = max(nearW·R, midW·G, farW·B)
```

It's a **crossfade**, not a hard switch — tiers dissolve into each other over a transition band.

### The distance metric

The game compares against `D = cameraConsts[36].z + cameraConsts[37].z`. The camera cbuffer dump showed regs 36/37 are both the camera world position, so **`D = 2 × cameraZ`**. The material thresholds `VisibilityDistance{Dashed,Regular,Bold} = 5000 / 18000 / 30000` are in that `D`-space; our camera-to-target distance is the same metric halved:

| Tier boundary | Game (`D`) | ÷2 → our distance |
|---|---|---|
| R → G | 5000 | **2500** |
| G → B | 18000 | **9000** |
| B → hidden | 30000 | **15000** |
| transition width | 300 | **150** |

`FAR = 15000` lands exactly on `SCHEMA_CAMERA_MAX_DISTANCE` — which is why the raw game values looked too large before the `2×` was decoded.

## Changes

- **Crossfade** — `maskNode` hard-discard replaced with the game's ramp/min crossfade, applied via `opacityNode` (tiers fade in/out under the existing additive blend). A `maskNode` still drops fully-faded fragments so inactive tiers cost nothing.
- **Thresholds** — `NEAR` stays 2500 (already exact), `MED` 7000 → **9000**, new `FAR` 15000, new `TRANSITION` 150. All decoded, no guesses.
- **Load-flicker fix** — `metroDistanceUniform` was seeded from the constant `SCHEMA_CAMERA_DEFAULT_DISTANCE`, so the first frame showed whatever tier that selected until the first camera move. Now seeded from the live camera at material creation.

## Effect

The metro shows the correct tier from the first frame (no more thin→wide jump on first move), and tiers dissolve smoothly instead of snapping as you zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)