### PR TITLE
feat(api): B2 server-side merge engine with district enrichment

### DIFF
--- a/worker/package.json
+++ b/worker/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "test": "node --test test/"
+    "test": "node --test"
   },
   "devDependencies": {
     "wrangler": "^4.107.0"

--- a/worker/src/districts.js
+++ b/worker/src/districts.js
@@ -1,0 +1,135 @@
+/**
+ * District/subdistrict assignment — server-side port of the client logic
+ * (assets/js/utils.js pointInPolygon/polygonCentroid + the resolveArea
+ * rule in assets/js/district-info.js). Polygons come from
+ * data/subdistricts.json and are in CET world coordinates, the same space
+ * as location `coordinates` — no transforms anywhere.
+ */
+
+/** Ray-casting point-in-polygon. `point` and `ring` vertices share a space. */
+export function pointInPolygon(point, ring) {
+  if (!ring || ring.length < 3) return false;
+  const [px, py] = point;
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const xi = ring[i][0], yi = ring[i][1];
+    const xj = ring[j][0], yj = ring[j][1];
+    const intersects = (yi > py) !== (yj > py) &&
+      px < ((xj - xi) * (py - yi)) / (yj - yi) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+/** Area-weighted (shoelace) centroid; vertex average for degenerate rings. */
+export function polygonCentroid(ring) {
+  if (!ring || ring.length === 0) return null;
+  let a = 0, cx = 0, cy = 0;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const cross = ring[j][0] * ring[i][1] - ring[i][0] * ring[j][1];
+    a += cross;
+    cx += (ring[j][0] + ring[i][0]) * cross;
+    cy += (ring[j][1] + ring[i][1]) * cross;
+  }
+  a *= 0.5;
+  if (Math.abs(a) < 1e-6) {
+    let sx = 0, sy = 0;
+    for (const p of ring) { sx += p[0]; sy += p[1]; }
+    return [sx / ring.length, sy / ring.length];
+  }
+  return [cx / (6 * a), cy / (6 * a)];
+}
+
+/** Absolute shoelace area — smallest containing polygon wins. */
+function polyArea(ring) {
+  let a = 0;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    a += (ring[j][0] + ring[i][0]) * (ring[j][1] - ring[i][1]);
+  }
+  return Math.abs(a) / 2;
+}
+
+/**
+ * Resolve the most specific area for a CET [x, y] point: the smallest-area
+ * subdistrict containing it (and that sub's parent district), else the
+ * smallest containing district polygon. Mirrors district-info.js
+ * resolveArea so the API and the map can never disagree.
+ *
+ * @param {number[]} pt CET [x, y]
+ * @param {Array} districts subdistricts.json `districts[]`
+ * @returns {{district: object, subdistrict: object|null}|null}
+ */
+export function resolveArea(pt, districts) {
+  let sub = null, subArea = Infinity, dist = null;
+  for (const d of districts) {
+    for (const s of d.subdistricts || []) {
+      if (s.polygon?.length && pointInPolygon(pt, s.polygon)) {
+        const a = polyArea(s.polygon);
+        if (a < subArea) { subArea = a; sub = s; dist = d; }
+      }
+    }
+  }
+  if (!sub) {
+    let dArea = Infinity;
+    for (const d of districts) {
+      if (d.polygon?.length && pointInPolygon(pt, d.polygon)) {
+        const a = polyArea(d.polygon);
+        if (a < dArea) { dArea = a; dist = d; }
+      }
+    }
+  }
+  return dist ? { district: dist, subdistrict: sub } : null;
+}
+
+/**
+ * The game's default district: anywhere outside every district polygon is
+ * Badlands (which is why it has no polygon of its own — its subdistricts
+ * are trigger areas transformed into polygons for the map, but the parent
+ * is the catch-all). The API mirrors that rule so in-game consumers and
+ * the game itself can never disagree.
+ */
+const DEFAULT_DISTRICT_ID = 'badlands';
+
+/**
+ * District/subdistrict names for a location's CET coordinates. Points
+ * outside every polygon default to Badlands (game behaviour); nulls only
+ * if the dataset has no default district at all (fixtures).
+ */
+export function assignDistrict(coordinates, districts) {
+  const hit = resolveArea([coordinates[0], coordinates[1]], districts);
+  if (hit) {
+    return {
+      district: hit.district.name,
+      subdistrict: hit.subdistrict ? hit.subdistrict.name : null,
+    };
+  }
+  const fallback = districts.find((d) => d.id === DEFAULT_DISTRICT_ID);
+  return { district: fallback ? fallback.name : null, subdistrict: null };
+}
+
+/**
+ * /v1/districts payload: hierarchy with names, centroids and FLATTENED
+ * boundaries ([x1,y1,x2,y2,...]) — the DTO contract forbids
+ * arrays-of-arrays (RedData FromJson limit).
+ */
+export function districtsPayload(districts) {
+  const flat = (ring) => ring.flat();
+  return districts.map((d) => ({
+    id: d.id ?? null,
+    name: d.name,
+    centroid: centroidObj(d.polygon),
+    boundary: flat(d.polygon || []),
+    subdistricts: (d.subdistricts || []).map((s) => ({
+      id: s.id ?? null,
+      name: s.name,
+      canonical: s.canonical !== false,
+      centroid: centroidObj(s.polygon),
+      boundary: flat(s.polygon || []),
+    })),
+  }));
+}
+
+function centroidObj(ring) {
+  const c = polygonCentroid(ring);
+  return c ? { x: c[0], y: c[1] } : null;
+}

