### PR TITLE
fix(3d): stop _m roof detail imaging onto sloped building faces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Fixed: `_m` roof detail imaged onto sloped building faces
+
+- Tilted building instances (~12.5% of the 255k boxes have oblique rotations) no longer show a ghostly 2-D patch of the district map on their slanted faces. The top-down `_m.dds` planar projection now applies only to near-flat tops; steeper faces sample the building's own centre texel instead.
+
 #### Three.js-Parity: in-game lighting pipeline (ACES tonemap + grade + LUT)
 
 - The 3D scene now reproduces the in-game map's full decoded colour pipeline — an ACES SSTS tonemap, the envparam colour grade, and the **braindance grading LUT** — all from `base/weather/24h_basic/3dmap.envparam`. New standalone module [`aces-tonemap.js`](assets/js/aces-tonemap.js) (the ACES Output Transform, registered as a custom WebGPU tone-mapping function); new [`scripts/build_lut.js`](scripts/build_lut.js) extracts the 32³ LUT to `assets/data/braindance-lut.bin`.

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -298,6 +298,17 @@ NCZ.BUILDING_EDGE_CAMDIST_K =  0.002; // game's camera-distance widening coeffic
 //   →   surface = 0.5·(0.8 + m) = 0.4 + 0.5·m
 NCZ.BUILDING_TEX_FLOOR      =   0.4;  // _m.dds brightness floor — game 0.5·0.8
 NCZ.BUILDING_TEX_RANGE      =   0.5;  // brightness range above the floor — game 0.5·m
