### PR TITLE
feat(map): district + subdistrict name labels at centroids (both views)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - District/subdistrict outlines now sit faint (5%) by default and brighten over 250 ms when the cursor enters a district's area, matching the in-game world map. Works in both the 3D (SCHEMA) and 2D (SAT) views.
 - Fixed dropped outline edges on hover: coincident borders of adjacent districts no longer fight over pixels — the hovered outline is forced to draw on top.
 
+#### District / subdistrict name labels
+
+- District and subdistrict names now render at their centroids in both views — district names zoomed out, subdistrict names zoomed in. Faint by default, fading in with an emphasis when the district is hovered (paired with the outline brighten). Badlands (no polygon) gets a hand-placed name with its own hover region.
+- On the satellite view the names carry a dark text-casing so they stay legible over the imagery; pins always render above labels.
+
 #### 3D World Map Fixed building assets
 
 - The 3D map can now render [malgalad's *3D World Map Fixed*](https://www.nexusmods.com/cyberpunk2077/mods/26500) building data, correcting misaligned/missing buildings (e.g. the Corpo Plaza cluster) and returning the Watson "ugly building". Toggle in **Settings → Map data → Fixed building assets** (on by default); the base-game layout stays available.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2414,6 +2414,100 @@ body::before {
     cursor: pointer;
 }
 