--- a/worker/src/merge.js
+++ b/worker/src/merge.js
@@ -1,0 +1,144 @@
+/**
+ * Dataset builder — the server-side version of the merge the browser does
+ * in assets/js/services.js (fetchNexusTaggedMods) + app.js concat.
+ *
+ * Pure function: all inputs are plain data, no fetching, no KV. The cron
+ * handler (B3) feeds it CDN files + Nexus nodes; tests feed it fixtures.
+ *
+ * Precedence rules (must match the site):
+ * - excluded_mods.json entries never appear, even with a valid block
+ * - manual entries win by nexus_id; the Nexus node only contributes
+ *   image/updatedAt metadata for thumbnail backfill
+ * - auto entries need a valid [NCZoning] block (coords + category)
+ *
+ * Contract rules (frozen): auto entries get stable id `nexus-<nexus_id>`;
+ * every location carries source ("manual"|"auto") and district/subdistrict.
+ */
+
+import { parseNcZoningBlock } from './parse.js';
+import { assignDistrict } from './districts.js';
+
+export const DESCRIPTION_MAX_LENGTH = 500;
+
+/**
+ * @param {object} input
+ * @param {Array}  input.manualMods   compiled mods.json array
+ * @param {object} input.tagsDict     data/tags.json ({tag: definition})
+ * @param {object} input.excluded     data/excluded_mods.json ({nexusId: reason})
+ * @param {Array}  input.nexusNodes   raw nodes from the NCZoning GraphQL query
+ * @param {Array}  input.districts    data/subdistricts.json `districts[]`
+ * @returns {{locations: Array, full: Object<string, object>, meta: object}}
+ */
+export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, districts }) {
+  const validTagNames = new Set(Object.keys(tagsDict));
+  const excludedIds = new Set(Object.keys(excluded || {}));
+
+  // Numeric nexus_ids of manual entries (WIP/Dummy have no Nexus page).
+  const existingNexusIds = new Set(
+    manualMods
+      .map((m) => String(m.nexus_id))
+      .filter((id) => !['wip', 'dummy'].includes(id.toLowerCase())),
+  );
+
+  const nexusThumbs = {}; // manual-entry image/updatedAt backfill, keyed by nexus_id
+  const autoEntries = [];
+  const skipped = []; // tagged mods with no valid block — surfaced for monitoring
+
+  for (const node of nexusNodes || []) {
+    const nexusId = String(node.modId);
+    if (excludedIds.has(nexusId)) continue;
+    if (existingNexusIds.has(nexusId)) {
+      nexusThumbs[nexusId] = {
+        pictureUrl: node.pictureUrl || null,
+        thumbnailUrl: node.thumbnailUrl || null,
+        updatedAt: node.updatedAt || null,
+      };
+      continue;
+    }
+
+    const parsed = parseNcZoningBlock(node.description, validTagNames);
+    if (!parsed) {
+      skipped.push({ nexus_id: nexusId, name: node.name || 'Unknown Mod' });
+      continue;
+    }
+
+    const uploaderName = node.uploader?.name || 'Unknown';
+    const summary = node.summary || '';
+    autoEntries.push({
+      id: `nexus-${nexusId}`,
+      name: node.name || 'Unknown Mod',
+      authors: [uploaderName, ...parsed.additionalAuthors],
+      ...(parsed.credits ? { credits: parsed.credits } : {}),
+      coordinates: parsed.coordinates,
+      ...(parsed.yaw !== null ? { yaw: parsed.yaw } : {}),
+      nexus_id: nexusId,
+      description:
+        summary.length > DESCRIPTION_MAX_LENGTH
+          ? summary.slice(0, DESCRIPTION_MAX_LENGTH - 3) + '...'
+          : summary,
+      category: parsed.category,
+      tags: ['nczoning', ...parsed.tags],
+      source: 'auto',
+      thumbnail_url: node.thumbnailUrl || null,
+      picture_url: node.pictureUrl || null,
+      updated_at: node.updatedAt || null,
+    });
+  }
+
+  const all = [
+    ...manualMods.map((m) => ({ ...m, source: 'manual' })),
+    ...autoEntries,
+  ].sort((a, b) => a.name.localeCompare(b.name));
+
+  const perDistrict = {};
+  const locations = [];
+  const full = {};
+
+  for (const entry of all) {
+    const { district, subdistrict } = assignDistrict(entry.coordinates, districts);
+    const key = district || 'Outside mapped districts';
+    perDistrict[key] = (perDistrict[key] || 0) + 1;
+
+    locations.push({
+      id: entry.id,
+      name: entry.name,
+      nexus_id: String(entry.nexus_id),
+      coordinates: entry.coordinates,
+      ...(entry.yaw !== undefined && entry.yaw !== null ? { yaw: entry.yaw } : {}),
+      category: entry.category,
+      tags: entry.tags,
+      authors: entry.authors,
+      source: entry.source,
+      district,
+      subdistrict,
+    });
+
+    full[entry.id] = {
+      ...locations[locations.length - 1],
+      description: entry.description ?? '',
+      ...(entry.credits ? { credits: entry.credits } : {}),
+      ...(entry.source === 'auto'
+        ? {
+            thumbnail_url: entry.thumbnail_url,
+            picture_url: entry.picture_url,
+            updated_at: entry.updated_at,
+          }
+        : {}),
+    };
+  }
+
+  return {
+    locations,
+    full,
+    meta: {
+      counts: {
+        manual: manualMods.length,
+        auto: autoEntries.length,
+        total: all.length,
+        per_district: perDistrict,
+      },
+      skipped,
+      nexus_thumbs: nexusThumbs,
+    },
+  };
+}

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -1,0 +1,84 @@
+/**
+ * Nexus V2 GraphQL auto-discovery fetch — server-side port of the
+ * pagination loop in assets/js/services.js fetchNexusTaggedMods, minus
+ * the merge (that lives in merge.js) and the localStorage cache (KV plays
+ * that role, in the B3 cron).
+ *
+ * The V2 API is technically unsupported (see docs/nexus-api-reference.md);
+ * callers must treat failures as "keep last-known-good", never as "empty
+ * dataset".
+ */
+
+export const NEXUS_GQL_ENDPOINT = 'https://api.nexusmods.com/v2/graphql';
+export const NEXUS_GAME_ID = 3333; // Cyberpunk 2077
+export const NEXUS_BATCH_SIZE = 50;
+
+const QUERY = `
+  query NCZoningMods($filter: ModsFilter!, $count: Int!, $offset: Int!) {
+    mods(filter: $filter, count: $count, offset: $offset) {
+      nodes {
+        modId
+        name
+        summary
+        description
+        pictureUrl
+        thumbnailUrl
+        updatedAt
+        uploader {
+          name
+        }
+      }
+      totalCount
+    }
+  }
+`;
+
+/**
+ * Fetch every mod tagged NCZoning for CP2077. Throws on any page failure —
+ * a partial node list must never be mistaken for the full tag population
+ * (missing mods would be dropped from the map).
+ *
+ * @param {typeof fetch} fetchImpl injectable for tests
+ * @returns {Promise<Array>} raw GraphQL nodes
+ */
+export async function fetchTaggedModNodes(fetchImpl = fetch) {
+  const nodes = [];
+  let offset = 0;
+  let totalCount = Infinity;
+
+  while (offset < totalCount) {
+    const res = await fetchImpl(NEXUS_GQL_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: QUERY,
+        variables: {
+          filter: {
+            gameId: [{ value: String(NEXUS_GAME_ID) }],
+            tag: [{ value: 'NCZoning' }],
+          },
+          count: NEXUS_BATCH_SIZE,
+          offset,
+        },
+      }),
+    });
+    if (!res.ok) throw new Error(`Nexus GraphQL HTTP ${res.status}`);
+
+    const json = await res.json();
+    const page = json?.data?.mods;
+    if (!page) {
+      throw new Error(
+        `Nexus GraphQL: no mods page in response${json?.errors ? ` (${JSON.stringify(json.errors).slice(0, 200)})` : ''}`,
+      );
+    }
+
+    totalCount = page.totalCount ?? 0;
+    const pageNodes = page.nodes || [];
+    if (pageNodes.length === 0) break;
+    nodes.push(...pageNodes);
+    offset += pageNodes.length;
+    if (pageNodes.length < NEXUS_BATCH_SIZE) break; // last page
+  }
+
+  return nodes;
+}

