### PR TITLE
three.js 0.185.0 → 0.185.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Changed
 
-- three.js upgraded r184 → r185; adopts the upstream fix for district outline rays at close zoom (#773).
+- three.js upgraded r184 → r185.1; adopts the upstream fix for district outline rays at close zoom (#773).
 - The render loop (including the showcase flyover) now runs on `renderer.setAnimationLoop`, the WebGPU-native frame driver; idle render-on-demand behaviour is unchanged (#768).
 - District outlines render through our own TSL line material instead of three.js `Line2NodeMaterial` (#775): true semi-transparent compositing over roads, metro and water, ring corners no longer over-brighten, and the r185 line workarounds (resize mitigation, alpha-to-coverage opt-out) are gone.
 - Roads, borders and the metro now layer correctly at every camera angle: no more borders or roads glowing through overlapping decks, and metro/tunnel roads render correctly over water (#770).

--- a/index.html
+++ b/index.html
@@ -620,10 +620,10 @@
     <script type="importmap">
     {
       "imports": {
-        "three":         "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.webgpu.min.js",
-        "three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.webgpu.min.js",
-        "three/tsl":     "https://cdn.jsdelivr.net/npm/three@0.185.0/build/three.tsl.min.js",
-        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.0/examples/jsm/"
+        "three":         "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.webgpu.min.js",
+        "three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.webgpu.min.js",
+        "three/tsl":     "https://cdn.jsdelivr.net/npm/three@0.185.1/build/three.tsl.min.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.185.1/examples/jsm/"
       }
     }
     </script>


### PR DESCRIPTION
## Summary

Bumps the importmap to three.js 0.185.1 (#773 close-out). The patch carries six fixes — relevant to us: the TSL MRT crash guard and the instanced matrix buffer capacity restore. None touch the r185 findings; the Line2 ones are moot since #775 replaced the material. The jsDelivr CORS propagation that blocked the earlier attempt has cleared (verified `access-control-allow-origin: *` on both bundles).

`scripts/r185_resize_spike.html` stays pinned at 0.185.0 deliberately — it's the repro artifact against the investigated version.

## Test plan

- [x] Init on WebGPU, intro fly-in
- [x] District outlines (band-forced bright) + hover raycast + info panel
- [x] Resize storm under continuous render — zero errors (no mitigation in the codebase anymore)
- [x] Idle render-on-demand: zero renders
- [x] Console clean throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)