+/* District / subdistrict name labels (CSS2DObject at the polygon centroid).
+   Colour comes per-label from --label-color (the district's palette colour).
+   pointer-events:none so labels never intercept the outline hover or pins.
+   The .district-label-anchor is what CSS2DRenderer positions (it owns the inline
+   transform); the inner .district-label scales/glows on hover independently. */
+.district-label-anchor {
+    pointer-events: none;
+}
+
+.district-label {
+    pointer-events: none;
+    font-family: var(--font-heading);
+    color: var(--label-color, var(--white));
+    text-transform: uppercase;
+    white-space: nowrap;
+    text-align: center;
+    font-weight: 600;
+    /* Dark halo keeps the name legible over the busy map without a filled plate. */
+    text-shadow:
+        0 0 4px var(--surface-tooltip-95, rgba(2, 8, 20, 0.95)),
+        0 1px 3px rgba(0, 0, 0, 0.9);
+    user-select: none;
+    /* Faint by default (like the outlines), brightening only on hover. Roughly
+       half the previous baseline so names stay readable but recede; the hover
+       state lifts the focused one to full. 250 ms matches the outline brighten. */
+    opacity: 0.5;
+    transition: opacity 0.25s ease, transform 0.25s ease, text-shadow 0.25s ease;
+}
+
+.district-label-district {
+    font-size: var(--text-sm);
+    letter-spacing: 0.14em;
+}
+
+.district-label-subdistrict {
+    font-size: var(--text-xs);
+    letter-spacing: 0.1em;
+    opacity: 0.45;
+}
+
+/* Outline-hover emphasis: the hovered district/subdistrict's label pops to full
+   opacity, scales up slightly, and gains a colour glow — paired with the
+   outline brighten in setHoveredDistrict (3D) / onMapMouseMove (2D). */
+.district-label.district-label-hover {
+    opacity: 1;
+    transform: scale(1.18);
+    text-shadow:
+        0 0 6px var(--label-color, #fff),
+        0 0 12px var(--surface-tooltip-95, rgba(2, 8, 20, 0.95)),
+        0 1px 3px rgba(0, 0, 0, 0.95);
+}
+
+/* 2D (Leaflet) labels reuse the .district-label skin via a permanent centre
+   tooltip; strip Leaflet's bubble/arrow so only the text shows. Leaflet
+   positions this root, leaving the inner .district-label free to scale on hover
+   (same trick as the 3D .district-label-anchor). */
+.leaflet-tooltip.district-label-tooltip {
+    background: none;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    white-space: nowrap;
+    pointer-events: none;
+}
+
+.leaflet-tooltip.district-label-tooltip::before {
+    display: none; /* no arrow */
+}
+
+/* The satellite imagery is bright and busy, so the 3D schematic's soft halo
+   isn't enough — give the SAT labels a solid dark text-casing (1px outline in
+   all four diagonals + glow) and a heavier weight / more present baseline so the
+   names stay legible over any tile. Scoped to the Leaflet tooltip so the 3D
+   labels keep their faint look. Higher specificity than the shared hover rule,
+   so the hover override below must match it (4 classes) to still win. */
+.leaflet-tooltip.district-label-tooltip .district-label {
+    /* Faded baseline (so the fade + hover-emphasis still read) but kept legible
+       by the solid dark casing below — the outline carries contrast even at low
+       fill opacity, where the old soft halo couldn't. */
+    opacity: 0.6;
+    font-weight: 700;
+    text-shadow:
+        -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000,
+        0 0 4px #000, 0 0 7px rgba(0, 0, 0, 0.9);
+}
+
+.leaflet-tooltip.district-label-tooltip .district-label.district-label-hover {
+    opacity: 1;
+    /* keep the dark casing under the colour glow on hover */
+    text-shadow:
+        -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000,
+        0 0 6px var(--label-color, #fff), 0 0 12px #000;
+}
+
 /* 3D tooltip anchor — wraps the shared `.pin-tooltip` skin (defined above).
    CSS2DRenderer projects the anchor to the pin's world position; the inner
    .pin-tooltip is then offset upward in screen space so the arrow points

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -182,6 +182,11 @@ NCZ.DISTRICT_COLORS = {
   badlands:       "#c882ff",  // Bright violet
 };
 
+// Badlands has no district polygon, so its name label has no centroid to sit at.
+// Hand-placed CET [x, y] in an open patch of the badlands (maintainer-chosen);
+// world (x,0,-y) in the 3D scene. Note y is negated from the three-space target.
+NCZ.BADLANDS_LABEL_CET = [2957.33, -691.04];
+
 // Overlay zoom thresholds (Leaflet zoom levels)
 NCZ.DISTRICT_ZOOM_THRESHOLD = 3;  // below = districts only, above = subdistricts
 

--- a/assets/js/overlay.js
+++ b/assets/js/overlay.js
@@ -34,9 +34,17 @@ NCZ.Overlay = (() => {
   // district's area (point-in-polygon, not a thin-line hit). Each entry knows
   // its tier so we only test outlines currently on the map. The 250 ms fade is
   // a CSS transition on the pane's paths (see .district-outline-pane in style.css).
-  const _hoverFeatures = []; // { ring:[[lat,lng]], area, layer, tier }
-  let _hovered = null;       // the currently brightened feature layer
-  const _tierLayers = {};    // tier name → L.geoJSON layer (for hasLayer checks)
+  const _hoverFeatures = []; // { ring:[[lat,lng]], area, layer, labelTip, tier }
+  let _hoveredFeature = null; // the currently brightened feature entry
+  let _badlandsLabel = null;  // standalone tooltip (no polygon to bind to)
+  const _tierLayers = {};     // tier name → L.geoJSON layer (for hasLayer checks)
+
+  // Resolve a feature's name-label element (the inner .district-label span)
+  // from its bound/standalone tooltip, if it's currently on the map.
+  function labelElOf(f) {
+    const tip = f.labelTip || f.layer?.getTooltip?.();
+    return tip?.getElement?.()?.querySelector('.district-label') || null;
+  }
 
   const styleFeature = f => ({
     color:   f.properties.color,
@@ -64,11 +72,17 @@ NCZ.Overlay = (() => {
       if (!_map.hasLayer(_tierLayers[f.tier])) continue;
       if (NCZ.pointInPolygon(pt, f.ring) && (!best || f.area < best.area)) best = f;
     }
-    const layer = best ? best.layer : null;
-    if (layer === _hovered) return;
-    if (_hovered) _hovered.setStyle({ opacity: NCZ.DISTRICT_LINE_OPACITY });
-    if (layer)    layer.setStyle({ opacity: NCZ.DISTRICT_LINE_OPACITY_HOVER });
-    _hovered = layer;
+    if (best === _hoveredFeature) return;
+    if (_hoveredFeature) {
+      _hoveredFeature.layer?.setStyle({ opacity: NCZ.DISTRICT_LINE_OPACITY });
+      labelElOf(_hoveredFeature)?.classList.remove('district-label-hover');
+    }
+    if (best) {
+      best.layer?.setStyle({ opacity: NCZ.DISTRICT_LINE_OPACITY_HOVER });
+      best.layer?.bringToFront?.(); // mirror the 3D renderOrder bump (draw on top)
+      labelElOf(best)?.classList.add('district-label-hover');
+    }
+    _hoveredFeature = best;
   }
 
   function init(map) {
@@ -78,6 +92,14 @@ NCZ.Overlay = (() => {
     map.getPane("districtPane").style.zIndex = 460;
     // Tag the pane so its SVG paths get the 250 ms stroke-opacity transition.
     map.getPane("districtPane").classList.add("district-outline-pane");
+
+    // Name labels live just above the outlines but BELOW the markerPane (600),
+    // so pins always render on top of labels — matching the 3D view. Leaflet's
+    // default tooltipPane (650) would put them above the pins. pointer-events:
+    // none so the pane never intercepts map/pin interaction.
+    map.createPane("districtLabelPane");
+    map.getPane("districtLabelPane").style.zIndex = 465;
+    map.getPane("districtLabelPane").style.pointerEvents = "none";
 
     fetch("data/subdistricts.json")
       .then(r => r.json())
@@ -123,10 +145,19 @@ NCZ.Overlay = (() => {
             style: styleFeature,
             pane: "districtPane",
             onEachFeature: (feature, layer) => {
+              const p = feature.properties;
+              const level = p.level === "district" ? "district" : "subdistrict";
+              // Permanent centre tooltip = the name label. Bound to the outline,
+              // so it shows/hides automatically with the layer's tier gating.
+              layer.bindTooltip(
+                `<span class="district-label district-label-${level}" style="--label-color:${p.color}">${NCZ.escapeHtml(p.name)}</span>`,
+                { permanent: true, direction: "center", className: "district-label-tooltip", interactive: false, pane: "districtLabelPane" }
+              );
               _hoverFeatures.push({
-                ring: feature.properties.ring,
-                area: ringArea(feature.properties.ring),
+                ring: p.ring,
+                area: ringArea(p.ring),
                 layer,
+                labelTip: layer.getTooltip(),
                 tier,
               });
             },
@@ -140,6 +171,24 @@ NCZ.Overlay = (() => {
         _tierLayers.outer  = outerLayer;
         _tierLayers.sub    = subLayer;
 
+        // Badlands has no polygon to bind a tooltip to → standalone label at the
+        // hand-placed spot, shown at the district tier. Hovering its area (any
+        // badlands sub ring, registered as label-only "outer" entries) emphasises
+        // it, mirroring the 3D label-only hover region.
+        const bl = data.districts.find(d => d.id === "badlands");
+        if (bl && NCZ.BADLANDS_LABEL_CET) {
+          const blPos = NCZ.cetToLeaflet(NCZ.BADLANDS_LABEL_CET[0], NCZ.BADLANDS_LABEL_CET[1]);
+          const blColor = NCZ.DISTRICT_COLORS.badlands || "#ffffff";
+          _badlandsLabel = L.tooltip({ permanent: true, direction: "center", className: "district-label-tooltip", interactive: false, pane: "districtLabelPane" })
+            .setLatLng(blPos)
+            .setContent(`<span class="district-label district-label-district" style="--label-color:${blColor}">${NCZ.escapeHtml(bl.name)}</span>`);
+          for (const sub of bl.subdistricts || []) {
+            if (!sub.polygon?.length) continue;
+            const ring = sub.polygon.map(pt => NCZ.cetToLeaflet(pt[0], pt[1]));
+            _hoverFeatures.push({ ring, area: ringArea(ring), layer: null, labelTip: _badlandsLabel, tier: "outer" });
+          }
+        }
+
         map.on("zoomend", updateZoom);
         map.on("mousemove", onMapMouseMove);
         if (districtsVisible) updateZoom();
@@ -150,8 +199,11 @@ NCZ.Overlay = (() => {
   // Drop the brightened state — a feature hidden mid-hover (zoom tier swap or
   // districts toggled off) would otherwise stay bright when it re-appears.
   function clearHover() {
-    if (_hovered) _hovered.setStyle({ opacity: NCZ.DISTRICT_LINE_OPACITY });
-    _hovered = null;
+    if (_hoveredFeature) {
+      _hoveredFeature.layer?.setStyle({ opacity: NCZ.DISTRICT_LINE_OPACITY });
+      labelElOf(_hoveredFeature)?.classList.remove('district-label-hover');
+    }
+    _hoveredFeature = null;
   }
 
   function updateZoom() {
@@ -170,6 +222,12 @@ NCZ.Overlay = (() => {
       if (!_map.hasLayer(outerLayer)) outerLayer.addTo(_map);
       if (_map.hasLayer(subLayer))    _map.removeLayer(subLayer);
     }
+
+    // Badlands name shows at the district tier only (mirrors outerLayer).
+    if (_badlandsLabel) {
+      if (!zoomedIn && !_map.hasLayer(_badlandsLabel)) _badlandsLabel.addTo(_map);
+      else if (zoomedIn && _map.hasLayer(_badlandsLabel)) _map.removeLayer(_badlandsLabel);
+    }
   }
 
   function setDistricts(visible) {
@@ -182,6 +240,7 @@ NCZ.Overlay = (() => {
       [alwaysLayer, outerLayer, subLayer].forEach(l => {
         if (l && _map.hasLayer(l)) _map.removeLayer(l);
       });
+      if (_badlandsLabel && _map.hasLayer(_badlandsLabel)) _map.removeLayer(_badlandsLabel);
     }
   }
 

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -36,6 +36,7 @@ import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { Line2 } from 'three/addons/lines/webgpu/Line2.js';
 import { LineGeometry } from 'three/addons/lines/LineGeometry.js';
 import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
+import { CSS2DObject } from 'three/addons/renderers/CSS2DRenderer.js';
 import Stats from 'three/addons/libs/stats.module.js';
 // The exact in-game 3D-map colour pipeline (decoded from 3dmap.envparam):
 // ACES tonemap + colour grade + braindance LUT — see assets/js/aces-tonemap.js.
@@ -950,10 +951,25 @@ const ThreeScene = (() => {
   let _districtSub    = null; // canonical subdistricts — visible at the subs band (7000 ≤ d < 11000)
   let _districtAlways = null; // no-sub districts (Dogtown / Morro Rock) + non-canonical subs (Casino) — visible whenever EITHER outline tier is
 
+  // Name labels: { css: CSS2DObject, group } — `group` is the outline tier the
+  // label belongs to, so the label is shown exactly when that tier is.
+  const _districtLabels = [];
+
+  // Gate each label per-leaf (CSS2D `visible` doesn't cascade from a parent
+  // group). A label shows when the Districts overlay is on AND its outline
+  // tier's group is currently visible — so district names appear at the
+  // district zoom band, subdistrict names at the subdistrict band.
+  function updateDistrictLabelVisibility() {
+    if (!_districtLabels.length) return;
+    const districtsOn = layers.districts ? layers.districts.visible : true;
+    for (const { css, group } of _districtLabels) css.visible = districtsOn && group.visible;
+  }
+
   function setLayerVisibility(name, visible) {
     if (name === 'districts') {
       if (layers.districts) layers.districts.visible = visible;
       if (visible) updateDistrictZoom();
+      updateDistrictLabelVisibility();
       requestRender();
       return;
     }
@@ -983,6 +999,7 @@ const ThreeScene = (() => {
     _districtOuter.visible = distance >= NCZ.DISTRICT_DISTANCE_3D;
     _districtSub.visible   = distance >= NCZ.SUBDISTRICT_DISTANCE_3D && distance < NCZ.DISTRICT_DISTANCE_3D;
     if (_districtAlways) _districtAlways.visible = distance >= NCZ.SUBDISTRICT_DISTANCE_3D;
+    updateDistrictLabelVisibility();
   }
 
   // ── District hover-brighten ─────────────────────────────────────────────
@@ -1018,13 +1035,16 @@ const ThreeScene = (() => {
     return Math.abs(a) / 2;
   }
 
-  function registerDistrictHover(ring, line, group) {
-    if (!ring || ring.length < 3 || !line?.material) return;
+  // line may be null for a label-only hover region (Badlands has no outline but
+  // still wants its name to emphasise when the cursor is over its area).
+  function registerDistrictHover(ring, line, group, labelEl) {
+    if (!ring || ring.length < 3) return;
     _districtHover.push({
       ring,
-      line,
-      material: line.material,
+      line: line || null,
+      material: line?.material || null,
       group,
+      labelEl: labelEl || null, // matched name label, emphasised in sync on hover
       area: polygonArea(ring),
       target: NCZ.DISTRICT_LINE_OPACITY,
     });
@@ -1057,8 +1077,18 @@ const ThreeScene = (() => {
 
   function setHoveredDistrict(entry) {
     if (entry === _hoveredEntry) return;
-    if (_hoveredEntry) { _hoveredEntry.target = NCZ.DISTRICT_LINE_OPACITY; _hoveredEntry.line.renderOrder = 0; }
-    if (entry)         { entry.target         = NCZ.DISTRICT_LINE_OPACITY_HOVER; entry.line.renderOrder = DISTRICT_HOVER_RENDER_ORDER; }
+    if (_hoveredEntry) {
+      _hoveredEntry.target = NCZ.DISTRICT_LINE_OPACITY;
+      if (_hoveredEntry.line) _hoveredEntry.line.renderOrder = 0;
+      _hoveredEntry.labelEl?.classList.remove('district-label-hover');
+    }
+    if (entry) {
+      entry.target = NCZ.DISTRICT_LINE_OPACITY_HOVER;
+      // line is null for label-only entries (Badlands has no outline).
+      if (entry.line) entry.line.renderOrder = DISTRICT_HOVER_RENDER_ORDER;
+      // Emphasise the matching name label in sync with the outline brighten.
+      entry.labelEl?.classList.add('district-label-hover');
+    }
     _hoveredEntry = entry;
     if (!_hoverFading) { _hoverFading = true; _hoverLastT = performance.now(); setContinuousRender(true); }
   }
@@ -1078,6 +1108,7 @@ const ThreeScene = (() => {
     const maxStep = range * (dt / NCZ.DISTRICT_HOVER_FADE_MS);
     let active = false;
     for (const e of _districtHover) {
+      if (!e.material) continue; // label-only entry (Badlands) — no outline to tween
       const diff = e.target - e.material.opacity;
       if (Math.abs(diff) <= maxStep || maxStep === 0) {
         if (e.material.opacity !== e.target) e.material.opacity = e.target;
@@ -1425,18 +1456,62 @@ const ThreeScene = (() => {
       alwaysGroup.name = 'districts-always';
       subGroup.name    = 'subdistricts';
 
+      // Name labels (CSS2DObject) live in their own group, rendered for free by
+      // ThreeMarkers' CSS2DRenderer pass (it traverses the whole scene). Each
+      // label is tagged with the visibility GROUP of its outline, so the label
+      // shows exactly when its outline tier does (handled in
+      // updateDistrictLabelVisibility — CSS2D visible doesn't cascade, so we set
+      // it per-leaf). Default layer 0 → labels aren't gated by the Pins toggle.
+      const labelGroup = new THREE.Group();
+      labelGroup.name = 'district-labels';
+      const addLabel = (name, posCet, colorHex, group, level) => {
+        if (!name || !posCet) return null;
+        // Anchor is what CSS2DRenderer positions (it overwrites the element's
+        // inline transform each frame). The inner .district-label is free to
+        // scale/glow on hover without fighting that transform.
+        const anchor = document.createElement('div');
+        anchor.className = 'district-label-anchor';
+        const el = document.createElement('div');
+        el.className = `district-label district-label-${level}`;
+        el.textContent = name;
+        el.style.setProperty('--label-color', colorHex);
+        anchor.appendChild(el);
+        const css = new CSS2DObject(anchor);
+        css.position.set(posCet[0], 0, -posCet[1]); // CET (x,y) → world (x,0,-y)
+        css.name = `district-label-${level}-${name}`;
+        labelGroup.add(css);
+        _districtLabels.push({ css, group });
+        return el; // returned so the outline hover can emphasise its label in sync
+      };
+
       for (const dist of data.districts) {
-        const color = new THREE.Color(window.NCZ.DISTRICT_COLORS[dist.id] || '#ffffff');
+        const colorHex = window.NCZ.DISTRICT_COLORS[dist.id] || '#ffffff';
+        const color = new THREE.Color(colorHex);
         const canonicalSubs = (dist.subdistricts || []).filter(s => s.canonical !== false);
         const hasSubs = canonicalSubs.length > 0;
+        const distGroup = hasSubs ? outerGroup : alwaysGroup;
 
         // District outline — always group if no canonical subs, outer group otherwise
         if (dist.polygon?.length) {
           const line = buildLine(dist.polygon, color, window.NCZ.DISTRICT_LINE_WIDTH);
           line.name = `district-outline-${dist.id}`;
-          const group = hasSubs ? outerGroup : alwaysGroup;
-          group.add(line);
-          registerDistrictHover(dist.polygon, line, group);
+          distGroup.add(line);
+          const labelEl = addLabel(dist.name, NCZ.polygonCentroid(dist.polygon), colorHex, distGroup, 'district');
+          registerDistrictHover(dist.polygon, line, distGroup, labelEl);
+        } else if (hasSubs) {
+          // Badlands has no district polygon (and no in-game district icon). The
+          // mean of its subdistrict centroids lands in a cramped/built-up spot;
+          // the maintainer picked this open patch of the badlands instead.
+          const pos = NCZ.BADLANDS_LABEL_CET || null;
+          if (pos) {
+            const labelEl = addLabel(dist.name, pos, colorHex, distGroup, 'district');
+            // No outline to hover, so register each subdistrict polygon as a
+            // district-tier, label-only hover region pointing at the Badlands
+            // label — hovering the badlands area emphasises the name.
+            for (const sub of dist.subdistricts || []) {
+              if (sub.polygon?.length) registerDistrictHover(sub.polygon, null, distGroup, labelEl);
+            }
+          }
         }
 
         for (const sub of dist.subdistricts || []) {
@@ -1446,7 +1521,8 @@ const ThreeScene = (() => {
           // canonical:false (casino etc) — always visible; otherwise zoom-gated.
           const group = sub.canonical === false ? alwaysGroup : subGroup;
           group.add(line);
-          registerDistrictHover(sub.polygon, line, group);
+          const labelEl = addLabel(sub.name, NCZ.polygonCentroid(sub.polygon), colorHex, group, 'subdistrict');
+          registerDistrictHover(sub.polygon, line, group, labelEl);
         }
       }
 
@@ -1462,6 +1538,9 @@ const ThreeScene = (() => {
       _districtAlways = alwaysGroup;
       layers.districts = parent;
       scene.add(parent);
+      scene.add(labelGroup);
+      layers.districtLabels = labelGroup;
+      updateDistrictLabelVisibility();
       requestRender();
       freezeStatic(parent);
       stepProgress(); // districts done

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -252,6 +252,29 @@ NCZ.cetToThree = function (cetX, cetY, cetZ) {
   return [cetX, cetZ || 0, -cetY];
 };
 
+// Area-weighted polygon centroid (shoelace) for a ring of [x, y] vertices.
+// Center of mass, so it handles non-convex rings far better than a plain vertex
+// average (which drifts toward dense corners). Returns [cx, cy] in the ring's
+// own space. Falls back to the vertex average for a degenerate (zero-area) ring.
+// Matches scripts/preview_district_borders.py's Shapely centroid.
+NCZ.polygonCentroid = function (ring) {
+  if (!ring || ring.length === 0) return null;
+  let a = 0, cx = 0, cy = 0;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const cross = ring[j][0] * ring[i][1] - ring[i][0] * ring[j][1];
+    a += cross;
+    cx += (ring[j][0] + ring[i][0]) * cross;
+    cy += (ring[j][1] + ring[i][1]) * cross;
+  }
+  a *= 0.5;
+  if (Math.abs(a) < 1e-6) {
+    let sx = 0, sy = 0;
+    for (const p of ring) { sx += p[0]; sy += p[1]; }
+    return [sx / ring.length, sy / ring.length];
+  }
+  return [cx / (6 * a), cy / (6 * a)];
+};
+
 // Ray-casting point-in-polygon test. Generic over coordinate space — `point`
 // and `ring` vertices are both [a, b] pairs in the SAME space (3D passes world
 // [x, -z]; 2D passes [lat, lng]). `ring` is the polygon's vertex list; the

--- a/data/subdistricts.json
+++ b/data/subdistricts.json
@@ -211,7 +211,7 @@
       "subdistricts": [
         {
           "id": "corpo_plaza",
-          "name": "Corporate Plaza",
+          "name": "Corpo Plaza",
           "trigger": "corpo_plaza_trigger",
           "polygon": [
             [

--- a/docs/district-hierarchy.md
+++ b/docs/district-hierarchy.md
@@ -72,7 +72,7 @@ Legend:
 ### Night City Districts
 
 #### **City Center** `[Q]` — UiState: CityCenter (Yellow #ffd741)
-- Corporate Plaza `[Q]`
+- Corpo Plaza `[Q]`
   - Arasaka Tower Atrium
   - Arasaka Tower CEO Floor
   - Arasaka Tower Jenkins Office

--- a/scripts/regenerate_subdistricts.py
+++ b/scripts/regenerate_subdistricts.py
@@ -43,7 +43,7 @@ DISTRICT_STRUCTURE = [
     {
         "id": "city_center", "name": "City Center", "trigger": "city_center_trigger",
         "subdistricts": [
-            {"id": "corpo_plaza", "name": "Corporate Plaza", "trigger": "corpo_plaza_trigger"},
+            {"id": "corpo_plaza", "name": "Corpo Plaza", "trigger": "corpo_plaza_trigger"},
             {"id": "downtown", "name": "Downtown", "trigger": "downtown_trigger"},
         ]
     },


### PR DESCRIPTION
Parity port of the in-game world map's district/subdistrict name labels. Closes project item #187458609 (labels). Icons (#187458631) are a separate follow-up.

## What changed

- **Name labels at centroids, both views.** District names show at the district zoom tier, subdistrict names at the subdistrict tier — mirroring the outline tier gating. 3D renders them as `CSS2DObject`s through ThreeMarkers' existing CSS2D pass; 2D binds permanent center tooltips to the outline polygons (so tier gating comes free with the polygon's layer).
- **Faint → hover.** Labels sit faint by default and fade in with a scale + colour glow when the district is hovered, paired with the outline brighten via the same hover path (`setHoveredDistrict` in 3D, `onMapMouseMove` in 2D).
- **Badlands** has no polygon: a hand-placed name (`NCZ.BADLANDS_LABEL_CET`) with a label-only hover region built from its subdistrict rings, so hovering the badlands area still emphasises the name.
- **SAT legibility.** Over the bright satellite imagery a faint colored label is unreadable, so the SAT labels carry a solid dark text-casing (4-direction outline) — the outline carries contrast while the fill stays faint, preserving the faint/hover behaviour.
- **Pins take precedence.** Labels render below pins in both views — 3D keeps the existing CSS2D ordering; 2D puts labels in a dedicated pane (z 465) below the `markerPane` (600).
- New `NCZ.polygonCentroid` (area-weighted shoelace) in `utils.js`.

## Verification

Driven via chrome-devtools across both views and both zoom tiers:
- District tier: 9 district names + casino; sub tier: subdistrict names. Correct colours/centroids.
- Hover emphasis (label scale/glow + outline brighten) confirmed in 3D and 2D, including the Badlands label-only hover region (hovering Laguna Bend emphasises "Badlands").
- SAT casing legible over imagery; pins confirmed above labels (pane z 465 < 600).

🤖 Generated with [Claude Code](https://claude.com/claude-code)