### PR TITLE
feat(api): B3 cron refresh into KV with last-known-good

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -19,15 +19,45 @@ curl http://127.0.0.1:8787/v1/health
 
 ## Deploy
 
+One-time setup (before the first deploy):
+
 ```bash
 cd worker
-npx wrangler login   # once per machine
+npx wrangler login                       # once per machine
+npx wrangler kv namespace create DATA    # paste the id into wrangler.jsonc
+npx wrangler secret put DISCORD_WEBHOOK_URL   # optional: refresh-failure alerts
 npm run deploy
 ```
 
 The `routes` entry in `wrangler.jsonc` binds `api.nczoning.net` as a custom
-domain on first deploy (DNS record + certificate are created automatically;
-the zone must be on the same Cloudflare account).
+domain on first deploy (DNS + certificate created automatically; the zone
+must be on the same Cloudflare account). The `triggers.crons` entry starts
+the 15-minute refresh once deployed.
+
+To seed KV immediately without waiting for the first cron tick, trigger the
+scheduled handler once from the dashboard (Worker → Triggers → run) or
+redeploy.
+
+## Dataset refresh (cron)
+
+Every 15 minutes the `scheduled` handler runs `runRefresh` (`src/refresh.js`):
+fetch `mods.json` + tags + exclusions + `subdistricts.json` from
+`SITE_ORIGIN`, run the Nexus auto-discovery merge with district enrichment,
+and write to KV **only when the content hash changes**. On any source
+failure it keeps the last-known-good dataset, sets `discovery_stale` in the
+meta record, and (if configured) posts a Discord alert — it never serves an
+empty or partial dataset.
+
+KV keys: `dataset:v1` (slim), `dataset:v1:full`, `dataset:v1:districts`,
+`dataset:v1:meta`.
+
+### Test the cron locally
+
+```bash
+npm run dev
+curl "http://127.0.0.1:8787/cdn-cgi/handler/scheduled"   # trigger one refresh
+npx wrangler kv key get "dataset:v1:meta" --binding DATA --local
+```
 
 ## Routes (current)
 
@@ -36,5 +66,6 @@ the zone must be on the same Cloudflare account).
 | `GET /v1/health` | `{ status, version }` in the standard envelope |
 
 Every response uses the envelope
-`{ schema, generated_at, dataset_version, data }`. Contract rules live in
-the plan doc; the full API reference ships in phase B5.
+`{ schema, generated_at, dataset_version, data }`. The read routes that
+serve the dataset from KV (`/v1/locations`, `/v1/districts`, `/v1/meta`,
+`/v1/tags`) ship in phase B4; the full API reference in B5.

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -10,6 +10,8 @@
  * - Path-based versioning: additive changes only within /v1/.
  */
 
