### PR TITLE
chore: Cloudflare Pages caching headers (migration prep)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 !/package-lock.json
 !/robots.txt
 !/sitemap.xml
+!/_headers
 
 # Large generated data files — regenerate with scripts, do not commit
 data/buildings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Infrastructure
+
+- The live site is now served by Cloudflare Pages instead of GitHub Pages, for faster loads via a closer edge and long-lived asset caching (see `docs/caching-strategy.md`).
+
 ### 3D Schematic Map
 
 #### Changed

--- a/_headers
+++ b/_headers
@@ -1,0 +1,41 @@
+# Cloudflare Pages response headers.
+# Read by Pages from the build output root; ignored by GitHub Pages.
+# Full rationale + maintainer procedures: docs/caching-strategy.md
+#
+# Strategy in one line: `immutable` ONLY for paths whose bytes never change
+# (tiles). Everything that can change at a stable path is `no-cache`
+# (cache + revalidate) so Cloudflare's ETag auto-refreshes browsers on deploy
+# with zero manual cache-busting.
+
+# --- Never-changing, thousands of files -> cache hard, skip revalidation ---
+# Tiles are content-stable at a fixed path. If you EVER regenerate them you must
+# bump the ?v= token in the L.tileLayer() URL in assets/js/app.js AND purge the
+# Cloudflare edge cache. See docs/caching-strategy.md#regenerating-tiles.
+/assets/tiles/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# --- Big binaries that CAN change at a stable path -> cache + always revalidate ---
+# DDS building data / GLB meshes update as new fixed assets land. `no-cache`
+# keeps them cached but sends a conditional request each load; Cloudflare's
+# ETag returns a tiny 304 when unchanged (no re-download) and the full file when
+# changed. Nothing to do on update beyond redeploying.
+/assets/dds/*
+  Cache-Control: public, no-cache
+/assets/glb-meshopt/*
+  Cache-Control: public, no-cache
+
+# --- Un-hashed code, changes every deploy -> revalidate ---
+/assets/js/*
+  Cache-Control: public, no-cache
+/assets/css/*
+  Cache-Control: public, no-cache
+/index.html
+  Cache-Control: public, no-cache
+
+# --- Images and audio -> revalidate ---
+# Includes the ~10 MB satellite_8k.webp base image. `no-cache` keeps it cached
+# and only re-downloads if a re-export changes the bytes (ETag 304 otherwise).
+/assets/img/*
+  Cache-Control: public, no-cache
+/assets/audio/*
+  Cache-Control: public, no-cache

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -567,7 +567,10 @@ async function initMap() {
     map.setMaxBounds(pannableBounds);
   }
 
-  L.tileLayer("assets/tiles/{z}/{x}/{y}.webp", {
+  // Tiles are served with `Cache-Control: immutable` (see _headers), so browsers
+  // never re-check them. If you regenerate the tile set, bump this ?v= token AND
+  // purge the Cloudflare edge cache. Full procedure: docs/caching-strategy.md.
+  L.tileLayer("assets/tiles/{z}/{x}/{y}.webp?v=1", {
     minZoom: 0,
     maxNativeZoom: 6,
     maxZoom: 8,

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -275,6 +275,9 @@ const ThreeScene = (() => {
   let landmarkMat        = null;  // shared MeshLambertMaterial for all landmark GLBs
 
   // District metadata — sourced directly from 3dmap_triangle_soup.Material.json.
+  // Cache note: the *.dds paths below are served `no-cache` (see _headers), so
+  // updating a texture needs no cache-busting — just redeploy. Only tile regen
+  // needs manual action. See docs/caching-strategy.md.
   // dataDds: _data.dds (DXGI_FORMAT_R16G16B16A16_UNORM — raw 16-bit RGBA instance data)
   // dataDdsFixed: optional alignment-fixed _data from malgalad's "3D World Map
   //   Fixed" mod (Nexus #26500). Same dimensions/transforms as the vanilla

--- a/docs/caching-strategy.md
+++ b/docs/caching-strategy.md
@@ -1,0 +1,103 @@
+# Caching strategy (Cloudflare Pages)
+
+The site is served by **Cloudflare Pages**. Cache behaviour is controlled by the
+[`_headers`](../_headers) file at the repo root, which Pages reads from the build
+output. GitHub Pages ignored this file, so none of this applied before the
+Cloudflare migration.
+
+## The one rule
+
+There are **two independent caches**, and only one of them is under your control
+after the fact:
+
+1. **Cloudflare's edge cache** — shared, on Cloudflare's servers. You can **purge**
+   it from the dashboard or API at any time.
+2. **The visitor's browser cache** — private, on their machine. You **cannot**
+   reach it. It obeys the `Cache-Control` header that was sent *when the file was
+   downloaded*, until that instruction expires.
+
+So the rule that drives everything here:
+
+> `immutable` is a promise to the browser that the bytes at this exact URL will
+> **never** change. Use it only for content that genuinely never changes at a
+> fixed path. Purging Cloudflare does **not** reach browsers that already hold an
+> `immutable` copy.
+
+`no-cache` does **not** mean "don't cache". It means "cache it, but revalidate
+before reusing". The browser keeps the file and sends a conditional request; if
+unchanged, Cloudflare (using an auto-generated content `ETag`) replies `304 Not
+Modified` — a few hundred bytes, no re-download. If changed, it sends the new
+file. This gives **automatic correctness on update** with almost no bandwidth
+cost, which is why it's the default for anything that can change.
+
+## What each asset class gets, and why
+
+| Path | Policy | Why |
+| --- | --- | --- |
+| `/assets/tiles/*` | `immutable`, 1 year | Thousands of files, content-stable at a fixed path. `immutable` skips even the revalidation round-trip. The *only* class that needs a manual bust on change. |
+| `/assets/dds/*` | `no-cache` | Building data textures. Change occasionally as new fixed assets land. ETag revalidation auto-refreshes browsers on deploy — nothing to remember. |
+| `/assets/glb-meshopt/*` | `no-cache` | Meshes. Same reasoning as DDS. |
+| `/assets/js/*`, `/assets/css/*`, `/index.html` | `no-cache` | Un-hashed filenames that change every deploy. Must revalidate or users run stale code. |
+
+## Maintainer procedures
+
+### Updating or adding DDS building data or GLB meshes
+
+**Nothing to do.** Drop the new/updated file in at its path and deploy. The file's
+content ETag changes, browsers revalidate on their next load and pull the new
+bytes automatically. This is the whole point of putting these on `no-cache`.
+
+### Changing JS, CSS, or `index.html`
+
+**Nothing to do.** Same automatic revalidation as above.
+
+### Regenerating tiles
+
+This is the **only** case that needs manual action, because tiles are
+`immutable` — browsers that already downloaded them will never re-check on their
+own. Two steps, both required:
+
+1. **Bump the version token** in the tile URL. In
+   [`assets/js/app.js`](../assets/js/app.js), find the `L.tileLayer(...)` call and
+   increment the `?v=` number:
+
+   ```js
+   L.tileLayer("assets/tiles/{z}/{x}/{y}.webp?v=2", { ... })
+   ```
+
+   Changing the query string makes every tile a new URL, so existing browsers
+   treat them as never-before-seen and fetch fresh. **Skipping this leaves
+   returning visitors on the old tiles for up to a year.**
+
+2. **Purge the Cloudflare edge cache** for the tiles (dashboard → Caching → purge,
+   or purge everything). This clears the *shared* cache so first-time and
+   cache-busted requests don't get served the old bytes from Cloudflare's edge.
+
+Step 1 fixes returning browsers; step 2 fixes the edge. You need both.
+
+## Dev vs prod caching
+
+The same [`_headers`](../_headers) applies to both the production site and the
+dev site (`dev.nczoning.net`), and that's intentional — it keeps the rules a
+single source of truth with no per-branch divergence to drift.
+
+This is fine for dev in practice: everything you iterate on (JS, CSS, DDS, GLB)
+is `no-cache`, so it always revalidates and you never see stale code or textures.
+The only hard-cached class is tiles (`immutable`), which you rarely regenerate on
+dev — and DevTools "Disable cache" overrides all of it during active development
+anyway.
+
+**If** stale tiles ever become a problem on dev, the fix is a **Cloudflare
+Response Header Transform Rule scoped to `dev.nczoning.net`** that overrides
+`Cache-Control` to `no-cache` for all responses. Keep this at the dashboard
+(platform) layer — do **not** give the `dev` branch a different `_headers` than
+`main`, as that reintroduces the exact drift this file exists to prevent. It must
+be a *response header* transform, not a cache-bypass rule: bypassing the edge
+cache doesn't change the `Cache-Control` the browser receives, so the browser
+would still honour `immutable`.
+
+## Where the config lives
+
+- [`_headers`](../_headers) — the actual Cloudflare Pages rules.
+- [`assets/js/app.js`](../assets/js/app.js) — the tile `?v=` bust token (with an
+  inline comment pointing back here).


### PR DESCRIPTION
Prep for moving the live site from GitHub Pages to Cloudflare Pages. This PR only adds the caching config + docs — it does **not** touch `deploy.yml` or do the cutover.

## Why this is safe to merge now
- GitHub Pages ignores `_headers`, so nothing changes on the current live host.
- The dev Cloudflare site (`dev.nczoning.net`) builds from `dev`, so on merge it starts honouring `_headers` immediately — a free rehearsal to confirm the real Cloudflare behaviour before the prod cutover.
- Rides along when `dev` → `main` ships the r185 update; the DNS flip to Cloudflare becomes the single "new map + faster site" go-live moment.

## Caching strategy
`immutable` **only** for paths whose bytes never change (tiles). Everything that can change at a stable path (JS/CSS/DDS/GLB/img/audio) is `no-cache` — cached but always revalidated, so Cloudflare's content ETag auto-refreshes browsers on deploy with **zero manual cache-busting**. A `304` on an unchanged file is a few hundred bytes, so this is cheap even for the big DDS/webp assets.

## Contents
- **`_headers`** — the Cloudflare Pages rules.
- **`docs/caching-strategy.md`** — two-cache (edge vs browser) model, per-asset rationale, the one manual procedure (regenerating tiles → bump `?v=` + purge edge), and the dev/prod Transform Rule fallback.
- **`assets/js/app.js`** — pre-wired `?v=1` bust token on the tile URL so a future re-tile is an increment, not a new mechanism.
- **`assets/js/three-scene.js`** — note at the DDS list that texture updates need no cache action.
- **`.gitignore`** — allow `/_headers` past the root `/*` ignore (without this the file silently never deploys).
- **`CHANGELOG.md`** — `[Unreleased] → Infrastructure` entry.

## Deliberately out of scope
- `deploy.yml` removal — kept as a warm GitHub Pages rollback target through the cutover; removed in a later follow-up.
- Creating the Cloudflare prod project + DNS cutover — dashboard steps done at ship time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)