### PR TITLE
fix(3d): debug dump reads WebGPU info.memory.programs (dead-write sweep)

### DIFF
--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -2434,7 +2434,9 @@ const ThreeScene = (() => {
       lines:      renderer.info.render.lines,
       geometries: renderer.info.memory.geometries,
       textures:   renderer.info.memory.textures,
-      programs:   renderer.info.programs ? renderer.info.programs.length : 0,
+      // WebGPU tracks compiled pipelines as a count on info.memory.programs;
+      // the WebGL2-era info.programs array doesn't exist on this backend.
+      programs:   renderer.info.memory.programs ?? 0,
     };
   }
 
@@ -2566,9 +2568,9 @@ const ThreeScene = (() => {
         // Indirect-storage-buffer bytes — confirms Phase 2B's draw buffers
         // (5 u32s × 8 districts = 160 bytes minimum) are allocated.
         indirectBufferBytes: renderer.info.memory.indirectStorageAttributesSize ?? 0,
-        // `info.programs` is a WebGL2-only array; WebGPU compiles pipelines
-        // lazily and doesn't expose a comparable count.
-        programs:     renderer.info.programs ? renderer.info.programs.length : null,
+        // WebGPU exposes the compiled-pipeline count at info.memory.programs
+        // (the WebGL2-era info.programs array doesn't exist on this backend).
+        programs:     renderer.info.memory.programs ?? null,
       } : null,
       rendererSettings: renderer ? {
         pixelRatio:     renderer.getPixelRatio(),


### PR DESCRIPTION
## What

The WebGL-era **dead-write sweep** ([project item](https://github.com/users/spuddeh/projects/1/views/10?pane=issue&itemId=201687025)) found one residual stale read in the runtime 3D code: `renderer.info.programs`.

On `WebGPURenderer` the `Info` class carries only `{ autoReset, frame, calls, render, compute, memory }` — there is **no `.programs`** (that array, read via `.length`, is a WebGL2-era idiom). The compiled-pipeline count lives at `info.memory.programs`, a plain number the engine increments/decrements as pipelines are built (three@0.184.0 `three.webgpu.js` ~31516/31532).

Two debug-snapshot sites read the dead path:
- `getRenderInfo()` — silently reported **`0`** (implies zero pipelines)
- copy-debug dump — reported **`null`**, and its comment wrongly claimed *"WebGPU doesn't expose a comparable count"*

Both now read `renderer.info.memory.programs`. Debug-tooling only; no runtime/visual behaviour change.

## Sweep coverage (all clean)

Audited every renderer/texture/light/material property **write** in `assets/js/*.js` against the exact engine build:

- Renderer top-level (`outputColorSpace`, `toneMapping`, `toneMappingExposure`) — live
- No removed props present (`outputEncoding`, `gammaFactor`, `physicallyCorrectLights`, `useLegacyLights`, `logarithmicDepthBuffer`)
- Texture (`format`/`flipY`/`generateMipmaps`/`anisotropy`/`colorSpace`) — consumed
- Light/shadow already modernized last session; `shadow.intensity` verified consumed (engine ~44385)
- No removed geometry/material APIs (`Geometry`, `Face3`, `morphTargets`, `*Encoding` constants, `WebGLRenderTarget`)

Method: read what the engine **consumes**, not what we write (per `webgpu-renderer-shadowmap-flags-inert`).

## Verification

- `node --check` (as ES module) passes
- Engine source confirms `info.memory.programs` exists and is populated

## Remaining for the project item

The docs-reconciliation half (`docs/3dmap-lighting-shadows.md` still documents the WebGL-era scene) is **not** in this PR — separate doc rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)