+import { runRefresh } from './refresh.js';
+
 const SCHEMA_VERSION = 1;
 
 const CORS_HEADERS = {
@@ -50,6 +52,11 @@ const routes = {
 };
 
 export default {
+  // 15-minute cron: rebuild the dataset into KV (see refresh.js).
+  async scheduled(controller, env, ctx) {
+    ctx.waitUntil(runRefresh(env));
+  },
+
   async fetch(request, env) {
     const url = new URL(request.url);
 

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -1,0 +1,121 @@
+/**
+ * Refresh orchestrator — the body of the 15-minute cron. Fetches the CDN
+ * source files + Nexus auto-discovery, rebuilds the dataset, and writes to
+ * KV only when the content hash changes.
+ *
+ * Failure posture (the load-bearing rule): if Nexus (or any source) fails,
+ * KEEP the last-known-good dataset, mark meta.discovery_stale, alert
+ * Discord, and never serve an empty/partial dataset. A partial Nexus page
+ * already throws in nexus.js, so a truncated tag population can't slip
+ * through as "complete".
+ *
+ * Pure-ish: all I/O is injected (fetchImpl, env), so the whole thing is
+ * unit-testable with a fake KV + fake fetch.
+ */
+
+import { fetchTaggedModNodes } from './nexus.js';
+import { buildDataset } from './merge.js';
+import { districtsPayload } from './districts.js';
+import { KEYS, contentHash, readMeta, writeDataset, writeMeta } from './store.js';
+
+const SCHEMA_VERSION = 1;
+
+/** Fetch a JSON file from the site origin; throws on non-200. */
+async function fetchJson(fetchImpl, origin, path) {
+  const res = await fetchImpl(`${origin}${path}`);
+  if (!res.ok) throw new Error(`GET ${path} → HTTP ${res.status}`);
+  return res.json();
+}
+
+/** Post a failure embed to Discord if a webhook is configured. */
+async function alertDiscord(env, fetchImpl, reason) {
+  if (!env.DISCORD_WEBHOOK_URL) return;
+  try {
+    await fetchImpl(env.DISCORD_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        embeds: [{
+          title: '⚠️ Data API refresh failed',
+          description: String(reason).slice(0, 1500),
+          color: 0xffb300,
+          footer: { text: 'Serving last-known-good dataset (discovery_stale=true)' },
+        }],
+      }),
+    });
+  } catch {
+    // Alerting must never mask the original failure.
+  }
+}
+
+/**
+ * Run one refresh cycle.
+ * @param {object} env  Worker env (DATA KV binding, SITE_ORIGIN?, DISCORD_WEBHOOK_URL?)
+ * @param {typeof fetch} fetchImpl  injectable
+ * @returns {Promise<{changed:boolean, version:string|null, stale:boolean, error?:string}>}
+ */
+export async function runRefresh(env, fetchImpl = fetch) {
+  const origin = env.SITE_ORIGIN || 'https://nczoning.net';
+  const generatedAt = new Date().toISOString();
+
+  try {
+    const [manualMods, tagsDict, excluded, subdistricts] = await Promise.all([
+      fetchJson(fetchImpl, origin, '/mods.json'),
+      fetchJson(fetchImpl, origin, '/data/tags.json'),
+      fetchJson(fetchImpl, origin, '/data/excluded_mods.json').catch(() => ({})),
+      fetchJson(fetchImpl, origin, '/data/subdistricts.json'),
+    ]);
+    const districts = subdistricts.districts;
+    const nexusNodes = await fetchTaggedModNodes(fetchImpl);
+
+    const { locations, full, meta } = buildDataset({
+      manualMods, tagsDict, excluded, nexusNodes, districts,
+    });
+    const districtsOut = districtsPayload(districts);
+
+    // Hash the content that actually varies (not generated_at).
+    const version = await contentHash(
+      JSON.stringify({ locations, full, districts: districtsOut }),
+    );
+
+    const prev = await readMeta(env);
+    if (prev && prev.dataset_version === version && !prev.discovery_stale) {
+      return { changed: false, version, stale: false };
+    }
+
+    await writeDataset(env, {
+      slim: locations,
+      full,
+      districts: districtsOut,
+      meta: {
+        schema: SCHEMA_VERSION,
+        generated_at: generatedAt,
+        dataset_version: version,
+        counts: meta.counts,
+        skipped: meta.skipped,
+        discovery_stale: false,
+      },
+    });
+    return { changed: true, version, stale: false };
+  } catch (err) {
+    // Keep last-known-good; flag stale; alert. Never wipe the dataset.
+    const prev = await readMeta(env);
+    if (prev) {
+      await writeMeta(env, {
+        ...prev,
+        discovery_stale: true,
+        last_error: String(err).slice(0, 300),
+        last_error_at: generatedAt,
+      });
+    }
+    await alertDiscord(env, fetchImpl, err);
+    return {
+      changed: false,
+      version: prev?.dataset_version ?? null,
+      stale: true,
+      error: String(err),
+    };
+  }
+}
+
+export { KEYS };

