### PR TITLE
fix(3d): carry viewport across the 2D ↔ 3D view switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Fixed: viewport now carries across the 2D ↔ 3D switch
+
+- Toggling between the SAT (2D) and SCHEMA (3D) views keeps your place — centre and zoom carry across in both directions, instead of each view holding its own independent camera. The 3D view preserves your current heading/tilt rather than snapping top-down. The first-load cinematic intro is unaffected.
+
 #### District outlines: faint baseline + hover-brighten
 
 - District/subdistrict outlines now sit faint (5%) by default and brighten over 250 ms when the cursor enters a district's area, matching the in-game world map. Works in both the 3D (SCHEMA) and 2D (SAT) views.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -614,6 +614,13 @@ async function initMap() {
     });
 
     if (viewName === "schema") {
+      // Capture the Leaflet viewport BEFORE hiding #map — getCenter()/getSize()
+      // only read true while the container is laid out. On the *first* SCHEMA
+      // entry the scene isn't built yet, so the E5 intro owns the framing; on
+      // later toggles we carry the 2D viewport across.
+      const wasInit  = NCZ.ThreeScene.isInitialized();
+      const leafletView = { center: [map.getCenter().lat, map.getCenter().lng], zoom: map.getZoom() };
+      const leafletPxW  = map.getSize().x;
       mapEl.style.display   = "none";
       map3dEl.style.display = "block";
       // ThreeScene.init() is async under WebGPURenderer (await renderer.init()).
@@ -628,15 +635,28 @@ async function initMap() {
           if (NCZ.ThreeScene.isWebGPUActive()) {
             NCZ.ThreeScene.startRenderLoop();
             if (GAMELIGHT) applyGameLightRef();
+            // Sync the 2D viewport into the 3D camera — but only once the scene
+            // already exists, so the first-entry intro fly-in isn't stomped.
+            if (wasInit) NCZ.ThreeScene.frameLeafletView({ ...leafletView, leafletPxW });
           } else {
             forceSatFallback();
           }
         });
     } else {
+      // Carry the 3D camera's viewport back to the Leaflet map. Capture from the
+      // canvas (Leaflet-independent) before showing #map; round zoom to an
+      // integer for tile crispness, clamp to the map's range. Use the *visible*
+      // 3D container's width for the px basis — map.getSize() reads 0 while #map
+      // is still display:none, which would collapse the derived zoom.
+      const view = NCZ.ThreeScene.getLeafletView?.({ leafletPxW: map3dEl.clientWidth });
       map3dEl.style.display = "none";
       mapEl.style.display   = "block";
       NCZ.ThreeScene.stopRenderLoop();
       map.invalidateSize();
+      if (view) {
+        const zoom = NCZ.clamp(Math.round(view.zoom), map.getMinZoom(), map.getMaxZoom());
+        map.setView(view.center, zoom, { animate: false });
+      }
     }
     onViewSwitched?.(viewName);
   }

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -3182,6 +3182,55 @@ const ThreeScene = (() => {
     return layers[name]?.visible ?? null;
   }
 
+  // Has init() run? app.js uses this to let the E5 intro own the *first* SCHEMA
+  // entry (skip view-sync) while syncing on every later toggle.
+  function isInitialized() {
+    return initialized;
+  }
+
+  // ── View-sync with the 2D Leaflet map ──────────────────────────────────
+  // Read the current camera as an equivalent Leaflet centre + zoom (for the
+  // SCHEMA→SAT switch). Ground target → CET → Leaflet; distance → zoom via the
+  // shared horizontal-extent transform. Returns null if the scene isn't built.
+  function getLeafletView({ leafletPxW }) {
+    if (!controls || !camera) return null;
+    const cetX = controls.target.x;
+    const cetY = -controls.target.z;          // inverse of cetToThree
+    const distance = camera.position.distanceTo(controls.target);
+    const { lat, lng, zoom } = NCZ.cameraExtentToLeafletView({
+      cetX, cetY, distance, aspect3d: camera.aspect, fov: camera.fov, leafletPxW,
+    });
+    return { center: [lat, lng], zoom };
+  }
+
+  // Frame a Leaflet centre + zoom in the 3D camera (for the SAT→SCHEMA switch).
+  // Preserves the user's current azimuth/tilt — only the ground target and the
+  // along-view distance move, so heading/tilt carry across the switch. Kept
+  // separate from setCameraState (which restores an absolute stored pose +
+  // sun state); this *derives* the pose from preserved θ/φ + computed distance.
+  function frameLeafletView({ center, zoom, leafletPxW }) {
+    if (!controls || !camera) return;
+    const { cetX, cetY, distance } = NCZ.leafletViewToCameraExtent({
+      centerLat: center[0], centerLng: center[1], zoom,
+      leafletPxW, aspect3d: camera.aspect, fov: camera.fov,
+    });
+    const d = NCZ.clamp(distance, controls.minDistance, controls.maxDistance);
+    const theta = controls.getAzimuthalAngle();
+    const phi   = controls.getPolarAngle();
+    const target = new THREE.Vector3(cetX, 0, -cetY);
+    const position = new THREE.Vector3(
+      target.x + d * Math.sin(phi) * Math.sin(theta),
+      target.y + d * Math.cos(phi),
+      target.z + d * Math.sin(phi) * Math.cos(theta),
+    );
+    // Cancel any in-flight intro fly-in so it doesn't fight the framing.
+    if (_introTween) { _introTween = null; setContinuousRender(false); }
+    controls.target.copy(target);
+    camera.position.copy(position);
+    controls.update();
+    requestRender();
+  }
+
   function getCameraState() {
     if (!controls || !camera) return null;
     return {
@@ -3210,7 +3259,7 @@ const ThreeScene = (() => {
     requestRender();
   }
 
-  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, setSceneExposure, getLightingState, getSunElevation, setGradeEnabled, getGradeEnabled, setEdgeGlowEnabled, getEdgeGlowEnabled, setSunSphereVisible, getShadowSnapshot, getCameraState, setCameraState, getSceneColorVars, getRenderInfo, getCullCounts, setOverrideMaterial, dumpDebugInfo, isWebGPUActive };
+  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, setSceneExposure, getLightingState, getSunElevation, setGradeEnabled, getGradeEnabled, setEdgeGlowEnabled, getEdgeGlowEnabled, setSunSphereVisible, getShadowSnapshot, getCameraState, setCameraState, isInitialized, getLeafletView, frameLeafletView, getSceneColorVars, getRenderInfo, getCullCounts, setOverrideMaterial, dumpDebugInfo, isWebGPUActive };
 })();
 
 window.NCZ.ThreeScene = ThreeScene;

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -49,6 +49,42 @@ NCZ.leafletDistanceMeters = function (a, b) {
   return distanceCetUnits / NCZ.CET_UNITS_PER_METER;
 };
 
