### PR TITLE
feat(api): B4 read endpoints from KV with ETag/304

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -59,13 +59,20 @@ curl "http://127.0.0.1:8787/cdn-cgi/handler/scheduled"   # trigger one refresh
 npx wrangler kv key get "dataset:v1:meta" --binding DATASET --local
 ```
 
-## Routes (current)
+## Routes
 
 | Route | Returns |
 | --- | --- |
-| `GET /v1/health` | `{ status, version }` in the standard envelope |
+| `GET /v1/health` | `{ status, version }` (uncached) |
+| `GET /v1/locations` | slim location array |
+| `GET /v1/locations/{id}` | one full entry (adds description/credits), or 404 |
+| `GET /v1/districts` | district/subdistrict hierarchy (flat boundaries) |
+| `GET /v1/tags` | tag dictionary |
+| `GET /v1/meta` | `{ counts, discovery_stale, skipped }` |
 
 Every response uses the envelope
-`{ schema, generated_at, dataset_version, data }`. The read routes that
-serve the dataset from KV (`/v1/locations`, `/v1/districts`, `/v1/meta`,
-`/v1/tags`) ship in phase B4; the full API reference in B5.
+`{ schema, generated_at, dataset_version, data }`. Dataset routes carry
+`ETag: "<dataset_version>"` and `Cache-Control: public, max-age=300,
+stale-while-revalidate=3600`; send `If-None-Match` to get a `304` when your
+copy is current. Before the first cron tick the dataset routes return `503
+not_ready`. The full API reference (repo doc + OpenAPI page) ships in B5.

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -8,9 +8,14 @@
  * - JSON stays DTO-mappable for the in-game RedData consumer:
  *   no arrays-of-arrays, property names are case-sensitive.
  * - Path-based versioning: additive changes only within /v1/.
+ *
+ * Data is served from KV (written by the 15-minute cron, see refresh.js).
+ * ETag = dataset_version (the content hash): a client sending a matching
+ * If-None-Match gets a 304 without the big data read.
  */
 
 import { runRefresh } from './refresh.js';
+import { KEYS } from './store.js';
 
 const SCHEMA_VERSION = 1;
 
@@ -20,12 +25,16 @@ const CORS_HEADERS = {
   'Access-Control-Allow-Headers': 'If-None-Match',
 };
 
-/** Wrap payload data in the versioned response envelope. */
-function envelope(data, datasetVersion = null) {
+// Dataset routes are cached for 5 min at the edge/browser, with a 1-hour
+// stale-while-revalidate window so a client never blocks on a refresh.
+const DATA_CACHE = 'public, max-age=300, stale-while-revalidate=3600';
+
+/** Wrap payload data in the versioned envelope (version/time from meta). */
+function envelope(data, meta) {
   return {
     schema: SCHEMA_VERSION,
-    generated_at: new Date().toISOString(),
-    dataset_version: datasetVersion,
+    generated_at: meta?.generated_at ?? null,
+    dataset_version: meta?.dataset_version ?? null,
     data,
   };
 }
@@ -43,13 +52,70 @@ function json(body, { status = 200, headers = {} } = {}) {
 }
 
 function notFound() {
-  return json(envelope({ error: 'not_found' }), { status: 404 });
+  return json(envelope({ error: 'not_found' }, null), { status: 404 });
+}
+
+/** Before the first successful cron, KV is empty — say so, don't 404. */
+function notReady() {
+  return json(envelope({ error: 'not_ready' }, null), {
+    status: 503,
+    headers: { 'Retry-After': '60' },
+  });
+}
+
+/**
+ * Serve a dataset payload from KV with ETag/304 + cache headers. `build`
+ * receives the parsed meta and returns the response `data`, or `undefined`
+ * to signal a 404 (e.g. an unknown location id).
+ */
+async function serveDataset(request, env, build) {
+  const meta = await env.DATASET.get(KEYS.meta, 'json');
+  if (!meta) return notReady();
+
+  const etag = `"${meta.dataset_version}"`;
+  if (request.headers.get('If-None-Match') === etag) {
+    return new Response(null, {
+      status: 304,
+      headers: { ...CORS_HEADERS, ETag: etag, 'Cache-Control': DATA_CACHE },
+    });
+  }
+
+  const data = await build(env, meta);
+  if (data === undefined) return notFound();
+
+  return json(envelope(data, meta), {
+    headers: { ETag: etag, 'Cache-Control': DATA_CACHE },
+  });
 }
 
 const routes = {
-  '/v1/health': (request, env) =>
-    json(envelope({ status: 'ok', version: env.API_VERSION })),
+  'GET /v1/health': (request, env) =>
+    json(envelope({ status: 'ok', version: env.API_VERSION }, null)),
+
+  'GET /v1/locations': (request, env) =>
+    serveDataset(request, env, (e) => e.DATASET.get(KEYS.slim, 'json')),
+
+  'GET /v1/districts': (request, env) =>
+    serveDataset(request, env, (e) => e.DATASET.get(KEYS.districts, 'json')),
+
+  'GET /v1/tags': (request, env) =>
+    serveDataset(request, env, (e) => e.DATASET.get(KEYS.tags, 'json')),
+
+  'GET /v1/meta': (request, env) =>
+    serveDataset(request, env, (e, meta) => ({
+      counts: meta.counts,
+      discovery_stale: meta.discovery_stale ?? false,
+      skipped: meta.skipped ?? [],
+    })),
 };
+
+/** GET /v1/locations/{id} — full entry, or 404. */
+function locationById(request, env, id) {
+  return serveDataset(request, env, async (e) => {
+    const full = await e.DATASET.get(KEYS.full, 'json');
+    return full?.[id]; // undefined → 404
+  });
+}
 
 export default {
   // 15-minute cron: rebuild the dataset into KV (see refresh.js).
@@ -64,10 +130,17 @@ export default {
       return new Response(null, { status: 204, headers: CORS_HEADERS });
     }
     if (request.method !== 'GET' && request.method !== 'HEAD') {
-      return json(envelope({ error: 'method_not_allowed' }), { status: 405 });
+      return json(envelope({ error: 'method_not_allowed' }, null), { status: 405 });
     }
 
-    const handler = routes[url.pathname];
-    return handler ? handler(request, env) : notFound();
+    // Static routes first.
+    const handler = routes[`GET ${url.pathname}`];
+    if (handler) return handler(request, env);
+
+    // Parametric: /v1/locations/{id}
+    const locMatch = url.pathname.match(/^\/v1\/locations\/([^/]+)$/);
+    if (locMatch) return locationById(request, env, decodeURIComponent(locMatch[1]));
+
+    return notFound();
   },
 };

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -73,9 +73,10 @@ export async function runRefresh(env, fetchImpl = fetch) {
     });
     const districtsOut = districtsPayload(districts);
 
-    // Hash the content that actually varies (not generated_at).
+    // Hash the content that actually varies (not generated_at). Tags are
+    // included so a tags.json edit propagates through the ETag.
     const version = await contentHash(
-      JSON.stringify({ locations, full, districts: districtsOut }),
+      JSON.stringify({ locations, full, districts: districtsOut, tags: tagsDict }),
     );
 
     const prev = await readMeta(env);
@@ -87,6 +88,7 @@ export async function runRefresh(env, fetchImpl = fetch) {
       slim: locations,
       full,
       districts: districtsOut,
+      tags: tagsDict,
       meta: {
         schema: SCHEMA_VERSION,
         generated_at: generatedAt,

--- a/worker/src/store.js
+++ b/worker/src/store.js
@@ -3,17 +3,19 @@
  * - dataset:v1           slim locations array (the workhorse read)
  * - dataset:v1:full      { id: fullEntry } map for /v1/locations/{id}
  * - dataset:v1:districts /v1/districts payload
+ * - dataset:v1:tags      tag dictionary ({ tagId: description })
  * - dataset:v1:meta      { schema, generated_at, dataset_version, counts,
  *                          discovery_stale, skipped }
  *
  * dataset_version is a content hash: the cron writes only when it changes,
- * and it doubles as the ETag for the read path (B4).
+ * and it doubles as the ETag for the read path.
  */
 
 export const KEYS = {
   slim: 'dataset:v1',
   full: 'dataset:v1:full',
   districts: 'dataset:v1:districts',
+  tags: 'dataset:v1:tags',
   meta: 'dataset:v1:meta',
 };
 
@@ -30,15 +32,16 @@ export async function readMeta(env) {
 }
 
 /**
- * Persist a freshly built dataset. Writes all four keys; callers only reach
- * here when the hash changed, so the per-key 1 write/s limit is never a risk
+ * Persist a freshly built dataset. Writes all keys; callers only reach here
+ * when the hash changed, so the per-key 1 write/s limit is never a risk
  * (cron runs every 15 min).
  */
-export async function writeDataset(env, { slim, full, districts, meta }) {
+export async function writeDataset(env, { slim, full, districts, tags, meta }) {
   await Promise.all([
     env.DATASET.put(KEYS.slim, JSON.stringify(slim)),
     env.DATASET.put(KEYS.full, JSON.stringify(full)),
     env.DATASET.put(KEYS.districts, JSON.stringify(districts)),
+    env.DATASET.put(KEYS.tags, JSON.stringify(tags)),
     env.DATASET.put(KEYS.meta, JSON.stringify(meta)),
   ]);
 }

--- a/worker/test/index.test.js
+++ b/worker/test/index.test.js
@@ -1,0 +1,137 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import worker from '../src/index.js';
+import { KEYS } from '../src/store.js';
+
+// In-memory KV seeded with a full dataset (matches what the cron writes).
+function fakeKV(entries = {}) {
+  const store = new Map(Object.entries(entries).map(([k, v]) => [k, JSON.stringify(v)]));
+  return {
+    async get(key, type) {
+      const v = store.get(key);
+      if (v === undefined) return null;
+      return type === 'json' ? JSON.parse(v) : v;
+    },
+    async put(key, value) { store.set(key, value); },
+  };
+}
+
+const META = {
+  schema: 1, generated_at: '2026-07-04T00:00:00.000Z', dataset_version: 'abc123',
+  counts: { manual: 1, auto: 1, total: 2, per_district: { Watson: 2 } },
+  skipped: [], discovery_stale: false,
+};
+const SLIM = [
+  { id: 'm1', name: 'Manual', nexus_id: '1', coordinates: [1, 2, 3], category: 'other', tags: [], authors: ['A'], source: 'manual', district: 'Watson', subdistrict: 'Kabuki' },
+  { id: 'nexus-2', name: 'Auto', nexus_id: '2', coordinates: [4, 5, 6], category: 'new-location', tags: ['nczoning'], authors: ['B'], source: 'auto', district: 'Watson', subdistrict: null },
+];
+const FULL = {
+  m1: { ...SLIM[0], description: 'a manual mod' },
+  'nexus-2': { ...SLIM[1], description: 'an auto mod' },
+};
+const DISTRICTS = [{ id: 'watson', name: 'Watson', boundary: [0, 0, 10, 0, 10, 10], centroid: { x: 5, y: 5 }, subdistricts: [] }];
+const TAGS = { apartment: 'a place', corpo: 'suits' };
+
+function seededEnv() {
+  return {
+    API_VERSION: '0.1.0',
+    DATASET: fakeKV({
+      [KEYS.meta]: META, [KEYS.slim]: SLIM, [KEYS.full]: FULL,
+      [KEYS.districts]: DISTRICTS, [KEYS.tags]: TAGS,
+    }),
+  };
+}
+
+const GET = (path, headers) => new Request(`https://api.nczoning.net${path}`, { headers });
+
+test('GET /v1/health returns ok + version, no ETag', async () => {
+  const res = await worker.fetch(GET('/v1/health'), seededEnv());
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('ETag'), null);
+  const body = await res.json();
+  assert.equal(body.data.status, 'ok');
+  assert.equal(body.data.version, '0.1.0');
+});
+
+test('GET /v1/locations returns the slim array in an envelope with ETag', async () => {
+  const res = await worker.fetch(GET('/v1/locations'), seededEnv());
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('ETag'), '"abc123"');
+  assert.match(res.headers.get('Cache-Control'), /max-age=300/);
+  assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
+  const body = await res.json();
+  assert.equal(body.schema, 1);
+  assert.equal(body.dataset_version, 'abc123');
+  assert.equal(body.data.length, 2);
+  assert.ok(!('description' in body.data[0])); // slim
+});
+
+test('matching If-None-Match yields 304 with no body', async () => {
+  const res = await worker.fetch(GET('/v1/locations', { 'If-None-Match': '"abc123"' }), seededEnv());
+  assert.equal(res.status, 304);
+  assert.equal(res.headers.get('ETag'), '"abc123"');
+  assert.equal(await res.text(), '');
+});
+
+test('stale If-None-Match yields a fresh 200', async () => {
+  const res = await worker.fetch(GET('/v1/locations', { 'If-None-Match': '"old"' }), seededEnv());
+  assert.equal(res.status, 200);
+});
+
+test('GET /v1/locations/{id} returns the full entry', async () => {
+  const res = await worker.fetch(GET('/v1/locations/nexus-2'), seededEnv());
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.description, 'an auto mod');
+});
+
+test('GET /v1/locations/{unknown} → 404', async () => {
+  const res = await worker.fetch(GET('/v1/locations/nope'), seededEnv());
+  assert.equal(res.status, 404);
+  assert.equal((await res.json()).data.error, 'not_found');
+});
+
+test('GET /v1/districts returns the hierarchy with flat boundaries', async () => {
+  const res = await worker.fetch(GET('/v1/districts'), seededEnv());
+  const body = await res.json();
+  assert.equal(body.data[0].name, 'Watson');
+  assert.ok(body.data[0].boundary.every((n) => typeof n === 'number'));
+});
+
+test('GET /v1/tags returns the dictionary', async () => {
+  const res = await worker.fetch(GET('/v1/tags'), seededEnv());
+  assert.deepEqual((await res.json()).data, TAGS);
+});
+
+test('GET /v1/meta returns counts + discovery_stale (not the raw record)', async () => {
+  const res = await worker.fetch(GET('/v1/meta'), seededEnv());
+  const body = await res.json();
+  assert.equal(body.data.counts.total, 2);
+  assert.equal(body.data.discovery_stale, false);
+  assert.ok(!('dataset_version' in body.data)); // version lives on the envelope
+});
+
+test('empty KV (pre-first-cron) → 503 not_ready', async () => {
+  const env = { API_VERSION: '0.1.0', DATASET: fakeKV() };
+  const res = await worker.fetch(GET('/v1/locations'), env);
+  assert.equal(res.status, 503);
+  assert.equal(res.headers.get('Retry-After'), '60');
+});
+
+test('OPTIONS preflight → 204 with CORS', async () => {
+  const res = await worker.fetch(
+    new Request('https://api.nczoning.net/v1/locations', { method: 'OPTIONS' }), seededEnv());
+  assert.equal(res.status, 204);
+  assert.equal(res.headers.get('Access-Control-Allow-Methods'), 'GET, HEAD, OPTIONS');
+});
+
+test('POST → 405', async () => {
+  const res = await worker.fetch(
+    new Request('https://api.nczoning.net/v1/locations', { method: 'POST' }), seededEnv());
+  assert.equal(res.status, 405);
+});
+
+test('unknown route → 404', async () => {
+  const res = await worker.fetch(GET('/v1/nope'), seededEnv());
+  assert.equal(res.status, 404);
+});