+// Sloped-face guard for the _m planar sample (see buildBuildingMaterial):
+// world-normal Y thresholds for the smoothstep blend between the per-fragment
+// planar UV (flat roofs — exact decoded behaviour) and the instance-centre UV
+// (steep/oblique faces — the building's own roof texel, which can't paint a
+// 2-D image of the district map onto a slanted surface).
+// Thresholds are tight because a partially-blended UV still draws a (squashed)
+// image: a ~30°-pitched face at a mid blend re-rendered the artifact as smeared
+// streaks. 88% of instances are exactly axis-aligned (top normal.y = 1.0), so
+// near-flat-only planar sampling leaves them untouched.
+NCZ.BUILDING_TEX_SLOPE_FADE_START = 0.95;  // normal.y ≤ this (pitch ≥ ~18°) → fully centre-sampled
+NCZ.BUILDING_TEX_SLOPE_FADE_END   = 0.995; // normal.y ≥ this (pitch ≤ ~6°)  → fully planar
 
 // Terrain "graph-paper" grid — decoded from the game's 3d_map_terrain pixel
 // shader (PIX DXIL capture; see wiki/sources/terrain-grid-shader.md). Three

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -1662,7 +1662,8 @@ const ThreeScene = (() => {
     const realIndex  = visibleIndicesBuffer.element(instanceIndex);
     const instMatrix = instanceMatricesBuffer.element(realIndex);
     mat.positionNode = instMatrix.mul(vec4(positionLocal, 1)).xyz;
-    mat.normalNode   = transformNormalToView(transformNormal(normalLocal, instMatrix));
+    const worldNormal = transformNormal(normalLocal, instMatrix); // also drives the _m slope guard below
+    mat.normalNode   = transformNormalToView(worldNormal);
 
     // World-space planar UV — XZ plane, normalised against the district's CET
     // bounds. Original GLSL: vMUv = ((wx - off.x - min.x)/(max.x - min.x),
@@ -1679,11 +1680,34 @@ const ThreeScene = (() => {
       wzNeg.sub(uOffset.y).sub(uTransMin.y).div(uTransMax.y.sub(uTransMin.y))
     );
 
+    // Sloped-face guard: ~12.5% of instances have oblique quaternions
+    // (_data.dds census — 32k of 255k tilted >2° off any 90° multiple), and on
+    // their slanted faces the fragment-position planar UV paints a recognisable
+    // 2-D patch of the district map — a top-down projection landing on a
+    // non-horizontal surface. The game has the same latent artifact (its
+    // vertical-AO gbuffer term ships disabled, and its near-top-down map camera
+    // never shows walls), but our tilting camera does. Steep faces therefore
+    // sample _m at the instance's own centre instead — each building's walls
+    // and slopes carry their own roof texel, which cannot image — blended by
+    // the world normal's up-ness so flat roofs keep the exact decoded planar
+    // sample. See wiki/learnings/planar-detail-texture-images-on-tilted-instances.md.
+    const instCenter4 = instMatrix.mul(vec4(0, 0, 0, 1)); // unit-cube origin = box centre
+    const centerUv = vec2(
+      instCenter4.x.sub(uOffset.x).sub(uTransMin.x).div(uTransMax.x.sub(uTransMin.x)),
+      instCenter4.z.negate().sub(uOffset.y).sub(uTransMin.y).div(uTransMax.y.sub(uTransMin.y))
+    );
+    const upness = smoothstep(
+      float(NCZ.BUILDING_TEX_SLOPE_FADE_START),
+      float(NCZ.BUILDING_TEX_SLOPE_FADE_END),
+      worldNormal.normalize().y
+    );
+    const mUv = mix(centerUv, planarUv, upness);
+
     // (1) Diffuse modulation — sample _m, scale base colour. The game's
     // gbuffer shader applies `surface = 0.4 + 0.5·m` to the albedo (decoded —
     // wiki/sources/building-edge-shader.md; the shader's vertical-AO term is
     // disabled by the default DebugScaleOffset, so it collapses to floor+range).
-    const mVal = texture(mTex, planarUv.clamp(0, 1)).r;
+    const mVal = texture(mTex, mUv.clamp(0, 1)).r;
     const modulation = float(NCZ.BUILDING_TEX_FLOOR).add(mVal.mul(NCZ.BUILDING_TEX_RANGE));
 
     // (2) Edge highlight — the decoded game algorithm with fwidth AA standing


### PR DESCRIPTION
## Problem

Reported as "`city_center_m.dds` appears on the side of a building": a ghostly 2-D patch of the district map rendered on a slanted tower face (camera state in the diagnosis session; reproducible).

`_m.dds` surface modulation samples a **top-down planar UV** from the fragment's world position. On a flat roof that's exact decoded-game behaviour; on a *non-horizontal* face the projection paints a recognisable 2-D image of the map. A quaternion census of all 8 `_data.dds` shows the exposure is systemic: **31,994 of 255,532 instances (12.5%) are oblique** (>2° off any 90° multiple), ~13k beyond 20°.

The game ships the identical latent artifact — its gbuffer formula `0.5·(0.05 + 0.75·ao + m)` carries a vertical-AO term that's disabled by the default `DebugScaleOffset`, and its near-top-down map camera never shows slanted faces. Our tilting camera does.

## Fix

Steep faces sample `_m` at the **instance's own centre** (unit-cube origin through the instance matrix) — each building's walls/slopes carry their own roof texel, which geometrically cannot image — blended with the per-fragment planar UV by the world normal's up-ness (`smoothstep`, positional `mix()` per the `tsl-mix-method-misorders-operands` learning). Near-flat tops (88% of instances are exactly axis-aligned) keep the exact decoded planar sample.

Blend thresholds are deliberately tight (`normal.y` 0.95 → 0.995): a first attempt with 0.7 → 0.95 left the reported ~30°-pitch face mid-blend, which re-rendered the artifact as a *squashed* image — a partial UV blend still draws the picture, just smaller.

## Verification (live, at the reported camera state)

| | Before | After |
|---|---|---|
| ~30° sloped face | 2-D map patch / smeared streaks | uniform surface, correct N·L shading |
| Flat roofs (top-down plaza view) | `_m` detail | `_m` detail unchanged |
| Edge highlight | — | unchanged |
| Console | — | no errors |

Cost: one `smoothstep` + `mix` per fragment, same single texture sample. No perf change expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)