### PR TITLE
feat(auto-discovery): exclusion list for mistagged NCZoning mods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-06-05
+
 ### Added
 
 - **Auto-discovery exclusion list** (`data/excluded_mods.json`): mods tagged `NCZoning` that shouldn't appear on the map (mistaken or too-minor tags) are listed here and skipped by both auto-discovery (`services.js`) and the health monitor — the latter stops re-flagging them daily. First entry: mod 29860.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Auto-discovery exclusion list** (`data/excluded_mods.json`): mods tagged `NCZoning` that shouldn't appear on the map (mistaken or too-minor tags) are listed here and skipped by both auto-discovery (`services.js`) and the health monitor — the latter stops re-flagging them daily. First entry: mod 29860.
+
+### Changed
+
+- **Monitor Discord alert**: clearer copy — each category now states the concrete action ("ask the author to regenerate", "add a manual entry or exclude"), and the footer/description note how many mods are on the exclusion list.
+
 ## [0.3.5] - 2026-05-16
 
 ### Added

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1005,16 +1005,17 @@ async function initMap() {
 
   // 3. Fetch and Setup Data
   try {
-    const { mods, tagsDict } = await NCZ.fetchModData();
+    const { mods, tagsDict, excludedIds } = await NCZ.fetchModData();
 
-    // Auto-discover mods tagged "NCZoning" on Nexus (manual entries win on conflict)
+    // Auto-discover mods tagged "NCZoning" on Nexus (manual entries win on conflict;
+    // excluded ids are never rendered, even with a valid block)
     const existingNexusIds = new Set(
       mods
         .filter((m) => m.nexus_id && !["WIP", "Dummy"].includes(String(m.nexus_id)))
         .map((m) => String(m.nexus_id)),
     );
     const validTagNames = new Set(Object.keys(tagsDict));
-    const { mods: autoMods, meta: autoMeta } = await NCZ.fetchNexusTaggedMods(existingNexusIds, validTagNames);
+    const { mods: autoMods, meta: autoMeta } = await NCZ.fetchNexusTaggedMods(existingNexusIds, validTagNames, excludedIds);
     mods.push(...autoMods);
 
     modCountEl.textContent = `(${mods.length})`;

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -63,6 +63,9 @@ NCZ.NEXUS_BATCH_SIZE = 50;
 // Data paths
 NCZ.DATA_MODS_PATH = "mods.json";
 NCZ.DATA_TAGS_PATH = "data/tags.json";
+// nexus_ids tagged "NCZoning" on Nexus but intentionally kept off the map
+// (mistaken/minor tags). Honoured by auto-discovery and the health monitor.
+NCZ.DATA_EXCLUDED_PATH = "data/excluded_mods.json";
 
 // Content limits
 NCZ.DESCRIPTION_MAX_LENGTH = 500;

--- a/assets/js/services.js
+++ b/assets/js/services.js
@@ -115,14 +115,20 @@ NCZ.fetchNexusThumbnailsFromApi = async function (validIds) {
 // ModsFilter schema: https://graphql.nexusmods.com/#definition-ModsFilter
 // Fields use [BaseFilterValue] = array of { value: ... } objects.
 // "uploader" on the Mod type is a plain string (username), not a nested object.
-NCZ.fetchNexusTaggedMods = async function (existingNexusIds, validTagNames) {
+NCZ.fetchNexusTaggedMods = async function (existingNexusIds, validTagNames, excludedNexusIds) {
+  // Mods tagged NCZoning by mistake (or too minor to map) — never rendered,
+  // even if their block parses. Optional arg so existing callers/tests don't break.
+  const excluded = excludedNexusIds || new Set();
   // Return cached auto-discovery results if still fresh
   const cached = NCZ.cacheGet(NCZ.AUTODISCOVERY_CACHE_KEY, NCZ.AUTODISCOVERY_CACHE_TTL);
   if (cached) {
-    // Re-filter against current manual entries (may have changed since cache was written)
+    // Re-filter against current manual + excluded entries (either may have
+    // changed since the cache was written).
     const cachedMods = Array.isArray(cached) ? cached : cached.mods;
     const cachedMeta = Array.isArray(cached) ? {} : (cached.meta || {});
-    const filtered = cachedMods.filter((m) => !existingNexusIds.has(m.nexus_id));
+    const filtered = cachedMods.filter(
+      (m) => !existingNexusIds.has(m.nexus_id) && !excluded.has(m.nexus_id),
+    );
     console.log(`NCZoning: serving ${filtered.length} auto-discovered mods from cache`);
     return { mods: filtered, meta: cachedMeta };
   }
@@ -189,6 +195,11 @@ NCZ.fetchNexusTaggedMods = async function (existingNexusIds, validTagNames) {
 
       for (const node of nodes) {
         const nexusId = String(node.modId);
+        if (excluded.has(nexusId)) {
+          // Intentionally off the map — skip without creating a meta entry.
+          console.log(`NCZoning: excluding mod ${nexusId} (${node.name}) — on the exclusion list`);
+          continue;
+        }
         if (existingNexusIds.has(nexusId)) {
           // Manual entry wins for mod data, but preserve API metadata for backfilling _updatedAt
           meta[nexusId] = {
@@ -242,14 +253,24 @@ NCZ.fetchNexusTaggedMods = async function (existingNexusIds, validTagNames) {
   return { mods: results, meta };
 };
 
-// Fetch mod registry (mods.json) and tag definitions (tags.json) in parallel.
-// Returns { mods: Array, tagsDict: Object }.
+// Fetch mod registry (mods.json), tag definitions (tags.json), and the
+// auto-discovery exclusion list (excluded_mods.json) in parallel.
+// Returns { mods: Array, tagsDict: Object, excludedIds: Set<string> }.
 NCZ.fetchModData = async function () {
-  const [modsRes, tagsRes] = await Promise.all([
+  const [modsRes, tagsRes, excludedRes] = await Promise.all([
     fetch(NCZ.DATA_MODS_PATH),
     fetch(NCZ.DATA_TAGS_PATH),
+    fetch(NCZ.DATA_EXCLUDED_PATH),
   ]);
   const mods = await modsRes.json();
   const tagsDict = await tagsRes.json();
-  return { mods, tagsDict };
+  // Flat { "nexusId": "reason" } object; a missing/broken file must not break
+  // the page, so fall back to an empty exclusion set.
+  let excludedIds = new Set();
+  try {
+    excludedIds = new Set(Object.keys(await excludedRes.json()).map(String));
+  } catch (err) {
+    console.warn("NCZoning: could not load exclusion list, proceeding with none", err);
+  }
+  return { mods, tagsDict, excludedIds };
 };

--- a/data/excluded_mods.json
+++ b/data/excluded_mods.json
@@ -1,0 +1,3 @@
+{
+  "29860": "Ripperdoc Sogo Interior Changes — tagged NCZoning on Nexus without a metadata block. Intentionally kept off the map (minor interior change); excluded so the auto-discovery monitor stops flagging it."
+}

--- a/docs/nczoning-auto-discovery.md
+++ b/docs/nczoning-auto-discovery.md
@@ -153,6 +153,27 @@ The **NCZoning** tag is provided by the Nexus Mods team specifically for this sy
 
 ---
 
+## Exclusion List (maintainers)
+
+Some mods carry the **NCZoning** tag but should not appear on the map — a mistaken tag, or a mod the maintainers judge too minor to register. These can't be handled by a manual entry (we don't *want* them on the map), and a tag we don't control can't simply be removed, so they are listed in `data/excluded_mods.json`:
+
+```json
+{
+  "29860": "Ripperdoc Sogo Interior Changes — minor mod, tagged without a block; kept off the map."
+}
+```
+
+The format is a flat `{ "nexusId": "reason" }` object (same shape as `data/tags.json`). The `reason` is a maintainer note only — it is never shown to users.
+
+An excluded id is honoured in two places:
+
+1. **Auto-discovery (`services.js`)** — the mod is never rendered as a pin, *even if its block parses correctly*. This is what stops a mistakenly-tagged mod that happens to have valid coordinates from showing up.
+2. **Health monitor (`scripts/monitor_auto_discovery.js`)** — the mod is skipped, so the daily Discord alert stops flagging it. Without this, an intentionally-excluded mod with no block would be reported every single day.
+
+To exclude a mod, add its Nexus id and a short reason to `data/excluded_mods.json` and open a PR. To re-include it later, delete the entry.
+
+---
+
 ## Using the BBCode Generator
 
 The map includes a built-in generator to make adding the block easier. Click **[+] Submit** in the map header (or the **Submit a New Mod Location** button in the sidebar) to open the generator. The modal walks you through four steps:

--- a/scripts/monitor_auto_discovery.js
+++ b/scripts/monitor_auto_discovery.js
@@ -79,6 +79,22 @@ function loadManualNexusIds() {
   return ids;
 }
 
+// --- Intentionally-excluded nexus_ids (data/excluded_mods.json) --------------
+// Mods tagged NCZoning by mistake, or too minor to map, that we deliberately
+// keep off the board. They have no manual entry and never will, so without
+// this list the monitor would flag them every single day. Flat
+// { "nexusId": "reason" } object — same shape as data/tags.json.
+function loadExcludedNexusIds() {
+  const file = path.join(ROOT, "data/excluded_mods.json");
+  try {
+    const obj = JSON.parse(fs.readFileSync(file, "utf8"));
+    return new Set(Object.keys(obj).map(String));
+  } catch {
+    // No list (or unreadable) just means nothing is excluded.
+    return new Set();
+  }
+}
+
 // --- Fetch every NCZoning-tagged mod (same query/pagination as services.js) --
 async function fetchTaggedMods({ endpoint, gameId, batchSize }) {
   const query = `
@@ -121,7 +137,7 @@ async function fetchTaggedMods({ endpoint, gameId, batchSize }) {
   return out;
 }
 
-async function postDiscord(failures, total) {
+async function postDiscord(failures, total, excludedCount) {
   const url = process.env.DISCORD_WEBHOOK_URL;
   const MAX_PER_GROUP = 12;
   const fmt = (group) => {
@@ -137,32 +153,45 @@ async function postDiscord(failures, total) {
   // a speculative/mistaken tag or an author who never finished setup.
   const malformed = failures.filter((f) => f.attemptedBlock);
   const noBlock = failures.filter((f) => !f.attemptedBlock);
+  const n = failures.length;
 
   const fields = [];
   if (malformed.length) {
     fields.push({
-      name: `🔧 Malformed block — ${malformed.length} (author tried, parse failed)`,
-      value: fmt(malformed),
+      name: `🔧 Malformed block — ${malformed.length}`,
+      value:
+        `Author added an \`NCZoning:\` block but it failed to parse. ` +
+        `**Action:** ask them to regenerate it with the in-app BBCode Generator.\n` +
+        fmt(malformed),
     });
   }
   if (noBlock.length) {
     fields.push({
-      name: `🏷️ Tagged, no block — ${noBlock.length} (no NCZoning: in description)`,
-      value: fmt(noBlock),
+      name: `🏷️ Tagged, no block — ${noBlock.length}`,
+      value:
+        `Tagged \`NCZoning\` but the description has no metadata block. ` +
+        `**Action:** add a manual registry entry if it belongs on the map, ` +
+        `or add its id to \`data/excluded_mods.json\` to stop this alert.\n` +
+        fmt(noBlock),
     });
   }
+
+  const excludedNote = excludedCount
+    ? ` ${excludedCount} mod${excludedCount === 1 ? "" : "s"} on the exclusion list ${excludedCount === 1 ? "is" : "are"} ignored.`
+    : "";
 
   const body = {
     embeds: [
       {
-        title: `⚠️ Auto-discovery: ${failures.length} NCZoning mod(s) missing from the map`,
+        title: `⚠️ Auto-discovery: ${n} NCZoning mod${n === 1 ? "" : "s"} tagged but not on the map`,
         description:
-          `Tagged **NCZoning** on Nexus but not appearing as live pins. ` +
-          `Malformed blocks need an author fix; no-block tags may be ` +
-          `mistaken or incomplete.`,
+          `${n} mod${n === 1 ? " is" : "s are"} tagged **NCZoning** on Nexus ` +
+          `but not showing as ${n === 1 ? "a live pin" : "live pins"}, because the ` +
+          `metadata block is missing or unreadable. Each entry below says what to do.` +
+          excludedNote,
         color: 15105570, // amber/orange — warning, not error
         fields,
-        footer: { text: `NC Zoning Board • ${total} tagged mods scanned` },
+        footer: { text: `NC Zoning Board • scanned ${total} NCZoning-tagged mod${total === 1 ? "" : "s"}` },
       },
     ],
   };
@@ -191,14 +220,19 @@ async function postDiscord(failures, total) {
     const consts = loadNexusConstants();
     const validTagNames = loadValidTagNames();
     const manualIds = loadManualNexusIds();
+    const excludedIds = loadExcludedNexusIds();
 
     const mods = await fetchTaggedMods(consts);
-    console.log(`Scanned ${mods.length} NCZoning-tagged mods (${manualIds.size} manual ids excluded).`);
+    console.log(
+      `Scanned ${mods.length} NCZoning-tagged mods ` +
+        `(${manualIds.size} manual, ${excludedIds.size} excluded).`,
+    );
 
     const failures = [];
     for (const mod of mods) {
       const id = String(mod.modId);
       if (manualIds.has(id)) continue; // manual registry covers it
+      if (excludedIds.has(id)) continue; // intentionally kept off the map
       if (!parse(mod.description, validTagNames)) {
         // A `NCZoning` mention means the author attempted a block that
         // failed to parse (actionable: fix it) vs. no block at all
@@ -219,7 +253,7 @@ async function postDiscord(failures, total) {
       for (const f of failures) {
         console.log(`   - ${f.modId}  [${f.attemptedBlock ? "malformed" : "no-block "}]  ${f.name}`);
       }
-      await postDiscord(failures, mods.length);
+      await postDiscord(failures, mods.length, excludedIds.size);
     }
     process.exit(0); // report, not a gate
   } catch (err) {


### PR DESCRIPTION
## What

Adds `data/excluded_mods.json` — a maintainer list of Nexus mods that carry the **NCZoning** tag but should **not** appear on the map (mistaken tags, or mods too minor to register). They can't be handled by a manual entry (we don't *want* them mapped) and the tag isn't ours to remove.

Format mirrors `data/tags.json` — a flat `{ "nexusId": "reason" }` object; the reason is a maintainer note, never shown to users.

## Why

Mod **29860** (*Ripperdoc Sogo Interior Changes*) was tagged NCZoning with no metadata block. Kao doesn't want it on the map (minor interior change), so there's no manual override — but that left the daily auto-discovery health monitor re-flagging it in Discord every day with no way to resolve it.

## How

The exclusion list is honoured in **two independent places**:

1. **`services.js` auto-discovery** — excluded ids are never rendered as a pin, *even if their block parses*. This covers the future case of a mistakenly-tagged mod that happens to have valid coordinates. Loaded via `fetchModData()` → `excludedIds` Set → passed to `fetchNexusTaggedMods(existing, validTags, excluded)`; the cache branch re-filters too. A missing/broken file falls back to an empty set (page never breaks).
2. **`scripts/monitor_auto_discovery.js`** — excluded ids are skipped like manual ids, so the daily Discord alert stops nagging.

Also **clarifies the monitor's Discord copy** (asked for separately):
- Each field now states the concrete action — *"ask the author to regenerate with the BBCode Generator"* / *"add a manual entry, or add its id to `data/excluded_mods.json` to stop this alert"*.
- Title/description/footer reworded and pluralised; description notes how many mods are on the exclusion list.

## Verification

- `node scripts/build_mods.js` → 270 entries, clean.
- `node scripts/validate_tags.js` → passed.
- `node --check` on all four touched JS files → clean.
- Live monitor dry-run: `Scanned 39 NCZoning-tagged mods (268 manual, 1 excluded).` → `✅ All non-manual tagged mods parse cleanly.` (mod 29860 now silenced).
- `data/excluded_mods.json` sits outside `validate-mods.yml`'s path filter (`data/locations/`, `data/tags.json`, `mods.schema.json`), so it isn't schema-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)