### PR TITLE
refactor(api): name KV namespace nczoning-api-dataset (was DATA)

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -24,7 +24,7 @@ One-time setup (before the first deploy):
 ```bash
 cd worker
 npx wrangler login                       # once per machine
-npx wrangler kv namespace create DATA    # paste the id into wrangler.jsonc
+npx wrangler kv namespace create nczoning-api-dataset   # paste the id into wrangler.jsonc
 npx wrangler secret put DISCORD_WEBHOOK_URL   # optional: refresh-failure alerts
 npm run deploy
 ```
@@ -56,7 +56,7 @@ KV keys: `dataset:v1` (slim), `dataset:v1:full`, `dataset:v1:districts`,
 ```bash
 npm run dev
 curl "http://127.0.0.1:8787/cdn-cgi/handler/scheduled"   # trigger one refresh
-npx wrangler kv key get "dataset:v1:meta" --binding DATA --local
+npx wrangler kv key get "dataset:v1:meta" --binding DATASET --local
 ```
 
 ## Routes (current)

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -50,7 +50,7 @@ async function alertDiscord(env, fetchImpl, reason) {
 
 /**
  * Run one refresh cycle.
- * @param {object} env  Worker env (DATA KV binding, SITE_ORIGIN?, DISCORD_WEBHOOK_URL?)
+ * @param {object} env  Worker env (DATASET KV binding, SITE_ORIGIN?, DISCORD_WEBHOOK_URL?)
  * @param {typeof fetch} fetchImpl  injectable
  * @returns {Promise<{changed:boolean, version:string|null, stale:boolean, error?:string}>}
  */

--- a/worker/src/store.js
+++ b/worker/src/store.js
@@ -26,7 +26,7 @@ export async function contentHash(str) {
 
 /** Read the current meta record (or null before the first successful cron). */
 export async function readMeta(env) {
-  return env.DATA.get(KEYS.meta, 'json');
+  return env.DATASET.get(KEYS.meta, 'json');
 }
 
 /**
@@ -36,14 +36,14 @@ export async function readMeta(env) {
  */
 export async function writeDataset(env, { slim, full, districts, meta }) {
   await Promise.all([
-    env.DATA.put(KEYS.slim, JSON.stringify(slim)),
-    env.DATA.put(KEYS.full, JSON.stringify(full)),
-    env.DATA.put(KEYS.districts, JSON.stringify(districts)),
-    env.DATA.put(KEYS.meta, JSON.stringify(meta)),
+    env.DATASET.put(KEYS.slim, JSON.stringify(slim)),
+    env.DATASET.put(KEYS.full, JSON.stringify(full)),
+    env.DATASET.put(KEYS.districts, JSON.stringify(districts)),
+    env.DATASET.put(KEYS.meta, JSON.stringify(meta)),
   ]);
 }
 
 /** Update only the meta record (last-known-good touch on a failed refresh). */
 export async function writeMeta(env, meta) {
-  await env.DATA.put(KEYS.meta, JSON.stringify(meta));
+  await env.DATASET.put(KEYS.meta, JSON.stringify(meta));
 }

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -78,44 +78,44 @@ function fakeFetch({ failNexus = false, failMods = false, discordSink } = {}) {
 }
 
 test('first run writes the full dataset (changed=true)', async () => {
-  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
   const r = await runRefresh(env, fakeFetch());
   assert.equal(r.changed, true);
   assert.ok(r.version);
-  const slim = await env.DATA.get(KEYS.slim, 'json');
+  const slim = await env.DATASET.get(KEYS.slim, 'json');
   assert.equal(slim.length, 2); // 1 manual + 1 auto (777 excluded)
   assert.ok(slim.every((l) => l.district));
-  const meta = await env.DATA.get(KEYS.meta, 'json');
+  const meta = await env.DATASET.get(KEYS.meta, 'json');
   assert.equal(meta.discovery_stale, false);
   assert.equal(meta.counts.total, 2);
   assert.equal(meta.dataset_version, r.version);
 });
 
 test('unchanged content on the second run skips the write (changed=false)', async () => {
-  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
   await runRefresh(env, fakeFetch());
-  const before = (await env.DATA.get(KEYS.meta, 'json')).generated_at;
+  const before = (await env.DATASET.get(KEYS.meta, 'json')).generated_at;
   const r2 = await runRefresh(env, fakeFetch());
   assert.equal(r2.changed, false);
   // generated_at unchanged because we didn't rewrite.
-  assert.equal((await env.DATA.get(KEYS.meta, 'json')).generated_at, before);
+  assert.equal((await env.DATASET.get(KEYS.meta, 'json')).generated_at, before);
 });
 
 test('Nexus failure keeps last-known-good and flags stale + alerts Discord', async () => {
   const env = {
-    DATA: fakeKV(), SITE_ORIGIN: 'https://x',
+    DATASET: fakeKV(), SITE_ORIGIN: 'https://x',
     DISCORD_WEBHOOK_URL: 'https://discord/webhook',
   };
   await runRefresh(env, fakeFetch()); // seed good data
-  const goodSlim = await env.DATA.get(KEYS.slim, 'json');
+  const goodSlim = await env.DATASET.get(KEYS.slim, 'json');
 
   const discordSink = [];
   const r = await runRefresh(env, fakeFetch({ failNexus: true, discordSink }));
   assert.equal(r.stale, true);
   assert.match(r.error, /503/);
   // Dataset preserved (not wiped).
-  assert.deepEqual(await env.DATA.get(KEYS.slim, 'json'), goodSlim);
-  const meta = await env.DATA.get(KEYS.meta, 'json');
+  assert.deepEqual(await env.DATASET.get(KEYS.slim, 'json'), goodSlim);
+  const meta = await env.DATASET.get(KEYS.meta, 'json');
   assert.equal(meta.discovery_stale, true);
   assert.match(meta.last_error, /503/);
   assert.equal(discordSink.length, 1);
@@ -123,19 +123,19 @@ test('Nexus failure keeps last-known-good and flags stale + alerts Discord', asy
 });
 
 test('failure with no prior dataset returns stale with null version, no crash', async () => {
-  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
   const r = await runRefresh(env, fakeFetch({ failMods: true }));
   assert.equal(r.stale, true);
   assert.equal(r.version, null);
-  assert.equal(await env.DATA.get(KEYS.slim, 'json'), null);
+  assert.equal(await env.DATASET.get(KEYS.slim, 'json'), null);
 });
 
 test('recovery after a stale cycle rewrites and clears the stale flag', async () => {
-  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
   await runRefresh(env, fakeFetch());
   await runRefresh(env, fakeFetch({ failNexus: true }));
-  assert.equal((await env.DATA.get(KEYS.meta, 'json')).discovery_stale, true);
+  assert.equal((await env.DATASET.get(KEYS.meta, 'json')).discovery_stale, true);
   const r = await runRefresh(env, fakeFetch());
   assert.equal(r.changed, true); // stale flag forces a rewrite even if hash matches
-  assert.equal((await env.DATA.get(KEYS.meta, 'json')).discovery_stale, false);
+  assert.equal((await env.DATASET.get(KEYS.meta, 'json')).discovery_stale, false);
 });

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -2,36 +2,40 @@
 // Deploys independently of the Pages site; shares only the nczoning.net zone.
 // See docs/data-api-plan.md for the architecture.
 {
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "nczoning-api",
-  "main": "src/index.js",
-  "compatibility_date": "2026-07-04",
-
-  // Custom domain: deploying creates the DNS record + cert on the zone
-  // automatically (the zone must be on the same Cloudflare account).
-  "routes": [
-    { "pattern": "api.nczoning.net", "custom_domain": true }
-  ],
-
-  "vars": {
-    // Bumped manually on releases; reported by /v1/health.
-    "API_VERSION": "0.1.0",
-    // Origin the cron pulls source files from (mods.json, tags, subdistricts).
-    "SITE_ORIGIN": "https://nczoning.net"
-  },
-
-  // Dataset store. Create with:
-  //   npx wrangler kv namespace create DATA
-  // then paste the returned id below (and a preview_id for `wrangler dev`).
-  "kv_namespaces": [
-    { "binding": "DATA", "id": "REPLACE_WITH_KV_ID" }
-  ],
-
-  // Rebuild the dataset every 15 minutes.
-  "triggers": {
-    "crons": ["*/15 * * * *"]
-  }
-
-  // DISCORD_WEBHOOK_URL is a secret (wrangler secret put DISCORD_WEBHOOK_URL),
-  // not committed here. Optional — refresh runs without it.
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "nczoning-api",
+	"main": "src/index.js",
+	"compatibility_date": "2026-07-04",
+	// Custom domain: deploying creates the DNS record + cert on the zone
+	// automatically (the zone must be on the same Cloudflare account).
+	"routes": [
+		{
+			"pattern": "api.nczoning.net",
+			"custom_domain": true
+		}
+	],
+	"vars": {
+		// Bumped manually on releases; reported by /v1/health.
+		"API_VERSION": "0.1.0",
+		// Origin the cron pulls source files from (mods.json, tags, subdistricts).
+		"SITE_ORIGIN": "https://nczoning.net"
+	},
+	// Dataset store (dashboard title: nczoning-api-dataset). Recreate with:
+	//   npx wrangler kv namespace create nczoning-api-dataset
+	// then paste the returned id below. Content is fully derived (rebuilt by
+	// the cron), so the namespace can be recreated at any time.
+	"kv_namespaces": [
+		{
+			"binding": "DATASET",
+			"id": "d86735e00790417e948e423c3df01d68"
+		}
+	],
+	// Rebuild the dataset every 15 minutes.
+	"triggers": {
+		"crons": [
+			"*/15 * * * *"
+		]
+	}
+	// DISCORD_WEBHOOK_URL is a secret (wrangler secret put DISCORD_WEBHOOK_URL),
+	// not committed here. Optional — refresh runs without it.
 }


### PR DESCRIPTION
## Summary

Follow-up to B3 (#787) - that PR was merged before this rename was committed, so the rename got stranded on the old branch. Cherry-picked onto a fresh branch off dev.

The KV namespace showed as a bare `DATA` in the Cloudflare dashboard - unrecognisable when browsing months later. Renamed:

- **Dashboard title**: `DATA` → `nczoning-api-dataset` (whose + what). Recreated the namespace (content is fully derived, rebuilt by the cron) and deleted the old one; the real id is now committed.
- **Code binding**: `env.DATA` → `env.DATASET` (matches the `dataset:v1*` keys) across `store.js`, `refresh.js`, tests, `wrangler.jsonc`, README.

## Verified

- 31 tests pass
- No residual `env.DATA` references
- `wrangler.jsonc` carries the live namespace id, so deploy needs no placeholder swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)