### PR TITLE
fix(3d): stop showcase pins ghosting into the sky (reversed-Z cull)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Three.js 3D Schematic Map (in progress — dev branch)
 
+#### Fixed: showcase pins floating in the sky
+
+- During the showcase with pins enabled, pins behind the camera (e.g. the city while a low sweep faces away from it) no longer ghost into the sky. CSS2DRenderer's behind-camera cull assumed a standard projection and broke under the renderer's reversed-Z depth; the marker pass now uses a standard-projection clone of the camera so culling is correct (on-screen pin positions unchanged).
+- Clicking a pin during the showcase no longer re-enables clustering — it stays in individual-pin mode.
+
 #### District hover info panel
 
 - Hovering a district shows a readout in the top-right (parity with the in-game world map): district icon + name, the subdistrict under the cursor, and location stats for that area — count, category breakdown, share of all locations, and how many were recently updated. Works in both the 3D (SCHEMA) and 2D (SAT) views.

--- a/assets/js/three-markers.js
+++ b/assets/js/three-markers.js
@@ -54,6 +54,8 @@ const ThreeMarkers = (() => {
   let _clusterLayer = null;
   const _clusterPool = [];          // CSS2DObject[] — reused across recomputes
   let _filterVisibleIds = new Set();
+  let _unclusteredMode = false;     // showcase: every filter-visible pin shown
+                                    // individually, cluster bubbles suppressed
   let _recomputeFrame = null;
   let _onClusterClick = null;       // cluster-click callback (set by app.js)
   let _onClustersChanged = null;    // recompute-fired callback (set by app.js)
@@ -388,6 +390,17 @@ const ThreeMarkers = (() => {
     if (!_clusterLayer || !_schemaCamera || !container || !controls) return;
     const w = container.clientWidth;
     if (!w) return;
+
+    // Showcase (unclustered) mode: keep every filter-visible pin individual and
+    // bubbles hidden. Synchronous recompute callers — notably openPopup /
+    // closePopup on a pin click — must NOT rebuild clusters here, or clicking a
+    // pin mid-cinematic snaps the scene back into number badges.
+    if (_unclusteredMode) {
+      pins.forEach((pin, id) => { pin.visible = _filterVisibleIds.has(id); });
+      for (const c of _clusterPool) c.visible = false;
+      _redraw();
+      return;
+    }
 
     // Convert "PIN_3D_CLUSTER_RADIUS_PX equivalent at current camera distance"
     // into world units. Perspective worldPerPixel at the *centre of screen*
@@ -796,10 +809,39 @@ const ThreeMarkers = (() => {
     card.classList.toggle('ncz-popup-bottom', flip);
   }
 
+  // CSS2DRenderer culls a marker when its projected point falls outside the
+  // NDC depth range (`z >= -1 && z <= 1`) — a test that assumes a STANDARD
+  // forward projection. Our WebGPU renderer runs with `reversedDepthBuffer:true`,
+  // so the renderer rebuilds `camera.projectionMatrix` with reversed Z; under
+  // it, behind-camera points land at z≈[-1,0) and slip through the test, getting
+  // mirror-projected into view as phantom "pins in the sky" (worst in the
+  // showcase's wide, low, away-facing sweeps where much of the city sits behind
+  // the camera). Reversed-Z only rewrites the projection's z row, never x/y, so
+  // we hand CSS2DRenderer a standard-projection clone for its depth-less pass:
+  // on-screen pin positions are byte-identical, but the behind-camera cull works.
+  // Same reversed-Z family as the Line2.trimSegment near-plane bug.
+  const _stdProj = new THREE.Matrix4();
+  function standardProjectionFor(cam) {
+    const near = cam.near, far = cam.far;
+    const top    = near * Math.tan((Math.PI / 360) * cam.fov) / (cam.zoom || 1);
+    const height = 2 * top;
+    const width  = cam.aspect * height;
+    const left   = -0.5 * width;
+    return _stdProj.makePerspective(
+      left, left + width, top, top - height, near, far, THREE.WebGLCoordinateSystem,
+    );
+  }
+
   function render() {
     if (!cssRenderer || !scene || !_schemaCamera) return;
     updateFlyTween();
-    cssRenderer.render(scene, getCam());
+    const cam = getCam();
+    // Swap in a standard projection for the CSS2D pass, then restore the
+    // renderer's reversed-Z matrix so nothing else sees the substitution.
+    const savedProj = cam.projectionMatrix;
+    cam.projectionMatrix = standardProjectionFor(cam);
+    cssRenderer.render(scene, cam);
+    cam.projectionMatrix = savedProj;
     if (popup) updatePopupPlacement();
   }
 
@@ -848,6 +890,7 @@ const ThreeMarkers = (() => {
   // (typically issued by setActiveCamera(null) on showcase exit), which
   // rebuilds the correct visible/clustered state from scratch.
   function setUnclusteredMode(active) {
+    _unclusteredMode = active;
     if (active) {
       pins.forEach((pin, modId) => { pin.visible = _filterVisibleIds.has(modId); });
       if (_clusterLayer) _clusterLayer.children.forEach(c => { c.visible = false; });


### PR DESCRIPTION
## Problem

Running the showcase with pins enabled, phantom pins floated **in the sky** — most obviously on low, wide, or **away-facing** sweeps (the Badlands/Rocky-Ridge end). They looked like duplicates of the real on-map pins, but were actually a *different* set: the mods **behind the camera**.

## Root cause

`CSS2DRenderer` culls a marker with `z ∈ [-1, 1]`, a test that assumes a **standard forward projection**. The scene renders with `reversedDepthBuffer: true`, so the WebGPU renderer rebuilds `camera.projectionMatrix` with **reversed Z**. Measured on the live flyover camera, a point 2000u **behind** the camera computes to `ndc.z ≈ -0.0005` — inside `[-1, 1]` — so it passes the test and gets mirror-projected into view.

- reversed-Z proj: front `+0.0005` (pass), behind `-0.0005` (**wrongly passes**)
- standard proj, same camera: front `0.999` (pass), behind `1.001` (correctly culled)

Same reversed-Z family as the `Line2.trimSegment` near-plane bug (#33570 / earlier learning).

## Fix

Reversed-Z only rewrites the projection's **z row** — x/y (which place the marker on screen) are untouched. So `ThreeMarkers.render()` hands CSS2DRenderer a **standard-projection clone** of the camera for its depth-less pass, then restores the reversed matrix. On-screen pin positions are byte-identical; the behind-camera cull is now correct. Also fixes latent behind-camera ghosting in the normal schema view.

Second fix in the same file: clicking a pin during the showcase opened a popup → `recomputeClusters()` → the scene snapped back into cluster badges. Added an `_unclusteredMode` guard so recompute is a no-op while the showcase is in individual-pin mode.

## Verification (chrome-devtools, live)

- Behind-camera-but-visible pins: **many → 0** across 8 sampled frames (camera heights 2583 → 255 wu).
- Low/away sweeps now render a clean sky.
- Clicking a pin mid-showcase: visible clusters stayed **0 before and after**, popup still opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)