### PR TITLE
three.js r185: custom TSL line material for district outlines (#775)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - three.js upgraded r184 → r185; adopts the upstream fix for district outline rays at close zoom (#773).
 - The render loop (including the showcase flyover) now runs on `renderer.setAnimationLoop`, the WebGPU-native frame driver; idle render-on-demand behaviour is unchanged (#768).
+- District outlines render through our own TSL line material instead of three.js `Line2NodeMaterial` (#775): true semi-transparent compositing over roads, metro and water, ring corners no longer over-brighten, and the r185 line workarounds (resize mitigation, alpha-to-coverage opt-out) are gone.
 - Roads, borders and the metro now layer correctly at every camera angle: no more borders or roads glowing through overlapping decks, and metro/tunnel roads render correctly over water (#770).
 
 #### Fixed

--- a/assets/js/district-line-material.js
+++ b/assets/js/district-line-material.js
@@ -1,0 +1,192 @@
+/**
+ * DistrictLineMaterial — custom TSL wide-line material for the district
+ * outlines (issue #775), replacing three's Line2NodeMaterial.
+ *
+ * Why not Line2NodeMaterial: the r185 rewrite doesn't support real
+ * transparency ("not supported, yet" — it forces NoBlending and fakes
+ * semi-transparent lines by blending against viewportOpaqueMipTexture(), a
+ * canvas-size copy of the opaque-only framebuffer, in-shader). For our
+ * outlines that fake was the root of three bugs at once: the #771 resize
+ * wedge (stale binding to the destroyed framebuffer copy), the unhovered
+ * colour regression (lines composited against the opaque backdrop, ignoring
+ * the roads/metro/water actually beneath them), and the alphaToCoverage
+ * quantisation of faint lines. See wiki
+ * learnings/line2-fake-transparency-root-of-r185-issues.
+ *
+ * What this ports from upstream (r185 Line2NodeMaterial, screen-space path):
+ *   - the instanced quad expansion from LineGeometry's instanceStart /
+ *     instanceEnd attributes (geometry pipeline unchanged — only the
+ *     material is swapped)
+ *   - the reversed-depth-aware near-plane segment trim (upstream #33572,
+ *     the fix this repo tracked as mrdoob#33570)
+ *   - round endcaps
+ *
+ * What it does differently:
+ *   - real alpha blending: NormalBlending + standard material.opacity, so
+ *     the hover fade tween and the faint resting opacity composite against
+ *     whatever is actually behind the line (r184-equivalent look)
+ *   - endcap edges are fwidth-AA'd unconditionally (no alphaToCoverage, no
+ *     MSAA sample-count gate — the sub-pixel-detail lesson from the terrain
+ *     grid / building edges applies here too)
+ *   - degenerate segments (zero NDC length after projection) are guarded
+ *     in-shader: belt-and-braces alongside dedupRing()'s data hygiene, so
+ *     bad ring data can never produce NaN direction rays again
+ *
+ * Not ported (unused by the district outlines): dashes, world units, vertex
+ * colors, raycast support.
+ *
+ * Joint dedup (the `stencilRef` parameter): every segment is an independent
+ * quad with cap extensions, so a ring self-overlaps at each corner — under
+ * real alpha blending that double-blend reads as a brighter dot at partial
+ * opacity. (r184 never showed it: its backdrop-premix fake made overlapping
+ * writes idempotent.) Fix: per-ring stencil ref with NotEqual + Replace —
+ * within a frame each ring's first fragment at a pixel stamps the ref and
+ * later fragments of the SAME ring fail the test, so a ring touches each
+ * pixel once. Coincident neighbour borders carry different refs and still
+ * draw over each other (hover-over-faint keeps working). Rings draw at
+ * renderOrder 7+, after the SeeThrough pass (renderOrder 5) has consumed
+ * the scene's OCCLUDER/water stencil values, so clobbering them is safe.
+ */
+
+import * as THREE from 'three';
+import {
+  Fn, If, float, vec2, vec4, attribute, uv, select,
+  positionGeometry, modelViewMatrix, cameraProjectionMatrix,
+  materialColor, materialOpacity, materialLineWidth, mix, smoothstep,
+  viewport, screenDPR,
+} from 'three/tsl';
+
+// Near-plane estimate from the projection matrix, branching on the depth
+// convention: te[10] is positive under a reversed depth buffer, so its sign
+// selects the formula (verbatim port of r185's trimSegmentAlpha — the r184
+// version assumed the WebGL layout and returned ~-far/2 under reversed-Z,
+// the rays-across-viewport bug).
+const trimSegmentAlpha = Fn(({ start, end }) => {
+  const a = cameraProjectionMatrix.element(2).element(2);
+  const b = cameraProjectionMatrix.element(3).element(2);
+  const nearEstimate = a.greaterThan(0).select(b.negate().div(a.add(1)), b.mul(-0.5).div(a));
+  return nearEstimate.sub(start.z).div(end.z.sub(start.z));
+}, { start: 'vec4', end: 'vec4', return: 'float' });
+
+// Vertex stage: expand each instanced segment into a screen-facing quad of
+// `linewidth` pixels, with one-segment-length cap extensions at both ends
+// (the fragment stage rounds them off).
+const districtLineClipPosition = /*@__PURE__*/ Fn(() => {
+  const instanceStart = attribute('instanceStart');
+  const instanceEnd   = attribute('instanceEnd');
+
+  // camera space
+  const start = vec4(modelViewMatrix.mul(vec4(instanceStart, 1.0))).toVar('start');
+  const end   = vec4(modelViewMatrix.mul(vec4(instanceEnd, 1.0))).toVar('end');
+
+  const aspect = viewport.z.div(viewport.w);
+
+  // Trim segments that cross the camera plane under perspective projection —
+  // NDC math below is meaningless for endpoints behind the camera.
+  const perspective = cameraProjectionMatrix.element(2).element(3).equal(-1.0);
+  If(perspective, () => {
+    If(start.z.lessThan(0.0).and(end.z.greaterThan(0.0)), () => {
+      const alpha = trimSegmentAlpha({ start, end });
+      end.assign(vec4(mix(start.xyz, end.xyz, alpha), end.w));
+    }).ElseIf(end.z.lessThan(0.0).and(start.z.greaterThanEqual(0.0)), () => {
+      const alpha = trimSegmentAlpha({ start: end, end: start });
+      start.assign(vec4(mix(end.xyz, start.xyz, alpha), start.w));
+    });
+  });
+
+  // clip → ndc
+  const clipStart = cameraProjectionMatrix.mul(start);
+  const clipEnd   = cameraProjectionMatrix.mul(end);
+  const ndcStart  = clipStart.xyz.div(clipStart.w);
+  const ndcEnd    = clipEnd.xyz.div(clipEnd.w);
+
+  // segment direction in aspect-corrected NDC — guarded against degenerate
+  // (zero-length after projection) segments instead of normalize(0,0) = NaN
+  const dir = ndcEnd.xy.sub(ndcStart.xy).toVar('dir');
+  dir.x.assign(dir.x.mul(aspect));
+  const dirLen = dir.length().toVar('dirLen');
+  dir.assign(select(dirLen.greaterThan(1e-7), dir.div(dirLen), vec2(1.0, 0.0)));
+
+  // perpendicular offset, back to un-corrected NDC
+  const offset = vec2(dir.y, dir.x.negate()).toVar('offset');
+  dir.x.assign(dir.x.div(aspect));
+  offset.x.assign(offset.x.div(aspect));
+
+  // quad corner side
+  offset.assign(positionGeometry.x.lessThan(0.0).select(offset.negate(), offset));
+
+  // endcap extension along the segment direction
+  If(positionGeometry.y.lessThan(0.0), () => {
+    offset.assign(offset.sub(dir));
+  }).ElseIf(positionGeometry.y.greaterThan(1.0), () => {
+    offset.assign(offset.add(dir));
+  });
+
+  // pixels → NDC (materialLineWidth reads material.linewidth)
+  offset.assign(offset.mul(materialLineWidth));
+  offset.assign(offset.div(viewport.w.div(screenDPR)));
+
+  // anchor on this vertex's segment end, offset in clip space
+  const clip = vec4(positionGeometry.y.lessThan(0.5).select(clipStart, clipEnd)).toVar('clip');
+  offset.assign(offset.mul(clip.w));
+  return clip.add(vec4(offset, 0, 0));
+})();
+
+// Fragment coverage: 1 in the quad body; round endcaps beyond uv.y ∈ [-1, 1]
+// with an fwidth-AA'd circular edge (always on — no sample-count gate).
+const districtLineCoverage = /*@__PURE__*/ Fn(() => {
+  const vUv = uv();
+  const alpha = float(1).toVar('alpha');
+  If(vUv.y.abs().greaterThan(1.0), () => {
+    const a = vUv.x;
+    const b = vUv.y.greaterThan(0.0).select(vUv.y.sub(1.0), vUv.y.add(1.0));
+    const len2 = a.mul(a).add(b.mul(b));
+    const dlen = float(len2.fwidth()).toVar('dlen');
+    alpha.assign(smoothstep(dlen.oneMinus(), dlen.add(1), len2).oneMinus());
+    alpha.lessThanEqual(0.0).discard();
+  });
+  return alpha;
+})();
+
+export class DistrictLineMaterial extends THREE.NodeMaterial {
+  static get type() { return 'DistrictLineMaterial'; }
+
+  constructor(parameters = {}) {
+    super();
+
+    this.isDistrictLineMaterial = true;
+
+    // Properties the TSL accessors read (materialColor / materialOpacity /
+    // materialLineWidth) — must exist before setValues copies parameters in.
+    this.color = new THREE.Color(0xffffff);
+    this.linewidth = 1;
+
+    this.lights = false;
+
+    // Per-ring self-overlap dedup (see header). stencilRef is a plain
+    // constructor parameter; pull it out before setValues (it's not a
+    // standard Material property).
+    const stencilRef = parameters.stencilRef;
+    delete parameters.stencilRef;
+    if (stencilRef !== undefined) {
+      this.stencilWrite     = true;
+      this.stencilRef       = stencilRef;
+      this.stencilFunc      = THREE.NotEqualStencilFunc;
+      this.stencilZPass     = THREE.ReplaceStencilOp;
+      this.stencilFail      = THREE.KeepStencilOp;
+      this.stencilZFail     = THREE.KeepStencilOp;
+      this.stencilFuncMask  = 0xff;
+      this.stencilWriteMask = 0xff;
+    }
+
+    // Wired once here, NOT in setup() — assigning node properties during
+    // setup() dirties the material every build and forces a full pipeline
+    // recompile per frame (~1 s/frame when first tried). The nodes are
+    // module-level singletons shared by all instances.
+    this.vertexNode  = districtLineClipPosition;
+    this.colorNode   = materialColor;
+    this.opacityNode = materialOpacity.mul(districtLineCoverage);
+
+    this.setValues(parameters);
+  }
+}

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -41,6 +41,9 @@ import Stats from 'three/addons/libs/stats.module.js';
 // The exact in-game 3D-map colour pipeline (decoded from 3dmap.envparam):
 // ACES tonemap + colour grade + braindance LUT — see assets/js/aces-tonemap.js.
 import { registerCP2077ToneMapping, loadBraindanceLUT, setSceneGradeEnabled } from './aces-tonemap.js';
+// Custom TSL wide-line material for district outlines (#775) — replaces
+// THREE.Line2NodeMaterial; see the header of district-line-material.js.
+import { DistrictLineMaterial } from './district-line-material.js';
 
 window.NCZ = window.NCZ || {};
 
@@ -1037,24 +1040,11 @@ const ThreeScene = (() => {
     camera.updateProjectionMatrix();
     updateShadowCamera();   // shadow camera follows the schema camera's aspect
     // flyCamera resize is handled in flyover.js
-    // Line2NodeMaterial pulls viewport size from a TSL screen node at
-    // shader-execution time, so the legacy resolution-set loop is no longer
-    // needed here. What IS needed on r185: dispose the district line
-    // materials after setSize so the backend drops their cached render state.
-    // The Line2 render path retains GPU state referencing the renderer's
-    // canvas-size RGBA16Float framebuffer target; setSize destroys and
-    // recreates that target but the cached state is never re-keyed, so every
-    // later submit that includes a district line binds the destroyed texture
-    // and the whole frame's submit is discarded — canvas wedges black until
-    // reload (#771; bisect 2026-07-03: base scene, buildings, shadows, roads
-    // and metro all resize clean — district Line2 alone carries the wedge;
-    // material.needsUpdate is NOT sufficient to flush it, dispose() is).
-    // Three rebuilds the disposed materials transparently on their next
-    // render. Gated on an actual buffer resize so resize-event storms during
-    // a window drag don't recompile the line pipelines redundantly.
-    if (bufferResized) {
-      for (const m of districtLineMaterials) m.dispose();
-    }
+    // District lines need no resize handling: DistrictLineMaterial (#775)
+    // reads the viewport from a TSL screen node at shader-execution time and
+    // binds no framebuffer-copy textures — the dispose-on-resize mitigation
+    // that Line2NodeMaterial's viewportOpaqueMipTexture binding required
+    // (#771) was removed with it.
     NCZ.ThreeMarkers?.onResize?.(w, h);
     updateScaleBar();
     requestRender();
@@ -2293,6 +2283,17 @@ const ThreeScene = (() => {
   // District line materials — stored so resolution can be updated on resize
   const districtLineMaterials = [];
 
+  // Per-ring stencil refs for the joint self-overlap dedup (see
+  // district-line-material.js header). Values 3..255 — 1 (OCCLUDER) and 2
+  // (water) belong to the scene's SeeThrough stencil chain. Cycling is safe:
+  // a collision would need two rings ~253 build-order apart sharing a border.
+  let _nextLineStencilRef = 3;
+  function nextLineStencilRef() {
+    const ref = _nextLineStencilRef;
+    _nextLineStencilRef = _nextLineStencilRef >= 255 ? 3 : _nextLineStencilRef + 1;
+    return ref;
+  }
+
   // Drop consecutive ring vertices within ε CET units of each other. The
   // cleanup script (scripts/regenerate_subdistricts.py) runs Shapely boolean
   // ops on subdistrict polygons and rounds the output to 2 decimal places —
@@ -2345,7 +2346,7 @@ const ThreeScene = (() => {
       // an empty Line2 so the caller's group structure is preserved.
       const empty = new LineGeometry();
       empty.setPositions([]);
-      const placeholderMat = new THREE.Line2NodeMaterial({ color, linewidth: lineWidth, depthTest: false, transparent: true, opacity: 0 });
+      const placeholderMat = new DistrictLineMaterial({ color, linewidth: lineWidth, depthTest: false, transparent: true, opacity: 0 });
       districtLineMaterials.push(placeholderMat);
       return new Line2(empty, placeholderMat);
     }
@@ -2358,22 +2359,18 @@ const ThreeScene = (() => {
     const geometry = new LineGeometry();
     geometry.setPositions(positions);
 
-    // Line2NodeMaterial reads the viewport size from a TSL screen node at
-    // shader-execution time — no `resolution` field to keep in sync on resize
-    // like the WebGL LineMaterial required.
-    const material = new THREE.Line2NodeMaterial({
+    // Our own TSL wide-line material (#775) — real alpha blending instead of
+    // Line2NodeMaterial's NoBlending + opaque-backdrop fake, which was the
+    // shared root of the #771 resize wedge, the unhovered colour regression
+    // and the alphaToCoverage quantisation. Reads the viewport from a TSL
+    // screen node; no `resolution` field to keep in sync on resize.
+    const material = new DistrictLineMaterial({
       color,
       linewidth: lineWidth,
       depthTest: false,
       transparent: true,
       opacity: NCZ.DISTRICT_LINE_OPACITY,
-      // Line2NodeMaterial defaults alphaToCoverage:true, gated in-shader on
-      // renderer.currentSamples > 0. On r184 that gate never fired; r185's
-      // MSAA sample-count fixes activated it, and alpha-to-coverage QUANTIZES
-      // alpha to covered samples — the 5% base opacity rounds to 0 of 4
-      // samples = invisible lines (hover at ~1.0 still showed). We want the
-      // smooth faint alpha blend, not coverage dithering.
-      alphaToCoverage: false,
+      stencilRef: nextLineStencilRef(),
     });
     districtLineMaterials.push(material);
 


### PR DESCRIPTION
## Summary

Replaces `THREE.Line2NodeMaterial` with our own `DistrictLineMaterial` (assets/js/district-line-material.js) for the district/subdistrict outlines — the r185 ship-gate (#775). User-verified live: r184-equivalent look with slightly better unhovered compositing.

### Why

r185's Line2 rewrite doesn't support real transparency (forces `NoBlending`; fakes semi-transparent lines against `viewportOpaqueMipTexture`, a canvas-size copy of the opaque-only framebuffer). That fake was the shared root of the #771 resize wedge, the unhovered outline colour regression, and the alphaToCoverage quantisation workaround.

### What the material does

- Instanced screen-space quad expansion over the existing `LineGeometry` attributes — geometry pipeline unchanged, material swapped
- Reversed-depth-aware near-plane trim (port of upstream #33572's fixed formula)
- Round endcaps, fwidth-AA'd unconditionally; in-shader degenerate-segment guard
- Real `NormalBlending` + standard `material.opacity` — hover fade tween untouched
- Per-ring stencil ref (NotEqual + Replace, refs 3–255, clear of the scene's OCCLUDER/water values) dedups joint self-overlap: under real blending the overlapping cap/body quads otherwise double-blend into brighter corner dots at partial opacity. Coincident neighbour borders keep different refs, so hover-over-faint layering is unchanged.

### Removed with the root cause

- The #771 dispose-on-resize mitigation in `onResize`
- The `alphaToCoverage: false` workaround (inapplicable — no a2c in our material)

## Test plan

- [x] Outlines at rest / hover-bright across zoom bands — correct colours, widths, compositing over roads/metro/water
- [x] Ring corners render as continuous lines (no bright joint dots) at resting opacity
- [x] Close perspective zoom at borders: no rays (near-plane trim, #772 acceptance holds)
- [x] Hover fade tween through the new material (212 frames, clean)
- [x] **Resize gauntlet WITHOUT the dispose mitigation**: plain resize, continuous render + resize storm, hide-districts-across-resize-then-reshow — zero destroyed-texture errors
- [x] Idle render-on-demand intact; continuous render at full refresh (no pipeline recompile churn)
- [x] Console clean across load / hover / band force / resize
- [x] User live sign-off 2026-07-03 (look approved incl. corner fix)

Closes #775. With this merged, the r185 ship-gate to main is satisfied (remaining queue: 0.185.1 re-bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)