+// Inverse: Leaflet [lat, lng] → CET (x, y). Exact inverse of cetToLeaflet.
+NCZ.leafletToCet = function (lat, lng) {
+  const cetX = NCZ.WORLD_MIN_X + (lng / 256) * (NCZ.WORLD_MAX_X - NCZ.WORLD_MIN_X);
+  const cetY = NCZ.WORLD_MAX_Y + (lat / 256) * (NCZ.WORLD_MAX_Y - NCZ.WORLD_MIN_Y);
+  return [cetX, cetY];
+};
+
+// View-sync bridge between the 2D Leaflet map and the 3D perspective camera.
+// Both directions match the *horizontal* visible CET width at screen centre —
+// exact at any camera tilt, since the camera's right vector stays in world XZ
+// (same reasoning as updateScaleBar()). The look-direction extent foreshortens
+// when tilted, so the vertical match is approximate by design; we preserve the
+// user's heading/tilt rather than snapping top-down.
+//   Leaflet horizontal CET width @ zoom z = pxW · RX / (256 · 2^z)
+//   Three  horizontal CET width @ dist d  = 2 · d · tan(fovY/2) · aspect
+// `fov` is the camera's vertical FOV in degrees (THREE.PerspectiveCamera.fov).
+NCZ.leafletViewToCameraExtent = function ({ centerLat, centerLng, zoom, leafletPxW, aspect3d, fov }) {
+  const rangeX = NCZ.WORLD_MAX_X - NCZ.WORLD_MIN_X;
+  const [cetX, cetY] = NCZ.leafletToCet(centerLat, centerLng);
+  const widthCet = (leafletPxW * rangeX) / (256 * Math.pow(2, zoom));
+  const halfFovY = (fov * Math.PI) / 360;
+  const distance = widthCet / (2 * Math.tan(halfFovY) * aspect3d);
+  return { cetX, cetY, distance };
+};
+
+// Inverse of leafletViewToCameraExtent: 3D camera ground target + distance → a
+// Leaflet centre + (fractional) zoom. Caller clamps/rounds zoom to its range.
+NCZ.cameraExtentToLeafletView = function ({ cetX, cetY, distance, aspect3d, fov, leafletPxW }) {
+  const rangeX = NCZ.WORLD_MAX_X - NCZ.WORLD_MIN_X;
+  const [lat, lng] = NCZ.cetToLeaflet(cetX, cetY);
+  const halfFovY = (fov * Math.PI) / 360;
+  const widthCet = 2 * distance * Math.tan(halfFovY) * aspect3d;
+  const zoom = Math.log2((leafletPxW * rangeX) / (256 * widthCet));
+  return { lat, lng, zoom };
+};
+
 
 NCZ.clamp = function (value, min, max) {
   return Math.min(Math.max(value, min), max);


### PR DESCRIPTION
Fixes the **View sync poll bug — Three.js camera ↔ Leaflet view** ([Project item](https://github.com/users/spuddeh/projects/1/views/10?pane=issue&itemId=184715254), Bugs stream).

## The bug

Despite the title, there was *no* view-sync at all. `switchView()` only toggled the two map containers' `display` — the Leaflet map (SAT) and the Three.js camera (SCHEMA) were two independent persistent viewports, so toggling between views lost your place. (The original ticket is doubly stale: the 3D camera is a `PerspectiveCamera` now, not orthographic, and the 200 ms `setInterval` poll only syncs overlay checkboxes + the sun slider — never the camera.)

## The fix

On each view switch, capture the outgoing view's centre + zoom and frame it into the incoming view — **bidirectional**.

- **`utils.js`** — `leafletToCet` (inverse of `cetToLeaflet`) + two pure extent helpers (`leafletViewToCameraExtent` / `cameraExtentToLeafletView`). They match the **horizontal** visible CET width, which is exact at any camera tilt (the camera's right vector stays in world XZ — same reasoning as `updateScaleBar()`).
- **`three-scene.js`** — `isInitialized()`, `getLeafletView()`, `frameLeafletView()`, reusing the existing scale-bar extent formula and `introCameraPose()` spherical math. `frameLeafletView` preserves the user's current azimuth/tilt (only moves the ground target + along-view distance) and cancels any in-flight intro tween.
- **`app.js`** — capture/apply wired into both branches of `switchView()`.

### Behaviour decisions (maintainer-confirmed)
- **Bidirectional** sync (2D→3D and 3D→2D).
- The **first-load E5 cinematic intro is preserved**: the first SCHEMA entry (scene not yet initialised) defers to the intro; sync kicks in on later toggles.
- 3D framing keeps your **heading/tilt** rather than snapping top-down.

## Verification (live, chrome-devtools)
- 2D set to `[-90.02, 150]` z5 → 3D camera framed it **exactly** (derived zoom 5.000).
- Round-trip 2D→3D→2D returns identical centre/zoom — **no creep**.
- Leaflet zoom 8 → camera clamps to min distance gracefully (no crash).
- Zero console errors/warnings; visual check confirmed both views show the same area (pins/roads/bay align).
- Caught + fixed an edge case: `map.getSize().x` reads 0 while `#map` is `display:none`, which would collapse the SAT-branch zoom — the px basis now uses the visible 3D container width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)