### PR TITLE
fix(2d): frame WebGPU fallback on the city, not all pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Toggling between the SAT (2D) and SCHEMA (3D) views keeps your place — centre and zoom carry across in both directions, instead of each view holding its own independent camera. The 3D view preserves your current heading/tilt rather than snapping top-down. The first-load cinematic intro is unaffected.
 
+#### Fixed: 2D fallback default framing (no WebGPU)
+
+- When WebGPU is unavailable and the board falls back to the 2D satellite map, it now opens framed on the city — the same view you get switching to 2D from the default 3D map — instead of a zoomed-out fit-to-all-pins that pushed the city into a corner.
+
 #### District outlines: faint baseline + hover-brighten
 
 - District/subdistrict outlines now sit faint (5%) by default and brighten over 250 ms when the cursor enters a district's area, matching the in-game world map. Works in both the 3D (SCHEMA) and 2D (SAT) views.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -664,6 +664,28 @@ async function initMap() {
     onViewSwitched?.(viewName);
   }
 
+  // Frame the 2D map at the view equivalent to the *default* 3D framing (the E5
+  // intro rest pose). Used by the WebGPU fallback, where the 3D camera never
+  // gets built — without this the map sits at its init fitBounds(mapBounds)
+  // (the whole 16k image, framing nothing). Runs the intro rest constants
+  // through the same horizontal-extent transform a real SCHEMA→SAT switch uses,
+  // so the fallback lands exactly where switching to 2D from the default 3D view
+  // would. Must be called while #map is visible (getSize() reads 0 otherwise).
+  function applyDefaultSatView() {
+    const size = map.getSize();
+    if (!size.x || !size.y) return;
+    const [cetX, cetY] = NCZ.SCHEMA_INTRO_REST_CENTER;
+    const { lat, lng, zoom } = NCZ.cameraExtentToLeafletView({
+      cetX, cetY,
+      distance: NCZ.SCHEMA_INTRO_REST_DISTANCE,
+      aspect3d: size.x / size.y,
+      fov: NCZ.SCHEMA_CAMERA_FOV,
+      leafletPxW: size.x,
+    });
+    const z = NCZ.clamp(Math.round(zoom), map.getMinZoom(), map.getMaxZoom());
+    map.setView([lat, lng], z, { animate: false });
+  }
+
   // WebGPU unavailable → the 3D view can't render correctly. Lock it off and
   // present the fully-functional 2D Leaflet map plus a one-time notice.
   // Idempotent: only the first call does anything.
@@ -672,6 +694,10 @@ async function initMap() {
     webgpuFallbackDone = true;
     threeDAvailable = false;
     switchView("sat");
+    // switchView's SAT branch can't carry a view across (no 3D camera exists on
+    // the fallback), so it leaves the init fitBounds in place — override it with
+    // the default 3D-equivalent framing now that #map is laid out.
+    applyDefaultSatView();
     const schemaBtn = document.querySelector('.map-view-btn[data-view="schema"]');
     if (schemaBtn) {
       schemaBtn.disabled = true;
@@ -2116,14 +2142,11 @@ async function initMap() {
         modListEl.appendChild(li);
       });
 
-    // Fit map to plotted pins
-    const pinBounds = L.latLngBounds(
-      mods.map((mod) => NCZ.cetToLeaflet(mod.coordinates[0], mod.coordinates[1])),
-    );
-    if (pinBounds.isValid()) {
-      map.invalidateSize();
-      map.fitBounds(pinBounds, { padding: [50, 50], maxZoom: 5 });
-    }
+    // (No initial fit-to-pins here.) The 2D map starts hidden under the 3D view;
+    // its visible framing comes from view-sync on a SCHEMA→SAT switch, or from
+    // applyDefaultSatView() on the WebGPU fallback. A fit-to-all-pins default
+    // squashed the city into a corner (badlands outliers stretch the bounds) and
+    // only ever showed on the fallback — superseded by the 3D-equivalent default.
 
     // Deep-link: open pin if ?mod= is in the URL
     const deepLinkParam = new URLSearchParams(window.location.search).get(NCZ.URL_PARAM_MOD);


### PR DESCRIPTION
## Problem

When WebGPU is unavailable, the board falls back to the 2D satellite map ([decision](https://github.com/spuddeh/nc-zoning-board/blob/dev/CLAUDE.md): WebGPU-unavailable → 2D Leaflet). But the fallback opened on a position that "doesn't suit anything" — a zoomed-out fit-to-**all**-pins that pushed the city into a corner (the badlands outliers stretch the bounds).

That fit-to-pins was the old default-position workaround. Now that 2D↔3D view-sync works (#744), the normal flow never shows it — it sets the *hidden* 2D map, then gets overwritten by view-sync on the first SCHEMA→SAT switch. Only the fallback ever displayed it, because `ThreeScene.init()` aborts before the camera exists when the renderer lands on WebGL2, so `getLeafletView()` returns `null` and nothing overrode the bad default.

## Fix

- **Add `applyDefaultSatView()`** — derives the 2D centre+zoom from the E5 intro rest constants (`SCHEMA_INTRO_REST_CENTER`, `SCHEMA_INTRO_REST_DISTANCE`, FOV 25°) through the *same* `cameraExtentToLeafletView` transform a real SCHEMA→SAT switch uses. Called from `forceSatFallback()` once `#map` is laid out.
- **Remove the vestigial `fitBounds(pinBounds)`** initial fit — `pinBounds` is referenced nowhere else, and it was racing with / clobbering the fallback framing.

The fallback now lands exactly where switching to 2D from the default 3D view does.

## Verification (chrome-devtools, `?forcewebgl` test gate)

- WebGPU fallback → city-framed (zoom 4, 500 m scale), bay left, City Center/Westbrook/Santo Domingo in view ✓
- Real SCHEMA→SAT from default 3D → **pixel-identical** framing ✓
- `node --check` clean on `app.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)