### PR TITLE
revert(3d): keep faceted terrain shading (community preference)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,10 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Tilted building instances (~12.5% of the 255k boxes have oblique rotations) no longer show a ghostly 2-D patch of the district map on their slanted faces. The top-down `_m.dds` planar projection now applies only to near-flat tops; steeper faces sample the building's own centre texel instead.
 
-#### Fixed: terrain lost its smooth shading
-
-- Terrain, water and cliffs render with smooth slope shading again. A stray `flatShading` flag on the hillshade material was discarding the meshes' vertex normals; it went unnoticed until the calibrated directional sun landed, which turned the per-face normals into visible triangle facets.
-
 #### Fixed: default sun time never applied on load
 
 - The documented default sun time now actually applies on cold load. The slider's init request fired before the 3D lights existed and was silently dropped; the UI-sync poll then wrote the scene's placeholder elevation (~63°, ≈ 15:00) back onto the slider, and the post-terrain re-apply locked it in.

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -399,11 +399,14 @@ const ThreeScene = (() => {
   function makeHillshadeMaterial(colorVar, fallback, extra = {}, brightness = 1) {
     const mat = new THREE.MeshLambertNodeMaterial({
       color: readThemeColor(colorVar, fallback),
-      // Smooth (interpolated vertex) normals — the terrain/water/cliffs GLBs
-      // ship NORMAL data, so the hillshade reads as smooth slopes. `flatShading`
-      // here discarded those normals for per-face ones; harmless while the scene
-      // was lit near-flat, but the decoded directional-sun pipeline (#694) made
-      // every triangle facet visible. "Hillshade" wants smooth shading.
+      // INTENTIONAL faceted look — do NOT "fix" this. `flatShading` discards
+      // the GLBs' (present) smooth vertex normals for per-face ones, so the
+      // directional sun (#694) renders the terrain/cliffs as crisp triangle
+      // facets. PR #741 removed this for "correct" smooth hillshading; a 12–3
+      // community vote (2–2 among the core team) preferred the faceted version,
+      // so it was restored as the deliberate style. Smooth shading is the
+      // one-line opposite (drop this flag) if the call is ever revisited.
+      flatShading: true,
       side: THREE.DoubleSide,
       ...extra,
     });


### PR DESCRIPTION
## What

Restores `flatShading: true` on the terrain/water/cliffs hillshade material — reverting the visual change from #741 — and documents it as an **intentional aesthetic choice** so it isn't "fixed" again.

## Why

#741 diagnosed a real latent flag: `flatShading` was discarding the GLBs' smooth vertex normals, and the calibrated directional sun (#694) turned that into visible triangle facets. Technically that was "wrong" (a hillshade should be smooth).

But when the smooth-vs-faceted comparison was put to the community, the **faceted look won 12–3** (and split 2–2 among the core team). Taste beats correctness here — the faceted terrain is the look people want, so it stays.

## Changes

- `three-scene.js` — `flatShading: true` restored, with a comment recording the decision and the 12–3 vote so the next reader doesn't re-remove it.
- `CHANGELOG.md` — the `[Unreleased]` "Fixed: terrain lost its smooth shading" entry is dropped. Both #741 and this revert are unreleased on `dev`, so the net user-facing change is zero; no need to log a fix-then-revert round trip.

## Note

Smooth shading remains a one-line change (drop the flag) if this is ever revisited, or if a "smooth terrain" Settings toggle is wanted later to serve the minority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)