### PR TITLE
chore: scrub local-only wiki references from committed files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,7 +214,7 @@ The 3D scene now has interactive mod pins matching the Leaflet view's behaviour.
 - **Distance scale bar in 3D** — bottom-right of the scene, between the view-toggle and controls strip. Picks "nice" 1/2/5 × 10ⁿ-metre rounded lengths closest to ~100 px wide, recomputed on every `controls.change` and on resize. Shares the `.leaflet-control-scale-line` skin with the SAT scale bar — single CSS source of truth, both views render identically.
 - **Cross-view popup state sync** — opening a popup in either view updates `?mod=` in the URL. Switching SAT ↔ SCHEMA re-opens the same pin in the new view.
 - **Popup chrome unified** — `.ncz-dynamic-popup` is now the single source of truth for popup background gradient, arrows, and category colours. Both `.leaflet-popup-content-wrapper` (2D) and `.three-popup` (3D) target the same shared rules; only Leaflet's structural reset and the 3D anchor positioning are view-specific. Removed ~100 lines of duplicated CSS in the process.
-- **Coordinate-system finding (retraction)** — the previous "elevation gap" claim between CET Z and terrain GLB Y (7–23m) was sampling bias from readings taken on top of platforms. In-game teleport experiment to five terrain-only locations confirmed the two are in the same coordinate space (±6m noise from player height + LOD smoothing). See `wiki/learnings/cet-z-equals-terrain-y.md`.
+- **Coordinate-system finding (retraction)** — the previous "elevation gap" claim between CET Z and terrain GLB Y (7–23m) was sampling bias from readings taken on top of platforms. In-game teleport experiment to five terrain-only locations confirmed the two are in the same coordinate space (±6m noise from player height + LOD smoothing).
 
 New constants in [`constants.js`](assets/js/constants.js):
 
