### PR TITLE
ci(api): B6 two-environment deploy (prod from main, staging from dev)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,49 @@
+name: Deploy Data API Worker
+
+# The API Worker deploys independently of the Pages site, mirroring the
+# site's main/dev split:
+#   push to main → production  (nczoning-api        @ api.nczoning.net)
+#   push to dev  → staging     (nczoning-api-staging @ api-dev.nczoning.net)
+# Path-filtered to worker/**, so unrelated pushes never redeploy the API.
+
+on:
+  push:
+    branches: [main, dev]
+    paths: ['worker/**', '.github/workflows/deploy-api.yml']
+
+concurrency:
+  group: deploy-api-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install
+        run: npm ci
+        working-directory: worker
+
+      - name: Test (gate)
+        run: npm test
+        working-directory: worker
+
+      - name: Deploy production
+        if: github.ref == 'refs/heads/main'
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: worker
+
+      - name: Deploy staging
+        if: github.ref == 'refs/heads/dev'
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: worker
+          environment: staging

--- a/worker/README.md
+++ b/worker/README.md
@@ -4,9 +4,19 @@ Cloudflare Worker serving the mod registry at `api.nczoning.net/v1/*` for
 in-game consumers (and, later, the website itself). Architecture and phase
 plan: [docs/data-api-plan.md](../docs/data-api-plan.md).
 
-Deploys independently of the Pages site. The Pages Git integration ignores
-this directory; the Worker ships via `wrangler deploy` (CI workflow arrives
-in phase B6).
+Deploys independently of the Pages site, but mirrors its main/dev split with
+two environments:
+
+| Env | Worker | Domain | Source origin | Deployed from |
+| --- | --- | --- | --- | --- |
+| production | `nczoning-api` | api.nczoning.net | nczoning.net | `main` |
+| staging | `nczoning-api-staging` | api-dev.nczoning.net | dev.nczoning.net | `dev` |
+
+CI (`.github/workflows/deploy-api.yml`) deploys production on push to `main`
+and staging on push to `dev`, path-filtered to `worker/**`. So the live site
+(main → nczoning.net → api.nczoning.net) only changes through the same
+dev→main gate that protects the site itself; dev work stays on the staging
+API.
 
 ## Local development
 
@@ -19,24 +29,27 @@ curl http://127.0.0.1:8787/v1/health
 
 ## Deploy
 
-One-time setup (before the first deploy):
+Normally you don't — CI deploys on merge (see the table above). Manual
+deploy for local iteration:
 
 ```bash
 cd worker
-npx wrangler login                       # once per machine
-npx wrangler kv namespace create nczoning-api-dataset   # paste the id into wrangler.jsonc
-npx wrangler secret put DISCORD_WEBHOOK_URL   # optional: refresh-failure alerts
-npm run deploy
+npx wrangler login                    # once per machine
+npm run deploy                        # production
+npx wrangler deploy --env staging     # staging
 ```
 
-The `routes` entry in `wrangler.jsonc` binds `api.nczoning.net` as a custom
-domain on first deploy (DNS + certificate created automatically; the zone
-must be on the same Cloudflare account). The `triggers.crons` entry starts
-the 15-minute refresh once deployed.
+CI needs one GitHub Actions secret: `CLOUDFLARE_API_TOKEN` (a token with
+Workers Scripts:Edit, Workers KV Storage:Edit, and Zone DNS:Edit on the
+nczoning.net zone — DNS is needed so the custom-domain route can be created).
+The `DISCORD_WEBHOOK_URL` Worker secret and the KV namespaces persist across
+deploys; they're set once with `wrangler secret put` / `kv namespace create`
+and are not touched by CI.
 
