### PR TITLE
docs: replace GitHub Pages references with Cloudflare Pages

### DIFF
--- a/ASSETS.md
+++ b/ASSETS.md
@@ -58,7 +58,7 @@ The `data/locations/` and `data/subdistricts.json` directories contain coordinat
 
 ## Attribution
 
-**NC Zoning Board** is maintained by the Cyberpunk 2077 modding community and hosted as a free resource on GitHub Pages.
+**NC Zoning Board** is maintained by the Cyberpunk 2077 modding community and hosted as a free resource on Cloudflare Pages.
 
 - **Original Vision:** Kaoziun
 - **Development Lead:** Spuddeh

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Prefer a permanent, manually curated entry? See **[docs/adding-mods.md](docs/add
 - **Vanilla JS / CSS** — No frameworks, purely static files
 - **[Sharp](https://sharp.pixelplumbing.com/)** — 8k map tile generation (dev dependency)
 - **GitHub Actions** — Automated JSON validation and PR pipeline
-- **GitHub Pages** — Static hosting
+- **Cloudflare Pages** — Static hosting (Git integration)
 
 ## Contributors & Community
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,8 +45,8 @@ nc-zoning-board/
 │   └── workflows/
 │       ├── auto-pr-submission.yml       # Bot: submission issue → PR with new JSON
 │       ├── modify-location-submission.yml # Bot: edit issue → PR with modified JSON
-│       ├── validate-mods.yml            # CI: validates mods.json against schema
-│       └── deploy.yml                   # CD: deploys to GitHub Pages
+│       └── validate-mods.yml            # CI: validates mods.json against schema
+│                                        # (deploys via Cloudflare Pages Git integration, not a workflow)
 │
 └── docs/                   # You are here
 ```

--- a/docs/dev-branch-maintainer-guide.md
+++ b/docs/dev-branch-maintainer-guide.md
@@ -19,10 +19,10 @@ The dev branch exists from **before Phase 0 started** through the eventual merge
 
 | Environment | Branch | URL | Deploys via |
 |-------------|--------|-----|-------------|
-| Production | `main` | [nczoning.net](https://nczoning.net) | GitHub Actions → GitHub Pages |
+| Production | `main` | [nczoning.net](https://nczoning.net) | Cloudflare Pages (native Git integration) |
 | Staging | `dev` | [dev.nczoning.net](https://dev.nczoning.net) | Cloudflare Pages (native Git integration) |
 
-Cloudflare Pages runs `node scripts/build_mods.js` on every push to `dev` and deploys the result. No GitHub Actions secrets or tokens needed — Cloudflare's GitHub integration handles authentication itself.
+Both environments are separate Cloudflare Pages projects on the same repo (prod builds `main`, staging builds `dev`). Cloudflare runs `node scripts/build_mods.js` on every push to the project's branch and deploys the result. No GitHub Actions secrets or tokens needed — Cloudflare's GitHub integration handles authentication itself.
 
 ## Contributing to a phase
 

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -13,8 +13,9 @@ The project has two deployment environments:
 | Production | `main` | [nczoning.net](https://nczoning.net) | Live site — always fully functional |
 | Staging | `dev` | [dev.nczoning.net](https://dev.nczoning.net) | In-progress Three.js work — may be incomplete |
 
-Production deploys via GitHub Actions → GitHub Pages on every push to `main`.
-Staging deploys via Cloudflare Pages Git integration on every push to `dev`.
+Both environments deploy via Cloudflare Pages Git integration: production on
+every push to `main`, staging on every push to `dev` (separate Pages projects on
+the same repo).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,7 +13,7 @@ The NC Zoning Board is an interactive map and coordinate registry for Cyberpunk 
 - ✅ Cyberpunk-themed UI (Orbitron/Rajdhani fonts, dark theme)
 - ✅ mods.json schema validation (CI via GitHub Actions)
 - ✅ Automated mod submission via GitHub Issue form → PR pipeline
-- ✅ GitHub Pages deployment
+- ✅ Cloudflare Pages deployment
 - ✅ Tile generation script (`scripts/generate_tiles.js`)
 - ✅ **Data refactor** — split `mods.json` into individual JSON files for cleaner management
 - ✅ **Custom pin icons** — colour-coded by mod category

--- a/docs/tile-generation.md
+++ b/docs/tile-generation.md
@@ -15,7 +15,7 @@ Source images are stored in `raw maps/` (not committed due to size):
 | 4k (4096²) | `4k/night_city.png` | 27 MB | Archive |
 | 8k (8192²) | `8k/night_city_8k_transparent.png` | 108 MB | Archive |
 | **16k (16384²)** | **`16k/night_city_16k.png`** | **529 MB** | **Current tile source** |
-| 32k (32768²) | `32k/night_city_32k.png` | ~1.7 GB | Available (too many tiles for GitHub Pages) |
+| 32k (32768²) | `32k/night_city_32k.png` | ~1.7 GB | Available (too many tiles for Cloudflare Pages' 20k-file deploy limit) |
 
 ## Generating Tiles
 
@@ -107,4 +107,4 @@ L.tileLayer('assets/tiles/{z}/{x}/{y}.webp', {
 
 ## Why Not 32k?
 
-The 32k source would give zoom 7 (128×128 = 16,384 tiles at native, ~21,845 total). At GitHub Pages' scale, this adds significant repo size (~100+ MB) for diminishing returns — users already get sharp detail at zoom 6 with only 4× upscaling at max zoom. The 32k source is available if we move to external hosting (CDN, blob storage) in the future.
+The 32k source would give zoom 7 (128×128 = 16,384 tiles at native, ~21,845 total). That alone exceeds Cloudflare Pages' 20,000-files-per-deployment limit (before counting the ~5,461 existing tiles and all other assets), and adds significant repo size (~100+ MB) for diminishing returns — users already get sharp detail at zoom 6 with only 4× upscaling at max zoom. The 32k source is available if we move tiles to external object storage (e.g. Cloudflare R2) in the future.


### PR DESCRIPTION
Follow-up to the hosting migration — scrubs stale GitHub Pages references from contributor-facing docs now that `nczoning.net` is served by Cloudflare Pages.

## Updated
- **README.md / ASSETS.md** — hosting is Cloudflare Pages.
- **docs/architecture.md** — removed `deploy.yml` (deleted in #781) from the workflow tree; noted deploys go via Cloudflare's Git integration.
- **docs/dev-branch-maintainer-guide.md / docs/dev-environment.md** — both prod and staging are Cloudflare Pages projects (prod builds `main`, staging builds `dev`).
- **docs/roadmap.md** — "Cloudflare Pages deployment".
- **docs/tile-generation.md** — the 32k tile-count ceiling is now Cloudflare Pages' 20k-files/deploy limit; external-storage note points at Cloudflare R2.

## Deliberately left unchanged
- **CHANGELOG.md** — those references are historical release records; rewriting shipped history would be wrong.
- **_headers / docs/caching-strategy.md** — they mention GitHub Pages *intentionally* (to explain that GH Pages ignored `_headers`, which is why the file exists).

Doc-only; no `data/` touched so `validate-mods` doesn't gate it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)