@@ -270,7 +270,7 @@ New helper script: [`scripts/query_terrain_heights.py`](scripts/query_terrain_he
 - Decoded at runtime by `MeshoptDecoder` (bundled with three.js examples, ~30 KB WASM, single fetch). Decoded geometry preserves vertex/index ordering, so GPU vertex cache stays warm
 - New build command: `npm run encode-meshopt`
 - **Side benefit:** gltfpack also merges sub-meshes per material → halved draw calls (67 → 33) and geometries (46 → 23). Replaces the legacy `strip_glb_attributes.js` step entirely
-- **Measured perf on Radeon 840M iGPU (external 1440p, AA on, full shadows):** idle FPS 44 → 63 (+43%) vs uncompressed; +31% over the considered Draco alternative (#617, closed). Full three-way comparison in `wiki/decisions/meshopt-over-draco.md`
+- **Measured perf on Radeon 840M iGPU (external 1440p, AA on, full shadows):** idle FPS 44 → 63 (+43%) vs uncompressed; +31% over the considered Draco alternative (#617, closed)
 - **Bug fixed during integration:** `loadLandmarks()` was creating new `THREE.Mesh` objects from only `geometry + material`, discarding the source mesh's `position`/`scale` — fine for uncompressed GLBs (identity transform) but broke `KHR_mesh_quantization` dequantization (vertices rendered at raw int16 scale, ~4× too large). Now copies position/quaternion/scale to mirror the existing `makeSeeThrough()` pattern
 - **Repo size reduction:** `assets/glb/` removed from version control (was 18.5 MB of dead weight; WolvenKit is the canonical source). Local re-encoding workflow: copy WKit exports to `assets/glb-source/`, run `npm run encode-meshopt`
 

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -317,8 +317,7 @@ html.theme-synthwave {
 html.theme-game {
     /* Cyberpunk 2077 in-game world-map palette. Every value is extracted
        verbatim from WolvenKit material/inkstyle exports — this is the one
-       theme that keeps the raw game colours instead of restyling them.
-       See wiki/sources/game-theme-colors.md for the full derivation. */
+       theme that keeps the raw game colours instead of restyling them. */
     --primary: #0e0e17;       /* MainColors.Fullscreen_PrimaryBackgroundDarkest */
     --secondary: #ff6159;     /* MainColors.Red (HDR clamped) */
     --tertiary: #5ef6ff;      /* MainColors.Blue (HDR clamped) */

--- a/assets/js/aces-tonemap.js
+++ b/assets/js/aces-tonemap.js
@@ -2,8 +2,7 @@
  * NC Zoning Board — CP2077 3D-map colour pipeline (ACES tonemap + grade + LUT)
  *
  * Reproduces the in-game 3D world map's full colour pipeline, decoded from
- * `base/weather/24h_basic/3dmap.envparam` (see wiki/sources/
- * 3dmap-envparam-lighting). The map renders:
+ * `base/weather/24h_basic/3dmap.envparam`. The map renders:
  *
  *     HDR scene  →  ACES tonemap  →  colour grade  →  braindance LUT  →  display
  *

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -350,12 +350,12 @@ NCZ.ASSET_SET_KEY     = 'ncz-asset-set';
 NCZ.ASSET_SET_DEFAULT = 'fixed';
 
 // Building edge highlight — decoded from the game's 3d_map_cubes.mt gbuffer
-// pixel shader (PIX capture; see wiki/sources/building-edge-shader.md).
+// pixel shader (PIX capture).
 // Per-district EdgeThickness / EdgeSharpnessPower live in DISTRICT_META
 // (three-scene.js) alongside the other per-district game constants.
 NCZ.BUILDING_EDGE_CAMDIST_K =  0.002; // game's camera-distance widening coefficient: k = camDist × this × EdgeThickness
 // _m surface modulation, decoded from the 3d_map_cubes.mt gbuffer shader
-// (PIX capture; see wiki/sources/building-edge-shader.md). Game formula:
+// (PIX capture). Game formula:
 //   surface = 0.5·(0.05 + 0.75·ao + m)   →   ao = 1 (the vertical-AO term is
 // gated by DebugScaleOffset, which ships at a default that disables it)
 //   →   surface = 0.5·(0.8 + m) = 0.4 + 0.5·m
@@ -374,7 +374,7 @@ NCZ.BUILDING_TEX_SLOPE_FADE_START = 0.95;  // normal.y ≤ this (pitch ≥ ~18°
 NCZ.BUILDING_TEX_SLOPE_FADE_END   = 0.995; // normal.y ≥ this (pitch ≤ ~6°)  → fully planar
 
 // Terrain "graph-paper" grid — decoded from the game's 3d_map_terrain pixel
-// shader (PIX DXIL capture; see wiki/sources/terrain-grid-shader.md). Three
+// shader (PIX DXIL capture). Three
 // nested anti-aliased line grids on world XZ, combined into one line factor.
 // Every value below is the game's exact decoded value — the "game:" note in
 // each comment keeps the original recoverable if a value is later tuned.
@@ -397,7 +397,7 @@ NCZ.DISTRICT_DISTANCE_3D    = 11000;
 NCZ.SUBDISTRICT_DISTANCE_3D =  7000;
 
 // Metro LOD — decoded from the game's 3d_map_metro.mt pixel shader (PIX
-// capture; see wiki/sources/metro-lod-shader.md). The metro mesh carries
+// capture). The metro mesh carries
 // three LOD tiers in COLOR_0, one channel per vertex:
 //   R = dotted (closest)   G = thin solid (medium)   B = wide solid (far)
 // Each tier is fully visible below its distance threshold and crossfades

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -226,9 +226,9 @@ const ThreeScene = (() => {
   // offset: world XY offset applied to decoded positions (no Z offset)
   // cubeSize: half-extent multiplier (from CubeSize shader parameter)
   // edgeThickness / edgeSharpness: EdgeThickness / EdgeSharpnessPower from
-  //   3d_map_cubes.mt — drive the building edge highlight (see
-  //   wiki/sources/building-edge-shader.md). edgeSharpness sets the visible
-  //   band width; edgeThickness only feeds the sub-pixel camera-distance term.
+  //   3d_map_cubes.mt — drive the building edge highlight. edgeSharpness sets
+  //   the visible band width; edgeThickness only feeds the sub-pixel
+  //   camera-distance term.
   const DISTRICT_META = [
     { name: 'westbrook',     dataDds: 'assets/dds/westbrook_data.dds',    dataDdsFixed: 'assets/dds/fixed/westbrook_data.dds',    mDds: 'assets/dds/westbrook_m.dds',    cubeSize: 197.0,        transMin: [-1078.94739, -1148.69434, -18.4205875],  transMax: [1155.12,      1562.87903,  507.894714],  offset: [  -97.209,    590.849], edgeThickness: 0.0001, edgeSharpness: 30 },
     { name: 'city_center',   dataDds: 'assets/dds/city_center_data.dds',  dataDdsFixed: 'assets/dds/fixed/city_center_data.dds',  mDds: 'assets/dds/city_center_m.dds',  cubeSize: 168.289993,   transMin: [ -770.609192, -530.549133, -40.6581497],  transMax: [1316.82483,    649.75531,  642.893127],  offset: [-2116.637,    106.508], edgeThickness: 0.0001, edgeSharpness: 30 },
@@ -312,10 +312,9 @@ const ThreeScene = (() => {
   // Derive edge highlight colour from the building base colour.
 
   // ── Terrain "graph-paper" grid ─────────────────────────────────────────────
-  // Decoded from the game's 3d_map_terrain pixel shader (PIX DXIL capture —
-  // see wiki/sources/terrain-grid-shader.md). In-game, terrain, water AND
-  // cliffs all use that one material template, so every hillshade material
-  // below carries the grid.
+  // Decoded from the game's 3d_map_terrain pixel shader (PIX DXIL capture).
+  // In-game, terrain, water AND cliffs all use that one material template, so
+  // every hillshade material below carries the grid.
 
   // Continuous anti-aliased grid-line coverage. The game's original formula
   // (round() + min(frac()·N,1), integrated over the pixel footprint) has hard
@@ -354,8 +353,8 @@ const ThreeScene = (() => {
   }
 
   // ── Building edge highlight ────────────────────────────────────────────────
-  // Decoded from the game's 3d_map_cubes.mt gbuffer pixel shader (PIX capture —
-  // see wiki/sources/building-edge-shader.md). The game computes
+  // Decoded from the game's 3d_map_cubes.mt gbuffer pixel shader (PIX capture).
+  // The game computes
   //   X    = max(|1-2u|, |1-2v|) + camDist·0.002·EdgeThickness / faceSize
   //   edge = saturate(pow(X, EdgeSharpnessPower))
   // `pow(X, power)` is NOT a step — it is a GRADIENT: ~0 across the inner face,
@@ -753,9 +752,9 @@ const ThreeScene = (() => {
     // map's drag handler lives on the container element above the marker
     // layer. Combined with the pointer-capture defeat below, this lets
     // OrbitControls see drag/zoom gestures that start on a pin while the
-    // pin's own `click` event still fires naturally on mouseup. See
-    // wiki/learnings about the prior synthetic-event approach failing
-    // because pointer capture redirected pointerup off the pin.
+    // pin's own `click` event still fires naturally on mouseup. (A prior
+    // synthetic-event approach failed because pointer capture redirected
+    // pointerup off the pin.)
     const _orbitDom = renderer.domElement.parentElement;
     controls = new OrbitControls(camera, _orbitDom);
     // Defeat OrbitControls' setPointerCapture — Leaflet doesn't use pointer
@@ -1194,8 +1193,8 @@ const ThreeScene = (() => {
         blending: THREE.AdditiveBlending,
         depthWrite: false,
       });
-      // Metro LOD — decoded from 3d_map_metro.mt's pixel shader (PIX capture;
-      // see wiki/sources/metro-lod-shader.md). The metro mesh carries three
+      // Metro LOD — decoded from 3d_map_metro.mt's pixel shader (PIX capture).
+      // The metro mesh carries three
       // tiers in COLOR_0 (R dotted / G thin / B wide), one channel per vertex.
       // Each tier is fully on below its distance threshold and crossfades out
       // over METRO_LOD_TRANSITION — the game dissolves tiers, it doesn't snap.
@@ -1698,7 +1697,7 @@ const ThreeScene = (() => {
   //
   //   2. Edge highlight (pre-lighting, via `colorNode`)
   //      The game's gbuffer shader lerps EdgeColor into the ALBEDO before
-  //      lighting (decoded — wiki/sources/building-edge-shader.md), so the
+  //      lighting (decoded from a PIX capture), so the
   //      edge is a recoloured lit surface, not an emissive overlay. We mix on
   //      `colorNode` for the same result. See `buildingEdgeCoverage`.
   //
@@ -1790,7 +1789,7 @@ const ThreeScene = (() => {
     // sample _m at the instance's own centre instead — each building's walls
     // and slopes carry their own roof texel, which cannot image — blended by
     // the world normal's up-ness so flat roofs keep the exact decoded planar
-    // sample. See wiki/learnings/planar-detail-texture-images-on-tilted-instances.md.
+    // sample.
     const instCenter4 = instMatrix.mul(vec4(0, 0, 0, 1)); // unit-cube origin = box centre
     const centerUv = vec2(
       instCenter4.x.sub(uOffset.x).sub(uTransMin.x).div(uTransMax.x.sub(uTransMin.x)),
@@ -1804,9 +1803,9 @@ const ThreeScene = (() => {
     const mUv = mix(centerUv, planarUv, upness);
 
     // (1) Diffuse modulation — sample _m, scale base colour. The game's
-    // gbuffer shader applies `surface = 0.4 + 0.5·m` to the albedo (decoded —
-    // wiki/sources/building-edge-shader.md; the shader's vertical-AO term is
-    // disabled by the default DebugScaleOffset, so it collapses to floor+range).
+    // gbuffer shader applies `surface = 0.4 + 0.5·m` to the albedo (decoded from
+    // a PIX capture; the shader's vertical-AO term is disabled by the default
+    // DebugScaleOffset, so it collapses to floor+range).
     const mVal = texture(mTex, mUv.clamp(0, 1)).r;
     const modulation = float(NCZ.BUILDING_TEX_FLOOR).add(mVal.mul(NCZ.BUILDING_TEX_RANGE));
 

--- a/docs/3d-map-lighting.md
+++ b/docs/3d-map-lighting.md
@@ -16,8 +16,6 @@ decoded from WolvenKit exports:
 | `base/weather/24h_basic/luts/cube_cp_braindance_v001.xbm` | the colour-grading LUT |
 | `base/materials/3d_map_*.mt` + per-asset `*.Material.json` | material albedo (`BaseColorScale`) |
 
-Full decode notes: `wiki/sources/3dmap-envparam-lighting.md`.
-
 ## The pipeline
 
 ```

--- a/docs/three-markers.md
+++ b/docs/three-markers.md
@@ -136,8 +136,7 @@ Single persistent `CSS2DObject` created at attach time. On pin `mouseenter`, pos
 
 ## Clustering
 
-Detailed page on the wiki ([three-markers-clustering.md](../wiki/sources/three-markers-clustering.md), Obsidian-only).
-TL;DR: **world-space XZ proximity grouping** (not screen-space — switched 2026-05 after Aki's UX feedback). Cluster radius is `PIN_3D_CLUSTER_RADIUS_PX` (40) converted to world units at current zoom, so clusters dissolve as the user zooms in (matching Leaflet's behaviour) but stay invariant to camera tilt and rotation (unlike the original screen-space approach which mis-clustered visually-close-but-far-apart pins at high tilt). Greedy O(N²) on filter-visible pins, recomputed on **zoom change** or filter change only — pan and tilt leave clusters intact. Cluster bubbles use `.marker-cluster` class + Leaflet's existing colour ramp. Pool of CSS2DObjects reused across recomputes.
+**world-space XZ proximity grouping** (not screen-space — switched 2026-05 after Aki's UX feedback). Cluster radius is `PIN_3D_CLUSTER_RADIUS_PX` (40) converted to world units at current zoom, so clusters dissolve as the user zooms in (matching Leaflet's behaviour) but stay invariant to camera tilt and rotation (unlike the original screen-space approach which mis-clustered visually-close-but-far-apart pins at high tilt). Greedy O(N²) on filter-visible pins, recomputed on **zoom change** or filter change only — pan and tilt leave clusters intact. Cluster bubbles use `.marker-cluster` class + Leaflet's existing colour ramp. Pool of CSS2DObjects reused across recomputes.
 
 ## Cluster panel integration
 

--- a/scripts/build_lut.js
+++ b/scripts/build_lut.js
@@ -3,7 +3,7 @@
  *
  * The CP2077 world map render-to-texture scene applies a colour grade whose
  * LDR LUT is `base/weather/24h_basic/luts/cube_cp_braindance_v001.xbm`
- * (decoded from `3dmap.envparam` — see wiki/sources/3dmap-envparam-lighting).
+ * (decoded from `3dmap.envparam`).
  * That `.xbm` is a 32×32×32 RGBA-float 3D colour cube.
  *
  * Source format — a `.cube` (Adobe Cube LUT): export the `.xbm` from WolvenKit

--- a/scripts/terrain_grid_spike.html
+++ b/scripts/terrain_grid_spike.html
@@ -8,7 +8,6 @@
   Standalone calibration demo for the in-game world-map terrain grid.
   The grid is procedural: decoded 2026-05-20 from a PIX GPU capture of
   Cyberpunk 2077 (pixel shader hash 8538a550680120453ca108b5628a9b1f).
-  See wiki/sources/terrain-grid-shader.md for the full DXIL decode.
 
   This runs the EXACT decoded algorithm on a flat plane spanning the
   terrain's world bounds (+/-8000). Lighting is omitted (flat plane);


### PR DESCRIPTION
## What

The committed repo cited the **gitignored, local-only** `wiki/` directory in code comments and docs — broken links for any contributor who doesn't have the local wiki. This removes all ~15 such references.

## Fix policy (per file)

| File | Refs | Fix |
| --- | --- | --- |
| `assets/js/constants.js` | 4 | Dropped `; see wiki/...` pointers — the inline `(PIX capture)` / `(PIX DXIL capture)` decode notes stand alone |
| `assets/js/three-scene.js` | 7 | Dropped wiki pointers; where a pointer carried the only "decoded" provenance, replaced with a one-line inline fact (`decoded from a PIX capture`) |
| `assets/css/theme.css` | 1 | Dropped trailing pointer (comment already says values are extracted verbatim from WolvenKit exports) |
| `scripts/build_lut.js` | 1 | Dropped wiki pointer, kept `(decoded from 3dmap.envparam)` |
| `scripts/terrain_grid_spike.html` | 1 | Dropped pointer (shader hash already cited inline) |
| `assets/js/aces-tonemap.js` | 1 | Dropped pointer, kept the `.envparam` source citation |
| `docs/3d-map-lighting.md` | 1 | Dropped redundant "Full decode notes" line — the source-of-truth table directly above already lists the decoded game files |
| `docs/three-markers.md` | 1 | Dropped the Obsidian-only clustering pointer; the TL;DR paragraph below it already covers the clustering design |
| `CHANGELOG.md` | 2 | Dropped the two trailing `See wiki/...` sentences (entry text stands alone) |

No committed repo doc was a clean 1:1 home for these specific decode facts, so the policy here was drop-pointer / inline-summary rather than repoint (unlike PR #739, where `docs/3dmap-fixed-assets.md` was an exact match).

## Scope

- **Comments and docs only** — zero behaviour change.
- Local `wiki/*.md` files untouched (cross-wiki `[[links]]` there are fine).
- All edited JS verified to parse (`node --check`).
- `grep -rn "wiki/" assets/ docs/ scripts/ index.html CHANGELOG.md ASSETS.md` now returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)