### PR TITLE
feat(3d): district outline faint baseline + hover-brighten (both views)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### District outlines: faint baseline + hover-brighten
+
+- District/subdistrict outlines now sit faint (5%) by default and brighten over 250 ms when the cursor enters a district's area, matching the in-game world map. Works in both the 3D (SCHEMA) and 2D (SAT) views.
+- Fixed dropped outline edges on hover: coincident borders of adjacent districts no longer fight over pixels — the hovered outline is forced to draw on top.
+
 #### 3D World Map Fixed building assets
 
 - The 3D map can now render [malgalad's *3D World Map Fixed*](https://www.nexusmods.com/cyberpunk2077/mods/26500) building data, correcting misaligned/missing buildings (e.g. the Corpo Plaza cluster) and returning the Watson "ugly building". Toggle in **Settings → Map data → Fixed building assets** (on by default); the base-game layout stays available.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2317,6 +2317,13 @@ body::before {
 	transition: stroke-dashoffset 0.3s ease-out, stroke-opacity 0.3s ease-in;
 }
 
+/* District outline hover-brighten: NCZ.Overlay flips the path's stroke-opacity
+   between the faint baseline and the hover value; this animates the 250 ms fade
+   to match the SCHEMA (Three.js) tween. Pane class added in overlay.js init(). */
+.district-outline-pane path {
+	transition: stroke-opacity 0.25s ease;
+}
+
 .marker-cluster-step {
     --cluster-hue: 120;
 	background-color: hsl(

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -188,7 +188,12 @@ NCZ.DISTRICT_ZOOM_THRESHOLD = 3;  // below = districts only, above = subdistrict
 // District border appearance — shared between SAT (Leaflet) and SCHEMA (Three.js)
 NCZ.DISTRICT_LINE_WIDTH     = 4;  // px — main district borders
 NCZ.SUBDISTRICT_LINE_WIDTH  = 3;  // px — subdistrict borders
-NCZ.DISTRICT_LINE_OPACITY   = 0.85;
+// Faint baseline matches the in-game inkLinePatternWidget.opacity (5%); the
+// hover-brighten state fades to ~full over 250 ms. See
+// wiki/sources/district-outline-widget.md.
+NCZ.DISTRICT_LINE_OPACITY        = 0.05;
+NCZ.DISTRICT_LINE_OPACITY_HOVER  = 1.0;
+NCZ.DISTRICT_HOVER_FADE_MS       = 250;
 
 // ── Three.js 3D scene ──────────────────────────────────────────────────────────
 

--- a/assets/js/overlay.js
+++ b/assets/js/overlay.js
@@ -29,6 +29,15 @@ NCZ.Overlay = (() => {
   let subLayer       = null; // canonical subdistricts — zoom-in only
   let districtsVisible = true;
 
+  // Hover-brighten registry — mirrors the SCHEMA (Three.js) behaviour: outlines
+  // sit at the faint baseline and brighten when the cursor is inside the
+  // district's area (point-in-polygon, not a thin-line hit). Each entry knows
+  // its tier so we only test outlines currently on the map. The 250 ms fade is
+  // a CSS transition on the pane's paths (see .district-outline-pane in style.css).
+  const _hoverFeatures = []; // { ring:[[lat,lng]], area, layer, tier }
+  let _hovered = null;       // the currently brightened feature layer
+  const _tierLayers = {};    // tier name → L.geoJSON layer (for hasLayer checks)
+
   const styleFeature = f => ({
     color:   f.properties.color,
     weight:  f.properties.level === "district" ? NCZ.DISTRICT_LINE_WIDTH : NCZ.SUBDISTRICT_LINE_WIDTH,
@@ -37,11 +46,38 @@ NCZ.Overlay = (() => {
     pane:    "districtPane",
   });
 
+  // Shoelace area (lat/lng space) — smallest matching ring wins so a small
+  // nested outline (casino inside Westbrook) takes the hover over its parent.
+  function ringArea(ring) {
+    let a = 0;
+    for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+      a += (ring[j][0] + ring[i][0]) * (ring[j][1] - ring[i][1]);
+    }
+    return Math.abs(a) / 2;
+  }
+
+  function onMapMouseMove(e) {
+    if (!districtsVisible) return;
+    const pt = [e.latlng.lat, e.latlng.lng];
+    let best = null;
+    for (const f of _hoverFeatures) {
+      if (!_map.hasLayer(_tierLayers[f.tier])) continue;
+      if (NCZ.pointInPolygon(pt, f.ring) && (!best || f.area < best.area)) best = f;
+    }
+    const layer = best ? best.layer : null;
+    if (layer === _hovered) return;
+    if (_hovered) _hovered.setStyle({ opacity: NCZ.DISTRICT_LINE_OPACITY });
+    if (layer)    layer.setStyle({ opacity: NCZ.DISTRICT_LINE_OPACITY_HOVER });
+    _hovered = layer;
+  }
+
   function init(map) {
     _map = map;
 
     map.createPane("districtPane");
     map.getPane("districtPane").style.zIndex = 460;
+    // Tag the pane so its SVG paths get the 250 ms stroke-opacity transition.
+    map.getPane("districtPane").classList.add("district-outline-pane");
 
     fetch("data/subdistricts.json")
       .then(r => r.json())
@@ -60,7 +96,8 @@ NCZ.Overlay = (() => {
             const coords = dist.polygon.map(pt => NCZ.cetToLeaflet(pt[0], pt[1]));
             const feature = {
               type: "Feature",
-              properties: { color, name: dist.name, level: "district" },
+              // `ring` ([lat,lng]) is carried for the hover point-in-polygon test.
+              properties: { color, name: dist.name, level: "district", ring: coords },
               geometry: { type: "Polygon", coordinates: [coords.map(c => [c[1], c[0]])] },
             };
             (hasSubs ? outerFeatures : alwaysFeatures).push(feature);
@@ -72,7 +109,7 @@ NCZ.Overlay = (() => {
             const coords = sub.polygon.map(pt => NCZ.cetToLeaflet(pt[0], pt[1]));
             const feature = {
               type: "Feature",
-              properties: { color, name: sub.name, level: "subdistrict" },
+              properties: { color, name: sub.name, level: "subdistrict", ring: coords },
               geometry: { type: "Polygon", coordinates: [coords.map(c => [c[1], c[0]])] },
             };
             // canonical:false (casino etc) — always visible
@@ -80,24 +117,47 @@ NCZ.Overlay = (() => {
           }
         }
 
-        const toLayer = features => L.geoJSON(
+        const toLayer = (features, tier) => L.geoJSON(
           { type: "FeatureCollection", features },
-          { style: styleFeature, pane: "districtPane" }
+          {
+            style: styleFeature,
+            pane: "districtPane",
+            onEachFeature: (feature, layer) => {
+              _hoverFeatures.push({
+                ring: feature.properties.ring,
+                area: ringArea(feature.properties.ring),
+                layer,
+                tier,
+              });
+            },
+          }
         );
 
-        alwaysLayer = toLayer(alwaysFeatures);
-        outerLayer  = toLayer(outerFeatures);
-        subLayer    = toLayer(subFeatures);
+        alwaysLayer = toLayer(alwaysFeatures, "always");
+        outerLayer  = toLayer(outerFeatures, "outer");
+        subLayer    = toLayer(subFeatures, "sub");
+        _tierLayers.always = alwaysLayer;
+        _tierLayers.outer  = outerLayer;
+        _tierLayers.sub    = subLayer;
 
         map.on("zoomend", updateZoom);
+        map.on("mousemove", onMapMouseMove);
         if (districtsVisible) updateZoom();
       })
       .catch(err => console.error("[NCZ] Failed to load subdistricts.json:", err));
   }
 
+  // Drop the brightened state — a feature hidden mid-hover (zoom tier swap or
+  // districts toggled off) would otherwise stay bright when it re-appears.
+  function clearHover() {
+    if (_hovered) _hovered.setStyle({ opacity: NCZ.DISTRICT_LINE_OPACITY });
+    _hovered = null;
+  }
+
   function updateZoom() {
     if (!_map || !alwaysLayer) return;
     if (!districtsVisible) return;
+    clearHover();
 
     const zoomedIn = _map.getZoom() > NCZ.DISTRICT_ZOOM_THRESHOLD;
 
@@ -118,6 +178,7 @@ NCZ.Overlay = (() => {
     if (visible) {
       updateZoom();
     } else {
+      clearHover();
       [alwaysLayer, outerLayer, subLayer].forEach(l => {
         if (l && _map.hasLayer(l)) _map.removeLayer(l);
       });

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -789,6 +789,12 @@ const ThreeScene = (() => {
         _sceneControls.addEventListener(evt, (e) => e.stopPropagation());
       }
     }
+    // District hover-brighten: cursor over a district's area fades its outline
+    // up. Listener on the container so moves over the CSS2D pin overlay still
+    // reach it (events bubble; pointer capture is no-op'd above). passive — we
+    // never preventDefault, so the camera drag path is untouched.
+    _orbitDom.addEventListener('mousemove', onSceneMouseMove, { passive: true });
+    _orbitDom.addEventListener('mouseleave', () => setHoveredDistrict(null), { passive: true });
     controls.mouseButtons = {
       LEFT:   THREE.MOUSE.PAN,
       MIDDLE: THREE.MOUSE.DOLLY,
@@ -977,6 +983,110 @@ const ThreeScene = (() => {
     _districtOuter.visible = distance >= NCZ.DISTRICT_DISTANCE_3D;
     _districtSub.visible   = distance >= NCZ.SUBDISTRICT_DISTANCE_3D && distance < NCZ.DISTRICT_DISTANCE_3D;
     if (_districtAlways) _districtAlways.visible = distance >= NCZ.SUBDISTRICT_DISTANCE_3D;
+  }
+
+  // ── District hover-brighten ─────────────────────────────────────────────
+  // In-game parity: outlines sit at NCZ.DISTRICT_LINE_OPACITY (5%) and brighten
+  // to ~full over 250 ms when the cursor enters the district's area. No pick
+  // geometry — the rings are flat on Y=0, so we intersect the cursor ray with
+  // the ground plane and run a CPU point-in-polygon over the in-memory rings.
+  // One registry entry per outline; `group` is its visibility tier so we only
+  // test (and brighten) outlines that are actually drawn at the current zoom.
+  const _districtHover = []; // { ring, line, material, group, area, target }
+  let _hoveredEntry = null;
+  // Draw the hovered outline last so it paints on top of any coincident faint
+  // neighbour. Outlines have depthTest:false (depth ignored), so the only thing
+  // that decides which of two coplanar coincident lines wins a pixel is paint
+  // order — and the transparent back-to-front sort is unstable for equal-
+  // distance lines. A high renderOrder forces the hovered line last; > metro (2)
+  // so a highlighted district reads above roads/metro too. Reset to 0 on exit.
+  const DISTRICT_HOVER_RENDER_ORDER = 10;
+  let _hoverFading  = false; // true while any material.opacity != its target
+  let _hoverLastT   = 0;
+  const _hoverRay    = new THREE.Raycaster();
+  const _hoverPlane  = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0); // y = 0
+  const _hoverNdc    = new THREE.Vector2();
+  const _hoverWorld  = new THREE.Vector3();
+
+  // Shoelace area (absolute) — used to prefer the smallest matching ring when a
+  // point sits inside nested outlines (e.g. the casino sub inside Westbrook).
+  function polygonArea(ring) {
+    let a = 0;
+    for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+      a += (ring[j][0] + ring[i][0]) * (ring[j][1] - ring[i][1]);
+    }
+    return Math.abs(a) / 2;
+  }
+
+  function registerDistrictHover(ring, line, group) {
+    if (!ring || ring.length < 3 || !line?.material) return;
+    _districtHover.push({
+      ring,
+      line,
+      material: line.material,
+      group,
+      area: polygonArea(ring),
+      target: NCZ.DISTRICT_LINE_OPACITY,
+    });
+  }
+
+  // Map a client-space cursor position to the district outline under it (or
+  // null). Only considers outlines whose tier group is currently visible.
+  function pickDistrictAt(clientX, clientY) {
+    if (!_districtHover.length || !layers.districts?.visible) return null;
+    const rect = renderer.domElement.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) return null;
+    _hoverNdc.set(
+      ((clientX - rect.left) / rect.width) * 2 - 1,
+      -(((clientY - rect.top) / rect.height) * 2 - 1)
+    );
+    _hoverRay.setFromCamera(_hoverNdc, camera);
+    // Near-horizontal rays barely graze Y=0 — bail rather than pick a point
+    // kilometres off (cf. ray-to-ground-thit-explodes-near-horizontal). Outlines
+    // only show when zoomed out/steep, so this never costs a real hover.
+    if (Math.abs(_hoverRay.ray.direction.y) < 1e-3) return null;
+    if (!_hoverRay.ray.intersectPlane(_hoverPlane, _hoverWorld)) return null;
+    const pt = [_hoverWorld.x, -_hoverWorld.z]; // world (x,z) → ring (cetX, cetY)
+    let best = null;
+    for (const e of _districtHover) {
+      if (!e.group.visible) continue;
+      if (NCZ.pointInPolygon(pt, e.ring) && (!best || e.area < best.area)) best = e;
+    }
+    return best;
+  }
+
+  function setHoveredDistrict(entry) {
+    if (entry === _hoveredEntry) return;
+    if (_hoveredEntry) { _hoveredEntry.target = NCZ.DISTRICT_LINE_OPACITY; _hoveredEntry.line.renderOrder = 0; }
+    if (entry)         { entry.target         = NCZ.DISTRICT_LINE_OPACITY_HOVER; entry.line.renderOrder = DISTRICT_HOVER_RENDER_ORDER; }
+    _hoveredEntry = entry;
+    if (!_hoverFading) { _hoverFading = true; _hoverLastT = performance.now(); setContinuousRender(true); }
+  }
+
+  function onSceneMouseMove(e) {
+    setHoveredDistrict(pickDistrictAt(e.clientX, e.clientY));
+  }
+
+  // Advance every outline material toward its target opacity. Linear over
+  // NCZ.DISTRICT_HOVER_FADE_MS for the full 0.05↔1.0 range; releases the
+  // continuous-render hold once all materials have settled.
+  function stepDistrictHoverFade(now) {
+    if (!_hoverFading) return;
+    const dt = Math.max(0, now - _hoverLastT);
+    _hoverLastT = now;
+    const range = NCZ.DISTRICT_LINE_OPACITY_HOVER - NCZ.DISTRICT_LINE_OPACITY;
+    const maxStep = range * (dt / NCZ.DISTRICT_HOVER_FADE_MS);
+    let active = false;
+    for (const e of _districtHover) {
+      const diff = e.target - e.material.opacity;
+      if (Math.abs(diff) <= maxStep || maxStep === 0) {
+        if (e.material.opacity !== e.target) e.material.opacity = e.target;
+      } else {
+        e.material.opacity += Math.sign(diff) * maxStep;
+        active = true;
+      }
+    }
+    if (!active) { _hoverFading = false; setContinuousRender(false); }
   }
 
   // ── Scale bar ───────────────────────────────────────────────────────
@@ -1324,18 +1434,19 @@ const ThreeScene = (() => {
         if (dist.polygon?.length) {
           const line = buildLine(dist.polygon, color, window.NCZ.DISTRICT_LINE_WIDTH);
           line.name = `district-outline-${dist.id}`;
-          (hasSubs ? outerGroup : alwaysGroup).add(line);
+          const group = hasSubs ? outerGroup : alwaysGroup;
+          group.add(line);
+          registerDistrictHover(dist.polygon, line, group);
         }
 
         for (const sub of dist.subdistricts || []) {
           if (!sub.polygon?.length) continue;
           const line = buildLine(sub.polygon, color, window.NCZ.SUBDISTRICT_LINE_WIDTH);
           line.name = `subdistrict-outline-${dist.id}/${sub.id}`;
-          if (sub.canonical === false) {
-            alwaysGroup.add(line); // casino etc — always visible
-          } else {
-            subGroup.add(line);    // zoom-gated
-          }
+          // canonical:false (casino etc) — always visible; otherwise zoom-gated.
+          const group = sub.canonical === false ? alwaysGroup : subGroup;
+          group.add(line);
+          registerDistrictHover(sub.polygon, line, group);
         }
       }
 
@@ -1881,7 +1992,15 @@ const ThreeScene = (() => {
   }
 
   // Build a Line2 (fat line) from CET [x, y] ring points.
-  // depthTest:false means lines always render over terrain, matching the game's UI overlay approach.
+  // depthTest:false means lines always render over terrain/buildings, matching
+  // the game's UI overlay approach (depth is ignored entirely, so a brightened
+  // outline shows through even tall downtown towers). Adjacent districts/
+  // subdistricts share exact border vertices, so their outlines are coincident
+  // at Y=0; with no depth test the renderer's back-to-front transparent sort is
+  // unstable for equal-distance coplanar lines, so the hovered (bright) line is
+  // not guaranteed to paint last and a faint 0.05 neighbour can overdraw its
+  // edges. The hover code promotes the hovered line's renderOrder to force it
+  // last — see setHoveredDistrict / DISTRICT_HOVER_RENDER_ORDER.
   function buildLine(ring, color, lineWidth) {
     const cleaned = dedupRing(ring);
     if (cleaned.length < 3) {
@@ -2089,6 +2208,7 @@ const ThreeScene = (() => {
     animationId = null;
     if (stats) stats.begin();
     updateIntroTween();   // E5 intro fly-in — mutate the camera before controls.update() reconciles
+    stepDistrictHoverFade(performance.now()); // district outline opacity tween
     const dampingActive = controls.update();
     // Phase 2B: dispatch per-district reset+cull computes BEFORE render.
     // Each district's `reset` clears its indirect.instanceCount to 0; `cull`

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -252,6 +252,25 @@ NCZ.cetToThree = function (cetX, cetY, cetZ) {
   return [cetX, cetZ || 0, -cetY];
 };
 
+// Ray-casting point-in-polygon test. Generic over coordinate space — `point`
+// and `ring` vertices are both [a, b] pairs in the SAME space (3D passes world
+// [x, -z]; 2D passes [lat, lng]). `ring` is the polygon's vertex list; the
+// closing edge back to ring[0] is handled implicitly. Returns true if the point
+// is inside (odd crossing count).
+NCZ.pointInPolygon = function (point, ring) {
+  if (!ring || ring.length < 3) return false;
+  const [px, py] = point;
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const xi = ring[i][0], yi = ring[i][1];
+    const xj = ring[j][0], yj = ring[j][1];
+    const intersects = (yi > py) !== (yj > py) &&
+      px < ((xj - xi) * (py - yi)) / (yj - yi) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+};
+
 // Builds the full popup HTML string for a mod.
 // View-agnostic: both Leaflet (marker.bindPopup) and Three.js (CSS2DObject) call this.
 NCZ.buildPopupHtml = function (mod, catStyle, nexusThumbs, tagsDict) {


### PR DESCRIPTION
Parity port of the in-game world map's district outline UX. Closes the first coupled pair of district-outline project items (#187458547 opacity baseline, #187458584 hover-brighten).

## What changed

- **Faint default**: `DISTRICT_LINE_OPACITY` 0.85 → 0.05, matching the in-game `inkLinePatternWidget.opacity`. Applies to both the 3D (SCHEMA) and 2D (SAT) views (the constant is shared).
- **Hover-brighten**: cursor inside a district's *area* fades that outline 0.05 → ~1.0 over 250 ms, reverses on exit.
- **Shared hit-test**: new `NCZ.pointInPolygon` drives "cursor inside the district" in both views — 3D unprojects the cursor ray to the `Y=0` ground plane; 2D uses Leaflet's `latlng`. Smallest-area match wins so a nested outline (e.g. the casino inside Westbrook) takes precedence. Tier-gated so only outlines drawn at the current zoom are tested.
- **3D fade**: tweens `Line2NodeMaterial.opacity` inside the render-on-demand loop, holding the loop open only while a fade is in flight.
- **2D fade**: flips Leaflet `stroke-opacity` and animates it via a CSS transition on the district pane.

## Bug fixed along the way — dropped outline edges on hover

Adjacent districts/subdistricts share *exact* border vertices, so their outlines are coincident at `Y=0`. With `depthTest:false` the lines ignore depth (`depthWrite` is a no-op), so paint order alone decides coincident pixels — and the transparent back-to-front sort is unstable for equal-distance coplanar lines. The hovered (bright) line wasn't guaranteed to paint last, so a faint 0.05 neighbour could overdraw its edges (only un-shared polygons like the self-authored casino rendered fully). Fix: the hovered outline is promoted to `renderOrder` 10 (> roads/metro) so it deterministically paints last.

## Verification

Driven via chrome-devtools across both zoom tiers and both views:
- Faint baseline confirmed (outlines barely visible by default).
- Hover brightens exactly the correct single district to its theme colour (City Center yellow, Santo Domingo blue, …) and fades back on exit.
- Closed-polygon render confirmed on hover at both the district tier (City Center) and sub tier (Downtown) after the renderOrder fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)