-To seed KV immediately without waiting for the first cron tick, trigger the
-scheduled handler once from the dashboard (Worker → Triggers → run) or
-redeploy.
+The `routes` entry binds the custom domain on first deploy (DNS + certificate
+created automatically; the zone must be on the same Cloudflare account). The
+`triggers.crons` entry starts the 15-minute refresh once deployed; a freshly
+deployed env returns `503 not_ready` until its first cron tick seeds KV.
 
 ## Dataset refresh (cron)
 

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -1,6 +1,15 @@
 // NC Zoning Data API — Cloudflare Worker config.
 // Deploys independently of the Pages site; shares only the nczoning.net zone.
 // See docs/data-api-plan.md for the architecture.
+//
+// Two environments mirror the site's main/dev split:
+//   `wrangler deploy`                 → PRODUCTION (top-level config below)
+//                                       nczoning-api @ api.nczoning.net
+//   `wrangler deploy --env staging`   → STAGING (env.staging)
+//                                       nczoning-api-staging @ api-dev.nczoning.net
+// CI (.github/workflows/deploy-api.yml) deploys prod from `main`, staging
+// from `dev`. Named environments do NOT inherit vars/kv/routes/triggers —
+// each is declared in full.
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "nczoning-api",
@@ -35,7 +44,37 @@
 		"crons": [
 			"*/15 * * * *"
 		]
-	}
+	},
 	// DISCORD_WEBHOOK_URL is a secret (wrangler secret put DISCORD_WEBHOOK_URL),
 	// not committed here. Optional — refresh runs without it.
+
+	"env": {
+		// Staging: pulls source files from the dev site, writes to a separate
+		// KV namespace, serves the dev site (B7). Isolated from production.
+		"staging": {
+			"name": "nczoning-api-staging",
+			"routes": [
+				{
+					"pattern": "api-dev.nczoning.net",
+					"custom_domain": true
+				}
+			],
+			"vars": {
+				"API_VERSION": "0.1.0",
+				"SITE_ORIGIN": "https://dev.nczoning.net"
+			},
+			// dashboard title: nczoning-api-dataset-staging
+			"kv_namespaces": [
+				{
+					"binding": "DATASET",
+					"id": "ac85bf5c0b6f47afac35085408857d4b"
+				}
+			],
+			"triggers": {
+				"crons": [
+					"*/15 * * * *"
+				]
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Project item **Data API B6**. Automates Worker deploys and, crucially, gives the API a staging twin so it honours the site''s main/dev isolation.

The API was a single production Worker with no staging equivalent. Once the site consumes `/v1/` (B7), the live site depends on the API - so a single API would let any API deploy affect nczoning.net, defeating the dev/main split. This restores the symmetry:

| Env | Worker | Domain | Source origin | Deploys from |
| --- | --- | --- | --- | --- |
| production | `nczoning-api` | api.nczoning.net | nczoning.net | `main` |
| staging | `nczoning-api-staging` | api-dev.nczoning.net | dev.nczoning.net | `dev` |

- `env.staging` in `wrangler.jsonc` (separate KV namespace, `SITE_ORIGIN=dev.nczoning.net`)
- `.github/workflows/deploy-api.yml`: runs `npm test` as a gate, then deploys prod on push to `main` / staging on push to `dev`, path-filtered to `worker/**` (unrelated 3D/site pushes never trigger it)
- README + wiki decision document the model

## Verified

- Both envs validate (`wrangler deploy --dry-run` prod + staging): correct KV ids + origins
- **Staging deployed live**: `api-dev.nczoning.net/v1/health` → 200; data routes → `503 not_ready` until its first cron tick (correct)
- dev.nczoning.net serves the cron''s source files (mods.json/tags/subdistricts all 200), so staging will seed from dev data
- 44 tests pass

## Before CI can deploy (one-time, user)

Add a GitHub Actions secret **`CLOUDFLARE_API_TOKEN`** - a token with **Workers Scripts:Edit**, **Workers KV Storage:Edit**, and **Zone DNS:Edit** on the nczoning.net zone (DNS is needed for the custom-domain routes). The Discord secret + KV namespaces already exist and persist across deploys.

After merge, this branch merging to `dev` will itself be the first CI staging deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)