--- a/worker/src/parse.js
+++ b/worker/src/parse.js
@@ -1,0 +1,68 @@
+/**
+ * NCZoning metadata-block parser — server-side port of
+ * assets/js/utils.js NCZ.parseNcZoningBlock (keep the two in sync; the
+ * client version's comment block documents the real-world breakage this
+ * strategy survives).
+ *
+ * Strategy: strip all BBCode, then treat `NCZoning:` as a token that can
+ * appear anywhere (not a whole line). Every occurrence is tried as a
+ * candidate; the first one whose following lines yield valid coords +
+ * category wins, so the coords/category validation — not the sentinel's
+ * position — is what disambiguates the real block from prose.
+ */
+
+const RECOGNIZED = new Set(['coords', 'category', 'tags', 'yaw', 'credits', 'authors']);
+const VALID_CATEGORIES = ['location-overhaul', 'new-location', 'other'];
+
+/**
+ * @param {string} description Raw Nexus mod description (BBCode).
+ * @param {Set<string>} validTagNames Known tag ids; unknown tags are dropped.
+ * @returns {{coordinates: number[], category: string, tags: string[],
+ *   credits: string|null, additionalAuthors: string[], yaw: number|null}|null}
+ */
+export function parseNcZoningBlock(description, validTagNames) {
+  if (!description) return null;
+
+  const text = description
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/\[\/?[a-z][^\]]*\]/gi, '');
+
+  const finalize = (data) => {
+    if (!data.coords) return null;
+    // coords: two or three comma-separated numbers [X, Y] or [X, Y, Z].
+    const coordParts = data.coords.split(',').map((s) => parseFloat(s.trim()));
+    if (coordParts.length < 2 || coordParts.length > 3 || coordParts.some(Number.isNaN)) return null;
+    if (!data.category || !VALID_CATEGORIES.includes(data.category)) return null;
+
+    return {
+      coordinates: coordParts,
+      category: data.category,
+      tags: data.tags
+        ? data.tags.split(',').map((t) => t.trim()).filter((t) => validTagNames.has(t))
+        : [],
+      credits: data.credits || null,
+      additionalAuthors: data.authors
+        ? data.authors.split(',').map((a) => a.trim()).filter(Boolean)
+        : [],
+      yaw: data.yaw && !Number.isNaN(parseFloat(data.yaw)) ? parseFloat(data.yaw) : null,
+    };
+  };
+
+  const sentinel = /NCZoning[ \t]*:/gi;
+  let m;
+  while ((m = sentinel.exec(text)) !== null) {
+    const data = {};
+    for (const raw of text.slice(m.index + m[0].length).split('\n')) {
+      const line = raw.trim();
+      if (!line) continue;
+      const eqIdx = line.indexOf('=');
+      const key = eqIdx === -1 ? '' : line.slice(0, eqIdx).trim().toLowerCase();
+      if (!RECOGNIZED.has(key)) break;
+      const value = line.slice(eqIdx + 1).trim();
+      if (value && !(key in data)) data[key] = value;
+    }
+    const parsed = finalize(data);
+    if (parsed) return parsed;
+  }
+  return null;
+}

