### PR TITLE
fix(3d): restore smooth terrain shading (drop stray flatShading)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tilted building instances (~12.5% of the 255k boxes have oblique rotations) no longer show a ghostly 2-D patch of the district map on their slanted faces. The top-down `_m.dds` planar projection now applies only to near-flat tops; steeper faces sample the building's own centre texel instead.
 
+#### Fixed: terrain lost its smooth shading
+
+- Terrain, water and cliffs render with smooth slope shading again. A stray `flatShading` flag on the hillshade material was discarding the meshes' vertex normals; it went unnoticed until the calibrated directional sun landed, which turned the per-face normals into visible triangle facets.
+
 #### Fixed: default sun time never applied on load
 
 - The documented default sun time now actually applies on cold load. The slider's init request fired before the 3D lights existed and was silently dropped; the UI-sync poll then wrote the scene's placeholder elevation (~63°, ≈ 15:00) back onto the slider, and the post-terrain re-apply locked it in.

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -398,7 +398,11 @@ const ThreeScene = (() => {
   function makeHillshadeMaterial(colorVar, fallback, extra = {}, brightness = 1) {
     const mat = new THREE.MeshLambertNodeMaterial({
       color: readThemeColor(colorVar, fallback),
-      flatShading: true,
+      // Smooth (interpolated vertex) normals — the terrain/water/cliffs GLBs
+      // ship NORMAL data, so the hillshade reads as smooth slopes. `flatShading`
+      // here discarded those normals for per-face ones; harmless while the scene
+      // was lit near-flat, but the decoded directional-sun pipeline (#694) made
+      // every triangle facet visible. "Hillshade" wants smooth shading.
       side: THREE.DoubleSide,
       ...extra,
     });


### PR DESCRIPTION
## What

Removes a stray `flatShading: true` from `makeHillshadeMaterial()` in `three-scene.js`, restoring smooth slope shading on terrain, water and cliffs.

## Why — the "terrain lost its smoothness" bug

`flatShading` discards a mesh's interpolated vertex normals and computes one normal per triangle. The terrain/water/cliffs GLBs **ship `NORMAL` data**, so the flag was throwing away usable smooth normals.

It was a **latent no-op for ~2 months**: flat shading only reveals facets when a directional-light gradient varies brightness across a slope. While the scene was lit near-flat the flag did nothing. PR #694 (May 22) added the decoded, calibrated directional sun — and *that* turned the per-face normals into the visible triangle faceting reported here.

Timeline confirms it:

| When | State | Terrain |
|---|---|---|
| May 21 (pre-#694) | terrain grid in, no real sun | **smooth** |
| May 22+ (#694) | calibrated directional sun | **faceted** |

The material is named *hillshade* — smooth slope shading — which `flatShading` directly contradicted.

## Fix

One line removed (plus an explanatory comment). No geometry change, no GLB re-export, no perf cost — the smooth normals were already in the buffers.

## Verification

Before/after captured at a fixed camera state + sun time (08:00) via chrome-devtools. Eastern ridge and bottom-right headland go from hard angular facets to smooth gradients, matching the older builds and the in-game map. Maintainer signed off on the look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)