### PR TITLE
fix(3d): default sun time never applied on cold load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Fixed: default sun time never applied on load
+
+- The documented default sun time now actually applies on cold load. The slider's init request fired before the 3D lights existed and was silently dropped; the UI-sync poll then wrote the scene's placeholder elevation (~63°, ≈ 15:00) back onto the slider, and the post-terrain re-apply locked it in.
+
 #### Three.js-Parity: in-game lighting pipeline (ACES tonemap + grade + LUT)
 
 - The 3D scene now reproduces the in-game map's full decoded colour pipeline — an ACES SSTS tonemap, the envparam colour grade, and the **braindance grading LUT** — all from `base/weather/24h_basic/3dmap.envparam`. New standalone module [`aces-tonemap.js`](assets/js/aces-tonemap.js) (the ACES Output Transform, registered as a custom WebGPU tone-mapping function); new [`scripts/build_lut.js`](scripts/build_lut.js) extracts the 32³ LUT to `assets/data/braindance-lut.bin`.

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -103,7 +103,7 @@ const ThreeScene = (() => {
   }
   let _shadowsOn     = true;  // shadows on by default; checkbox reflects this via poll
   let _sunSphere     = null; // visible sun disc — shown during showcase only
-  let _sunAz = Math.PI * 0.25, _sunEl = Math.PI * 0.35; // last setSunPosition args
+  let _sunAz = Math.PI * 0.25, _sunEl = Math.PI * 0.35; // last *requested* setSunPosition args — placeholders only until the first call (the slider init in app.js), which may land before the lights exist
   let _terrainBox = null;     // THREE.Box3 of the terrain GLB; gates pan-bound clamp
                               // because the bound shouldn't activate before terrain loads
   let _introTween   = null;   // E5 intro fly-in tween, or null when idle
@@ -2676,9 +2676,16 @@ const ThreeScene = (() => {
   // GLB space axes: East = +X, South = +Z, West = -X, North = -Z, Up = +Y
   // So az=0 (south) → Z+; az=π/2 (west) → X-; az=-π/2 (east) → X+
   function setSunPosition(azimuthRad, altitudeRad) {
-    if (!_dirLight || !_hemiLight) return;
+    // Store the requested state BEFORE the lights-exist guard. getSunElevation()
+    // — and the app.js UI-sync poll that reverse-maps it onto the sun slider —
+    // must see what was requested even when this call lands before init() has
+    // built the lights (the slider's initial applySunTime fires that early).
+    // When the request was dropped here instead, the poll read the placeholder
+    // elevation (~63°), wrote it back onto the slider, and the post-terrain
+    // re-apply then locked the wrong sun in on every cold load.
     _sunAz = azimuthRad;
     _sunEl = altitudeRad;
+    if (!_dirLight || !_hemiLight) return;
     const el = altitudeRad;
     const az = azimuthRad;
 


### PR DESCRIPTION
## Problem

Every cold load of the 3D map ran a ~15:00 sun (el ≈ 63°) instead of the documented `DEFAULT_SUN_MINUTES` (10:00). The default was effectively dead code, and all calibration/screenshots taken "at default" were actually taken at the placeholder sun.

## Root cause — three-step race, deterministic

1. `app.js` slider init calls `applySunTime(600)` → `setSunPosition()` **early-returns** because the directional/hemisphere lights don't exist yet — the request is dropped and the scene keeps its placeholder `_sunEl = π·0.35` (63°).
2. The 200 ms UI-sync poll reads `getSunElevation()` → gets the *placeholder*, reverse-maps it via SunCalc scan, and **overwrites the slider 600 → 897** (~14:57). The poll always wins — terrain load takes seconds.
3. The post-terrain re-dispatch (`three-scene.js`, terrain-loaded path) re-fires the slider's `input` with the polluted value → the wrong sun is locked in. Confirmed live: loaded `sunEl = 1.1008 rad` = SunCalc's 14:57 altitude, exactly.

## Fix

Store the requested `_sunAz`/`_sunEl` **before** the lights-exist guard (state-before-hardware). `getSunElevation()` now reports requested state, so the poll round-trips the true default and the post-terrain re-apply applies what was asked for.

## Verification

Cold reload (cache-bypassed): slider `600`, time display `10:00`, `getCameraState().sunEl = 48.3°` — was `897` / `~15:00` / `63.1°`.

## Notes

- Affects `feat/physical-lighting` too (its envelope calibration "V1 default load" was actually tuned at 63° — it will be re-validated after rebasing on this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)