--- a/worker/test/districts.test.js
+++ b/worker/test/districts.test.js
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  pointInPolygon, polygonCentroid, resolveArea, assignDistrict, districtsPayload,
+} from '../src/districts.js';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const { districts } = JSON.parse(
+  readFileSync(join(repoRoot, 'data', 'subdistricts.json'), 'utf8'),
+);
+
+// Deterministic interior point: walk from the centroid toward a vertex
+// until the ray-cast test agrees the point is inside (handles concave rings).
+function interiorPoint(ring) {
+  const c = polygonCentroid(ring);
+  if (pointInPolygon(c, ring)) return c;
+  for (const v of ring) {
+    for (const t of [0.5, 0.25, 0.75, 0.9]) {
+      const p = [c[0] + (v[0] - c[0]) * t, c[1] + (v[1] - c[1]) * t];
+      if (pointInPolygon(p, ring)) return p;
+    }
+  }
+  throw new Error('no interior point found');
+}
+
+test('real subdistricts.json loads with the expected shape', () => {
+  assert.ok(districts.length >= 8, `expected >=8 districts, got ${districts.length}`);
+  for (const d of districts) {
+    assert.equal(typeof d.name, 'string');
+    // Badlands has no parent polygon — only subdistrict polygons.
+    const hasOwnRing = Array.isArray(d.polygon) && d.polygon.length >= 3;
+    const hasSubRings = (d.subdistricts || []).some(
+      (s) => Array.isArray(s.polygon) && s.polygon.length >= 3,
+    );
+    assert.ok(hasOwnRing || hasSubRings, `${d.name}: no polygons at all`);
+  }
+});
+
+test('an interior point of every subdistrict resolves to that subdistrict', () => {
+  for (const d of districts) {
+    for (const s of d.subdistricts || []) {
+      const p = interiorPoint(s.polygon);
+      const hit = resolveArea(p, districts);
+      assert.ok(hit, `${s.name}: no area resolved`);
+      // Smallest containing subdistrict wins; overlapping rings mean the hit
+      // may legitimately be a smaller neighbour, but the common case is exact.
+      assert.ok(hit.subdistrict, `${s.name}: resolved district-only`);
+    }
+  }
+});
+
+test('outside every polygon defaults to Badlands (game rule)', () => {
+  assert.deepEqual(assignDistrict([99999, 99999, 0], districts), {
+    district: 'Badlands',
+    subdistrict: null,
+  });
+});
+
+test('every real location gets a district (Badlands catch-all included)', () => {
+  const locDir = join(repoRoot, 'data', 'locations');
+  const files = readdirSync(locDir).filter((f) => f.endsWith('.json'));
+  assert.ok(files.length > 200, `expected >200 location files, got ${files.length}`);
+  let assigned = 0, subs = 0;
+  for (const f of files) {
+    const mod = JSON.parse(readFileSync(join(locDir, f), 'utf8'));
+    const { district, subdistrict } = assignDistrict(mod.coordinates, districts);
+    if (district) assigned++;
+    if (subdistrict) subs++;
+  }
+  assert.equal(assigned, files.length, 'district must never be null on real data');
+  assert.ok(subs / files.length > 0.6,
+    `only ${subs}/${files.length} locations got a subdistrict`);
+});
+
+test('districtsPayload flattens boundaries (DTO rule: no arrays-of-arrays)', () => {
+  const payload = districtsPayload(districts);
+  for (const d of payload) {
+    assert.ok(d.boundary.every((n) => typeof n === 'number'), `${d.name}: non-flat boundary`);
+    assert.equal(d.boundary.length % 2, 0);
+    if (d.centroid) {
+      assert.equal(typeof d.centroid.x, 'number');
+      assert.equal(typeof d.centroid.y, 'number');
+    }
+    for (const s of d.subdistricts) {
+      assert.ok(s.boundary.every((n) => typeof n === 'number'), `${s.name}: non-flat boundary`);
+      assert.equal(typeof s.canonical, 'boolean');
+    }
+  }
+});