--- a/worker/src/store.js
+++ b/worker/src/store.js
@@ -1,0 +1,49 @@
+/**
+ * KV storage layer for the dataset. Keys under `dataset:v1*`:
+ * - dataset:v1           slim locations array (the workhorse read)
+ * - dataset:v1:full      { id: fullEntry } map for /v1/locations/{id}
+ * - dataset:v1:districts /v1/districts payload
+ * - dataset:v1:meta      { schema, generated_at, dataset_version, counts,
+ *                          discovery_stale, skipped }
+ *
+ * dataset_version is a content hash: the cron writes only when it changes,
+ * and it doubles as the ETag for the read path (B4).
+ */
+
+export const KEYS = {
+  slim: 'dataset:v1',
+  full: 'dataset:v1:full',
+  districts: 'dataset:v1:districts',
+  meta: 'dataset:v1:meta',
+};
+
+/** SHA-256 hex of a string, via Web Crypto (Workers + Node 24). */
+export async function contentHash(str) {
+  const bytes = new TextEncoder().encode(str);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/** Read the current meta record (or null before the first successful cron). */
+export async function readMeta(env) {
+  return env.DATA.get(KEYS.meta, 'json');
+}
+
+/**
+ * Persist a freshly built dataset. Writes all four keys; callers only reach
+ * here when the hash changed, so the per-key 1 write/s limit is never a risk
+ * (cron runs every 15 min).
+ */
+export async function writeDataset(env, { slim, full, districts, meta }) {
+  await Promise.all([
+    env.DATA.put(KEYS.slim, JSON.stringify(slim)),
+    env.DATA.put(KEYS.full, JSON.stringify(full)),
+    env.DATA.put(KEYS.districts, JSON.stringify(districts)),
+    env.DATA.put(KEYS.meta, JSON.stringify(meta)),
+  ]);
+}
+
+/** Update only the meta record (last-known-good touch on a failed refresh). */
+export async function writeMeta(env, meta) {
+  await env.DATA.put(KEYS.meta, JSON.stringify(meta));
+}

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -1,0 +1,141 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { runRefresh } from '../src/refresh.js';
+import { KEYS } from '../src/store.js';
+
+// Minimal in-memory KV: get(key, 'json') + put(key, string).
+function fakeKV(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    async get(key, type) {
+      const v = store.get(key);
+      if (v === undefined) return null;
+      return type === 'json' ? JSON.parse(v) : v;
+    },
+    async put(key, value) { store.set(key, value); },
+    _dump: () => Object.fromEntries(store),
+  };
+}
+
+const TAGS = { apartment: 'a place', corpo: 'suits' };
+const EXCLUDED = { 777: 'mistagged' };
+const SUBDISTRICTS = {
+  districts: [
+    {
+      id: 'testville', name: 'Testville',
+      polygon: [[0, 0], [1000, 0], [1000, 1000], [0, 1000]],
+      subdistricts: [
+        { id: 'little', name: 'Little Fixture', polygon: [[0, 0], [500, 0], [500, 500], [0, 500]] },
+      ],
+    },
+    { id: 'badlands', name: 'Badlands', subdistricts: [] },
+  ],
+};
+const MODS = [
+  {
+    id: 'm1', name: 'Manual Loft', authors: ['Spud'], coordinates: [250, 250, 10],
+    nexus_id: '12345', description: 'x', category: 'new-location', tags: ['apartment'],
+  },
+];
+
+// GraphQL response with one valid auto mod (888) and the excluded 777.
+const NEXUS_PAGE = {
+  data: {
+    mods: {
+      nodes: [
+        {
+          modId: 888, name: 'Auto Bar', summary: 'auto',
+          description: 'NCZoning:\ncoords=600,600\ncategory=other',
+          uploader: { name: 'Up888' },
+        },
+        {
+          modId: 777, name: 'Mistagged', summary: 'no',
+          description: 'NCZoning:\ncoords=1,1\ncategory=other',
+          uploader: { name: 'X' },
+        },
+      ],
+      totalCount: 2,
+    },
+  },
+};
+
+// fetch stub keyed by URL substring; nexus POST returns the page.
+function fakeFetch({ failNexus = false, failMods = false, discordSink } = {}) {
+  return async (url, init) => {
+    if (url.includes('/mods.json')) {
+      return failMods ? { ok: false, status: 500 } : { ok: true, json: async () => MODS };
+    }
+    if (url.includes('/tags.json')) return { ok: true, json: async () => TAGS };
+    if (url.includes('/excluded_mods.json')) return { ok: true, json: async () => EXCLUDED };
+    if (url.includes('/subdistricts.json')) return { ok: true, json: async () => SUBDISTRICTS };
+    if (url.includes('api.nexusmods.com')) {
+      if (failNexus) return { ok: false, status: 503 };
+      return { ok: true, json: async () => NEXUS_PAGE };
+    }
+    if (url.includes('discord')) { discordSink?.push(JSON.parse(init.body)); return { ok: true }; }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+}
+
+test('first run writes the full dataset (changed=true)', async () => {
+  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const r = await runRefresh(env, fakeFetch());
+  assert.equal(r.changed, true);
+  assert.ok(r.version);
+  const slim = await env.DATA.get(KEYS.slim, 'json');
+  assert.equal(slim.length, 2); // 1 manual + 1 auto (777 excluded)
+  assert.ok(slim.every((l) => l.district));
+  const meta = await env.DATA.get(KEYS.meta, 'json');
+  assert.equal(meta.discovery_stale, false);
+  assert.equal(meta.counts.total, 2);
+  assert.equal(meta.dataset_version, r.version);
+});
+
+test('unchanged content on the second run skips the write (changed=false)', async () => {
+  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  await runRefresh(env, fakeFetch());
+  const before = (await env.DATA.get(KEYS.meta, 'json')).generated_at;
+  const r2 = await runRefresh(env, fakeFetch());
+  assert.equal(r2.changed, false);
+  // generated_at unchanged because we didn't rewrite.
+  assert.equal((await env.DATA.get(KEYS.meta, 'json')).generated_at, before);
+});
+
+test('Nexus failure keeps last-known-good and flags stale + alerts Discord', async () => {
+  const env = {
+    DATA: fakeKV(), SITE_ORIGIN: 'https://x',
+    DISCORD_WEBHOOK_URL: 'https://discord/webhook',
+  };
+  await runRefresh(env, fakeFetch()); // seed good data
+  const goodSlim = await env.DATA.get(KEYS.slim, 'json');
+
+  const discordSink = [];
+  const r = await runRefresh(env, fakeFetch({ failNexus: true, discordSink }));
+  assert.equal(r.stale, true);
+  assert.match(r.error, /503/);
+  // Dataset preserved (not wiped).
+  assert.deepEqual(await env.DATA.get(KEYS.slim, 'json'), goodSlim);
+  const meta = await env.DATA.get(KEYS.meta, 'json');
+  assert.equal(meta.discovery_stale, true);
+  assert.match(meta.last_error, /503/);
+  assert.equal(discordSink.length, 1);
+  assert.match(discordSink[0].embeds[0].title, /refresh failed/);
+});
+
+test('failure with no prior dataset returns stale with null version, no crash', async () => {
+  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const r = await runRefresh(env, fakeFetch({ failMods: true }));
+  assert.equal(r.stale, true);
+  assert.equal(r.version, null);
+  assert.equal(await env.DATA.get(KEYS.slim, 'json'), null);
+});
+
+test('recovery after a stale cycle rewrites and clears the stale flag', async () => {
+  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  await runRefresh(env, fakeFetch());
+  await runRefresh(env, fakeFetch({ failNexus: true }));
+  assert.equal((await env.DATA.get(KEYS.meta, 'json')).discovery_stale, true);
+  const r = await runRefresh(env, fakeFetch());
+  assert.equal(r.changed, true); // stale flag forces a rewrite even if hash matches
+  assert.equal((await env.DATA.get(KEYS.meta, 'json')).discovery_stale, false);
+});

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -15,10 +15,23 @@
 
   "vars": {
     // Bumped manually on releases; reported by /v1/health.
-    "API_VERSION": "0.1.0"
+    "API_VERSION": "0.1.0",
+    // Origin the cron pulls source files from (mods.json, tags, subdistricts).
+    "SITE_ORIGIN": "https://nczoning.net"
+  },
+
+  // Dataset store. Create with:
+  //   npx wrangler kv namespace create DATA
+  // then paste the returned id below (and a preview_id for `wrangler dev`).
+  "kv_namespaces": [
+    { "binding": "DATA", "id": "REPLACE_WITH_KV_ID" }
+  ],
+
+  // Rebuild the dataset every 15 minutes.
+  "triggers": {
+    "crons": ["*/15 * * * *"]
   }
 
-  // B3 will add:
-  // - "kv_namespaces": [{ "binding": "DATA", "id": "..." }]
-  // - "triggers": { "crons": ["*/15 * * * *"] }
+  // DISCORD_WEBHOOK_URL is a secret (wrangler secret put DISCORD_WEBHOOK_URL),
+  // not committed here. Optional — refresh runs without it.
 }


