### PR TITLE
feat(3d): night-time lighting — real moon, day-night cycle, shadow rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reproduces the in-game map's decoded colour pipeline — ACES tonemap, colour grade and the braindance grading LUT — from the game's environment data (#694).
 - **Time-of-day** lighting: the sun slider drives Night City's real (Morro Bay) sun position — spanning summer-solstice sunrise to sunset (the longest day, for the most daylight to play with); midday holds a calibrated brightness while sunrise/sunset stay dim and atmospheric, readable across the whole day (#737).
+- **Night-time** lighting: the time slider now runs a full day–night cycle. As the sun sets, a real moon — on its own lunar arc — lights the city with cool moonlight, with a smooth dusk/dawn transition and a cool night sky. The sun and moon are visible discs that rise and set along their real paths.
 
 #### Shadows
 
 - Real-time sun shadows on terrain, buildings, cliffs and landmarks — including casters just off-screen, so edge-of-view shadows don't pop in (#647, #651).
 - Shadow edges stay put as you pan, rotate and tilt instead of crawling/shimmering (#754).
 - The **Shadows** toggle now fully skips the shadow render when off (a real performance gain, not just hidden shadows), and shadows stop re-rendering on frames that don't change geometry (#751).
+- Shadows now fade out through dusk and are gone at night (moonlight casts none), and the shadow coverage no longer "boxes" or drifts when fully zoomed out.
 
 #### Themes
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -605,6 +605,10 @@ async function initMap() {
   // A reproducible reference frame — same URL always yields the identical
   // lighting state. Debug/calibration only; not linked from the UI.
   const GAMELIGHT = new URLSearchParams(window.location.search).has('gamelight');
+  // ?night — start at the most moonlit hour so the night lighting / moon arc are
+  // immediately visible for calibration (overlays off). Just sets the slider's
+  // initial value; the slider stays fully scrubbable.
+  const NIGHT = new URLSearchParams(window.location.search).has('night');
   function switchView(viewName) {
     if (viewName === "schema" && !threeDAvailable) return;
     document.querySelectorAll(".map-view-btn").forEach(btn => {
@@ -749,9 +753,17 @@ async function initMap() {
     date.setUTCHours((Math.floor(morroMinutes / 60) - PDT_OFFSET) % 24, morroMinutes % 60, 0, 0);
     const pos = SunCalc.getPosition(date, SUN_LAT, SUN_LNG);
     NCZ.ThreeScene.setSunPosition(pos.azimuth, pos.altitude);
+    // The moon on its own real lunar arc (same anchor + date), so scrubbing past
+    // sunset shows a real moon rise/set, not a recoloured sun. Phase brightness
+    // is a tunable constant in the scene (NCZ.MOON_PHASE); here we only supply
+    // the real position. Below-horizon altitudes are fine — the scene gates the
+    // moon key light + disc on altitude.
+    const moon = SunCalc.getMoonPosition(date, SUN_LAT, SUN_LNG);
+    NCZ.ThreeScene.setMoonPosition?.(moon.azimuth, moon.altitude);
     // Time-of-day exposure — floor the dark ends without flattening the natural
-    // day/night variation. Keyed on elevation so the flyover shares it. See
-    // NCZ.SCENE_EXPOSURE_CURVE + NCZ.exposureForSunElevation.
+    // day/night variation. Keyed on elevation so the flyover shares it; the curve
+    // now extends below the horizon for night. See NCZ.SCENE_EXPOSURE_CURVE +
+    // NCZ.exposureForSunElevation.
     NCZ.ThreeScene?.setSceneExposure?.(NCZ.exposureForSunElevation(pos.altitude));
     const h = String(Math.floor(morroMinutes / 60)).padStart(2, '0');
     const m = String(morroMinutes % 60).padStart(2, '0');
@@ -761,21 +773,33 @@ async function initMap() {
   if (sunSlider) {
     sunSlider.addEventListener("input", () => applySunTime(parseInt(sunSlider.value)));
 
-    if (typeof SunCalc !== 'undefined') {
-      // Compute solstice sunrise/sunset in UTC minutes, then convert to Morro Bay PDT
-      const times      = SunCalc.getTimes(SOLSTICE, SUN_LAT, SUN_LNG);
-      const utcToMorro = (date) => ((date.getUTCHours() * 60 + date.getUTCMinutes()) + PDT_OFFSET * 60 + 1440) % 1440;
-      sunSlider.min    = utcToMorro(times.sunrise); // ~353 min = 05:53 PDT
-      sunSlider.max    = utcToMorro(times.sunset);  // ~1216 min = 20:16 PDT
-    } else {
-      sunSlider.min = 353;
-      sunSlider.max = 1216;
+    // Full 24h domain (Morro Bay PDT minutes): the slider now wraps through the
+    // night so the sun sets, the moon rises on its real arc, and night lighting
+    // takes over. (Previously clamped to sunrise→sunset, daytime only.)
+    sunSlider.min = 0;
+    sunSlider.max = 1439;
+
+    // ?night — jump to the most moonlit hour: the dark-sky minute (sun well below
+    // the horizon) where the real moon is highest, so the moon is always visibly
+    // up regardless of the year's lunar geometry. Falls back to ~22:00 PDT.
+    function bestNightMinutes() {
+      if (typeof SunCalc === 'undefined') return 1320;
+      let best = { alt: -Infinity, min: 1320 };
+      const SUN_DARK = -6 * Math.PI / 180;
+      for (let m = 0; m < 1440; m += 5) {
+        const d = new Date(SOLSTICE);
+        d.setUTCHours((Math.floor(m / 60) - PDT_OFFSET + 24) % 24, m % 60, 0, 0);
+        if (SunCalc.getPosition(d, SUN_LAT, SUN_LNG).altitude >= SUN_DARK) continue;
+        const moonAlt = SunCalc.getMoonPosition(d, SUN_LAT, SUN_LNG).altitude;
+        if (moonAlt > best.alt) best = { alt: moonAlt, min: m };
+      }
+      return best.alt > 0 ? best.min : 1320;
     }
 
     // Default: 8:00 AM PDT — sun ~24° elevation from the east. The high-noon
     // default (10am, el 48°) over-lights building tops under the new photometric
     // lighting; a moderate morning sun reads as 3D-massed city without blasting.
-    const DEFAULT_SUN_MINUTES = 480;
+    const DEFAULT_SUN_MINUTES = NIGHT ? bestNightMinutes() : 480;
     sunSlider.value = DEFAULT_SUN_MINUTES;
     applySunTime(DEFAULT_SUN_MINUTES);
   }

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -288,7 +288,7 @@ NCZ.CAMERA_ROTATE_SPEED = 0.6;            // rotateSpeed     (Three.js default: 
 // for now; a CSM revisit is queued — the original "no cascades because schema
 // is ortho" rationale no longer holds since the schema camera moved to perspective
 // (FOV 25°, TweakDB-aligned), see [[align-schematic-camera-to-game]].
-NCZ.SHADOW_MAP_SIZE      = 4096;  // px² — ~3 u/texel at a whole-city zoom; razor-sharp zoomed in (the footprint shrinks with zoom)
+NCZ.SHADOW_MAP_SIZE      = 8192;  // px² — ~1.5 u/texel at a whole-city zoom, razor-sharp zoomed in. Always-on (interactive + showcase): the fine texels keep the showcase's fast sun from shimmering. One fixed size, not resized per-mode (maintainer call).
 NCZ.SHADOW_MAX_DISTANCE  =  8600; // CET units — cap on the footprint half-side. Matches the world half-diagonal (sqrt((WORLD_MAX_X-WORLD_MIN_X)² + (WORLD_MAX_Y-WORLD_MIN_Y)²) / 2 ≈ 8565 wu) with tiny headroom: nothing renders past the world bounds, so a larger cap just stretches texels over empty void. Trace data on PR #656 showed `half` pinned at the cap (12600 = 12000 cap + 600 margin) every showcase frame; reducing the cap shrinks the box uniformly → ~1.4× sharper texels for free at no performance cost.
 NCZ.SHADOW_GROUND_MARGIN =   600; // CET units the footprint extends past the visible ground — covers building heights / terrain relief + a sliver of just-off-screen casters. Wider off-screen-caster coverage waits on the union-frustum cull (a follow-up).
 NCZ.SHADOW_SIZE_QUANTUM  =  1.10; // multiplicative ladder the ortho box half-side snaps UP to, so texel size is piecewise-constant. The texel snap (updateShadowCamera) only cancels swim while texelSize holds frame-to-frame; pan/azimuth already keep `half` constant (sphere fit), but tilt + zoom change it continuously. Quantising holds the box on one rung across a slow tilt, trading continuous edge shimmer for an occasional ~10% resolution step. Smaller (→1.0) = sharper/adaptive but reintroduces swim; larger = more stable but coarser/poppier.
@@ -340,15 +340,22 @@ NCZ.SCENE_EXPOSURE     = 0.720;                     // renderer.toneMappingExpos
 // setSunPosition directly, so it must apply exposure itself.
 //
 // [elevationDeg, exposure], ascending; interpolated piecewise-linear, clamped
-// to the endpoints. Tune the two ends: row 0 = horizon cap (dawn/dusk),
-// last row = midday base.
+// to the endpoints. Tune the two ends: row 0 = deep-night floor, the [0,…] row
+// = horizon cap (dawn/dusk), last row = midday base.
+//
+// Below the horizon (negative elevation) the night lighting takes over — a dim
+// cool moon key + warm skyglow ambient (see MOON_* / AMBIENT_*_NIGHT). Exposure
+// backs OFF from the dawn/dusk peak so the (already much dimmer) night radiance
+// reads dark-but-readable rather than being lifted into a washed-out "day".
 NCZ.SCENE_EXPOSURE_CURVE = [
-  [0,  0.95],  // horizon (sunrise/sunset) — capped lift so it stays atmospheric, not daylight
-  [5,  0.80],
-  [15, 0.58],
-  [30, 0.49],
-  [50, 0.45],  // calibrated midday base — natural variation comes from the sun, not exposure
-  [90, 0.45],
+  [-18, 0.68],  // astronomical night — dark but readable (lifted a touch for moonless-night legibility; calibrate live with ?night)
+  [-6,  0.78],  // civil/nautical twilight transition
+  [0,   0.95],  // horizon (sunrise/sunset) — capped lift so it stays atmospheric, not daylight
+  [5,   0.80],
+  [15,  0.58],
+  [30,  0.49],
+  [50,  0.45],  // calibrated midday base — natural variation comes from the sun, not exposure
+  [90,  0.45],
 ];
 
 // Building edge "glow" — self-lit emissive on the decoded edge highlight, a
@@ -367,6 +374,37 @@ NCZ.SHADOW_INTENSITY   = 0.60;                      // cast-shadow strength when
 NCZ.SUN_DIST           = 22000;  // CET units the sun light (and its shadow camera) sits up the sun ray from the visible-ground centre — only the direction matters for shading; large enough that the whole footprint stays in front of the shadow camera even at a low sun
 NCZ.SUN_SPHERE_DIST    = 20000;  // visible sun disc distance from world centre
 NCZ.SUN_SPHERE_RADIUS  =   600;  // CET units — ≈1.7° apparent diameter at SUN_SPHERE_DIST (≈3× real sun)
+
+// ── Night lighting (Stage 1 — moonlight foundation) ─────────────────────────
+// Day-night runs on TWO permanent directional lights that crossfade by
+// nightFactor (smoothstep on SUN elevation; see NCZ.nightFactorForSunElevation):
+// a warm SUN that casts shadows (its shadow strength fades out as it sets — see
+// SUN_SHADOW_FADE_* below) and a cool MOON that casts NONE. Moonlight shadows are
+// physically imperceptible, and dropping them removes the night/dusk "shadow box"
+// cut-out entirely (no caster ⇒ nothing to clip against the coverage cap). Crisp
+// moon shadows at any zoom would need CSM (queued). castShadow is never toggled on
+// either light (only shadow.intensity is faded) ⇒ no WebGPURenderer teardown crash.
+// All values are first-cut, calibrated live with ?night + overlays off. Colours
+// are linear RGB, matching the SUN/AMBIENT block.
+NCZ.MOON_COLOR_RGB         = [0.62, 0.74, 1.00]; // cool moonlight (linear)
+NCZ.MOON_INTENSITY         = 0.50;               // key intensity at full night & full phase, moon at zenith (vs SUN_INTENSITY 3.0)
+NCZ.MOON_PHASE             = 0.85;               // illuminated fraction 0=new→1=full; tunable (real getMoonIllumination ignored so we never land on a dark new moon). Scales moonlight; disc-phase terminator is a follow-up.
+NCZ.AMBIENT_SKY_RGB_NIGHT  = [0.12, 0.16, 0.28]; // dark blue from above at night
+NCZ.AMBIENT_GROUND_RGB_NIGHT = [0.17, 0.18, 0.22]; // cool near-neutral fill from below — was a warm orange "light-pollution" bounce, but at the high moonless ambient it read sun-warm; deliberate neon/city underglow belongs in the theme-driven Stage 2, not the baseline
+NCZ.AMBIENT_INTENSITY_NIGHT = 0.50;              // night ambient when the MOON IS UP — kept low so directional moonlight dominates
+NCZ.AMBIENT_INTENSITY_NIGHT_MOONLESS = 0.85;     // night ambient when the moon is BELOW the horizon — skyglow/starlight fill so a moonless night stays legible (scaled in by 1−moonAlt; never washes out moonlit nights)
+NCZ.KEY_LIGHT_MIN_DIR_Y    = 0.10;               // floor on the SUN direction's Y (~5.7°) — shadow-camera safety so its lookAt can't degenerate near/below the horizon. Kept at 0.10: a lower floor lets a low sun graze further, lengthening dawn/dusk shadows until they overrun the SHADOW_MAX_DISTANCE coverage cap and cut out. Less critical now that SUN_SHADOW_FADE_* fades low-sun shadows out, but still the degeneracy guard.
+// Sun-shadow strength fades with the sun's real elevation (deg): full at/above
+// FULL, zero at/below OFF. Fades shadows out through dusk and kills them at night
+// (sun below horizon) so there's no caster to clip against the coverage cap.
+NCZ.SUN_SHADOW_FADE_OFF_DEG  =  3;               // sun elevation at/below which cast shadows are fully off
+NCZ.SUN_SHADOW_FADE_FULL_DEG = 12;               // sun elevation at/above which cast shadows are at full strength
+// nightFactor ramp, in SUN-elevation degrees: 0 (full day) at/above DAY, 1 (full
+// night) at/below NIGHT. The ramp band roughly spans civil twilight.
+NCZ.NIGHT_FACTOR_DAY_DEG   =  8;                 // sun elevation at/above which nightFactor = 0
+NCZ.NIGHT_FACTOR_NIGHT_DEG = -4;                 // sun elevation at/below which nightFactor = 1
+NCZ.MOON_SPHERE_RADIUS     = 360;                // visible moon disc — ~0.6× the sun disc (SUN_SPHERE_RADIUS 600); rule-of-cool, not to true scale
+NCZ.MOON_SPHERE_COLOR      = 0xdfe8ff;           // cool-white disc (sRGB hex for MeshBasicNodeMaterial)
 
 // Building instance decode — DDS _data.dds (DXGI_FORMAT_R16G16B16A16_UNORM, DX10 header)
 // Each pixel encodes one building instance across three horizontal blocks: position | rotation | scale.

--- a/assets/js/flyover.js
+++ b/assets/js/flyover.js
@@ -221,8 +221,15 @@ const Flyover = (() => {
     if (!_sunriseMs || !_sunsetMs || !NCZ.ThreeScene?.setSunPosition) return;
     const t = Math.min(1, Math.max(0, audioCurrentTime / FLYOVER_DURATION_S));
     const epochMs = _sunriseMs + (_sunsetMs - _sunriseMs) * t;
-    const pos = SunCalc.getPosition(new Date(epochMs), MORRO_BAY.lat, MORRO_BAY.lng);
+    const when = new Date(epochMs);
+    const pos = SunCalc.getPosition(when, MORRO_BAY.lat, MORRO_BAY.lng);
     NCZ.ThreeScene.setSunPosition(pos.azimuth, pos.altitude);
+    // Drive the moon on its real arc too, so the twilight ends of the showcase
+    // (sunrise/sunset, where nightFactor is high) get the moon in the sky and the
+    // night lighting blend — matching the interactive map. Night lighting itself
+    // is automatic via nightFactor inside setSunPosition.
+    const moon = SunCalc.getMoonPosition(when, MORRO_BAY.lat, MORRO_BAY.lng);
+    NCZ.ThreeScene.setMoonPosition?.(moon.azimuth, moon.altitude);
     // Drive exposure off the same elevation curve as the slider — the flyover
     // animates the sun directly (bypassing applySunTime), so without this the
     // exposure froze at its pre-showcase value and the whole flyover rendered
@@ -552,7 +559,9 @@ const Flyover = (() => {
 
     initFlyoverSun();
     NCZ.ThreeScene.setShadowsEnabled?.(true);    // always on during showcase
-    NCZ.ThreeScene.setSunSphereVisible?.(true);  // show the sun in the sky
+    // Sun/moon discs are auto-shown by elevation (updateKeyLight); the flyover
+    // runs sunrise→sunset, so it opens and closes in twilight/night lighting
+    // with the moon up at the dusk end — no manual disc toggle needed.
     FLYOVER_EVENTS[0]();
     if (_runOpts.revealLayers) scheduleLayerReveal();
     // Create fade overlay, show title card, then fade the scene in from black
@@ -607,7 +616,8 @@ const Flyover = (() => {
       resetFade();
       NCZ.ThreeScene.setControlsEnabled(true);
       NCZ.ThreeScene.startRenderLoop();
-      NCZ.ThreeScene.setSunSphereVisible?.(false);
+      // Sun/moon disc visibility is auto-managed by elevation; the slider restore
+      // below re-applies the pre-showcase sun (and moon), correcting both discs.
 
       // Restore whichever theme the user had before showcase started
       if (_savedTheme) { applyThemeSmooth(_savedTheme); _savedTheme = null; }

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -61,9 +61,12 @@ const ThreeScene = (() => {
   let loadingFillEl  = null;
   let loadStepsTotal = 0;
   let loadStepsDone  = 0;
-  let _dirLight      = null; // the sun (DirectionalLight + single fitted shadow camera)
+  let _dirLight      = null; // the SUN (DirectionalLight + single fitted shadow camera) — the only shadow caster
+  let _moonLight     = null; // the MOON (DirectionalLight, castShadow:false) — cool night fill, no shadows
   let _hemiLight     = null; // sky/ground fill (replaces a flat AmbientLight)
-  let _sunDir        = SUN_DIR.clone(); // unit, ground→sun; updated by setSunPosition, consumed by updateShadowCamera
+  let _sunDir        = SUN_DIR.clone(); // unit, ground→sun; updated by updateDayNightLighting, consumed by updateShadowCamera
+  let _moonDir       = new THREE.Vector3(); // unit, ground→moon; scratch for the moon light direction
+  let _sunShadowFade = 1;    // 0..1 shadow strength by sun elevation — fades shadows out as the sun sets (night/dusk ⇒ no caster ⇒ no shadow box)
   let _shadowScratchV = new THREE.Vector3();     // reused by updateShadowCamera so it doesn't allocate per camera move
   // Light-space basis + up vector for the shadow texel-snap (see updateShadowCamera).
   // _SHADOW_UP matches Three's default OrthographicCamera up, so the basis we build
@@ -155,8 +158,11 @@ const ThreeScene = (() => {
   // the constant; the Shadows overlay multiplies by this when enabled, by 0 when
   // off (so the tuned strength survives a Shadows toggle).
   let _shadowIntensity = NCZ.SHADOW_INTENSITY;
-  let _sunSphere     = null; // visible sun disc — shown during showcase only
+  let _sunSphere     = null; // visible sun disc — always present, traces the real solar arc (positionSkyBody); terrain occludes it at the horizon
+  let _moonSphere    = null; // visible moon disc — always present, traces the real lunar arc (incl. daytime); terrain occludes it at the horizon
   let _sunAz = Math.PI * 0.25, _sunEl = Math.PI * 0.35; // last *requested* setSunPosition args — placeholders only until the first call (the slider init in app.js), which may land before the lights exist
+  let _moonAz = 0, _moonEl = -Math.PI * 0.25; // last *requested* setMoonPosition args — seeded below the horizon so the moon is absent until app.js drives it
+  let _nightFactor = 0; // 0 = full day, 1 = full night; derived from sun elevation in updateDayNightLighting, read by getNightFactor (and later stages)
   let _terrainBox = null;     // THREE.Box3 of the terrain GLB; gates pan-bound clamp
                               // because the bound shouldn't activate before terrain loads
   let _introTween   = null;   // E5 intro fly-in tween, or null when idle
@@ -797,6 +803,20 @@ const ThreeScene = (() => {
     scene.add(_dirLight);
     scene.add(_dirLight.target);
 
+    // Moon light — a SECOND permanent directional light (cool), no shadows. The
+    // sun above is the only shadow caster; the moon just adds soft cool fill at
+    // night (intensity driven in updateDayNightLighting). castShadow:false is set
+    // once and never toggled — safe under WebGPURenderer. Direction comes from the
+    // real lunar arc; target sits at the world centre so only direction matters.
+    _moonLight = new THREE.DirectionalLight(0xffffff, 0);
+    _moonLight.color.setRGB(...NCZ.MOON_COLOR_RGB, THREE.LinearSRGBColorSpace);
+    _moonLight.castShadow = false;
+    _moonLight.name = 'moon';
+    _moonLight.target.name = 'moon-target';
+    _moonLight.target.position.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
+    scene.add(_moonLight);
+    scene.add(_moonLight.target);
+
     // Hemisphere ambient — the decoded envparam ambient cube collapses to a
     // hemisphere: 5 bright cool-white faces (sky + sides) over 1 dim blue face
     // (ground). Fixed colour + intensity, matching the game's fixed environment.
@@ -807,15 +827,28 @@ const ThreeScene = (() => {
     scene.add(_hemiLight);
     // Sun position is applied by app.js via the slider once terrain has loaded.
 
-    // Visible sun sphere — hidden by default, shown during showcase only.
+    // Visible sun sphere — always present, traces the real solar arc (map AND
+    // showcase use the same path). Seeded hidden for the one frame before the
+    // first applySunTime positions it; updateDayNightLighting then keeps it shown.
     // Radius NCZ.SUN_SPHERE_RADIUS units at NCZ.SUN_SPHERE_DIST distance ≈ 1.7° apparent diameter (≈3× real sun).
     _sunSphere = new THREE.Mesh(
       new THREE.SphereGeometry(NCZ.SUN_SPHERE_RADIUS, 16, 16),
-      new THREE.MeshBasicNodeMaterial({ color: 0xffcc44 })
+      new THREE.MeshBasicNodeMaterial({ color: 0xffcc44 })  // opaque — depth-tested so terrain at the horizon occludes it (the disc sets behind ridgelines)
     );
     _sunSphere.name = 'sun-sphere';
     _sunSphere.visible = false;
     scene.add(_sunSphere);
+
+    // Visible moon disc — always present, traces the real lunar arc (incl. daytime,
+    // same path as the sun disc). Flat cool-white sphere reads as a full moon at
+    // the default ~full phase; a phase terminator is a follow-up.
+    _moonSphere = new THREE.Mesh(
+      new THREE.SphereGeometry(NCZ.MOON_SPHERE_RADIUS, 16, 16),
+      new THREE.MeshBasicNodeMaterial({ color: NCZ.MOON_SPHERE_COLOR })  // opaque — depth-tested so terrain at the horizon occludes it (the disc sets behind ridgelines)
+    );
+    _moonSphere.name = 'moon-sphere';
+    _moonSphere.visible = false;
+    scene.add(_moonSphere);
 
     // OrbitControls — left=pan, right=tilt, middle=zoom.
     //
@@ -3111,42 +3144,109 @@ const ThreeScene = (() => {
     _sunAz = azimuthRad;
     _sunEl = altitudeRad;
     if (!_dirLight || !_hemiLight) return;
-    const el = altitudeRad;
-    const az = azimuthRad;
-
-    // Sun direction (unit, ground→sun). Floor the Y at ~6° elevation so the
-    // shadow camera's lookAt never goes degenerate-horizontal; the visible sun
-    // sphere below uses the *unclamped* elevation so it still sets at the horizon.
-    _sunDir.set(-Math.cos(el) * Math.sin(az), Math.max(0.1, Math.sin(el)), Math.cos(el) * Math.cos(az)).normalize();
-    // Re-orient the light around its current target (updateShadowCamera owns the
-    // target = visible-ground centre; here we just keep the light up the sun ray
-    // from it). Orthographic ⇒ only the direction matters for shading.
-    _dirLight.position.copy(_dirLight.target.position).addScaledVector(_sunDir, NCZ.SUN_DIST);
-    flagShadowUpdate();   // sun moved ⇒ re-render the shadow depth map next frame (no-op while shadows off)
-
-    // Sun + ambient colour and intensity are fixed (calibrated to 3dmap.envparam,
-    // set once at light construction) — the in-game map has no time-of-day
-    // variation. The slider only moves the sun's direction, above.
-
-    // Move the visible sun sphere (shown during showcase only).
-    // Centred on Night City (WORLD_CX, 0, -WORLD_CY) so it hangs over the map.
-    if (_sunSphere) {
-      const SUN_SPHERE_DIST = NCZ.SUN_SPHERE_DIST;
-      const nx = -Math.cos(el) * Math.sin(az);
-      const ny =  Math.sin(el); // unclamped — terrain naturally occludes it at sunrise/sunset
-      const nz =  Math.cos(el) * Math.cos(az);
-      _sunSphere.position.set(
-        NCZ.WORLD_CX + nx * SUN_SPHERE_DIST,
-        ny * SUN_SPHERE_DIST,
-        -NCZ.WORLD_CY + nz * SUN_SPHERE_DIST,
-      );
-    }
+    // Move the visible sun sphere (showcase-only). Unclamped elevation so it
+    // sets at the horizon naturally. Centred on Night City so it hangs over the map.
+    if (_sunSphere) positionSkyBody(_sunSphere, azimuthRad, altitudeRad, NCZ.SUN_SPHERE_DIST);
+    updateDayNightLighting();
     requestRender();
   }
 
-  function setSunSphereVisible(visible) {
-    if (_sunSphere) _sunSphere.visible = visible;
+  // Night moon — its own real arc (SunCalc.getMoonPosition, driven from app.js).
+  // Same azimuth/elevation convention as setSunPosition.
+  function setMoonPosition(azimuthRad, altitudeRad) {
+    _moonAz = azimuthRad;
+    _moonEl = altitudeRad;
+    if (!_dirLight || !_moonLight || !_hemiLight) return;
+    if (_moonSphere) positionSkyBody(_moonSphere, azimuthRad, altitudeRad, NCZ.SUN_SPHERE_DIST);
+    updateDayNightLighting();
     requestRender();
+  }
+
+  // Position a sky-body mesh (sun/moon disc) on the sky shell over Night City,
+  // using the UNCLAMPED elevation so it rises/sets at the horizon.
+  function positionSkyBody(mesh, az, el, dist) {
+    mesh.position.set(
+      NCZ.WORLD_CX + (-Math.cos(el) * Math.sin(az)) * dist,
+       Math.sin(el) * dist,
+      -NCZ.WORLD_CY + ( Math.cos(el) * Math.cos(az)) * dist,
+    );
+  }
+
+  // Apply the effective sun-shadow strength: the user's Shadows toggle (_shadowsOn)
+  // gates it on/off; _sunShadowFade fades it with the sun's elevation. Changing
+  // shadow.intensity is a uniform tweak (no depth re-render needed).
+  function applyShadowIntensity() {
+    if (_dirLight) _dirLight.shadow.intensity = _shadowsOn ? _shadowIntensity * _sunShadowFade : 0;
+  }
+
+  // Day-night lighting. TWO permanent directional lights, each driven by its own
+  // real body — no morphing, no slerp, just a crossfade:
+  //   • SUN  — warm, casts shadows. castShadow stays ON permanently (never toggled
+  //     ⇒ no WebGPU depth-texture teardown crash); its shadow STRENGTH fades out
+  //     with elevation (_sunShadowFade). Intensity fades to 0 by nightFactor.
+  //   • MOON — cool, casts NO shadows; intensity by its own altitude × phase × nf.
+  // Net: night is soft moonlight + ambient with NO cast shadows. That's both
+  // physically right (moonlight shadows are imperceptible) and removes the shadow-
+  // box artifact at night/dusk — a low/absent caster has nothing to clip against
+  // the SHADOW_MAX_DISTANCE coverage cap. At nightFactor==0 (sun up) this is
+  // byte-identical to the original daytime lighting (sun = SUN_INTENSITY, moon 0).
+  // Called whenever the sun OR moon moves.
+  function updateDayNightLighting() {
+    if (!_dirLight || !_moonLight || !_hemiLight) return;
+    const nf = _nightFactor = NCZ.nightFactorForSunElevation(_sunEl);
+    const lerp = (a, b, t) => a + (b - a) * t;
+    const smooth = (e0, e1, x) => { const t = Math.min(1, Math.max(0, (x - e0) / (e1 - e0))); return t * t * (3 - 2 * t); };
+
+    // ── Sun (the shadow caster) ── real direction, Y floored for shadow-camera
+    // safety; warm colour was set once at init. Intensity fades out by nightFactor.
+    _sunDir.set(-Math.cos(_sunEl) * Math.sin(_sunAz), Math.max(NCZ.KEY_LIGHT_MIN_DIR_Y, Math.sin(_sunEl)), Math.cos(_sunEl) * Math.cos(_sunAz)).normalize();
+    _dirLight.position.copy(_dirLight.target.position).addScaledVector(_sunDir, NCZ.SUN_DIST);
+    _dirLight.intensity = NCZ.SUN_INTENSITY * (1 - nf);
+
+    // Shadow strength fades with the sun's real elevation: full when high, gone by
+    // the time it nears the horizon — so dusk softens shadows out and night (sun
+    // below horizon) has none. No caster ⇒ no shadow-box cut-out.
+    _sunShadowFade = smooth(NCZ.SUN_SHADOW_FADE_OFF_DEG, NCZ.SUN_SHADOW_FADE_FULL_DEG, _sunEl * 180 / Math.PI);
+    applyShadowIntensity();
+
+    // ── Moon (no shadows) ── real direction; cool colour set once at init.
+    // Intensity gated by the moon's own altitude (0 below the horizon ⇒ a moonless
+    // night is just ambient) and by nightFactor (off during the day).
+    const moonUp = Math.max(0, Math.min(1, Math.sin(_moonEl) / Math.sin(10 * Math.PI / 180)));
+    _moonDir.set(-Math.cos(_moonEl) * Math.sin(_moonAz), Math.sin(_moonEl), Math.cos(_moonEl) * Math.cos(_moonAz)).normalize();
+    _moonLight.position.copy(_moonLight.target.position).addScaledVector(_moonDir, NCZ.SUN_DIST);
+    _moonLight.intensity = NCZ.MOON_INTENSITY * NCZ.MOON_PHASE * moonUp * nf;
+
+    // ── Ambient ── day sky/ground cube → night skyglow cube by nightFactor.
+    _hemiLight.color.setRGB(
+      lerp(NCZ.AMBIENT_SKY_RGB[0], NCZ.AMBIENT_SKY_RGB_NIGHT[0], nf),
+      lerp(NCZ.AMBIENT_SKY_RGB[1], NCZ.AMBIENT_SKY_RGB_NIGHT[1], nf),
+      lerp(NCZ.AMBIENT_SKY_RGB[2], NCZ.AMBIENT_SKY_RGB_NIGHT[2], nf),
+      THREE.LinearSRGBColorSpace,
+    );
+    _hemiLight.groundColor.setRGB(
+      lerp(NCZ.AMBIENT_GROUND_RGB[0], NCZ.AMBIENT_GROUND_RGB_NIGHT[0], nf),
+      lerp(NCZ.AMBIENT_GROUND_RGB[1], NCZ.AMBIENT_GROUND_RGB_NIGHT[1], nf),
+      lerp(NCZ.AMBIENT_GROUND_RGB[2], NCZ.AMBIENT_GROUND_RGB_NIGHT[2], nf),
+      THREE.LinearSRGBColorSpace,
+    );
+    // Night ambient intensity: base when the moon is up (let moonlight dominate),
+    // boosted toward the moonless level as the moon sets — so a moonless deep
+    // night stays legible without washing out the moonlit hours (both are nf==1).
+    const nightAmbient = lerp(NCZ.AMBIENT_INTENSITY_NIGHT_MOONLESS, NCZ.AMBIENT_INTENSITY_NIGHT, moonUp);
+    _hemiLight.intensity = lerp(NCZ.AMBIENT_INTENSITY, nightAmbient, nf);
+
+    // Sky discs trace their full real arcs (positionSkyBody already uses the true
+    // unclamped elevation, so they descend below the horizon as the body sets).
+    // No visibility gate or opacity fade — celestial bodies don't blink out; they
+    // follow a continuous path. Below the horizon the disc is simply below the
+    // ground plane and naturally out of a top-down view.
+    if (_sunSphere)  _sunSphere.visible  = true;
+    if (_moonSphere) _moonSphere.visible = true;
+
+    // Re-render the shadow depth map only when the sun actually casts (fade > 0);
+    // at night the faded-out sun isn't worth a depth pass.
+    if (_sunShadowFade > 0) flagShadowUpdate();
   }
 
   // Re-fit the single shadow camera (the OrthographicCamera that renders the
@@ -3171,24 +3271,37 @@ const ThreeScene = (() => {
     // controls constrain tilt below horizontal, so corners always hit ground at
     // reasonable distances. This is the "shadows look good on schema map" path.
     //
-    // Showcase fly cam (cinematic perspective, often near-horizontal):
-    // fixed-size box centred where the camera's forward ray meets the
-    // ground. Half-side is the cap (`SHADOW_MAX_DISTANCE + GROUND_MARGIN`),
-    // size never changes per frame. Box translates smoothly with the
-    // cinematic camera — no per-frame size discontinuities, no visible
-    // "shadow box pop" at camera-tilt transitions. Coarser texels than the
-    // schema cam, but cinematic motion masks that and consistency matters
-    // more than peak sharpness here. (Trace analysis on this branch showed
-    // rect-fit on the fly cam produced 11000-wu single-frame `half` jumps
-    // at every WP that crossed the horizon line, regardless of maxT
-    // clamping — see shadow_trace_2.json analysis.)
+    // Showcase fly cam (cinematic perspective, often near-horizontal) AND the
+    // schema cam when zoomed out past the cap: a WORLD-LOCKED cap-sized box (half =
+    // `SHADOW_MAX_DISTANCE + GROUND_MARGIN`) centred on the world. Since that box
+    // already spans the whole ~12 km world, there's no texel-density gain from
+    // following the camera — and a camera-following centre clamps toward a world
+    // edge (leaving the far side unshadowed) and crawls. World-locking gives full
+    // coverage and a static centre every frame; only the moving-sun crawl remains,
+    // masked by the wider showcase PCF blur (`SHADOW_RADIUS_SHOWCASE`). Coarser
+    // texels than the tight schema fit, but cinematic motion masks that.
+    // (History: the fly cam previously used a forward-ray-to-ground + tHit-cap
+    // fit to avoid the "shadow box pop" rect-fit caused at horizon-crossing
+    // waypoints — see shadow_trace_2/3.json; world-locking subsumes that.)
     let half, center;
     let rectValid = false;
     if (renderCam === camera && controls) {
       _computeVisibleGroundSphere(renderCam);
       rectValid = _groundSphereValid;
-      if (rectValid) {
-        half = Math.min(_groundSphereRadius, NCZ.SHADOW_MAX_DISTANCE) + NCZ.SHADOW_GROUND_MARGIN;
+      if (rectValid && _groundSphereRadius > NCZ.SHADOW_MAX_DISTANCE) {
+        // View is larger than the shadow map can cover (zoomed out). Capping a box
+        // centred on the visible footprint turns it into a camera-tracking slice
+        // that leaves the rest of the world unshadowed — the "moving shadow box":
+        // the footprint centroid even clamps to a world corner at extreme tilt.
+        // Instead, cover the WHOLE WORLD from its centre. The world half-diagonal
+        // (~8564 wu) is ≤ cap+margin, so a cap-sized box centred here reaches every
+        // corner, and a fixed centre means it no longer tracks the camera.
+        half = NCZ.SHADOW_MAX_DISTANCE + NCZ.SHADOW_GROUND_MARGIN;
+        center = _shadowScratchV.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
+      } else if (rectValid) {
+        // View fits inside the cap (zoomed in): tight camera-fit, sharp + tracks
+        // exactly what you see.
+        half = _groundSphereRadius + NCZ.SHADOW_GROUND_MARGIN;
         center = _shadowScratchV.copy(_groundSphereCenter);
       } else {
         // Degenerate (shouldn't happen for the schema cam given controls.maxPolarAngle,
@@ -3197,27 +3310,16 @@ const ThreeScene = (() => {
         center = _shadowScratchV.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
       }
     } else {
-      // External cam (showcase fly cam) — fixed-size box, ray-to-ground centre,
-      // with tHit capped. Without the cap, a camera looking near-horizontal
-      // (dy just below -1e-4, e.g. -0.003) produces tHit ≈ cam.y / |dy| = tens
-      // of thousands of wu, sending the box centre far outside the world and
-      // making shadows vanish (trace shadow_trace_3.json: M#2 had centre at
-      // [-14213, -81284] when cam was at +617). Cap keeps the centre within
-      // a reasonable distance in the camera-forward direction; for cameras
-      // looking up or horizontal (dy >= threshold) we project the same cap
-      // distance forward so the centre stays near what's framed.
+      // External cam (showcase fly cam) — world-locked box, same as the schema
+      // zoomed-out case above. The box is already cap-sized (half ≈ 9200 wu),
+      // which spans the whole ~12 km world, so centring it on the camera buys no
+      // texel-density gain — it only risks clamping toward a world edge (leaving
+      // the far side unshadowed) and crawling as the cam moves. World-locking
+      // gives full coverage every frame and a static centre (only the moving-sun
+      // crawl remains, masked by SHADOW_RADIUS_SHOWCASE). This replaces the old
+      // forward-ray-to-ground + tHit-cap fit, now redundant.
       half = NCZ.SHADOW_MAX_DISTANCE + NCZ.SHADOW_GROUND_MARGIN;
-      const dir = _shadowScratchV.set(0, 0, -1).applyQuaternion(renderCam.quaternion);
-      const dy  = dir.y;
-      const MAX_T_HIT = NCZ.SHADOW_MAX_DISTANCE * 0.6;   // ≈ 7200 wu — covers world half-diagonal (~8.5km) without ballooning
-      const tHit = (dy < -1e-4)
-        ? Math.min(-renderCam.position.y / dy, MAX_T_HIT) // ground in front — clamp far hits
-        : MAX_T_HIT;                                       // looking up / horizontal — project forward by cap
-      center = _shadowScratchV.set(
-        renderCam.position.x + dir.x * tHit,
-        0,
-        renderCam.position.z + dir.z * tHit,
-      );
+      center = _shadowScratchV.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
     }
     // Clamp the centre to world bounds. The scene is finite (~12km × 12km);
     // nothing is rendered outside it, so a centre past the world edge wastes
@@ -3339,7 +3441,7 @@ const ThreeScene = (() => {
     // correct immediately, and updateShadowFrustumUniforms poisons the cull's shadow
     // frustum so off-screen casters stop being drawn into the main pass.
     if (_dirLight) {
-      _dirLight.shadow.intensity = enabled ? _shadowIntensity : 0;
+      applyShadowIntensity();   // enabled ? _shadowIntensity × _sunShadowFade : 0
       if (!enabled) _dirLight.shadow.needsUpdate = false;  // drop any pending re-render so the pass truly stops
     }
     if (enabled && renderer) {
@@ -3352,6 +3454,9 @@ const ThreeScene = (() => {
 
   function getShadowsEnabled() { return _shadowsOn; }
   function getSunElevation() { return _sunEl; }
+  // 0 = full day, 1 = full night (smoothstep on sun elevation). Read by later
+  // stages (district glow, lit windows, bloom) so they share one night ramp.
+  function getNightFactor() { return _nightFactor; }
 
   // Exposure setter — driven by the time-of-day curve (applySunTime /
   // updateFlyoverSun) and the metering harness.
@@ -3502,7 +3607,7 @@ const ThreeScene = (() => {
     requestRender();
   }
 
-  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, setSceneExposure, getLightingState, getSunElevation, setGradeEnabled, getGradeEnabled, setEdgeGlowEnabled, getEdgeGlowEnabled, setSunSphereVisible, getShadowSnapshot, getCameraState, setCameraState, isInitialized, getLeafletView, frameLeafletView, getSceneColorVars, getRenderInfo, getCullCounts, setOverrideMaterial, dumpDebugInfo, isWebGPUActive };
+  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setMoonPosition, setShadowsEnabled, getShadowsEnabled, setSceneExposure, getLightingState, getSunElevation, getNightFactor, setGradeEnabled, getGradeEnabled, setEdgeGlowEnabled, getEdgeGlowEnabled, getShadowSnapshot, getCameraState, setCameraState, isInitialized, getLeafletView, frameLeafletView, getSceneColorVars, getRenderInfo, getCullCounts, setOverrideMaterial, dumpDebugInfo, isWebGPUActive };
 })();
 
 window.NCZ.ThreeScene = ThreeScene;

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -115,6 +115,24 @@ NCZ.exposureForSunElevation = function (elevationRad) {
 };
 
 /**
+ * Night blend factor [0..1] for a given SUN elevation: 0 = full day, 1 = full
+ * night. Smoothstep ramp between NCZ.NIGHT_FACTOR_DAY_DEG (→0) and
+ * NCZ.NIGHT_FACTOR_NIGHT_DEG (→1) — roughly civil twilight. The single source of
+ * truth for "how night is it"; drives the sun→moon key-light morph, the ambient
+ * day→night lerp, and (later stages) emissive neon ramps. Keyed on elevation
+ * (not clock time) so the slider and the flyover share it, exactly like
+ * NCZ.exposureForSunElevation above.
+ * @param {number} elevationRad sun elevation above the horizon, in radians
+ */
+NCZ.nightFactorForSunElevation = function (elevationRad) {
+  const deg = elevationRad * 180 / Math.PI;
+  const day = NCZ.NIGHT_FACTOR_DAY_DEG, night = NCZ.NIGHT_FACTOR_NIGHT_DEG;
+  // Normalise so t=0 at the DAY edge and t=1 at the NIGHT edge (day > night).
+  const t = Math.min(1, Math.max(0, (day - deg) / (day - night)));
+  return t * t * (3 - 2 * t); // smoothstep
+};
+
+/**
  * Chooses an anchor side and calculates a clamped box position + arrow anchor.
  * Consumers apply the returned values to their own DOM elements/styles.
  */

--- a/docs/3d-map-lighting.md
+++ b/docs/3d-map-lighting.md
@@ -40,17 +40,39 @@ writes a normal). We reproduce the same chain.
 
 ## Lighting — `three-scene.js`
 
-Decoded from `3dmap.envparam`:
+The **daytime** base is decoded from `3dmap.envparam`:
 
 - **Sun** — `DirectionalLight`, colour `(0.975, 0.869, 0.774)` (warm white,
-  linear), a fixed low south-west direction (azimuth 107°, elevation 7°). The
-  time-of-day slider moves only the *direction*; the colour is fixed — the
-  in-game map has no time-of-day variation.
+  linear). Its direction follows real SunCalc data (the time-of-day slider /
+  showcase sweep it); the decoded colour/intensity are the daytime values.
 - **Ambient** — `HemisphereLight`: sky `(0.796, 0.895, 1.0)`, ground
   `(0.566, 0.766, 1.0)` — the decoded 6-direction ambient cube collapsed to a
   hemisphere (bright cool dome, dim blue floor).
 - Cast shadows are an intentional artistic layer; the in-game map's own
   shadows are subtle.
+
+### Night-time lighting (moon + `nightFactor`)
+
+A full day–night cycle is layered on the decoded daytime base, driven by one
+control — `nightFactor`, a `smoothstep` over the sun's elevation (0 by day, 1 at
+night; `NCZ.nightFactorForSunElevation`). At `nightFactor == 0` the scene is
+byte-identical to the calibrated daytime above.
+
+- **Sun** intensity fades to 0 as `nightFactor`→1; its colour stays the decoded warm.
+- **Moon** — a second `DirectionalLight` (cool, `MOON_COLOR_RGB (0.62, 0.74, 1.0)`),
+  positioned from real `SunCalc.getMoonPosition` (the lunar arc). It casts **no**
+  shadows. Intensity = `MOON_INTENSITY × MOON_PHASE × moon-altitude-gate × nightFactor`.
+  `MOON_PHASE` is a tunable constant (default ~full) so a new-moon date can't leave the
+  night dark — the *arc* is real, the *phase brightness* is a rule-of-cool choice.
+- **Ambient** lerps from the day cube to a cool **night skyglow** cube; when the moon
+  is below the horizon it boosts toward `AMBIENT_INTENSITY_NIGHT_MOONLESS` so a moonless
+  deep night stays legible without washing out moonlit nights.
+- **Visible discs** — the sun and moon are drawn as orbs (`MeshBasicNodeMaterial`)
+  tracing their true arcs; terrain depth-occludes them at the horizon. The moon disc is
+  ~0.6× the sun disc.
+
+See `docs/3dmap-lighting-shadows.md` for the light/shadow plumbing (the two-light model,
+sun-only fading shadows, the shared `updateDayNightLighting`).
 
 ## Tonemap — `aces-tonemap.js`
 
@@ -136,8 +158,9 @@ low sun stays atmospheric without going unusably black.
 > floor model replaced it.
 
 The curve is `[elevationDeg, exposure]` rows, interpolated piecewise-linearly and
-clamped to the endpoints. Tune the two ends: the first row is the horizon cap
-(sunrise/sunset), the last is the midday base. Because it's keyed on elevation,
+clamped to the endpoints. It now extends into **negative** elevations for the
+night side (a darker floor below the horizon), so the same lookup carries the full
+day→dusk→night→dawn cycle alongside `nightFactor` (above). Because it's keyed on elevation,
 **both** the time-of-day slider (`applySunTime`) and the showcase flyover
 (`updateFlyoverSun`) drive it through the same function,
 `NCZ.exposureForSunElevation` (in `utils.js`) — the flyover animates the sun

--- a/docs/3dmap-lighting-shadows.md
+++ b/docs/3dmap-lighting-shadows.md
@@ -10,48 +10,64 @@ Reference for the sun/shadow/lighting system in the Three.js schematic view.
 
 ---
 
-## Sun and Ambient Light
+## Day–night lighting model
 
-Lighting is calibrated to the in-game 3D map's environment file
-(`base/weather/24h_basic/3dmap.envparam`), which lights the world map with a fixed
-low sun + a 6-direction ambient cube through an ACES tonemap. We reproduce that with
-**one `DirectionalLight` (sun) + one `HemisphereLight` (ambient)**, both at fixed,
-calibrated colour and intensity — the in-game map has no time-of-day variation.
+The daytime base is calibrated to the in-game 3D map's environment file
+(`base/weather/24h_basic/3dmap.envparam`) — a low sun + a 6-direction ambient cube
+through an ACES tonemap. Layered on top is a full **day–night cycle** driven by one
+control, `nightFactor` (a `smoothstep` over the sun's elevation: 0 by day, 1 at
+night; `NCZ.nightFactorForSunElevation`). At `nightFactor == 0` the scene is
+byte-identical to the original calibrated daytime.
+
+**Three lights — two celestial, one ambient:**
 
 ```javascript
-// Sun — warm white, fixed intensity (envparam LightAreaSettings.sunColor)
-_dirLight = new THREE.DirectionalLight(0xffffff, NCZ.SUN_INTENSITY); // 3.00
-_dirLight.color.setRGB(...NCZ.SUN_COLOR_RGB, THREE.LinearSRGBColorSpace); // [0.975, 0.869, 0.774]
+// SUN — warm, casts shadows. Intensity fades out with nightFactor.
+_dirLight  = new THREE.DirectionalLight(0xffffff, NCZ.SUN_INTENSITY);   // 3.00 by day → 0 at night
+_dirLight.color.setRGB(...NCZ.SUN_COLOR_RGB, THREE.LinearSRGBColorSpace);  // [0.975, 0.869, 0.774]
 
-// Ambient — the envparam ambient cube collapses to a hemisphere:
-// 5 bright cool-white faces (sky+sides) over 1 dim blue face (ground)
-_hemiLight = new THREE.HemisphereLight(0xffffff, 0xffffff, NCZ.AMBIENT_INTENSITY); // 0.405
-_hemiLight.color.setRGB(...NCZ.AMBIENT_SKY_RGB, THREE.LinearSRGBColorSpace);    // [0.796, 0.895, 1.0]
-_hemiLight.groundColor.setRGB(...NCZ.AMBIENT_GROUND_RGB, THREE.LinearSRGBColorSpace); // [0.566, 0.766, 1.0]
+// MOON — cool, casts NO shadows (castShadow stays false, set once). Real lunar arc.
+_moonLight = new THREE.DirectionalLight(0xffffff, 0);                    // → MOON_INTENSITY × phase × altitude × nightFactor
+_moonLight.color.setRGB(...NCZ.MOON_COLOR_RGB, THREE.LinearSRGBColorSpace); // [0.62, 0.74, 1.0]
+
+// AMBIENT — hemisphere; day cube ⇄ night skyglow cube by nightFactor.
+_hemiLight = new THREE.HemisphereLight(0xffffff, 0xffffff, NCZ.AMBIENT_INTENSITY); // 0.405 day
 ```
 
-Sun : ambient ≈ 7.4 : 1 (envelope-fit). Cast shadows are layered on top as an
-intentional artistic choice — the in-game map has them disabled.
+Both bodies are positioned from **real ephemeris** (SunCalc, at the Morro Bay anchor
+on the June solstice): the sun via `getPosition`, the moon via `getMoonPosition`. The
+moon's brightness uses a tunable phase constant (`NCZ.MOON_PHASE`, default ~full) so a
+new-moon date can't leave the night dark. As `nightFactor`→1 the warm sun crossfades
+out and the cool moon (gated by its own altitude) crossfades in; the ambient lerps to a
+cool night skyglow, boosted toward `AMBIENT_INTENSITY_NIGHT_MOONLESS` as the moon sets
+so a moonless deep night stays legible. See `docs/3d-map-lighting.md` for the full
+colour/exposure model.
 
-### Updating sun position
+> **Shadows belong to the sun.** Only `_dirLight` casts; the moon never does
+> (moonlight shadows are physically imperceptible, and a moon caster would re-introduce
+> the shadow-box artifact at night). Shadow *strength* also fades with the sun's
+> elevation (`SUN_SHADOW_FADE_*`), so dusk softens shadows out and night has none.
 
-`NCZ.ThreeScene.setSunPosition(azimuthRad, altitudeRad)` moves **only the sun's
-direction** — colour and intensity are fixed at construction. The slider/showcase
-sweep the direction so shadows move and faces relight; the look stays calibrated.
+### Updating sun / moon position
 
-It:
+`NCZ.ThreeScene.setSunPosition(az, alt)` and `setMoonPosition(az, alt)` store the
+body's az/el (`_sunAz/_sunEl`, `_moonAz/_moonEl`), move that body's visible disc, then
+call the shared **`updateDayNightLighting()`** which recomputes everything from
+`nightFactor`: both light directions/colours/intensities, the ambient lerp, and the
+sun-shadow fade. `setSunPosition` stores its az/el **before** the lights-exist guard
+(so an early pre-`init()` call still propagates to the UI-sync poll — PR #733).
 
-- Stores the requested az/el in `_sunAz` / `_sunEl` **before** the lights-exist guard
-  (so an early call before `init()` still propagates to the UI-sync poll — see
-  PR #733, the cold-load sun-init race)
-- Recomputes `_sunDir` and re-places the light `SUN_DIST` up the sun ray from the
-  shadow camera's target (orthographic ⇒ only direction matters for shading)
-- **Floors the sun direction's Y at ~6° elevation** (`Math.max(0.1, sin(el))`) so the
-  shadow camera's `lookAt` never goes degenerate-horizontal. The visible sun *sphere*
-  (showcase only) uses the unclamped elevation so it still sets at the horizon.
-- Calls `flagShadowUpdate()` (sun moved ⇒ re-render the depth map next frame)
+- The **sun** drives the shadow camera. `_sunDir`'s Y is floored at
+  `NCZ.KEY_LIGHT_MIN_DIR_Y` (~5.7°) so the shadow camera's `lookAt` can't go
+  degenerate near the horizon.
+- The **visible discs** use the *unclamped* elevation (`positionSkyBody`) so they
+  trace their true arcs — they're not gated on/off; terrain depth-occludes them at the
+  horizon (they crest ridgelines naturally). Over open sea, with no terrain, a low disc
+  simply hovers (accepted — no horizon to set behind).
+- `flagShadowUpdate()` fires only when the sun actually casts (`_sunShadowFade > 0`).
 
-The showcase flyover drives `setSunPosition()` automatically during its animation.
+The showcase flyover drives **both** `setSunPosition()` and `setMoonPosition()` each
+frame from the same SunCalc data — so the map and showcase share one path.
 
 ---
 
@@ -65,7 +81,7 @@ renderer.shadowMap.enabled = true;
 renderer.shadowMap.type    = THREE.PCFSoftShadowMap;
 
 _dirLight.castShadow         = true;
-_dirLight.shadow.mapSize.set(NCZ.SHADOW_MAP_SIZE, NCZ.SHADOW_MAP_SIZE); // 4096²
+_dirLight.shadow.mapSize.set(NCZ.SHADOW_MAP_SIZE, NCZ.SHADOW_MAP_SIZE); // 8192²
 _dirLight.shadow.camera.near = NCZ.SHADOW_CAM_NEAR;  //     1
 _dirLight.shadow.camera.far  = NCZ.SHADOW_CAM_FAR;   // 40000
 _dirLight.shadow.bias        = NCZ.SHADOW_BIAS;      //     0
@@ -76,6 +92,16 @@ _dirLight.shadow.bias        = NCZ.SHADOW_BIAS;      //     0
 ample depth precision, so the old WebGL RGBA8-packed-depth cushion (`-0.0005`) is no
 longer needed. The geometric self-shadow (a shadow texel covering a depth range) is
 handled entirely by the **normal bias** instead.
+
+### Shadow strength fades with the sun (night has no cast shadows)
+
+`updateDayNightLighting()` sets the live shadow strength as
+`_shadowsOn ? _shadowIntensity × _sunShadowFade : 0`, where `_sunShadowFade` is a
+`smoothstep` over the sun's elevation: full at/above `SUN_SHADOW_FADE_FULL_DEG` (12°),
+0 at/below `SUN_SHADOW_FADE_OFF_DEG` (3°). So crisp shadows in daylight, fading through
+dusk, **none at night** — and with the moon casting nothing, night has no caster at
+all. This is what removes the night/dusk "shadow box" by construction: no caster ⇒
+nothing to clip against the coverage cap.
 
 ### Shadow render-on-demand (WebGPU) — the gate is on the *light*
 
@@ -108,23 +134,24 @@ casters stop being drawn into the main pass. (PR #751.)
 ### Dynamic shadow camera
 
 The single shadow camera (an `OrthographicCamera`) is **re-fitted every camera change**
-in `updateShadowCamera(renderCam = camera)` to concentrate the 4096² map on exactly the
-visible-ground footprint — far sharper shadows when zoomed in. Two fit paths, because the
-camera shapes differ too much to share one:
+in `updateShadowCamera(renderCam = camera)` to concentrate the 8192² map on the visible
+ground — far sharper shadows when zoomed in. The fit switches by *regime*, not by camera:
 
-- **Schema cam** (interactive top-down perspective): **rect-fit** — ray-cast the view's
-  NDC corners to the `Y=0` ground plane, take the bbox. Tight and sharp; always succeeds
-  because `controls` constrain tilt below horizontal.
-- **Showcase fly cam** (cinematic, often near-horizontal): **fixed-size box** centred
-  where the camera's forward ray meets the ground, with `tHit` capped. Constant size →
-  no per-frame "shadow box pop" as the cinematic camera crosses the horizon.
+- **Zoomed in** (visible-ground sphere radius ≤ `SHADOW_MAX_DISTANCE`): **camera-fit** —
+  bounding-sphere of the view's NDC corners ray-cast to `Y=0`. Tight, sharp, tracks
+  what you see.
+- **Zoomed out** (radius > the cap) **and the showcase fly cam**: **world-locked box** —
+  centred on the world, half = cap. The box already spans the whole ~12 km world, so
+  following the camera buys no sharpness and only causes the **"moving shadow box"**
+  (a capped, camera-tracking slice whose centre clamps to a world edge, leaving the far
+  side unshadowed). World-locking gives full coverage from a static centre. This
+  subsumes the fly cam's old forward-ray + `tHit`-cap fit (now removed).
 
 ```javascript
 function updateShadowCamera(renderCam = camera) {
-  // half = min(0.5 * hypot(W, D), SHADOW_MAX_DISTANCE) + SHADOW_GROUND_MARGIN  (schema)
-  //      = SHADOW_MAX_DISTANCE + SHADOW_GROUND_MARGIN                          (fly cam)
-  // center is clamped to world bounds (the scene is finite; a centre past the
-  // edge would waste half the map on empty void)
+  // Zoomed in : half = groundSphereRadius + SHADOW_GROUND_MARGIN, centre = footprint
+  // Zoomed out / fly cam : half = SHADOW_MAX_DISTANCE + SHADOW_GROUND_MARGIN, centre = WORLD centre
+  // (world half-diagonal ≈ the cap, so a world-centred cap-sized box covers every corner)
   shadowCam.left = -half; shadowCam.right = half;
   shadowCam.top  =  half; shadowCam.bottom = -half;
   shadowCam.near = NCZ.SHADOW_CAM_NEAR;
@@ -149,8 +176,10 @@ Key constants:
 
 | Constant | Value | Purpose |
 | --- | --- | --- |
-| `SHADOW_MAP_SIZE` | 4096 | Shadow map resolution (4096² texels) |
-| `SHADOW_MAX_DISTANCE` | 8600 | Cap on the footprint half-side (≈ world half-diagonal; nothing renders past the world bounds) |
+| `SHADOW_MAP_SIZE` | 8192 | Shadow map resolution (8192² texels). Always-on (not resized per-mode): the fine texels keep the showcase's fast sun from shimmering; runtime resize is unreliable on r184 (three.js #30766, fixed r185). Interactive cost is bounded by render-on-demand (re-renders only on camera moves). |
+| `SUN_SHADOW_FADE_OFF_DEG` / `…_FULL_DEG` | 3 / 12 | Sun elevation over which cast-shadow strength ramps 0→full. Below 3° (dusk/night) shadows fade out — no caster ⇒ no shadow box. |
+| `KEY_LIGHT_MIN_DIR_Y` | 0.10 | Floor on the sun direction's Y (~5.7°) so the shadow camera's `lookAt` can't degenerate near the horizon. |
+| `SHADOW_MAX_DISTANCE` | 8600 | Cap on the footprint half-side (≈ world half-diagonal; nothing renders past the world bounds). Past the cap the box world-locks. |
 | `SHADOW_GROUND_MARGIN` | 600 | Footprint extends this far past the visible ground (building heights + a sliver of off-screen casters) |
 | `SHADOW_CAM_NEAR` | 1 | Shadow camera near clip |
 | `SHADOW_CAM_FAR` | 40000 | Far clip — the camera sits `SUN_DIST` up the sun ray, so this must reach the far edge even at a low sun (orthographic ⇒ wide range is free) |
@@ -169,6 +198,8 @@ Key constants:
 | Buildings | ✓ | ✓ | `MeshLambertNodeMaterial` + TSL nodes | Instanced; stencil=1 |
 | Roads | — | — | `MeshBasicNodeMaterial` (additive) | Overlay layer; no shadow |
 | Metro | — | — | `MeshBasicNodeMaterial` (additive) | Overlay layer; no shadow |
+| Sun disc | — | — | `MeshBasicNodeMaterial` | Visible orb; traces the solar arc, terrain-occluded |
+| Moon disc | — | — | `MeshBasicNodeMaterial` | Visible orb; traces the lunar arc (incl. daytime) |
 
 **Note on `frustumCulled=false`:** terrain and cliffs are always included in the shadow
 pass regardless of the dynamic shadow camera position.

--- a/docs/showcase-flyover.md
+++ b/docs/showcase-flyover.md
@@ -137,6 +137,6 @@ E:\Audio\Cyberpunk 2077\GMNC - District beats.txt
 | `transitionToColors(from, to, ms)` | Lerp materials to explicit colors — beat cycle (includes buildings) |
 | `setLayerVisibility(name, bool)` | Toggle terrain/water/cliffs/roads/metro/buildings/districts |
 | `getLayerVisibility(name)` | Read current layer visibility (used for state save/restore) |
-| `setSunPosition(az, alt)` | Move directional light + sun sphere |
+| `setSunPosition(az, alt)` | Move sun light + sun disc |
+| `setMoonPosition(az, alt)` | Move moon light + moon disc (showcase drives both bodies) |
 | `setShadowsEnabled(bool)` | Toggle shadow casting |
-| `setSunSphereVisible(bool)` | Show/hide the visible sun orb |


### PR DESCRIPTION
## What

The 3D map's time slider now runs a **full day–night cycle**. As the sun sets, a **real moon** (on its own lunar arc) lights the city with cool moonlight; the sun and moon are visible discs that rise and set along their real paths. Includes a ground-up rework of the shadow system so it behaves correctly across the whole cycle.

Everything is driven by one control — `nightFactor`, a `smoothstep` over the sun's elevation. At `nightFactor == 0` the daytime scene is **byte-identical** to before.

## Lighting

- **Two directional lights**, each on real SunCalc ephemeris at the Morro Bay anchor: a warm **sun** (`getPosition`) and a cool **moon** (`getMoonPosition`). They crossfade by `nightFactor` — no morphing/slerp.
- **Moon phase is a tunable constant** (`MOON_PHASE`, default ~full): the *arc* is real, the *phase brightness* is a rule-of-cool choice so a new-moon date can't leave the night dark.
- Cool **night ambient** (skyglow), boosted toward a moonless level as the moon sets so a moonless deep night stays legible without washing out moonlit nights.
- Exposure curve extended into negative elevations for the night side.

## Shadows (the rework)

- **Shadows belong to the sun.** Only the sun casts; the moon casts none (moonlight shadows are imperceptible, and a moon caster re-introduced the night "shadow box"). Shadow *strength* fades with sun elevation, so dusk softens and **night has none**.
- **Two permanent lights, not one morphing light** — keeps `castShadow` static (toggling it crashes WebGPU) and removes the night shadow-box by construction.
- **World-locked shadow box when zoomed out** — the old code centred a cap-sized box on the camera footprint, so zoomed out it became a camera-tracking slice that left the far map unshadowed (the "moving box"). Past the coverage cap it now centres on the world. The showcase fly cam shares this (dropping its old ray/tHit fit).
- **Always-8192 shadow map** to kill the showcase's fast-sun shimmer (a full day in ~60s re-rasterises the depth map from a fast-changing angle; finer texels halve the shimmer). Not resized per-mode: runtime shadow-map resize is broken under WebGPU r184 — three.js #30766 ("Destroyed texture used in a submit"), fixed in r185 (#33511/#33680) but unreleased. Interactive cost is bounded by render-on-demand (the static-sun map only re-renders on camera moves).

## Sun/moon discs

- The discs **trace their true arcs** (no visibility gate, no fade) and are **depth-occluded by the floating terrain/water** at the horizon, so they rise and set behind the land at the real camera angles. Moon disc ~0.6× the sun.
- Map and showcase now share **one** lighting/disc path; removed the dead `setSunSphereVisible`.

## Verification

Driven live via chrome-devtools across the full cycle + a showcase run: smooth dusk/dawn (no jar), no night/dusk/zoomed-out shadow box, sun cresting the mountains at sunrise, daytime numerically unchanged (`nightFactor==0` → sun 3.0 / ambient 0.405 / exposure 0.45), console clean.

## Deferred follow-ups (tracked separately)

- Neon stages (glowing districts, lit-window facades, bloom revival — night is now the bright-against-dark condition bloom needs).
- Moon-disc phase terminator (crescent shading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
