### PR TITLE
feat(3d): cinematic intro camera fly-in on first load (E5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Three.js-Parity: intro camera fly-in (E5)
+
+- The 3D map now opens with a brief (~1.2 s) fly-in — the camera eases from a far, slightly leaned-back pose down to a whole-city framing (11000 wu). Skipped when a `?mod=` deep-link is present. New `NCZ.SCHEMA_INTRO_*` constants.
+- Fixed: the map silently opened fully zoomed out. The old `fitCameraToBox` opening computed a fit distance that always exceeded `controls.maxDistance`, so the documented opening distance never took effect. `fitCameraToBox` removed; `resetCamera` now snaps to the fly-in's rest pose.
+
 #### Three.js-Parity: metro LOD crossfade
 
 - Metro LOD tiers (dotted / thin / wide) now **crossfade** by camera distance instead of hard-switching, decoded from the `3d_map_metro.mt` pixel shader (PIX capture). Real thresholds: tiers change at 2500 / 9000 / 15000 wu (game `VisibilityDistance*` ÷ 2 — the game's metric is `2 × cameraZ`), crossfading over a 150 wu band.
@@ -68,7 +73,7 @@ New constants in [`constants.js`](assets/js/constants.js): `NCZ.STENCIL_WATER` (
 
 - Schema camera is now `PerspectiveCamera` at **FOV 25°** matching the game's TopDown view. Values mirror TweakDB `WorldMap.TopDownCameraSettingsDefault` (zoom min/default/max = 800 / 3000 / 15000 CET units). Replaces the prior `OrthographicCamera` — chosen originally without reference to the game's actual setup. See [`docs/data/worldmap_tweakdb_tree.json`](docs/data/worldmap_tweakdb_tree.json) for the full record dump.
 - Downstream perspective-aware refactors: shadow camera footprint via a 4-corner ray-cast against `Y=0` (handles tilt without an analytic `1/cos` stretch); scale bar, district→subdistrict label switch, and pin cluster threshold all driven by camera-to-target distance; `flyTo` lands at `SCHEMA_FLY_TO_DISTANCE = 1250` (TweakDB `zoomToZoomValue`).
-- **Pan envelope** now uses the game's canonical `cursorBoundary` (X[−5500..6050], Y[−7300..5000] in CET → Z[−5000..7300] in Three.js) instead of the wider terrain GLB extent. **`resetCamera`** restores the first-load `fitCameraToBox` view (whole-map fit) instead of dropping to default distance.
+- **Pan envelope** now uses the game's canonical `cursorBoundary` (X[−5500..6050], Y[−7300..5000] in CET → Z[−5000..7300] in Three.js) instead of the wider terrain GLB extent.
 - **Showcase exit** dips the 3D container's opacity for ~150 ms across the camera swap (schema 25° ↔ flyover 55° FOV) so the perspective change reads as an intentional transition rather than a hard cut.
 - **Metro LOD** mutex tier switch (B wide → G thin → R dotted) driven by schema camera-to-target distance, replacing the legacy `camera.zoom` reading. Thresholds at `MED = 7000` and `NEAR = 2500` (CET wu) align with the WorldMap zoom-ladder rather than the metro material's `VisibilityDistance*` values — the latter don't map onto a camera-to-target metric since our `zoomMax = 15000 < 18000`. Constants page documents the deviation.
 - Follow-ups queued: **CSM shadows** (the "no cascades because schema is ortho" rationale dissolved with this change); cluster-radius re-tune for the new screen-space behaviour; `pitchRelativeToZoom` lean-back curve from TweakDB; **Line2 near-plane clipping** under perspective (district outline segments whose endpoints cross the camera near plane stretch as straight rays across the viewport — pre-existing latent bug, only visible under perspective).

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -189,10 +189,30 @@ NCZ.MAX_DEVICE_PIXEL_RATIO = 1.5;
 NCZ.SCHEMA_CAMERA_FOV              = 25;     // degrees — game canonical (TopDownCameraSettingsDefault.fovMin/Max)
 NCZ.SCHEMA_CAMERA_NEAR             = 10;     // CET units — perspective near clip; must be > 0
 NCZ.SCHEMA_CAMERA_FAR              = 50000;  // CET units — far clip; covers shadow camera + sun sphere
-NCZ.SCHEMA_CAMERA_DEFAULT_DISTANCE = 3000;   // CET units — opening distance (TweakDB zoomDefault)
 NCZ.SCHEMA_CAMERA_MIN_DISTANCE     = 800;    // CET units — zoom-in limit  (TweakDB zoomMin)
 NCZ.SCHEMA_CAMERA_MAX_DISTANCE     = 15000;  // CET units — zoom-out limit (TweakDB zoomMax)
 NCZ.SCHEMA_FLY_TO_DISTANCE         = 1250;   // CET units — fly-to-pin target distance (TweakDB zoomToZoomValue)
+
+// 3D-map intro fly-in (E5) — on first load the camera drops in from a far,
+// near-straight-down pose, descending and leaning back to a resting framing
+// of the city. Skipped when a ?mod= deep-link is present (the deep-link
+// fly-to takes over). The near-vertical start "feels" like a top-down reveal;
+// the rest tilt matches the game's leaned-back default for its world map.
+//
+// START_TILT is 2°, not 0°: at *exactly* straight-down the camera-to-target
+// offset is (0, +y, 0) and OrbitControls derives the azimuth as
+// atan2(0, 0) — degenerate, so float noise picks the angle and makeSafe()
+// perpetuates it as a camera roll (the map renders rotated/upside-down).
+// 2° gives the offset a solid z-component → stable azimuth 0. Visually
+// indistinguishable from dead top-down.
+NCZ.SCHEMA_INTRO_START_DISTANCE = 15000;       // CET units — far pose (= SCHEMA_CAMERA_MAX_DISTANCE)
+NCZ.SCHEMA_INTRO_REST_DISTANCE  = 12200;       // CET units — resting framing distance (whole city in frame)
+NCZ.SCHEMA_INTRO_START_TILT     = 2;           // degrees off vertical at the far pose — near top-down (see note above)
+NCZ.SCHEMA_INTRO_REST_TILT      = 11;          // degrees off vertical at the rest pose — game world-map lean-back
+NCZ.SCHEMA_INTRO_AZIMUTH        = 0;           // radians — compass heading of the lean; constant start→rest (no sweep)
+NCZ.SCHEMA_INTRO_DURATION_MS    = 1200;        // fly-in length — ~"first second after load" per E5
+NCZ.SCHEMA_INTRO_REST_CENTER    = [-800, -500]; // [cetX, cetY] framed by the rest pose — the city's visual centre
+                                                // (not the world centre, which is biased south into the badlands)
 
 // Pan envelope — clamps controls.target so the camera can't roam off the map.
 // Source: TweakDB WorldMap.DefaultSettings.cursorBoundary{Min,Max}.

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -107,6 +107,8 @@ const ThreeScene = (() => {
   let _sunAz = Math.PI * 0.25, _sunEl = Math.PI * 0.35; // last setSunPosition args
   let _terrainBox = null;     // THREE.Box3 of the terrain GLB; gates pan-bound clamp
                               // because the bound shouldn't activate before terrain loads
+  let _introTween   = null;   // E5 intro fly-in tween, or null when idle
+  let _introLastTime = 0;     // performance.now() of the previous intro frame
 
   // Material refs — stored so updateMaterials() can re-apply theme colors live
   let terrainMat = null;
@@ -586,8 +588,11 @@ const ThreeScene = (() => {
       NCZ.SCHEMA_CAMERA_FOV, aspect, NCZ.SCHEMA_CAMERA_NEAR, NCZ.SCHEMA_CAMERA_FAR,
     );
     camera.name = 'schema-camera';
-    camera.position.set(NCZ.WORLD_CX, NCZ.SCHEMA_CAMERA_DEFAULT_DISTANCE, -NCZ.WORLD_CY);
-    camera.lookAt(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
+    // Open at the E5 intro's far pose; playIntro() flies it down to the rest
+    // pose once the scene has finished loading.
+    const _introStart = introCameraPose(NCZ.SCHEMA_INTRO_START_DISTANCE, NCZ.SCHEMA_INTRO_START_TILT);
+    camera.position.copy(_introStart.position);
+    camera.lookAt(_introStart.target);
     camera.up.set(0, 1, 0);
     camera.updateProjectionMatrix();
 
@@ -706,7 +711,11 @@ const ThreeScene = (() => {
     // horizontal drag moves it left/right. Ortho hid the drift; perspective
     // surfaces it. See controls 'change' handler — no y-clamp needed.
     controls.screenSpacePanning = false;
-    controls.target.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
+    // Target the same point the camera is posed over (the E5 intro start —
+    // see camera.position above). A mismatch here would make controls.update()
+    // derive a bogus azimuth from the off-axis offset, rotating the pre-intro
+    // loading view ~180° (it looked upside-down before this).
+    controls.target.copy(_introStart.target);
     controls.update();
     updateFrustumUniforms();   // seed frustum planes for the first cull dispatch
     updateShadowCamera();      // seed the shadow camera from the initial pose
@@ -717,6 +726,12 @@ const ThreeScene = (() => {
       updateFrustumUniforms();   // Phase 2B: refresh the 6 cull-frustum planes
       updateScaleBar();
       requestRender();
+    });
+
+    // Cancel the E5 intro fly-in the moment the user grabs the controls, and
+    // release the render-loop hold the tween took (paired setContinuousRender).
+    controls.addEventListener('start', () => {
+      if (_introTween) { _introTween = null; setContinuousRender(false); }
     });
 
     // Pan bounds — clamp controls.target so the camera can't drift
@@ -978,8 +993,8 @@ const ThreeScene = (() => {
       // (the visible square) instead of the playable-CET-world extent
       // (which is asymmetric north-south).
       const box = new THREE.Box3().setFromObject(terrainScene);
-      _terrainBox = box;
-      fitCameraToBox(box);
+      _terrainBox = box;   // retained for the pan-bound clamp; the opening
+                           // camera framing is the E5 intro fly-in (playIntro).
 
       stepProgress(); // terrain done
       updateShadowCamera(); // re-fit the shadow camera now the schema camera is sized to terrain
@@ -993,7 +1008,7 @@ const ThreeScene = (() => {
       // Tier 2+3: start all concurrent tasks, hide loading only when all complete.
       // Add future loaders (loadLandmarks etc.) to this array.
       Promise.all([loadRoadsMetro(), loadDistricts(), loadBuildings(), loadLandmarks()])
-        .then(hideLoading);
+        .then(() => { hideLoading(); playIntro(); });
 
     } catch (err) {
       console.error('[NCZ] Terrain GLB load failed:', err);
@@ -1713,22 +1728,80 @@ const ThreeScene = (() => {
     return line;
   }
 
-  function fitCameraToBox(box) {
-    const size   = box.getSize(new THREE.Vector3());
-    const center = box.getCenter(new THREE.Vector3());
-    const aspect = renderer.domElement.clientWidth / renderer.domElement.clientHeight;
-    // Distance needed to fit the larger of width / height into the perspective
-    // frustum, accounting for aspect on the horizontal axis. tan(FOV/2) × distance
-    // = halfHeight; horizontal frustum half-width = halfHeight × aspect.
-    const halfFovY = (NCZ.SCHEMA_CAMERA_FOV * Math.PI) / 360;
-    const distForHeight = (size.z / 2) / Math.tan(halfFovY);
-    const distForWidth  = (size.x / 2) / (Math.tan(halfFovY) * aspect);
-    const distance = Math.max(distForHeight, distForWidth);
+  // ── E5 intro fly-in ────────────────────────────────────────────────────
+  // On first load the camera eases from a far, leaned-back pose down to a
+  // whole-city framing. Replaces the old fitCameraToBox opening: that fit
+  // distance always exceeded controls.maxDistance (the terrain box is far
+  // taller than the ~6650 wu the FOV can frame at maxDistance), so the map
+  // silently opened fully zoomed out — the "opens too far" bug E5 closes.
 
-    controls.target.set(center.x, 0, center.z);
-    camera.position.set(center.x, distance, center.z);
-    camera.lookAt(center.x, 0, center.z);
-    controls.update();
+  // Camera pose for the intro: position offset from the framing target by
+  // `distance` at `tiltDeg` off vertical, along the fixed intro azimuth.
+  // The target is SCHEMA_INTRO_REST_CENTER ([cetX, cetY]) or world centre —
+  // the same point for the start and rest poses, so the fly-in is a straight
+  // top-down descent with no sideways pan. (Three spherical: phi = polar
+  // angle from +Y, theta = azimuth.)
+  function introCameraPose(distance, tiltDeg) {
+    const c = NCZ.SCHEMA_INTRO_REST_CENTER;
+    const target = c
+      ? new THREE.Vector3(c[0], 0, -c[1])
+      : new THREE.Vector3(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
+    const phi    = (tiltDeg * Math.PI) / 180;
+    const theta  = NCZ.SCHEMA_INTRO_AZIMUTH;
+    const position = new THREE.Vector3(
+      target.x + distance * Math.sin(phi) * Math.sin(theta),
+      target.y + distance * Math.cos(phi),
+      target.z + distance * Math.sin(phi) * Math.cos(theta),
+    );
+    return { target, position };
+  }
+
+  const easeInOutCubic = (u) =>
+    u < 0.5 ? 4 * u * u * u : 1 - Math.pow(-2 * u + 2, 3) / 2;
+
+  // Start the intro fly-in. When a ?mod= deep-link is present the intro is
+  // skipped — the camera snaps straight to the rest pose so app.js's
+  // deep-link handler flies to the pin from a sensible whole-city framing.
+  function playIntro() {
+    if (!controls || !camera) return;
+    const rest = introCameraPose(NCZ.SCHEMA_INTRO_REST_DISTANCE, NCZ.SCHEMA_INTRO_REST_TILT);
+
+    if (new URLSearchParams(window.location.search).get(NCZ.URL_PARAM_MOD)) {
+      controls.target.copy(rest.target);
+      camera.position.copy(rest.position);
+      controls.update();
+      requestRender();
+      return;
+    }
+
+    const start = introCameraPose(NCZ.SCHEMA_INTRO_START_DISTANCE, NCZ.SCHEMA_INTRO_START_TILT);
+    _introTween = {
+      startTarget: start.target, endTarget: rest.target,
+      startPos:    start.position, endPos:  rest.position,
+      elapsed: 0,
+      duration: NCZ.SCHEMA_INTRO_DURATION_MS,
+    };
+    _introLastTime = performance.now();
+    setContinuousRender(true);   // hold the loop open for the fly's duration
+    requestRender();
+  }
+
+  // Advance the intro fly-in one frame. Called at the top of renderLoop so
+  // the camera mutation lands before controls.update() reconciles it — that
+  // reconcile fires the 'change' listener, refreshing district zoom, metro
+  // LOD, the shadow camera, scale bar and cull frustum as the camera moves.
+  function updateIntroTween() {
+    if (!_introTween) return;
+    const now = performance.now();
+    _introTween.elapsed += now - _introLastTime;
+    _introLastTime = now;
+    const e = easeInOutCubic(Math.min(_introTween.elapsed / _introTween.duration, 1));
+    controls.target.lerpVectors(_introTween.startTarget, _introTween.endTarget, e);
+    camera.position.lerpVectors(_introTween.startPos, _introTween.endPos, e);
+    if (_introTween.elapsed >= _introTween.duration) {
+      _introTween = null;
+      setContinuousRender(false);  // release the hold; render-on-demand resumes
+    }
   }
 
   // ── Render loop ────────────────────────────────────────────────────────
@@ -1824,6 +1897,7 @@ const ThreeScene = (() => {
   function renderLoop() {
     animationId = null;
     if (stats) stats.begin();
+    updateIntroTween();   // E5 intro fly-in — mutate the camera before controls.update() reconciles
     const dampingActive = controls.update();
     // Phase 2B: dispatch per-district reset+cull computes BEFORE render.
     // Each district's `reset` clears its indirect.instanceCount to 0; `cull`
@@ -2366,17 +2440,14 @@ const ThreeScene = (() => {
   function resetCamera() {
     if (!controls) return;
 
-    // Match the first-load view: fit the camera to the terrain box (same code
-    // path init runs after terrain loads), capped at maxDistance by OrbitControls
-    // on the controls.update() below. Falls back to the default distance pose if
-    // terrain hasn't loaded yet (early reset before assets ready).
-    if (_terrainBox) {
-      fitCameraToBox(_terrainBox);
-    } else {
-      controls.target.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
-      camera.position.set(NCZ.WORLD_CX, NCZ.SCHEMA_CAMERA_DEFAULT_DISTANCE, -NCZ.WORLD_CY);
-      camera.lookAt(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
-    }
+    // Snap back to the E5 intro's rest pose — the whole-city framing the
+    // camera comes to rest at on first load. Cancel an in-flight intro
+    // (and release its render-loop hold) if Reset is hit during the fly-in.
+    if (_introTween) { _introTween = null; setContinuousRender(false); }
+    const rest = introCameraPose(NCZ.SCHEMA_INTRO_REST_DISTANCE, NCZ.SCHEMA_INTRO_REST_TILT);
+    controls.target.copy(rest.target);
+    camera.position.copy(rest.position);
+    camera.lookAt(rest.target);
     camera.up.set(0, 1, 0);
 
     controls.autoRotate = false;


### PR DESCRIPTION
## What

Implements **E5 — Cinematic intro camera on first load**. On first load the 3D-map camera eases from a far, near-top-down pose down to a whole-city framing over ~1.2 s, then rests. Skipped when a `?mod=` deep-link is present (the deep-link fly-to takes over).

## Why — the bug this closes

The 3D map silently opened **fully zoomed out**, not at its documented opening distance. `fitCameraToBox` computed the distance to frame the ~16,000 wu terrain square at FOV 25° (~36,000 wu) — but `controls.maxDistance` is 15,000, so OrbitControls clamped *every* opening to the max. The fit math was dead code: any terrain box taller than ~6,650 wu always overshoots the clamp. `SCHEMA_CAMERA_DEFAULT_DISTANCE = 3000` described a pose nothing ever used.

Surfaced during the metro LOD work (#688): the metro seeded its distance uniform from that constant and jumped tiers on the first camera move, because the real opening distance was 15,000, not 3,000.

## Changes

- **`constants.js`** — removed the dead `SCHEMA_CAMERA_DEFAULT_DISTANCE`; added `SCHEMA_INTRO_*` (start 15000 / rest 12200 wu, start tilt 2° / rest tilt 11°, azimuth, 1200 ms, rest centre).
- **`three-scene.js`** — `introCameraPose` / `playIntro` / `updateIntroTween`; the tween is driven from `renderLoop` (camera mutated before `controls.update()` reconciles, so the `change` listener refreshes district zoom / metro LOD / shadow / scale bar as it flies) and cancelled the moment the user grabs the controls. `resetCamera` snaps to the fly-in rest pose. `fitCameraToBox` removed.
- **`CHANGELOG.md`** — E5 entry; corrected the now-stale `resetCamera` line.

## Two intra-PR bugs fixed during review (camera rendered upside-down during loading)

- **Target/position mismatch** — `controls.target` was still hardcoded to world centre while the camera was posed over the city centre; OrbitControls derived a ~200° azimuth from the off-axis offset, rotating the view. `controls.target` now matches the intro pose.
- **`atan2(0,0)` gimbal singularity** — at *exactly* straight-down the position→target offset is `(0,+y,0)`; OrbitControls computes azimuth as `atan2(0,0)`, degenerate, and `makeSafe()` perpetuates the float-noise result as a camera roll. `SCHEMA_INTRO_START_TILT` is 2°, not 0° — visually still top-down, but the offset has a solid z-component so `atan2` is well-conditioned.

## Verification

Driven live in Chrome (WebGPU): captured the fly-in trajectory frame-by-frame (15000 wu / 2° → 12200 wu / 11°, eased); confirmed the loading pose holds a stable `polar 2° / azimuth 0°` across all loading frames (was `polar 4.8° / azimuth 121°` upside-down before the fix). Framing tuned visually against screenshots — centred on the city's visual mass, not the world centre (which sits south in the badlands).

Closes project item E5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)