--- a/worker/test/merge.test.js
+++ b/worker/test/merge.test.js
@@ -1,0 +1,129 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildDataset } from '../src/merge.js';
+
+// One square district (0,0)-(1000,1000) with a subdistrict in its SW quarter.
+const DISTRICTS = [
+  {
+    id: 50, name: 'Testville',
+    polygon: [[0, 0], [1000, 0], [1000, 1000], [0, 1000]],
+    subdistricts: [
+      { id: 54, name: 'Little Fixture', polygon: [[0, 0], [500, 0], [500, 500], [0, 500]] },
+    ],
+  },
+];
+
+const TAGS = { apartment: 'a place', corpo: 'suits' };
+
+const MANUAL = [
+  {
+    id: 'aaaa-1111', name: 'Zeta Manual Loft', authors: ['Spud'],
+    coordinates: [250, 250, 10], yaw: 90, nexus_id: '12345',
+    description: 'A manual entry.', category: 'new-location', tags: ['apartment'],
+  },
+  {
+    id: 'bbbb-2222', name: 'Alpha WIP Spot', authors: ['Spud'],
+    coordinates: [750, 750], nexus_id: 'WIP',
+    description: 'Not on Nexus yet.', category: 'other', tags: [],
+  },
+];
+
+const NODES = [
+  { // duplicate of the manual entry — must only contribute thumbs
+    modId: 12345, name: 'Zeta Manual Loft (Nexus page)', summary: 'dup',
+    description: 'NCZoning:\ncoords=1,1\ncategory=other',
+    pictureUrl: 'pic-dup', thumbnailUrl: 'thumb-dup', updatedAt: '2026-07-01',
+    uploader: { name: 'Spud' },
+  },
+  { // excluded — never appears even with a valid block
+    modId: 777, name: 'Mistagged Mod', summary: 'oops',
+    description: 'NCZoning:\ncoords=2,2\ncategory=other',
+    uploader: { name: 'Someone' },
+  },
+  { // valid auto-discovered mod
+    modId: 888, name: 'Mango Auto Bar', summary: 'An auto entry.',
+    description: '[code]NCZoning:\ncoords=600,600,5\nyaw=45\ncategory=location-overhaul\ntags=corpo,bogus\ncredits=Team X\nauthors=Friend[/code]',
+    pictureUrl: 'pic-888', thumbnailUrl: 'thumb-888', updatedAt: '2026-07-02',
+    uploader: { name: 'Uploader888' },
+  },
+  { // tagged but no valid block — skipped, surfaced in meta
+    modId: 999, name: 'Blockless Mod', summary: 'no block',
+    description: 'Just prose.', uploader: { name: 'Nobody' },
+  },
+];
+
+const dataset = buildDataset({
+  manualMods: MANUAL,
+  tagsDict: TAGS,
+  excluded: { 777: 'tagged by mistake' },
+  nexusNodes: NODES,
+  districts: DISTRICTS,
+});
+
+test('merges manual + auto with exclusions and duplicates handled', () => {
+  assert.equal(dataset.locations.length, 3); // 2 manual + 1 auto
+  const ids = dataset.locations.map((l) => l.id);
+  assert.ok(ids.includes('nexus-888'), 'stable nexus-<id> for auto entries');
+  assert.ok(!ids.some((id) => id.includes('777')), 'excluded mod absent');
+});
+
+test('sorted alphabetically by name', () => {
+  const names = dataset.locations.map((l) => l.name);
+  assert.deepEqual(names, [...names].sort((a, b) => a.localeCompare(b)));
+});
+
+test('manual entry wins by nexus_id; node contributes thumbnail backfill', () => {
+  const zeta = dataset.locations.find((l) => l.nexus_id === '12345');
+  assert.equal(zeta.name, 'Zeta Manual Loft'); // manual name, not the Nexus page name
+  assert.equal(zeta.source, 'manual');
+  assert.deepEqual(dataset.meta.nexus_thumbs['12345'], {
+    pictureUrl: 'pic-dup', thumbnailUrl: 'thumb-dup', updatedAt: '2026-07-01',
+  });
+});
+
+test('auto entry: authors, tags (nczoning + known only), yaw, images in full', () => {
+  const auto = dataset.locations.find((l) => l.id === 'nexus-888');
+  assert.deepEqual(auto.authors, ['Uploader888', 'Friend']);
+  assert.deepEqual(auto.tags, ['nczoning', 'corpo']); // 'bogus' dropped
+  assert.equal(auto.yaw, 45);
+  assert.equal(auto.source, 'auto');
+  const fullAuto = dataset.full['nexus-888'];
+  assert.equal(fullAuto.credits, 'Team X');
+  assert.equal(fullAuto.thumbnail_url, 'thumb-888');
+});
+
+test('district enrichment: subdistrict wins inside it, district elsewhere', () => {
+  const zeta = dataset.locations.find((l) => l.id === 'aaaa-1111'); // (250,250) in SW quarter
+  assert.equal(zeta.district, 'Testville');
+  assert.equal(zeta.subdistrict, 'Little Fixture');
+  const auto = dataset.locations.find((l) => l.id === 'nexus-888'); // (600,600) outside sub
+  assert.equal(auto.district, 'Testville');
+  assert.equal(auto.subdistrict, null);
+});
+
+test('meta counts + skipped monitoring list', () => {
+  assert.deepEqual(dataset.meta.counts, {
+    manual: 2, auto: 1, total: 3,
+    per_district: { Testville: 3 },
+  });
+  assert.deepEqual(dataset.meta.skipped, [{ nexus_id: '999', name: 'Blockless Mod' }]);
+});
+
+test('slim entries omit description; full carries it', () => {
+  for (const l of dataset.locations) assert.ok(!('description' in l));
+  assert.equal(dataset.full['aaaa-1111'].description, 'A manual entry.');
+});
+
+test('DTO contract: no arrays-of-arrays anywhere in the slim payload', () => {
+  const walk = (v, path) => {
+    if (Array.isArray(v)) {
+      for (const [i, item] of v.entries()) {
+        assert.ok(!Array.isArray(item), `nested array at ${path}[${i}]`);
+        walk(item, `${path}[${i}]`);
+      }
+    } else if (v && typeof v === 'object') {
+      for (const [k, val] of Object.entries(v)) walk(val, `${path}.${k}`);
+    }
+  };
+  walk(dataset.locations, 'locations');
+});

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fetchTaggedModNodes, NEXUS_BATCH_SIZE } from '../src/nexus.js';
+
+function fakeFetch(pages) {
+  let call = 0;
+  const calls = [];
+  const impl = async (url, init) => {
+    const body = JSON.parse(init.body);
+    calls.push(body.variables.offset);
+    const page = pages[call++];
+    if (page instanceof Error) throw page;
+    return {
+      ok: page.ok ?? true,
+      status: page.status ?? 200,
+      json: async () => page.json,
+    };
+  };
+  impl.calls = calls;
+  return impl;
+}
+
+const node = (i) => ({ modId: i, name: `Mod ${i}` });
+
+test('paginates until the short page', async () => {
+  const first = Array.from({ length: NEXUS_BATCH_SIZE }, (_, i) => node(i));
+  const second = Array.from({ length: 10 }, (_, i) => node(100 + i));
+  const impl = fakeFetch([
+    { json: { data: { mods: { nodes: first, totalCount: 60 } } } },
+    { json: { data: { mods: { nodes: second, totalCount: 60 } } } },
+  ]);
+  const nodes = await fetchTaggedModNodes(impl);
+  assert.equal(nodes.length, 60);
+  assert.deepEqual(impl.calls, [0, NEXUS_BATCH_SIZE]);
+});
+
+test('HTTP error throws (partial results must not look complete)', async () => {
+  const impl = fakeFetch([{ ok: false, status: 503, json: {} }]);
+  await assert.rejects(() => fetchTaggedModNodes(impl), /HTTP 503/);
+});
+
+test('missing mods page throws with error detail', async () => {
+  const impl = fakeFetch([{ json: { errors: [{ message: 'boom' }] } }]);
+  await assert.rejects(() => fetchTaggedModNodes(impl), /no mods page/);
+});
+
+test('second-page failure throws rather than returning half the tag population', async () => {
+  const first = Array.from({ length: NEXUS_BATCH_SIZE }, (_, i) => node(i));
+  const impl = fakeFetch([
+    { json: { data: { mods: { nodes: first, totalCount: 60 } } } },
+    { ok: false, status: 500, json: {} },
+  ]);
+  await assert.rejects(() => fetchTaggedModNodes(impl), /HTTP 500/);
+});

