### PR TITLE
docs: Data API v1 plan (api.nczoning.net)

### DIFF
--- a/docs/data-api-plan.md
+++ b/docs/data-api-plan.md
@@ -1,0 +1,111 @@
+# Data API Plan (v1)
+
+Plan for a read-only API backend at `api.nczoning.net`, so Cyberpunk 2077 mods
+can consume the registry in-game. Approved 2026-07-04; not yet built.
+
+## Why an API
+
+The static `mods.json` is not enough for game clients, for three reasons:
+
+1. **It is incomplete.** The auto-discovery merge (Nexus mods tagged
+   `NCZoning`, parsed and merged with manual entries) runs client-side in the
+   browser (`assets/js/services.js`). A game mod reading the static file would
+   miss every auto-discovered mod.
+2. **It is a build artifact, not a contract.** `mods.json` can change shape
+   whenever the site refactors. `/v1/` is a versioned promise that shipped
+   game mods can rely on.
+3. **It shields clients from Nexus.** The Nexus V2 GraphQL API is unsupported
+   and may change; with the merge running server-side, game clients never
+   touch it.
+
+## Architecture
+
+- **Standalone Cloudflare Worker** on `api.nczoning.net/v1/*`, code in this
+  repo under `worker/`. Its own project: it shares only the domain with the
+  proposed submission-system Worker (separate concern, separate deploys).
+- **Workers KV** storage, refreshed by a **Cron Trigger every 15 minutes**:
+  fetch `mods.json` + `data/excluded_mods.json` + `data/tags.json` +
+  `data/subdistricts.json` from the CDN, run the auto-discovery merge (port of
+  `services.js` / `scripts/monitor_auto_discovery.js`), enrich each location
+  with `district` and `subdistrict` via point-in-polygon (the polygons in
+  `data/subdistricts.json` are already in CET world coordinates), then write
+  to KV only when the content hash changes.
+- **Failure posture:** keep last-known-good data, set `discovery_stale=true`,
+  alert Discord (same pattern as `monitor-auto-discovery.yml`). Never serve an
+  empty or partial dataset. Git remains the source of truth for manual
+  entries; the Worker only reads deployed CDN artifacts.
+- **Free tier:** ~1 conditional GET per player session against a 100k req/day
+  cap; KV writes at most 96/day. Passes with a huge margin.
+
+## Routes
+
+Every response uses the envelope
+`{ "schema": 1, "generated_at": "...", "dataset_version": "<hash>", "data": ... }`.
+
+| Route | Returns |
+| --- | --- |
+| `GET /v1/locations` | Slim list: id, name, nexus_id, coordinates, yaw, category, tags, authors, source, district, subdistrict |
+| `GET /v1/locations/{id}` | Full entry (adds description, credits) |
+| `GET /v1/districts` | District/subdistrict hierarchy with names, centroids and boundaries |
+| `GET /v1/meta` | dataset_version, generated_at, counts, discovery_stale, min_client, notices |
+| `GET /v1/tags` | Tag dictionary |
+| `GET /v1/health` | 200 + Worker version |
+
+Caching: `ETag` + `If-None-Match` (a 304 is the delta mechanism at ~300
+entries), `Cache-Control: public, max-age=300, stale-while-revalidate=3600`,
+edge cache, CORS `*` on GET, one WAF rate-limit rule.
+
+## Contract rules
+
+- **Stable ids:** manual entries keep their UUID; auto-discovered entries get
+  the deterministic id `nexus-<nexus_id>`.
+- **DTO-mappable JSON:** the in-game consumer (RedData `FromJson`) cannot
+  parse arrays-of-arrays, and property names are case-sensitive. Flat numeric
+  arrays such as `coordinates: [X, Y, Z]` are fine; polygon boundaries are
+  served flattened (`[x1, y1, x2, y2, ...]`). Any future field must respect
+  this.
+- **Versioning:** path-based. Additive fields are non-breaking; breaking
+  changes go to `/v2/` with `/v1/` kept alive for at least 6 months.
+
+## Consumer: the NCZoningCore framework mod
+
+A companion Cyberpunk 2077 mod (separate project) fetches `/v1/` via
+RedHttpClient, caches offline via RedFileSystem, and exposes the registry to
+other mods through a public redscript module (`NCZoning.Api`) and Codeware
+events. First consumers: a Simple Location Manager integration tab, plus small
+demos (district guide, nearby-location notification). Details live with the
+mod project; the frozen contract above is the interface between the two.
+
+## Phases
+
+| Phase | Scope | Size |
+| --- | --- | --- |
+| B0 | Decision docs + contract freeze (unblocks the mod side) | S |
+| B1 | Worker scaffold, `api.nczoning.net` custom domain, `/v1/health` | S |
+| B2 | Server-side merge engine + district enrichment (testable module) | M |
+| B3 | Cron to KV refresh, last-known-good, Discord alerting | M |
+| B4 | Read endpoints live, payload size measured, contract finalised | M |
+| B5 | WAF rate rule + public `docs/api-reference.md` | S |
+| B6 | Worker CI deploy (wrangler action, path-filtered) | S |
+
+The mod project runs in parallel from B0 using local fixtures; it ships only
+against the live `/v1/`.
+
+## Risks
+
+- Nexus V2 GraphQL volatility: contained in the cron path; clients only ever
+  see KV data.
+- TLS: the in-game HTTP client requires HTTPS with TLS 1.2+. Cloudflare
+  Universal SSL satisfies this; verify the zone minimum TLS version is 1.2 or
+  lower.
+- Abuse: read-only, edge-cached, rate-limited; the hard ceiling is the free
+  plan's request cap.
+
+## Deferred
+
+- Live player-position features (opt-in heartbeat): sketched only; privacy
+  design deliberately deferred.
+- Fast-travel / metro-station / POI data: no such dataset exists in the repo
+  yet (future TweakDB/WolvenKit extraction).
+- The submission-system Worker (separate proposal) and the website itself
+  consuming `/v1/` instead of client-side Nexus calls.


### PR DESCRIPTION
## Summary

Adds `docs/data-api-plan.md` - the approved plan for a read-only API backend at `api.nczoning.net/v1/*` so Cyberpunk 2077 mods can consume the registry in-game.

Key points:
- Standalone Cloudflare Worker (own project, shares only the domain with the proposed submission-system Worker), KV storage, 15-minute cron refresh
- Server-side auto-discovery merge (the reason static mods.json is not enough for game clients - the merge currently runs in the browser)
- District/subdistrict enrichment via point-in-polygon on data/subdistricts.json (already CET-space)
- ETag/304 as the delta mechanism; DTO-mappable contract rules (no arrays-of-arrays) for the in-game RedData consumer
- Phases B0-B6; the companion NCZoningCore framework mod is a separate project consuming the frozen /v1 contract

Doc-only change; no code or data touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)