### PR DESCRIPTION
## Summary

Project item **Data API B3**. Wires the B2 merge engine into the scheduled cron and Workers KV.

- `worker/src/store.js` - KV keys (`dataset:v1` slim / `:full` / `:districts` / `:meta`), SHA-256 content hash (the ETag/delta value for B4), read/write helpers
- `worker/src/refresh.js` - the refresh cycle: fetch `mods.json` + tags + exclusions + `subdistricts.json` from `SITE_ORIGIN`, run the merge + district enrichment, **write only when the content hash changes**. On any source failure: keep last-known-good, set `meta.discovery_stale`, post a Discord alert - never serve an empty/partial dataset
- `worker/src/index.js` - `scheduled()` handler via `ctx.waitUntil(runRefresh(env))`
- `worker/wrangler.jsonc` - `DATA` KV binding, `SITE_ORIGIN` var, `*/15 * * * *` cron

## Verified

**Unit** (5 new refresh tests, 31 total, all pass) with a fake KV + fake fetch: first-write, hash-gate skip on unchanged content, Nexus-failure keeps the dataset + flags stale + fires the Discord embed, failure-with-no-prior-data doesn''t crash, stale-then-recover rewrites and clears the flag.

**End-to-end** with `wrangler dev` against the LIVE site + real Nexus API:

- `curl .../cdn-cgi/handler/scheduled` → 290 locations written to KV (281 manual + 9 auto), all with a district, meta counts populated
- `dataset:v1:districts` = 9 districts, flat boundaries + centroids
- `dataset:v1:full` = 290 entries with descriptions
- Second trigger left `generated_at` unchanged → hash-gate confirmed, no wasteful KV write

## After merge (user action, once)

```
cd worker
npx wrangler kv namespace create DATA     # paste id into wrangler.jsonc
npx wrangler secret put DISCORD_WEBHOOK_URL   # optional
npm run deploy
```

The cron then refreshes every 15 min. `wrangler.jsonc` currently has an `id: "REPLACE_WITH_KV_ID"` placeholder - that one line is the only thing blocking deploy, filled from the `kv namespace create` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)