--- a/worker/test/parse.test.js
+++ b/worker/test/parse.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseNcZoningBlock } from '../src/parse.js';
+
+const TAGS = new Set(['apartment', 'corpo', 'neokitsch']);
+
+test('parses a clean [code]-wrapped block', () => {
+  const desc = `My cool mod.
+[code]
+NCZoning:
+coords=-1234.5,678.9,12.3
+yaw=180.0
+category=new-location
+tags=apartment,neokitsch
+credits=Team NC
+authors=CoAuthor1,CoAuthor2
+[/code]`;
+  const p = parseNcZoningBlock(desc, TAGS);
+  assert.deepEqual(p.coordinates, [-1234.5, 678.9, 12.3]);
+  assert.equal(p.category, 'new-location');
+  assert.deepEqual(p.tags, ['apartment', 'neokitsch']);
+  assert.equal(p.credits, 'Team NC');
+  assert.deepEqual(p.additionalAuthors, ['CoAuthor1', 'CoAuthor2']);
+  assert.equal(p.yaw, 180.0);
+});
+
+test('survives lost [code] wrapper and per-line styling tags', () => {
+  const desc = `[size=4]Great mod![/size]
+NCZoning:
+[b]coords=100,200[/b]
+[color=red]category=other[/color]`;
+  const p = parseNcZoningBlock(desc, TAGS);
+  assert.deepEqual(p.coordinates, [100, 200]);
+  assert.equal(p.category, 'other');
+});
+
+test('sentinel glued to prose still parses', () => {
+  const desc = `Check it out — it's Preem, Making![code]NCZoning:
+coords=1,2,3
+category=location-overhaul[/code]`;
+  const p = parseNcZoningBlock(desc, TAGS);
+  assert.deepEqual(p.coordinates, [1, 2, 3]);
+});
+
+test('false-positive NCZoning mention earlier; real block later wins', () => {
+  const desc = `I love NCZoning: it is a great map.
+
+[code]
+NCZoning:
+coords=5,6
+category=other
+[/code]`;
+  const p = parseNcZoningBlock(desc, TAGS);
+  assert.deepEqual(p.coordinates, [5, 6]);
+});
+
+test('missing category → null', () => {
+  const p = parseNcZoningBlock('NCZoning:\ncoords=1,2,3', TAGS);
+  assert.equal(p, null);
+});
+
+test('bad coords rejected: too few, too many, NaN', () => {
+  for (const coords of ['1', '1,2,3,4', '1,abc']) {
+    assert.equal(parseNcZoningBlock(`NCZoning:\ncoords=${coords}\ncategory=other`, TAGS), null);
+  }
+});
+
+test('unknown tags silently dropped, yaw optional', () => {
+  const p = parseNcZoningBlock(
+    'NCZoning:\ncoords=1,2\ncategory=other\ntags=apartment,unknowntag', TAGS);
+  assert.deepEqual(p.tags, ['apartment']);
+  assert.equal(p.yaw, null);
+});
+
+test('empty/absent description → null', () => {
+  assert.equal(parseNcZoningBlock('', TAGS), null);
+  assert.equal(parseNcZoningBlock(null, TAGS), null);
+});
+
+test('html <br> line breaks are normalised', () => {
+  const p = parseNcZoningBlock('NCZoning:<br>coords=9,8,7<br/>category=other', TAGS);
+  assert.deepEqual(p.coordinates, [9, 8, 7]);
+});