### PR DESCRIPTION
## Summary

Project item **Data API B4** - the read layer. The dataset in KV is now reachable over HTTP.

| Route | Returns |
| --- | --- |
| `GET /v1/locations` | slim location array |
| `GET /v1/locations/{id}` | one full entry (adds description/credits), or 404 |
| `GET /v1/districts` | district/subdistrict hierarchy (flat boundaries) |
| `GET /v1/tags` | tag dictionary |
| `GET /v1/meta` | `{ counts, discovery_stale, skipped }` |

- Envelope `{ schema, generated_at, dataset_version, data }` on every response
- **ETag = `dataset_version`**; `If-None-Match` match returns `304` *before* the big data read (the delta mechanism - no custom diffing)
- `Cache-Control: public, max-age=300, stale-while-revalidate=3600`
- `503 not_ready` before the first cron tick, `404` unknown id/route, `405` non-GET, CORS `*`
- **Tags now persisted** to `dataset:v1:tags` and folded into the content hash, so a `tags.json` edit propagates through the ETag (touches `store.js` + `refresh.js`)

## Verified

44 tests pass (13 new fetch-handler tests: 200/304/404/503/405/CORS, slim-vs-full, meta shape, flat district boundaries).

**Local end-to-end** (`wrangler dev`, seeded via the scheduled handler against the live site):

- `/v1/locations` → 290 entries, `ETag` + `Cache-Control` present
- `If-None-Match` with the current ETag → **304, 0 bytes**
- `/v1/locations/nexus-27618` → full entry with description (Atari Canyon, City Center)
- `/v1/districts` → 9, flat boundaries; `/v1/tags` → 14; `/v1/meta` → total 290, per-district counts
- unknown id → 404

## Note on deploy

The content hash changed (tags are now hashed in), so the first cron tick after deploy will rewrite KV once with the new `dataset_version` - expected, harmless. After merge + deploy, `curl https://api.nczoning.net/v1/locations` returns the 290 entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)