### PR TITLE
three.js r185: upgrade, regression fixes, setAnimationLoop render loop, resize-wedge mitigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+- Resizing the window no longer permanently blacks out the 3D view on three.js r185 (#771); the showcase also renders at native fullscreen resolution now instead of an upscaled windowed buffer.
 - Showcase: pins and district labels stay locked to the ground, the sidebar hides during the show, and district outlines display (bright, hover-style) regardless of starting zoom (#769).
 - Showcase options now offer district names and district outlines as separate toggles.
 - District outlines were invisible at their resting brightness on three.js r185 (#773).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 3D Schematic Map
+
+#### Changed
+
+- three.js upgraded r184 → r185; adopts the upstream fix for district outline rays at close zoom (#773).
+- Roads, borders and the metro now layer correctly at every camera angle: no more borders or roads glowing through overlapping decks, and metro/tunnel roads render correctly over water (#770).
+
+#### Fixed
+
+- Showcase: pins and district labels stay locked to the ground, the sidebar hides during the show, and district outlines display (bright, hover-style) regardless of starting zoom (#769).
+- Showcase options now offer district names and district outlines as separate toggles.
+- District outlines were invisible at their resting brightness on three.js r185 (#773).
+
 ## [1.0.0] - 2026-06-28
 
 > **Headline: the flat schematic is now a live 3D map.** A navigable 3D recreation of Cyberpunk 2077's in-game world map: terrain, hundreds of thousands of buildings, roads, the metro, district borders and landmarks, lit and shaded like the game. Everything below ships together as one update.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 - three.js upgraded r184 → r185; adopts the upstream fix for district outline rays at close zoom (#773).
+- The render loop (including the showcase flyover) now runs on `renderer.setAnimationLoop`, the WebGPU-native frame driver; idle render-on-demand behaviour is unchanged (#768).
 - Roads, borders and the metro now layer correctly at every camera angle: no more borders or roads glowing through overlapping decks, and metro/tunnel roads render correctly over water (#770).
 
 #### Fixed

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -926,13 +926,19 @@ async function initMap() {
     // Marker-overlay visibility during the showcase is owned by flyover.js:
     // it sets the flyCamera's layer mask based on opts.showPins and swaps
     // ThreeMarkers' active camera reference so projection lands correctly.
+    // Suppress renderer.setSize for the showcase's duration BEFORE entering
+    // fullscreen. The flyover renders in a continuous loop, and under r185 a
+    // setSize mid-loop poisons the WebGPU render-context binding cache (every
+    // subsequent frame submits a destroyed texture). Rendering at the current
+    // resolution and letting CSS stretch to fullscreen sidesteps it — restored
+    // in exitShowcase, where the loop has stopped and a resize is safe again.
+    NCZ.ThreeScene.setResizeSuppressed?.(true);
     document.getElementById('map-3d').classList.add('showcase-fullscreen');
     NCZ.Flyover.startFlyover(opts); // creates and manages the fade overlay internally
     flyoverBtn.classList.add("active");
     flyoverBtn.textContent = "Exit showcase";
     // Request native browser fullscreen — must be called from a user gesture (button click)
     document.documentElement.requestFullscreen().catch(() => {});
-    setTimeout(() => window.dispatchEvent(new Event("resize")), 100);
   }
 
   function exitShowcase() {
@@ -945,6 +951,10 @@ async function initMap() {
     flyoverBtn.classList.remove("active");
     flyoverBtn.textContent = "Showcase";
     if (document.fullscreenElement) document.exitFullscreen().catch(() => {});
+    // Re-enable resize now the continuous flyover loop has stopped, then
+    // reconcile the canvas to its true (windowed) size on-demand — safe here
+    // because on-demand renders only a frame or two, not a continuous loop.
+    NCZ.ThreeScene.setResizeSuppressed?.(false);
     setTimeout(() => window.dispatchEvent(new Event("resize")), 100);
   }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -933,24 +933,18 @@ async function initMap() {
     // Marker-overlay visibility during the showcase is owned by flyover.js:
     // it sets the flyCamera's layer mask based on opts.showPins and swaps
     // ThreeMarkers' active camera reference so projection lands correctly.
-    // Suppress renderer.setSize for the showcase's duration BEFORE entering
-    // fullscreen (issue #771). The flyover renders in a continuous loop, and
-    // under r185 a setSize mid-loop poisons the WebGPU render-context binding
-    // cache (every subsequent frame submits a destroyed texture). The drawing
-    // buffer holds its pre-showcase size and CSS stretches it to fullscreen;
-    // restored in exitShowcase, where the loop has stopped and a resize is
-    // safe again.
-    NCZ.ThreeScene.setResizeSuppressed?.(true);
     document.getElementById('map-3d').classList.add('showcase-fullscreen');
     NCZ.Flyover.startFlyover(opts); // creates and manages the fade overlay internally
     flyoverBtn.classList.add("active");
     flyoverBtn.textContent = "Exit showcase";
     // Request native browser fullscreen — must be called from a user gesture (button click)
     document.documentElement.requestFullscreen().catch(() => {});
-    // Reconcile everything EXCEPT the suppressed renderer.setSize to the new
-    // container size — the fullscreen class grows #map-3d without firing a
-    // window resize, and the CSS2DRenderer must adopt the new client size or
-    // every pin/cluster/district label drifts off its world anchor (#769).
+    // Reconcile the renderer + CSS2DRenderer to the new container size — the
+    // fullscreen class grows #map-3d without firing a window resize, and the
+    // CSS2DRenderer must adopt the new client size or every pin/cluster/
+    // district label drifts off its world anchor (#769). (Mid-showcase
+    // setSize was suppressed here while the r185 resize wedge (#771) was
+    // unmitigated; the dispose-on-resize fix in three-scene.js made it safe.)
     setTimeout(() => window.dispatchEvent(new Event("resize")), 100);
   }
 
@@ -964,10 +958,7 @@ async function initMap() {
     flyoverBtn.classList.remove("active");
     flyoverBtn.textContent = "Showcase";
     if (document.fullscreenElement) document.exitFullscreen().catch(() => {});
-    // Re-enable resize now the continuous flyover loop has stopped, then
-    // reconcile the canvas to its true (windowed) size on-demand — safe here
-    // because on-demand renders only a frame or two, not a continuous loop.
-    NCZ.ThreeScene.setResizeSuppressed?.(false);
+    // Reconcile the canvas to its true (windowed) size.
     setTimeout(() => window.dispatchEvent(new Event("resize")), 100);
   }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -855,7 +855,8 @@ async function initMap() {
   const showcaseThemeSelect     = document.getElementById("showcase-theme");
   const showcaseShowPinsCb      = document.getElementById("showcase-show-pins");
   const showcaseRevealLayersCb  = document.getElementById("showcase-reveal-layers");
-  const showcaseDistrictsCb     = document.getElementById("showcase-districts");
+  const showcaseDistrictNamesCb    = document.getElementById("showcase-district-names");
+  const showcaseDistrictOutlinesCb = document.getElementById("showcase-district-outlines");
   const showcaseAudioCb         = document.getElementById("showcase-audio");
   const showcaseLoopCb          = document.getElementById("showcase-loop");
 
@@ -874,7 +875,8 @@ async function initMap() {
     theme: "cycle",
     showPins: false,
     revealLayers: false,
-    districts: false,
+    districtNames: false,
+    districtOutlines: false,
     audio: true,
     loop: false,
   });
@@ -885,11 +887,15 @@ async function initMap() {
       if (!raw) return { ...SHOWCASE_DEFAULTS };
       const parsed = JSON.parse(raw);
       const validThemes = new Set(["cycle", ...(NCZ.THEMES || []).map(t => t.id)]);
+      // Back-compat: the single `districts` boolean (pre-split) seeds both
+      // new options so a stored "on" preference survives the upgrade.
+      const legacyDistricts = typeof parsed.districts === "boolean" ? parsed.districts : null;
       return {
         theme:        validThemes.has(parsed.theme) ? parsed.theme : SHOWCASE_DEFAULTS.theme,
         showPins:     typeof parsed.showPins     === "boolean" ? parsed.showPins     : SHOWCASE_DEFAULTS.showPins,
         revealLayers: typeof parsed.revealLayers === "boolean" ? parsed.revealLayers : SHOWCASE_DEFAULTS.revealLayers,
-        districts:    typeof parsed.districts    === "boolean" ? parsed.districts    : SHOWCASE_DEFAULTS.districts,
+        districtNames:    typeof parsed.districtNames    === "boolean" ? parsed.districtNames    : (legacyDistricts ?? SHOWCASE_DEFAULTS.districtNames),
+        districtOutlines: typeof parsed.districtOutlines === "boolean" ? parsed.districtOutlines : (legacyDistricts ?? SHOWCASE_DEFAULTS.districtOutlines),
         audio:        typeof parsed.audio        === "boolean" ? parsed.audio        : SHOWCASE_DEFAULTS.audio,
         loop:         typeof parsed.loop         === "boolean" ? parsed.loop         : SHOWCASE_DEFAULTS.loop,
       };
@@ -903,7 +909,8 @@ async function initMap() {
     if (showcaseThemeSelect)    showcaseThemeSelect.value      = opts.theme;
     if (showcaseShowPinsCb)     showcaseShowPinsCb.checked     = opts.showPins;
     if (showcaseRevealLayersCb) showcaseRevealLayersCb.checked = opts.revealLayers;
-    if (showcaseDistrictsCb)    showcaseDistrictsCb.checked    = opts.districts;
+    if (showcaseDistrictNamesCb)    showcaseDistrictNamesCb.checked    = opts.districtNames;
+    if (showcaseDistrictOutlinesCb) showcaseDistrictOutlinesCb.checked = opts.districtOutlines;
     if (showcaseAudioCb)        showcaseAudioCb.checked        = opts.audio;
     if (showcaseLoopCb)         showcaseLoopCb.checked         = opts.loop;
     showcaseModal?.classList.remove("hidden");
@@ -914,7 +921,7 @@ async function initMap() {
   }
 
   function enterShowcase(opts) {
-    ['header', '#sidebar-open', '#discover-location-btn',
+    ['header', '#sidebar', '#sidebar-open', '#discover-location-btn',
      '#overlay-controls', '#map-view-toggle', '#scene-controls', '#scene-scale']
       .forEach(sel => {
         const el = document.querySelector(sel);
@@ -927,11 +934,12 @@ async function initMap() {
     // it sets the flyCamera's layer mask based on opts.showPins and swaps
     // ThreeMarkers' active camera reference so projection lands correctly.
     // Suppress renderer.setSize for the showcase's duration BEFORE entering
-    // fullscreen. The flyover renders in a continuous loop, and under r185 a
-    // setSize mid-loop poisons the WebGPU render-context binding cache (every
-    // subsequent frame submits a destroyed texture). Rendering at the current
-    // resolution and letting CSS stretch to fullscreen sidesteps it — restored
-    // in exitShowcase, where the loop has stopped and a resize is safe again.
+    // fullscreen (issue #771). The flyover renders in a continuous loop, and
+    // under r185 a setSize mid-loop poisons the WebGPU render-context binding
+    // cache (every subsequent frame submits a destroyed texture). The drawing
+    // buffer holds its pre-showcase size and CSS stretches it to fullscreen;
+    // restored in exitShowcase, where the loop has stopped and a resize is
+    // safe again.
     NCZ.ThreeScene.setResizeSuppressed?.(true);
     document.getElementById('map-3d').classList.add('showcase-fullscreen');
     NCZ.Flyover.startFlyover(opts); // creates and manages the fade overlay internally
@@ -939,6 +947,11 @@ async function initMap() {
     flyoverBtn.textContent = "Exit showcase";
     // Request native browser fullscreen — must be called from a user gesture (button click)
     document.documentElement.requestFullscreen().catch(() => {});
+    // Reconcile everything EXCEPT the suppressed renderer.setSize to the new
+    // container size — the fullscreen class grows #map-3d without firing a
+    // window resize, and the CSS2DRenderer must adopt the new client size or
+    // every pin/cluster/district label drifts off its world anchor (#769).
+    setTimeout(() => window.dispatchEvent(new Event("resize")), 100);
   }
 
   function exitShowcase() {
@@ -968,7 +981,8 @@ async function initMap() {
       theme:        showcaseThemeSelect?.value ?? SHOWCASE_DEFAULTS.theme,
       showPins:     !!showcaseShowPinsCb?.checked,
       revealLayers: !!showcaseRevealLayersCb?.checked,
-      districts:    !!showcaseDistrictsCb?.checked,
+      districtNames:    !!showcaseDistrictNamesCb?.checked,
+      districtOutlines: !!showcaseDistrictOutlinesCb?.checked,
       audio:        !!showcaseAudioCb?.checked,
       loop:         !!showcaseLoopCb?.checked,
     };
@@ -987,7 +1001,8 @@ async function initMap() {
     if (showcaseThemeSelect)    showcaseThemeSelect.value      = SHOWCASE_DEFAULTS.theme;
     if (showcaseShowPinsCb)     showcaseShowPinsCb.checked     = SHOWCASE_DEFAULTS.showPins;
     if (showcaseRevealLayersCb) showcaseRevealLayersCb.checked = SHOWCASE_DEFAULTS.revealLayers;
-    if (showcaseDistrictsCb)    showcaseDistrictsCb.checked    = SHOWCASE_DEFAULTS.districts;
+    if (showcaseDistrictNamesCb)    showcaseDistrictNamesCb.checked    = SHOWCASE_DEFAULTS.districtNames;
+    if (showcaseDistrictOutlinesCb) showcaseDistrictOutlinesCb.checked = SHOWCASE_DEFAULTS.districtOutlines;
     if (showcaseAudioCb)        showcaseAudioCb.checked        = SHOWCASE_DEFAULTS.audio;
     if (showcaseLoopCb)         showcaseLoopCb.checked         = SHOWCASE_DEFAULTS.loop;
     try { localStorage.setItem(NCZ.SHOWCASE_OPTIONS_KEY, JSON.stringify(SHOWCASE_DEFAULTS)); } catch (_) {}

--- a/assets/js/flyover.js
+++ b/assets/js/flyover.js
@@ -360,7 +360,6 @@ const Flyover = (() => {
 
   let flyCamera       = null;
   let flyActive       = false;
-  let flyFrameId      = null;
   let flySeg          = 0;
   let flySegStart     = 0;
   let _paused         = false; // spacebar pause — freezes camera + audio, keeps pins clickable
@@ -561,7 +560,7 @@ const Flyover = (() => {
           _audio.addEventListener('ended', _onAudioEnded, { once: true });
           return;
         }
-        if (flyFrameId !== null) { cancelAnimationFrame(flyFrameId); flyFrameId = null; }
+        NCZ.ThreeScene.setFlyoverFrame(null);
         fadeToBlack(() => {
           document.dispatchEvent(new CustomEvent('flyover:ended'));
           resetFade();
@@ -587,7 +586,9 @@ const Flyover = (() => {
     flySeg      = 0;
     flySegStart = performance.now();
     _paused     = false;
-    flyoverLoop();
+    // Drive fly frames through the scene's shared animation loop (issue #768)
+    // — the loop invokes flyoverFrame every tick while the callback is set.
+    NCZ.ThreeScene.setFlyoverFrame(flyoverFrame);
   }
 
   // Short fade-out/in across the camera swap. The showcase camera renders at
@@ -599,7 +600,7 @@ const Flyover = (() => {
   function stopFlyover() {
     if (!flyActive) return;
     flyActive = false;
-    if (flyFrameId !== null) { cancelAnimationFrame(flyFrameId); flyFrameId = null; }
+    NCZ.ThreeScene.setFlyoverFrame(null);
 
     const canvas    = NCZ.ThreeScene.getCanvasElement?.();
     const container = canvas?.parentElement || null;
@@ -685,9 +686,10 @@ const Flyover = (() => {
     }, EXIT_FADE_MS);
   }
 
-  function flyoverLoop() {
+  // Per-tick showcase frame — invoked by three-scene's shared animation loop
+  // while registered via setFlyoverFrame (no private rAF; issue #768).
+  function flyoverFrame() {
     if (!flyActive) return;
-    flyFrameId = requestAnimationFrame(flyoverLoop);
 
     // Paused: hold the current pose. Re-render every frame so pins stay drawn
     // and clickable (popup placement tracks the frozen camera), but advance
@@ -708,8 +710,7 @@ const Flyover = (() => {
       // Last waypoint reached — hold this frame and wait for audio.ended to trigger the fade.
       // If audio isn't available, fall back to fading immediately.
       if (!_audio) {
-        cancelAnimationFrame(flyFrameId);
-        flyFrameId = null;
+        NCZ.ThreeScene.setFlyoverFrame(null);
         fadeToBlack(() => { document.dispatchEvent(new CustomEvent('flyover:ended')); resetFade(); });
       }
       // With audio: just keep rendering the last frame; audio.ended fires the fade.

--- a/assets/js/flyover.js
+++ b/assets/js/flyover.js
@@ -106,10 +106,12 @@ const Flyover = (() => {
     // WP 0 — Ocean: snap to opening theme; showcase always controls its own layer state.
     // _runOpts.revealLayers=true  → hide everything, stagger layers back in over 6.9s
     // _runOpts.revealLayers=false → all layers on from frame 1 (immediate shadows)
-    // Districts honour _runOpts.districts in both branches.
+    // Districts honour the split _runOpts.districtNames/districtOutlines in
+    // both branches (the parent layer carries names + outlines; which of the
+    // two actually renders is decided by forceDistrictBand's mode).
     // Either way, exit always restores the user's pre-showcase layer state.
     0: () => {
-      const showDistricts = !!_runOpts?.districts;
+      const showDistricts = !!(_runOpts?.districtNames || _runOpts?.districtOutlines);
       if (_runOpts?.revealLayers) {
         NCZ.ThreeScene.setLayerVisibility('roads',     false);
         NCZ.ThreeScene.setLayerVisibility('metro',     false);
@@ -126,7 +128,11 @@ const Flyover = (() => {
     },
     // WP 9 — Badlands sweep: drop districts so the city behind camera reads cleaner.
     // Skipped when the user opted to keep districts visible.
-    9: () => { if (!_runOpts?.districts) NCZ.ThreeScene.setLayerVisibility('districts', false); },
+    9: () => {
+      if (!(_runOpts?.districtNames || _runOpts?.districtOutlines)) {
+        NCZ.ThreeScene.setLayerVisibility('districts', false);
+      }
+    },
   };
 
   // ── Beat-cycle visualiser ─────────────────────────────────────────────────
@@ -469,13 +475,26 @@ const Flyover = (() => {
       theme:        typeof opts.theme === 'string' ? opts.theme : 'cycle',
       showPins:     !!opts.showPins,
       revealLayers: !!opts.revealLayers,
-      districts:    !!opts.districts,
+      // Back-compat: a legacy boolean `districts` (pre-split callers) seeds both.
+      districtNames:    !!(opts.districtNames    ?? opts.districts),
+      districtOutlines: !!(opts.districtOutlines ?? opts.districts),
       audio:        opts.audio !== false, // default true
       loop:         !!opts.loop,
     };
 
     NCZ.ThreeScene.stopRenderLoop();
     NCZ.ThreeScene.setControlsEnabled(false);
+    // Pin the main-district outline tier for the flight. The zoom-band logic
+    // reads the (frozen) schema camera, so starting a showcase zoomed in
+    // below the outline band would otherwise leave every tier hidden and the
+    // district options silently dead. The mode carries the names/outlines
+    // split (labels vs Line2 rings) and renders the rings at the hovered
+    // opacity. Waypoint actions still toggle the parent districts layer on
+    // top of this. Restored on stop.
+    NCZ.ThreeScene.forceDistrictBand?.('district', {
+      names:    _runOpts.districtNames,
+      outlines: _runOpts.districtOutlines,
+    });
 
     if (!flyCamera) {
       const canvas = NCZ.ThreeScene.getCanvasElement();
@@ -595,6 +614,9 @@ const Flyover = (() => {
       // also re-runs cluster recompute (suppressed while a non-schema camera
       // is active).
       NCZ.ThreeMarkers?.setActiveCamera?.(null);
+      // Hand the district-outline band back to the schema camera's zoom logic
+      // (pinned to the main-district tier for the flight — see startFlyover).
+      NCZ.ThreeScene.forceDistrictBand?.(null);
       clearLayerReveal();
       _paused = false;
       removePauseHint();

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -683,6 +683,34 @@ const ThreeScene = (() => {
       hideLoading();
       return;
     }
+    // r185's #33700 "fixed" render-list sorting under reversedDepthBuffer with
+    // a wholesale list.reverse() AFTER the painter sort. The sort key is
+    // groupOrder → renderOrder → z → id, so the reverse fixes the z direction
+    // but also INVERTS renderOrder semantics — our transparent chain
+    // (water 0 → SeeThrough roads 1 → metro 2) drew backwards: metro first
+    // (then hidden under water's depthWrite) and SeeThrough roads before water
+    // had written stencil=STENCIL_WATER (tunnel roads gone). Compensate by
+    // handing the sorter comparators that are the exact NEGATION of the order
+    // we want — the engine's trailing .reverse() then lands the desired order:
+    // renderOrder ascending (the documented contract), z direction correct for
+    // reversed-depth projected z (larger z = nearer). The id tiebreaker makes
+    // the order total, so reverse(sort(-D)) == sort(D) exactly — no stability
+    // caveats. Remove when upstream replaces the wholesale reverse with a
+    // z-only fix: https://github.com/mrdoob/three.js/pull/33700
+    if (renderer.reversedDepthBuffer === true) {
+      const desiredOpaque = (a, b) =>       // front-to-back: z DESC (reversed z, near is larger)
+        a.groupOrder !== b.groupOrder ? a.groupOrder - b.groupOrder :
+        a.renderOrder !== b.renderOrder ? a.renderOrder - b.renderOrder :
+        a.z !== b.z ? b.z - a.z :
+        a.id - b.id;
+      const desiredTransparent = (a, b) =>  // back-to-front: z ASC (reversed z, far is smaller)
+        a.groupOrder !== b.groupOrder ? a.groupOrder - b.groupOrder :
+        a.renderOrder !== b.renderOrder ? a.renderOrder - b.renderOrder :
+        a.z !== b.z ? a.z - b.z :
+        a.id - b.id;
+      renderer.setOpaqueSort((a, b) => -desiredOpaque(a, b));
+      renderer.setTransparentSort((a, b) => -desiredTransparent(a, b));
+    }
     // Make the sRGB-correct colour pipeline explicit. These match Three.js r170
     // defaults (since r152 / r155 respectively) but stating them here protects
     // the scene's appearance against future Three.js default changes — both flags
@@ -981,27 +1009,36 @@ const ThreeScene = (() => {
     loadTerrain();
   }
 
-  // Suppresses renderer.setSize during the showcase. r185's WebGPURenderer
-  // caches a bind group referencing the internal HDR render-context target and
-  // does NOT invalidate it when setSize recreates that texture — so a setSize
-  // during the flyover's continuous loop makes every subsequent frame submit a
-  // destroyed texture ("Destroyed texture ... used in a submit"). The showcase's
-  // fullscreen enter fires a resize; suppressing setSize for its duration keeps
-  // the cached binding valid (we render at the pre-showcase resolution and let
-  // CSS stretch to fullscreen — a negligible resolution trade on a maximised
-  // window). See scripts/r185_resize_spike.html for the minimal repro; the real
-  // fix is upstream (bind-group cache must re-key on target recreation).
+  // Suppresses ONLY renderer.setSize during the showcase (issue #771). r185's
+  // WebGPURenderer keeps a stale binding to the internal HDR render-context
+  // target after setSize destroys/recreates it — a setSize during the
+  // flyover's continuous loop then makes every subsequent frame submit a
+  // destroyed texture ("Destroyed texture ... used in a submit"). The
+  // showcase's fullscreen enter fires a resize; holding the drawing buffer at
+  // its pre-showcase size keeps the cached binding valid, and CSS stretches
+  // the canvas to fullscreen. Geometrically safe: flyover.js keeps
+  // flyCamera.aspect synced to the *client* aspect, and the NDC→client
+  // mapping is identical whether the buffer resizes or CSS stretches.
+  //
+  // Everything else in onResize MUST still run — in particular
+  // ThreeMarkers.onResize (the CSS2DRenderer maps NDC to its own stored
+  // size; leaving it stale while the client size changes offsets every pin,
+  // cluster and district label from its world anchor — issue #769, the
+  // "floating pins" bug the original full-early-return version caused).
+  // See scripts/r185_resize_spike.html for the repro seed; the real fix is
+  // upstream (bind-group cache must re-key on target recreation).
   let _resizeSuppressed = false;
   function setResizeSuppressed(on) { _resizeSuppressed = !!on; }
 
   function onResize() {
     if (!renderer) return;
-    if (_resizeSuppressed) return;
     const container = renderer.domElement.parentElement;
     if (!container || container.style.display === 'none') return;
     const w = container.clientWidth;
     const h = container.clientHeight;
-    renderer.setSize(w, h, false); // updateStyle:false — CSS width/height stay at 100%
+    if (!_resizeSuppressed) {
+      renderer.setSize(w, h, false); // updateStyle:false — CSS width/height stay at 100%
+    }
     camera.aspect = w / h;
     camera.updateProjectionMatrix();
     updateShadowCamera();   // shadow camera follows the schema camera's aspect
@@ -1044,7 +1081,11 @@ const ThreeScene = (() => {
   function updateDistrictLabelVisibility() {
     if (!_districtLabels.length) return;
     const districtsOn = layers.districts ? layers.districts.visible : true;
-    for (const { css, group } of _districtLabels) css.visible = districtsOn && group.visible;
+    // Showcase mode: names are a user option independent of the outline tier
+    // (the tier groups stay visible to carry the pinned outlines — see
+    // forceDistrictBand — so the label gate needs its own switch).
+    const namesOn = _showcaseDistricts ? _showcaseDistricts.names : true;
+    for (const { css, group } of _districtLabels) css.visible = districtsOn && group.visible && namesOn;
   }
 
   function setLayerVisibility(name, visible) {
@@ -1066,7 +1107,49 @@ const ThreeScene = (() => {
     requestRender();
   }
 
+  // Pins the district-outline tier independent of the schema camera's zoom
+  // band. The showcase flyover renders through its own camera while the
+  // schema camera (which drives updateDistrictZoom) is frozen — starting a
+  // showcase zoomed in below SUBDISTRICT_DISTANCE_3D froze ALL outline tiers
+  // hidden for the whole flight, so "Show district outlines" silently did
+  // nothing. 'district' pins the main-district tier (the cinematic look the
+  // waypoint script was written for); null restores zoom-band control.
+  //
+  // opts { names, outlines } split the showcase district feature: names gate
+  // the CSS2D labels (see updateDistrictLabelVisibility), outlines gate the
+  // Line2 rings per-line (the tier groups stay visible either way so labels
+  // can show without outlines). Outlines render at the HOVERED opacity for
+  // the whole flight — the 5% base is illegible from cinematic distances.
+  let _districtBandForced = null; // 'district' | null
+  let _showcaseDistricts  = null; // { names, outlines } | null
+  function forceDistrictBand(band, opts = null) {
+    _districtBandForced = band;
+    _showcaseDistricts  = band === 'district'
+      ? { names: !!(opts?.names ?? true), outlines: !!(opts?.outlines ?? true) }
+      : null;
+    if (band === 'district') {
+      if (_districtOuter)  _districtOuter.visible  = true;
+      if (_districtSub)    _districtSub.visible    = false;
+      if (_districtAlways) _districtAlways.visible = true;
+      for (const e of _districtHover) {
+        if (e.line) e.line.visible = _showcaseDistricts.outlines;
+        e.target = NCZ.DISTRICT_LINE_OPACITY_HOVER;
+        if (e.material) e.material.opacity = NCZ.DISTRICT_LINE_OPACITY_HOVER;
+      }
+    } else {
+      for (const e of _districtHover) {
+        if (e.line) e.line.visible = true;
+        e.target = NCZ.DISTRICT_LINE_OPACITY;
+        if (e.material) e.material.opacity = NCZ.DISTRICT_LINE_OPACITY;
+      }
+      updateDistrictZoom();
+    }
+    updateDistrictLabelVisibility();
+    requestRender();
+  }
+
   function updateDistrictZoom() {
+    if (_districtBandForced) return; // showcase owns the band — see forceDistrictBand
     if (!_districtOuter || !_districtSub || !controls) return;
     // Three-state visibility, matching WorldMap.ZoomLevel* records:
     //   d ≥ 11000: main district outlines (ZoomLevelDistricts.showDistricts = 1)
@@ -1097,8 +1180,13 @@ const ThreeScene = (() => {
   // neighbour. Outlines have depthTest:false (depth ignored), so the only thing
   // that decides which of two coplanar coincident lines wins a pixel is paint
   // order — and the transparent back-to-front sort is unstable for equal-
-  // distance lines. A high renderOrder forces the hovered line last; > metro (2)
-  // so a highlighted district reads above roads/metro too. Reset to 0 on exit.
+  // distance lines. District outlines sit at tier 7 of the explicit transparent
+  // chain (water 0 → roads depth/colour 1/2 → borders depth/colour 3/4 →
+  // SeeThrough 5 → metro 6 → districts 7) so they always draw after water — a
+  // shared tier would fall back to camera-angle-dependent centroid-z ties.
+  // A higher renderOrder forces the hovered line last so it reads above its
+  // siblings. Reset to the base tier on exit.
+  const DISTRICT_LINE_RENDER_ORDER  = 7;
   const DISTRICT_HOVER_RENDER_ORDER = 10;
   let _hoverFading  = false; // true while any material.opacity != its target
   let _hoverLastT   = 0;
@@ -1168,7 +1256,7 @@ const ThreeScene = (() => {
     if (entry === _hoveredEntry) return;
     if (_hoveredEntry) {
       _hoveredEntry.target = NCZ.DISTRICT_LINE_OPACITY;
-      if (_hoveredEntry.line) _hoveredEntry.line.renderOrder = 0;
+      if (_hoveredEntry.line) _hoveredEntry.line.renderOrder = DISTRICT_LINE_RENDER_ORDER;
       _hoveredEntry.labelEl?.classList.remove('district-label-hover');
     }
     if (entry) {
@@ -1183,6 +1271,10 @@ const ThreeScene = (() => {
   }
 
   function onSceneMouseMove(e) {
+    // Showcase mode pins every outline at the hovered opacity — the pointer
+    // must not re-target materials mid-flight (and the pick raycast uses the
+    // schema camera, which is wrong under the fly camera anyway).
+    if (_showcaseDistricts) return;
     const gp = groundPointAt(e.clientX, e.clientY);
     setHoveredDistrict(pickDistrictAt(gp)); // outline/label brighten (tier-gated)
     // Info panel resolves the subdistrict under the cursor at any tier; stats
@@ -1405,13 +1497,61 @@ const ThreeScene = (() => {
       // alpha 255 → both full-strength additive. (Roads were Normal-blend opacity
       // 0.8 — an eyeballed guess that also let the road colour drift with whatever
       // sat under it; additive is the game-faithful blend.)
-      normalRoadsMat   = new THREE.MeshBasicNodeMaterial({ color: roadColor,   transparent: true, opacity: 1.0, blending: THREE.AdditiveBlending });
-      normalBordersMat = new THREE.MeshBasicNodeMaterial({ color: borderColor, transparent: true, opacity: 1.0, blending: THREE.AdditiveBlending, depthWrite: false });
+      // Surface roads/borders over-stamp stencil=STENCIL_OCCLUDER where they
+      // are the visible surface — the same pattern terrain/cliffs/buildings
+      // use in the opaque pass. This makes the surface and SeeThrough copies
+      // mutually exclusive per pixel: where the surface copy draws (passes
+      // depth), the stencil is no longer STENCIL_WATER, so the SeeThrough
+      // copy skips it. Without this, the below-sea-level tunnel-entrance
+      // cutting drew BOTH copies (water stamps 2 → surface ramp draws → the
+      // SeeThrough copy draws again on top = bright double-drawn band).
+      const roadOverstamp = {
+        stencilWrite: true, stencilRef: NCZ.STENCIL_OCCLUDER,
+        stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
+      };
+      // Depth pre-pass + Equal colour pass — additive layers can't occlude
+      // themselves (every overlapping fragment adds), so overlapping road
+      // decks / crossing borders drew twice (bright hot spots at any angle:
+      // draw order within a tier is buffer order, not per-fragment depth).
+      // Each layer first lays down its nearest-surface depth (colorWrite off,
+      // transparent:true keeps it in the transparent pass AFTER water — an
+      // opaque prepass would depth-block water under bridges and shift the
+      // additive base colour), then the colour pass draws with
+      // depthFunc:Equal so exactly one surface per pixel receives colour.
+      // The vertex path is identical between the two passes, so rasterized
+      // depth matches exactly.
+      const depthPrepassMat = new THREE.MeshBasicNodeMaterial({ transparent: true, colorWrite: false });
+      // r185 routes material.depthFunc through ReversedDepthFuncs under
+      // reversedDepthBuffer and wrongly inverts EqualDepth → NotEqualDepth
+      // (equality is direction-independent; the upstream map blanket-inverts
+      // every comparator). Hand it NotEqual so the broken inversion lands on
+      // the Equal we actually want — the same pre-compensation pattern as the
+      // render-list sort comparators above. Symptom if this regresses: roads
+      // invisible over terrain/water but visible through buildings.
+      // Remove together with the sort compensation when upstream fixes.
+      const equalDepth = renderer.reversedDepthBuffer === true ? THREE.NotEqualDepth : THREE.EqualDepth;
+      normalRoadsMat   = new THREE.MeshBasicNodeMaterial({ color: roadColor,   transparent: true, opacity: 1.0, blending: THREE.AdditiveBlending, depthFunc: equalDepth, depthWrite: false, ...roadOverstamp });
+      normalBordersMat = new THREE.MeshBasicNodeMaterial({ color: borderColor, transparent: true, opacity: 1.0, blending: THREE.AdditiveBlending, depthFunc: equalDepth, depthWrite: false, ...roadOverstamp });
 
       applyMaterial(roadsScene,   normalRoadsMat);
       applyMaterial(bordersScene, normalBordersMat);
 
-      // Metro: normal depth-tested, renderOrder=1 so it renders above roads.
+      // Explicit transparent-pass tiers — the whole water/roads/metro chain is
+      // order-dependent, and any two overlays sharing a renderOrder fall back
+      // to per-object centroid-z ties that flip with camera angle (the cause
+      // of the old "road borders vanish over water at some angles" bug):
+      //   water 0 → roads depth 1 → roads colour 2 → borders depth 3
+      //   → borders colour 4 → SeeThrough copies 5 → metro 6
+      //   → district outlines 7 → hover DISTRICT_HOVER_RENDER_ORDER.
+      // Borders draw AFTER the roads passes: a border under an overlapping
+      // road deck must depth-fail against that deck. Each layer's own
+      // depth-prepass → Equal-colour pair collapses self-overlap (deck over
+      // street, crossing borders) to a single additive contribution.
+      roadsScene.traverse(o   => { if (o.isMesh) o.renderOrder = 2; });
+      bordersScene.traverse(o => { if (o.isMesh) o.renderOrder = 4; });
+
+      // Metro: normal depth-tested, renderOrder=6 — after water (0) so it
+      // shows over the bay, after the road passes so it layers above both.
       //
       // LOD discard: COLOR_0 vertex attribute carries the LOD tier as one
       // mutually-exclusive channel per vertex (per the building/metro extraction
@@ -1487,11 +1627,10 @@ const ThreeScene = (() => {
       // loadTerrain). Pacifica tunnel: water writes stencil=STENCIL_WATER → the tunnel road + border
       // (below the water) draw on top of it = visible through the water ✓.  Mountain / city roads:
       // terrain/cliffs/buildings over-stamp stencil=STENCIL_OCCLUDER ≠ STENCIL_WATER → hidden ✓.
-      // (A road *bridging* the bay still gets a SeeThrough copy where stencil==STENCIL_WATER — its
-      // road is the same blue as the surface copy so no visible change, and its border's extra
-      // additive cyan reads as a slightly brighter edge over the bay. Tried masking that out by
-      // world-Y < waterline; it just dimmed the bay-area road borders for no real gain, so it's
-      // intentionally left as-is.)
+      // (Bridge-over-bay double-draw is gone since the surface copies over-stamp
+      // stencil=STENCIL_OCCLUDER where visible — the SeeThrough copy only draws
+      // where water remains the visible surface, so the two copies are mutually
+      // exclusive per pixel.)
       const stBase = {
         transparent: true, depthTest: false, depthWrite: false,
         stencilWrite: true, stencilWriteMask: 0x00,
@@ -1517,13 +1656,25 @@ const ThreeScene = (() => {
       stBorders.name  = 'road-borders-seethrough';
       nameSubtree(stRoads,   'road-st');
       nameSubtree(stBorders, 'road-border-st');
-      stRoads.traverse(o => { if (o.isMesh) o.renderOrder = 1; });
-      stBorders.traverse(o => { if (o.isMesh) o.renderOrder = 1; });
+      stRoads.traverse(o => { if (o.isMesh) o.renderOrder = 5; });
+      stBorders.traverse(o => { if (o.isMesh) o.renderOrder = 5; });
+
+      // Depth pre-passes (see depthPrepassMat above) — same geometry cloned
+      // via makeSeeThrough with the colourless depth-writing material, drawn
+      // one tier before their colour pass.
+      const dpRoads   = makeSeeThrough(roadsScene,   depthPrepassMat);
+      const dpBorders = makeSeeThrough(bordersScene, depthPrepassMat);
+      dpRoads.name    = 'roads-depth-prepass';
+      dpBorders.name  = 'road-borders-depth-prepass';
+      nameSubtree(dpRoads,   'road-dp');
+      nameSubtree(dpBorders, 'road-border-dp');
+      dpRoads.traverse(o   => { if (o.isMesh) o.renderOrder = 1; });
+      dpBorders.traverse(o => { if (o.isMesh) o.renderOrder = 3; });
 
       const roadsGroup = new THREE.Group();
       roadsGroup.name = 'roads';
-      roadsGroup.add(roadsScene, bordersScene, stRoads, stBorders);
-      metroScene.traverse(o => { if (o.isMesh) o.renderOrder = 2; });
+      roadsGroup.add(roadsScene, bordersScene, stRoads, stBorders, dpRoads, dpBorders);
+      metroScene.traverse(o => { if (o.isMesh) o.renderOrder = 6; });
 
       const metroGroup = new THREE.Group();
       metroGroup.name = 'metro';
@@ -2208,11 +2359,19 @@ const ThreeScene = (() => {
       depthTest: false,
       transparent: true,
       opacity: NCZ.DISTRICT_LINE_OPACITY,
+      // Line2NodeMaterial defaults alphaToCoverage:true, gated in-shader on
+      // renderer.currentSamples > 0. On r184 that gate never fired; r185's
+      // MSAA sample-count fixes activated it, and alpha-to-coverage QUANTIZES
+      // alpha to covered samples — the 5% base opacity rounds to 0 of 4
+      // samples = invisible lines (hover at ~1.0 still showed). We want the
+      // smooth faint alpha blend, not coverage dithering.
+      alphaToCoverage: false,
     });
     districtLineMaterials.push(material);
 
     const line = new Line2(geometry, material);
     line.computeLineDistances();
+    line.renderOrder = DISTRICT_LINE_RENDER_ORDER;
     return line;
   }
 
@@ -3518,7 +3677,7 @@ const ThreeScene = (() => {
     requestRender();
   }
 
-  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, setResizeSuppressed, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, setSceneExposure, getLightingState, getSunElevation, setGradeEnabled, getGradeEnabled, setEdgeGlowEnabled, getEdgeGlowEnabled, setSunSphereVisible, getShadowSnapshot, getCameraState, setCameraState, isInitialized, getLeafletView, frameLeafletView, getSceneColorVars, getRenderInfo, getCullCounts, setOverrideMaterial, dumpDebugInfo, isWebGPUActive };
+  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, setResizeSuppressed, forceDistrictBand, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, setSceneExposure, getLightingState, getSunElevation, setGradeEnabled, getGradeEnabled, setEdgeGlowEnabled, getEdgeGlowEnabled, setSunSphereVisible, getShadowSnapshot, getCameraState, setCameraState, isInitialized, getLeafletView, frameLeafletView, getSceneColorVars, getRenderInfo, getCullCounts, setOverrideMaterial, dumpDebugInfo, isWebGPUActive };
 })();
 
 window.NCZ.ThreeScene = ThreeScene;

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -981,8 +981,22 @@ const ThreeScene = (() => {
     loadTerrain();
   }
 
+  // Suppresses renderer.setSize during the showcase. r185's WebGPURenderer
+  // caches a bind group referencing the internal HDR render-context target and
+  // does NOT invalidate it when setSize recreates that texture — so a setSize
+  // during the flyover's continuous loop makes every subsequent frame submit a
+  // destroyed texture ("Destroyed texture ... used in a submit"). The showcase's
+  // fullscreen enter fires a resize; suppressing setSize for its duration keeps
+  // the cached binding valid (we render at the pre-showcase resolution and let
+  // CSS stretch to fullscreen — a negligible resolution trade on a maximised
+  // window). See scripts/r185_resize_spike.html for the minimal repro; the real
+  // fix is upstream (bind-group cache must re-key on target recreation).
+  let _resizeSuppressed = false;
+  function setResizeSuppressed(on) { _resizeSuppressed = !!on; }
+
   function onResize() {
     if (!renderer) return;
+    if (_resizeSuppressed) return;
     const container = renderer.domElement.parentElement;
     if (!container || container.style.display === 'none') return;
     const w = container.clientWidth;
@@ -3504,7 +3518,7 @@ const ThreeScene = (() => {
     requestRender();
   }
 
-  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, setSceneExposure, getLightingState, getSunElevation, setGradeEnabled, getGradeEnabled, setEdgeGlowEnabled, getEdgeGlowEnabled, setSunSphereVisible, getShadowSnapshot, getCameraState, setCameraState, isInitialized, getLeafletView, frameLeafletView, getSceneColorVars, getRenderInfo, getCullCounts, setOverrideMaterial, dumpDebugInfo, isWebGPUActive };
+  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, setResizeSuppressed, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, setSceneExposure, getLightingState, getSunElevation, setGradeEnabled, getGradeEnabled, setEdgeGlowEnabled, getEdgeGlowEnabled, setSunSphereVisible, getShadowSnapshot, getCameraState, setCameraState, isInitialized, getLeafletView, frameLeafletView, getSceneColorVars, getRenderInfo, getCullCounts, setOverrideMaterial, dumpDebugInfo, isWebGPUActive };
 })();
 
 window.NCZ.ThreeScene = ThreeScene;

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -1008,26 +1008,18 @@ const ThreeScene = (() => {
     loadTerrain();
   }
 
-  // Suppresses ONLY renderer.setSize during the showcase (issue #771). r185's
-  // WebGPURenderer keeps a stale binding to the internal HDR render-context
-  // target after setSize destroys/recreates it — a setSize during the
-  // flyover's continuous loop then makes every subsequent frame submit a
-  // destroyed texture ("Destroyed texture ... used in a submit"). The
-  // showcase's fullscreen enter fires a resize; holding the drawing buffer at
-  // its pre-showcase size keeps the cached binding valid, and CSS stretches
-  // the canvas to fullscreen. Geometrically safe: flyover.js keeps
-  // flyCamera.aspect synced to the *client* aspect, and the NDC→client
-  // mapping is identical whether the buffer resizes or CSS stretches.
+  // NOTE (issue #771 history): a `setResizeSuppressed` guard used to hold the
+  // drawing buffer at its pre-showcase size because any r185 setSize wedged
+  // the canvas (stale Line2 binding to the destroyed viewport-mip texture —
+  // see the dispose() below). With that mitigation in place the guard was
+  // retested (showcase + mid-flight window resizes, zero errors) and removed;
+  // the showcase now renders at native fullscreen resolution instead of a
+  // CSS-stretched windowed buffer.
   //
-  // Everything else in onResize MUST still run — in particular
-  // ThreeMarkers.onResize (the CSS2DRenderer maps NDC to its own stored
-  // size; leaving it stale while the client size changes offsets every pin,
-  // cluster and district label from its world anchor — issue #769, the
-  // "floating pins" bug the original full-early-return version caused).
-  // See scripts/r185_resize_spike.html for the repro seed; the real fix is
-  // upstream (bind-group cache must re-key on target recreation).
-  let _resizeSuppressed = false;
-  function setResizeSuppressed(on) { _resizeSuppressed = !!on; }
+  // ThreeMarkers.onResize must ALWAYS run here — the CSS2DRenderer maps NDC
+  // to its own stored size; leaving it stale while the client size changes
+  // offsets every pin, cluster and district label from its world anchor
+  // (issue #769, the "floating pins" bug).
   let _lastBufferW = 0, _lastBufferH = 0; // last size the drawing buffer was set to
 
   function onResize() {
@@ -1036,7 +1028,7 @@ const ThreeScene = (() => {
     if (!container || container.style.display === 'none') return;
     const w = container.clientWidth;
     const h = container.clientHeight;
-    const bufferResized = !_resizeSuppressed && (w !== _lastBufferW || h !== _lastBufferH);
+    const bufferResized = w !== _lastBufferW || h !== _lastBufferH;
     if (bufferResized) {
       renderer.setSize(w, h, false); // updateStyle:false — CSS width/height stay at 100%
       _lastBufferW = w; _lastBufferH = h;
@@ -3739,7 +3731,7 @@ const ThreeScene = (() => {
     requestRender();
   }
 
-  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, setFlyoverFrame, setResizeSuppressed, forceDistrictBand, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, setSceneExposure, getLightingState, getSunElevation, setGradeEnabled, getGradeEnabled, setEdgeGlowEnabled, getEdgeGlowEnabled, setSunSphereVisible, getShadowSnapshot, getCameraState, setCameraState, isInitialized, getLeafletView, frameLeafletView, getSceneColorVars, getRenderInfo, getCullCounts, setOverrideMaterial, dumpDebugInfo, isWebGPUActive };
+  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, setFlyoverFrame, forceDistrictBand, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, setSceneExposure, getLightingState, getSunElevation, setGradeEnabled, getGradeEnabled, setEdgeGlowEnabled, getEdgeGlowEnabled, setSunSphereVisible, getShadowSnapshot, getCameraState, setCameraState, isInitialized, getLeafletView, frameLeafletView, getSceneColorVars, getRenderInfo, getCullCounts, setOverrideMaterial, dumpDebugInfo, isWebGPUActive };
 })();
 
 window.NCZ.ThreeScene = ThreeScene;

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -1028,6 +1028,7 @@ const ThreeScene = (() => {
   // upstream (bind-group cache must re-key on target recreation).
   let _resizeSuppressed = false;
   function setResizeSuppressed(on) { _resizeSuppressed = !!on; }
+  let _lastBufferW = 0, _lastBufferH = 0; // last size the drawing buffer was set to
 
   function onResize() {
     if (!renderer) return;
@@ -1035,8 +1036,10 @@ const ThreeScene = (() => {
     if (!container || container.style.display === 'none') return;
     const w = container.clientWidth;
     const h = container.clientHeight;
-    if (!_resizeSuppressed) {
+    const bufferResized = !_resizeSuppressed && (w !== _lastBufferW || h !== _lastBufferH);
+    if (bufferResized) {
       renderer.setSize(w, h, false); // updateStyle:false — CSS width/height stay at 100%
+      _lastBufferW = w; _lastBufferH = h;
     }
     camera.aspect = w / h;
     camera.updateProjectionMatrix();
@@ -1044,8 +1047,22 @@ const ThreeScene = (() => {
     // flyCamera resize is handled in flyover.js
     // Line2NodeMaterial pulls viewport size from a TSL screen node at
     // shader-execution time, so the legacy resolution-set loop is no longer
-    // needed here — left as a single retained `districtLineMaterials` ref so
-    // the registry still exists for any future per-material resize work.
+    // needed here. What IS needed on r185: dispose the district line
+    // materials after setSize so the backend drops their cached render state.
+    // The Line2 render path retains GPU state referencing the renderer's
+    // canvas-size RGBA16Float framebuffer target; setSize destroys and
+    // recreates that target but the cached state is never re-keyed, so every
+    // later submit that includes a district line binds the destroyed texture
+    // and the whole frame's submit is discarded — canvas wedges black until
+    // reload (#771; bisect 2026-07-03: base scene, buildings, shadows, roads
+    // and metro all resize clean — district Line2 alone carries the wedge;
+    // material.needsUpdate is NOT sufficient to flush it, dispose() is).
+    // Three rebuilds the disposed materials transparently on their next
+    // render. Gated on an actual buffer resize so resize-event storms during
+    // a window drag don't recompile the line pipelines redundantly.
+    if (bufferResized) {
+      for (const m of districtLineMaterials) m.dispose();
+    }
     NCZ.ThreeMarkers?.onResize?.(w, h);
     updateScaleBar();
     requestRender();

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -50,7 +50,6 @@ const SUN_DIR = new THREE.Vector3(-1, 1.5, -1).normalize();
 
 const ThreeScene = (() => {
   let renderer, camera, scene, controls;
-  let animationId = null;
   let initialized = false;
   // True only when the renderer ended up on a real WebGPU backend. The webgpu
   // build reports renderer.isWebGPURenderer === true even on its WebGL2
@@ -212,7 +211,7 @@ const ThreeScene = (() => {
   const _shadowFrustumScratch    = new THREE.Frustum();
   const _shadowFrustumScratchMat = new THREE.Matrix4();
   // Per-district compute nodes (reset + cull) registered during loadBuildings.
-  // Dispatched in pairs from `renderLoop` before `renderer.render`.
+  // Dispatched in pairs from the animation-loop `frame()` before `renderer.render`.
   const _cullComputes = [];
 
   function updateFrustumUniforms(renderCam = camera) {
@@ -2433,7 +2432,7 @@ const ThreeScene = (() => {
     requestRender();
   }
 
-  // Advance the intro fly-in one frame. Called at the top of renderLoop so
+  // Advance the intro fly-in one frame. Called at the top of frame() so
   // the camera mutation lands before controls.update() reconciles it — that
   // reconcile fires the 'change' listener, refreshing district zoom, metro
   // LOD, the shadow camera, scale bar and cull frustum as the camera moves.
@@ -2524,25 +2523,54 @@ const ThreeScene = (() => {
     console.log('  NCZ.ThreeScene.dumpDebugInfo()       → full diagnostic snapshot (also bound to the "Copy debug info" button)');
   }
 
-  // Render-on-demand: rAF runs only when something has changed (camera moved,
-  // damping in progress, sun/theme/layer/material updated, pins added, or a
-  // module explicitly held the loop open via setContinuousRender). Idle map
-  // views cost zero GPU/CPU — the previous unconditional rAF chewed a full
-  // frame's worth of work even when the scene was identical to the last one.
-  // Triggered via requestRender(); any state mutation that affects pixels
-  // calls it. Damping continuation is detected from controls.update()'s
-  // return value (true = state still interpolating).
+  // Render-on-demand over renderer.setAnimationLoop — the WebGPU-native frame
+  // driver (issue #768; the WebGL-era manual rAF chain is retired). The loop
+  // fn stays armed while work exists and early-returns on non-dirty ticks;
+  // after IDLE_DISARM_MS of consecutive idle ticks it disarms itself via
+  // setAnimationLoop(null), so a truly idle map costs zero renders AND zero
+  // rAF wakeups. requestRender() marks the frame dirty and re-arms — hook it
+  // into any state mutation that affects pixels. The grace window (rather
+  // than disarm-on-first-idle-tick) keeps bursty input (wheel ticks, hover
+  // in/out) on a warm loop instead of churning setAnimationLoop.
+  // Damping continuation is detected from controls.update()'s return value
+  // (true = state still interpolating).
   //
-  // _suppressed — flyover stops the schema loop and runs its own rAF that
-  // calls renderFrame(flyCamera) directly. Beat-driven transitionToColors
-  // still fires requestRender during the flyover, which would otherwise
-  // resurrect the schema renderLoop and race the flyover camera. The flag
-  // gates requestRender so the flyover's own loop stays the sole renderer.
+  // _suppressed — flyover stops the schema loop and drives frames through
+  // _flyoverFrame (setFlyoverFrame below) on this same animation loop. Beat-
+  // driven transitionToColors still fires requestRender during the flyover,
+  // which would otherwise mark the schema path dirty and race the flyover
+  // camera. The flag gates requestRender so the flyover callback stays the
+  // sole renderer.
+  const IDLE_DISARM_MS = 250;
   let _continuousRenderRefs = 0;
   let _suppressed = false;
+  let _frameDirty = false;
+  let _loopArmed = false;
+  let _idleSince = 0;
+  let _flyoverFrame = null;   // showcase per-frame callback; loop persists while set
+  let _framesRendered = 0;    // lifetime renderer.render count — idle verification
 
-  function renderLoop() {
-    animationId = null;
+  function armLoop() {
+    if (_loopArmed || !renderer) return;
+    renderer.setAnimationLoop(frame);
+    _loopArmed = true;
+  }
+
+  function disarmLoop() {
+    if (!_loopArmed) return;
+    renderer.setAnimationLoop(null);
+    _loopArmed = false;
+  }
+
+  function frame(time) {
+    if (_flyoverFrame) { _flyoverFrame(time); return; }
+    if (_suppressed || (!_frameDirty && _continuousRenderRefs === 0)) {
+      // Idle tick — nothing changed since the last render. Disarm once the
+      // grace window has passed with no new work.
+      if ((time ?? performance.now()) - _idleSince > IDLE_DISARM_MS) disarmLoop();
+      return;
+    }
+    _frameDirty = false;
     if (stats) stats.begin();
     updateIntroTween();   // E5 intro fly-in — mutate the camera before controls.update() reconciles
     stepDistrictHoverFade(performance.now()); // district outline opacity tween
@@ -2561,6 +2589,7 @@ const ThreeScene = (() => {
       renderer.compute(c.cull);
     }
     renderer.render(scene, camera);
+    _framesRendered++;
     NCZ.ThreeMarkers?.render?.();
     if (stats) {
       statsCallsPanel.update(renderer.info.render.calls,         200);
@@ -2590,25 +2619,37 @@ const ThreeScene = (() => {
       const tilt = Math.round(90 - polarDegrees);
       tiltDisplay.textContent = `Tilt: ${tilt}°`;
     }
-    if (dampingActive || _continuousRenderRefs > 0) requestRender();
+    if (dampingActive || _continuousRenderRefs > 0) _frameDirty = true;
+    else _idleSince = performance.now();
   }
 
   // Schedule one frame. Idempotent — multiple calls within the same tick
-  // collapse to a single rAF. Hook into any state change that affects pixels.
+  // collapse to a single dirty flag. Hook into any state change that affects
+  // pixels. Re-arms the animation loop if it has idle-disarmed.
   function requestRender() {
     if (_suppressed) return;
-    if (animationId !== null) return;
     if (!renderer || !scene || !camera) return;
-    animationId = requestAnimationFrame(renderLoop);
+    _frameDirty = true;
+    armLoop();
   }
 
   // Hold the loop open across an arbitrary number of frames. Counter-based so
   // multiple animations (theme dissolve + sun arc + beat pulse) compose cleanly
   // — each pairs a true/false call. Flyover doesn't use this; it bypasses the
-  // schema renderLoop entirely with its own rAF + renderFrame(flyCamera) path.
+  // schema frame body entirely via its setFlyoverFrame callback.
   function setContinuousRender(active) {
     _continuousRenderRefs = Math.max(0, _continuousRenderRefs + (active ? 1 : -1));
     if (_continuousRenderRefs > 0) requestRender();
+  }
+
+  // Showcase frame driver (issue #768). While a callback is set, the shared
+  // animation loop invokes it every tick instead of the schema frame body —
+  // a cinematic is continuous by nature, so no dirty flag and no idle disarm.
+  // Clearing it falls back to the schema path, which (still _suppressed until
+  // startRenderLoop) idles out through the normal grace window.
+  function setFlyoverFrame(fn) {
+    _flyoverFrame = fn || null;
+    if (_flyoverFrame) armLoop();
   }
 
   // Backward-compat shims — external callers (app.js view switch, flyover
@@ -2616,7 +2657,7 @@ const ThreeScene = (() => {
   // renders soon" which on-demand satisfies via a single requestRender.
   // start also clears the flyover suppression flag in case stopRenderLoop
   // was the call that engaged it; stop sets it so any in-flight requestRender
-  // (e.g. from a still-running color tween) doesn't resurrect the loop.
+  // (e.g. from a still-running color tween) doesn't mark the schema path dirty.
   function startRenderLoop() {
     _suppressed = false;
     // The showcase flyover fits the shadow camera, the cull-frustum uniforms,
@@ -2636,10 +2677,10 @@ const ThreeScene = (() => {
 
   function stopRenderLoop() {
     _suppressed = true;
-    if (animationId !== null) {
-      cancelAnimationFrame(animationId);
-      animationId = null;
-    }
+    _frameDirty = false;
+    // Disarm now unless the flyover is (about to be) driving frames — in the
+    // flyover start sequence setFlyoverFrame() follows immediately and re-arms.
+    if (!_flyoverFrame) disarmLoop();
     _lastFrameTime = 0; // Reset so the next frame after restart doesn't sample the gap
   }
 
@@ -2649,6 +2690,9 @@ const ThreeScene = (() => {
   function getRenderInfo() {
     if (!renderer) return null;
     return {
+      // Lifetime count of frames actually rendered (schema + flyover) — poll
+      // twice to verify render-on-demand idles at zero (issue #768 acceptance).
+      framesRendered: _framesRendered,
       drawCalls:  renderer.info.render.calls,
       triangles:  renderer.info.render.triangles,
       points:     renderer.info.render.points,
@@ -3051,9 +3095,9 @@ const ThreeScene = (() => {
     if (!renderer || !scene) return;
     // The showcase flyover renders through its own PerspectiveCamera —
     // re-fit the shadow camera AND the cull-frustum uniforms to *its* view
-    // each frame (the schema renderLoop is suppressed during showcase, so
+    // each frame (the schema frame body is suppressed during showcase, so
     // nothing else is keeping these in sync). Then dispatch the per-frame
-    // Phase 2B cull computes the same way renderLoop does — without this,
+    // Phase 2B cull computes the same way frame() does — without this,
     // the indirect buffer's instanceCount is frozen at whatever the schema
     // cam last culled, so both the shadow pass and the main pass draw a
     // stale building set (the original symptom: shadows missing under
@@ -3074,6 +3118,7 @@ const ThreeScene = (() => {
       }
     }
     renderer.render(scene, cam);
+    _framesRendered++;
   }
 
   function setControlsEnabled(enabled) {
@@ -3677,7 +3722,7 @@ const ThreeScene = (() => {
     requestRender();
   }
 
-  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, setResizeSuppressed, forceDistrictBand, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, setSceneExposure, getLightingState, getSunElevation, setGradeEnabled, getGradeEnabled, setEdgeGlowEnabled, getEdgeGlowEnabled, setSunSphereVisible, getShadowSnapshot, getCameraState, setCameraState, isInitialized, getLeafletView, frameLeafletView, getSceneColorVars, getRenderInfo, getCullCounts, setOverrideMaterial, dumpDebugInfo, isWebGPUActive };
+  return { init, startRenderLoop, stopRenderLoop, requestRender, setContinuousRender, setFlyoverFrame, setResizeSuppressed, forceDistrictBand, resetCamera, setLayerVisibility, getLayerVisibility, updateMaterials, renderFrame, setControlsEnabled, getCanvasElement, captureColors, transitionMaterials, transitionToColors, setSunPosition, setShadowsEnabled, getShadowsEnabled, setSceneExposure, getLightingState, getSunElevation, setGradeEnabled, getGradeEnabled, setEdgeGlowEnabled, getEdgeGlowEnabled, setSunSphereVisible, getShadowSnapshot, getCameraState, setCameraState, isInitialized, getLeafletView, frameLeafletView, getSceneColorVars, getRenderInfo, getCullCounts, setOverrideMaterial, dumpDebugInfo, isWebGPUActive };
 })();
 
 window.NCZ.ThreeScene = ThreeScene;

--- a/index.html
+++ b/index.html
@@ -585,7 +585,8 @@
                     </select>
                     <label class="bbcode-checkbox-label"><input type="checkbox" id="showcase-show-pins"> Show mod pins during showcase</label>
                     <label class="bbcode-checkbox-label"><input type="checkbox" id="showcase-reveal-layers"> Stagger layer reveal at start</label>
-                    <label class="bbcode-checkbox-label"><input type="checkbox" id="showcase-districts"> Show district outlines</label>
+                    <label class="bbcode-checkbox-label"><input type="checkbox" id="showcase-district-names"> Show district names</label>
+                    <label class="bbcode-checkbox-label"><input type="checkbox" id="showcase-district-outlines"> Show district outlines</label>
                     <label class="bbcode-checkbox-label"><input type="checkbox" id="showcase-audio" checked> Play music</label>
                     <label class="bbcode-checkbox-label"><input type="checkbox" id="showcase-loop"> Loop showcase</label>
                 </div>

--- a/index.html
+++ b/index.html
@@ -619,10 +619,10 @@
     <script type="importmap">
     {
       "imports": {
-        "three":         "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.webgpu.min.js",
-        "three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.webgpu.min.js",
-        "three/tsl":     "https://cdn.jsdelivr.net/npm/three@0.184.0/build/three.tsl.min.js",
-        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.184.0/examples/jsm/"
+        "three":         "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.webgpu.min.js",
+        "three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.webgpu.min.js",
+        "three/tsl":     "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.tsl.min.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.0/examples/jsm/"
       }
     }
     </script>

--- a/scripts/r185_resize_spike.html
+++ b/scripts/r185_resize_spike.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<!-- SCRATCH SPIKE — r185 resize/destroyed-texture investigation. Delete after. -->
+<html>
+<head><meta charset="utf-8"><title>r185 resize spike</title>
+<style>html,body{margin:0;height:100%;background:#0a192f;overflow:hidden}#c{width:100vw;height:100vh}</style>
+<script type="importmap">
+{ "imports": {
+  "three": "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.webgpu.min.js",
+  "three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.webgpu.min.js",
+  "three/tsl": "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.tsl.min.js"
+} }
+</script>
+</head>
+<body>
+<div id="c"></div>
+<script type="module">
+import * as THREE from 'three/webgpu';
+import { Fn, instancedArray, instanceIndex, vec4, float } from 'three/tsl';
+
+// URL flags:
+//   ?loop=manual|sal   manual rAF (default) vs setAnimationLoop
+//   ?tone=1            enable ACESFilmic tone mapping (forces HDR RGBA16Float intermediate)
+//   ?compute=1         dispatch a compute pass each frame (mimics our building cull)
+const P = new URLSearchParams(location.search);
+const MODE = P.get('loop') || 'manual';
+const TONE = P.get('tone') === '1';
+const COMPUTE = P.get('compute') === '1';
+window.__spikeErrors = 0;
+
+const container = document.getElementById('c');
+const scene = new THREE.Scene();
+scene.background = new THREE.Color('#0a192f');
+const camera = new THREE.PerspectiveCamera(60, container.clientWidth/container.clientHeight, 0.1, 1000);
+camera.position.set(0, 0, 5);
+
+const mesh = new THREE.Mesh(
+  new THREE.BoxGeometry(1,1,1),
+  new THREE.MeshBasicNodeMaterial({ color: 0x00f0ff })
+);
+scene.add(mesh);
+
+// Match our app's renderer config as closely as relevant.
+const renderer = new THREE.WebGPURenderer({ antialias: true, stencil: true, reversedDepthBuffer: true });
+if (TONE) renderer.toneMapping = THREE.ACESFilmicToneMapping;
+renderer.setPixelRatio(window.devicePixelRatio);
+renderer.setSize(container.clientWidth, container.clientHeight, false);
+container.appendChild(renderer.domElement);
+
+await renderer.init();
+
+// Optional compute pass — mimics our per-frame building cull (instancedArray + compute()).
+let computeNode = null;
+if (COMPUTE) {
+  const buf = instancedArray(1024, 'vec4');
+  computeNode = Fn(() => { buf.element(instanceIndex).assign(vec4(float(instanceIndex), 0, 0, 1)); })().compute(1024);
+}
+
+window.__spikeReady = true;
+window.__spikeMode = MODE + (TONE?'+tone':'') + (COMPUTE?'+compute':'');
+
+function frame() {
+  mesh.rotation.x += 0.01;
+  mesh.rotation.y += 0.013;
+  if (computeNode) renderer.compute(computeNode);
+  renderer.render(scene, camera);
+}
+
+if (MODE === 'sal') {
+  // WebGPU-native idiom.
+  renderer.setAnimationLoop(frame);
+} else {
+  // WebGL-era pattern: manual rAF + render().
+  (function loop(){ frame(); requestAnimationFrame(loop); })();
+}
+
+// Exposed so the harness can trigger a mid-loop resize deterministically.
+window.__spikeResize = (w, h) => {
+  container.style.width = w + 'px';
+  container.style.height = h + 'px';
+  camera.aspect = w / h;
+  camera.updateProjectionMatrix();
+  renderer.setSize(w, h, false);
+};
+</script>
+</body>
+</html>

--- a/scripts/r185_resize_spike.html
+++ b/scripts/r185_resize_spike.html
@@ -7,7 +7,8 @@
 { "imports": {
   "three": "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.webgpu.min.js",
   "three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.webgpu.min.js",
-  "three/tsl": "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.tsl.min.js"
+  "three/tsl": "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.tsl.min.js",
+  "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.0/examples/jsm/"
 } }
 </script>
 </head>
@@ -20,11 +21,17 @@ import { Fn, instancedArray, instanceIndex, vec4, float } from 'three/tsl';
 // URL flags:
 //   ?loop=manual|sal   manual rAF (default) vs setAnimationLoop
 //   ?tone=1            enable ACESFilmic tone mapping (forces HDR RGBA16Float intermediate)
+//   ?ctone=1           register the app's CUSTOM CP2077 tone mapping (library.addToneMapping + LUT)
+//   ?shadow=1          directional light + shadow map pass (mimics our sun shadows)
 //   ?compute=1         dispatch a compute pass each frame (mimics our building cull)
+//   ?line=1            add a Line2 + Line2NodeMaterial ring (mimics our district outlines)
 const P = new URLSearchParams(location.search);
 const MODE = P.get('loop') || 'manual';
 const TONE = P.get('tone') === '1';
+const CTONE = P.get('ctone') === '1';
+const SHADOW = P.get('shadow') === '1';
 const COMPUTE = P.get('compute') === '1';
+const LINE = P.get('line') === '1';
 window.__spikeErrors = 0;
 
 const container = document.getElementById('c');
@@ -35,13 +42,48 @@ camera.position.set(0, 0, 5);
 
 const mesh = new THREE.Mesh(
   new THREE.BoxGeometry(1,1,1),
-  new THREE.MeshBasicNodeMaterial({ color: 0x00f0ff })
+  SHADOW ? new THREE.MeshLambertNodeMaterial({ color: 0x00f0ff })
+         : new THREE.MeshBasicNodeMaterial({ color: 0x00f0ff })
 );
 scene.add(mesh);
+
+if (LINE) {
+  // Match the district-outline material config (three-scene.js loadDistricts).
+  const { Line2 } = await import('three/addons/lines/webgpu/Line2.js');
+  const { LineGeometry } = await import('three/addons/lines/LineGeometry.js');
+  const geo = new LineGeometry();
+  const pts = [];
+  for (let i = 0; i <= 32; i++) { const a = i / 32 * Math.PI * 2; pts.push(Math.cos(a) * 2, Math.sin(a) * 2, 0); }
+  geo.setPositions(pts);
+  const lineMat = new THREE.Line2NodeMaterial({
+    color: 0x00f0ff, linewidth: 2, depthTest: false,
+    transparent: true, opacity: 0.35, alphaToCoverage: false,
+  });
+  const line = new Line2(geo, lineMat);
+  scene.add(line);
+  window.__spikeLine = line; // exposed so the harness can hide/show across a resize
+}
+
+if (SHADOW) {
+  mesh.castShadow = true;
+  const ground = new THREE.Mesh(new THREE.PlaneGeometry(20, 20), new THREE.MeshLambertNodeMaterial({ color: 0x223344 }));
+  ground.rotation.x = -Math.PI / 2; ground.position.y = -2; ground.receiveShadow = true;
+  scene.add(ground);
+  const sun = new THREE.DirectionalLight(0xffffff, 2);
+  sun.position.set(3, 5, 2); sun.castShadow = true;
+  sun.shadow.mapSize.set(1024, 1024);
+  scene.add(sun);
+  scene.add(new THREE.AmbientLight(0x8899aa, 0.5));
+}
 
 // Match our app's renderer config as closely as relevant.
 const renderer = new THREE.WebGPURenderer({ antialias: true, stencil: true, reversedDepthBuffer: true });
 if (TONE) renderer.toneMapping = THREE.ACESFilmicToneMapping;
+if (CTONE) {
+  const { registerCP2077ToneMapping } = await import('../assets/js/aces-tonemap.js');
+  renderer.toneMapping = registerCP2077ToneMapping(renderer);
+  renderer.toneMappingExposure = 0.72;
+}
 renderer.setPixelRatio(window.devicePixelRatio);
 renderer.setSize(container.clientWidth, container.clientHeight, false);
 container.appendChild(renderer.domElement);
@@ -56,7 +98,7 @@ if (COMPUTE) {
 }
 
 window.__spikeReady = true;
-window.__spikeMode = MODE + (TONE?'+tone':'') + (COMPUTE?'+compute':'');
+window.__spikeMode = MODE + (TONE?'+tone':'') + (CTONE?'+ctone':'') + (SHADOW?'+shadow':'') + (COMPUTE?'+compute':'') + (LINE?'+line':'');
 
 function frame() {
   mesh.rotation.x += 0.01;


### PR DESCRIPTION
## Summary

Upgrades three.js r184 → r185 (milestone `r185`, tracking #773) and lands everything the upgrade shook loose. User-verified live at each increment.

### Upgrade + regression fixes (`b95865e`, `3879cdf`)

- three.js 0.184.0 → 0.185.0 (adopts upstream #33572, the `trimSegment` reversed-depth fix we tracked as mrdoob#33570).
- Transparent chain reworked to fully explicit tiers: water 0 → roads depth/colour 1/2 → borders depth/colour 3/4 → SeeThrough 5 → metro 6 → districts 7. Surface passes over-stamp stencil=OCCLUDER; per-layer depth-prepass → Equal-colour collapses additive self-overlap.
- Pre-compensations for two r185 engine bugs under `reversedDepthBuffer` (held upstream drafts): the transparent-sort list `.reverse()` inverting `renderOrder`, and `ReversedDepthFuncs` mapping `Equal→NotEqual`. Marked in-code; remove when upstream fixes land.
- `alphaToCoverage: false` on district Line2 materials (r185's MSAA fixes activated a2c, quantising faint outlines invisible).
- Showcase: district names/outlines split into separate options; outline tier pinned for the flight; sidebar hidden.

### Render loop on `setAnimationLoop` (#768) (`edae4a9`, `b7c7d76`)

- Manual rAF chain replaced with the WebGPU-native frame driver: one persistent `frame()` with a dirty-flag early-return; disarms itself via `setAnimationLoop(null)` after 250 ms idle, re-armed by `requestRender()`. Idle = zero renders AND zero rAF wakeups (observable via the new `framesRendered` counter in `getRenderInfo()`).
- Flyover's private rAF retired — the showcase registers its per-frame callback via `setFlyoverFrame()` on the shared loop. `setContinuousRender` refcounting, `startRenderLoop` resync and suppression semantics preserved exactly.

### r185 resize wedge — root cause + mitigation (#771) (`985b55d`, `f2aac93`, `2a0ee19`)

- **Root cause** (layer bisect + r184/r185 A/B worktrees): ANY `renderer.setSize` on r185 permanently wedges the canvas (every submit binds a destroyed canvas-size RGBA16Float texture; black until reload) — but only with the district Line2 outlines in the scene. r185's `Line2NodeMaterial` doesn't support real transparency: it fakes it by sampling `viewportOpaqueMipTexture()` (canvas-size copy of the opaque framebuffer), and that binding goes stale across resize. Continuous render was never required; it only turned the wedge into a flood.
- **Mitigation**: `dispose()` the district line materials after a real buffer resize (`needsUpdate` does NOT flush the stale state). Gated on actual size change. Verified zero errors across plain resize, the continuous+resize flood repro, hide-layer-across-resize, and showcase enter/exit.
- **`setResizeSuppressed` removed**: with the mitigation in place the showcase setSize guard retested clean end to end, so it's gone. The showcase now renders at native fullscreen resolution instead of a CSS-stretched windowed buffer (user-approved: looks better).
- Repro spike (`scripts/r185_resize_spike.html`) extended with `ctone`/`shadow`/`line` flags; minimal combos do not reproduce — findings on #771.

### Known-remaining (gated on #775)

The unhovered district-outline colour differs from r184 (same fake-transparency root: lines composite against the opaque-only backdrop, ignoring roads/metro/water beneath). Per the recorded decision, **r185 does not ship dev→main until #775** (custom TSL line material) lands — that also deletes the dispose mitigation and the a2c workaround.

Closes #768, closes #769, closes #770, closes #772.
Refs #771 (mitigated here; upstream root cause, drafts held), #773, #775.

## Test plan

- [x] Idle render-on-demand: zero renders + zero rAF wakeups (framesRendered frozen over 4 s)
- [x] Intro fly-in, hover fade, theme dissolve, continuous holds compose and release
- [x] Showcase: start, pause/resume, Esc exit, post-exit idle; audio-end restart path unchanged
- [x] Resize: idle, during continuous render (the old #771 flood repro), hidden-districts-across-resize, mid-showcase — zero destroyed-texture errors
- [x] District rings at close perspective zoom: no rays (#772 acceptance)
- [x] Console clean across load / showcase / manual resize
- [x] User live sign-off 2026-07-03 (resize behaviour, native-res showcase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)