### PR DESCRIPTION
## Summary

Project item **Data API B2**. Pure data modules for the Worker - no fetch/KV wiring yet (that is B3), so everything is testable offline.

- `worker/src/parse.js` - server port of `NCZ.parseNcZoningBlock` (same resilience strategy: strip BBCode, sentinel-as-token, validation disambiguates)
- `worker/src/districts.js` - `pointInPolygon`/`polygonCentroid` ports + the exact `resolveArea` rule from `district-info.js` (smallest-area subdistrict wins), **plus the game rule: outside every district polygon defaults to Badlands** (why Badlands has no polygon - its subdistricts are converted trigger areas). `district` is therefore never null on real data. Also the `/v1/districts` payload builder with FLATTENED boundaries per the DTO contract.
- `worker/src/merge.js` - the server-side version of the browser merge: exclusion list, manual-wins-by-nexus_id (node contributes thumbnail backfill only), stable `nexus-<id>` ids, slim/full split, per-district counts, skipped-mods monitoring list
- `worker/src/nexus.js` - paginated NCZoning GraphQL fetch; throws on any page failure so partial results can never masquerade as the full tag population

## Verified

26 tests, all passing (`npm test` in `worker/`): parser edge cases (lost `[code]`, glued sentinel, false-positive mention), district assignment against the REAL registry, merge precedence/counts/DTO-invariant walker, Nexus pagination + failure modes.

**Live end-to-end merge run** (real mods.json + real Nexus API):

- 290 locations = 281 manual + 9 auto-discovered, matching the live site
- 290/290 have a district (Badlands catch-all incl. Kujira at the map edge); 8/9 auto entries land in a named subdistrict that matches their mod name (H10 → Watson/Little China, Glen → Heywood/The Glen, Stone Manor → Badlands/Rocky Ridge)
- Per-district: Watson 81, Westbrook 59, Badlands 44, Heywood 36, Dogtown 24, Santo Domingo 17, City Center 16, Pacifica 13
- 0 tagged mods skipped for unparseable blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)