### PR TITLE
feat(api): B5 modder docs (OpenAPI + Scalar page + api-reference)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,153 @@
+# NC Zoning Data API — reference
+
+Read-only API serving the NC Zoning Board registry (Cyberpunk 2077 location
+mods) to in-game mods and the website.
+
+- **Production:** `https://api.nczoning.net`
+- **Staging:** `https://api-dev.nczoning.net` (serves the dev site's data)
+- **Interactive docs:** open the base URL in a browser (rendered from
+  [`worker/openapi.json`](../worker/openapi.json)).
+
+Everything here is GET-only, unauthenticated, HTTPS-only (TLS 1.2+), and
+CORS-open.
+
+## The envelope
+
+Every response is wrapped:
+
+```json
+{
+  "schema": 1,
+  "generated_at": "2026-07-05T00:00:00.000Z",
+  "dataset_version": "87cc60cf7332…",
+  "data": <route-specific>
+}
+```
+
+`dataset_version` is a content hash of the whole dataset. It's also the
+`ETag`, so it's how you detect changes (see [Caching](#caching)).
+
+## Contract rules (why the JSON looks the way it does)
+
+The shapes are frozen to stay parseable by the in-game **RedData** JSON
+parser:
+
+- **No arrays-of-arrays.** `coordinates` is a flat `[X, Y, Z]`; district
+  boundaries are flattened to `[x1, y1, x2, y2, …]`. This maps cleanly to
+  redscript `array<Float>`.
+- **Property names are case-sensitive** and stable — they match DTO field
+  names exactly.
+- **Coordinates are raw CET world values** — the same numbers
+  `GetWorldPosition()` returns in-game. No transform needed to teleport to
+  them or compare against the player.
+- **Stable ids:** manual entries keep a UUID; auto-discovered mods get
+  `nexus-<nexus_id>`. Safe to bookmark.
+- **`district` is never null** — anywhere outside every district polygon is
+  Badlands (the game's own default). `subdistrict` may be null.
+- **Additive versioning:** new fields may appear within `/v1/`; breaking
+  changes would ship as `/v2/`.
+
+## Routes
+
+| Route | Returns |
+| --- | --- |
+| `GET /v1/health` | `{ status, version }` (uncached) |
+| `GET /v1/locations` | all locations, slim |
+| `GET /v1/locations/{id}` | one full entry (adds `description`, `credits`), or 404 |
+| `GET /v1/districts` | district/subdistrict hierarchy (flat boundaries + centroids) |
+| `GET /v1/tags` | tag id → description |
+| `GET /v1/meta` | `{ counts, discovery_stale, skipped }` |
+
+A location (slim):
+
+```json
+{
+  "id": "nexus-27618",
+  "name": "Atari Canyon - Blade Runner",
+  "nexus_id": "27618",
+  "coordinates": [-2229.57, 3618.96, 12.22],
+  "yaw": 180.0,
+  "category": "new-location",
+  "tags": ["nczoning", "corpo"],
+  "authors": ["SomeModder"],
+  "source": "auto",
+  "district": "City Center",
+  "subdistrict": "Corpo Plaza"
+}
+```
+
+`/v1/locations/{id}` adds `description` and (if present) `credits`.
+
+## Caching
+
+Dataset routes send:
+
+```
+ETag: "87cc60cf7332…"
+Cache-Control: public, max-age=300, stale-while-revalidate=3600
+```
+
+Store the `dataset_version` from your last fetch and send it back as
+`If-None-Match`. If nothing changed you get a **`304 Not Modified`** with no
+body — the cheap path. The data changes at most a few times a day, so one
+fetch per game session (plus an optional occasional re-check) is plenty.
+
+Before the very first dataset build a route returns **`503 not_ready`** —
+retry shortly.
+
+## Using it from a mod
+
+The API is designed for the **RedHttpClient + RedData** stack (see the
+NCZoningCore framework). Minimal redscript:
+
+```swift
+import RedHttpClient.*
+import RedData.Json.*
+
+// DTO — field names match the JSON exactly (case-sensitive).
+public class NCZLocation {
+  let id: String;
+  let name: String;
+  let coordinates: array<Float>;   // [X, Y, Z] raw CET
+  let category: String;
+  let district: String;
+  let subdistrict: String;
+}
+
+public class NCZExample extends ScriptableSystem {
+  private func Fetch() {
+    let cb = HttpCallback.Create(this, n"OnLocations");
+    AsyncHttpClient.Get(cb, "https://api.nczoning.net/v1/locations");
+  }
+
+  private cb func OnLocations(response: ref<HttpResponse>) {
+    // Runs on a worker thread — parse/store here, apply game changes on the
+    // next tick via DelaySystem.
+    let root = response.GetJson();          // the envelope
+    let data = (root as JsonObject).GetKey("data") as JsonArray;
+    let i = 0u;
+    while i < data.GetSize() {
+      let loc = FromJson(data.GetItem(i) as JsonObject, n"NCZLocation") as NCZLocation;
+      FTLog(s"\(loc.name) @ \(loc.district)");
+      i += 1u;
+    }
+  }
+}
+```
+
+From **CET (Lua)**, use `NewProxy` for the callback and CET's own
+`json.decode` on `response:GetText()` if you're not using RedData.
+
+**Threading note:** RedHttpClient delivers callbacks on a worker thread, not
+the game thread. Parse and store there; bounce any game/UI mutation to the
+next tick (DelaySystem / a Codeware event). Send `If-None-Match` to avoid
+re-downloading unchanged data.
+
+## Notes
+
+- The API never talks to Nexus on your behalf at request time — a cron
+  rebuilds the dataset every 15 minutes and serves it from cache, so you're
+  shielded from Nexus API hiccups. If a refresh fails, `meta.discovery_stale`
+  is `true` and the last-known-good data is served.
+- `meta.skipped` lists mods tagged `NCZoning` whose metadata block didn't
+  parse — useful if you're a mod author debugging why yours isn't appearing.

--- a/worker/README.md
+++ b/worker/README.md
@@ -62,7 +62,7 @@ meta record, and (if configured) posts a Discord alert — it never serves an
 empty or partial dataset.
 
 KV keys: `dataset:v1` (slim), `dataset:v1:full`, `dataset:v1:districts`,
-`dataset:v1:meta`.
+`dataset:v1:tags`, `dataset:v1:meta`.
 
 ### Test the cron locally
 
@@ -76,6 +76,8 @@ npx wrangler kv key get "dataset:v1:meta" --binding DATASET --local
 
 | Route | Returns |
 | --- | --- |
+| `GET /` | interactive docs (Scalar, renders `openapi.json`) |
+| `GET /openapi.json` | the OpenAPI 3.1 spec |
 | `GET /v1/health` | `{ status, version }` (uncached) |
 | `GET /v1/locations` | slim location array |
 | `GET /v1/locations/{id}` | one full entry (adds description/credits), or 404 |
@@ -88,4 +90,22 @@ Every response uses the envelope
 `ETag: "<dataset_version>"` and `Cache-Control: public, max-age=300,
 stale-while-revalidate=3600`; send `If-None-Match` to get a `304` when your
 copy is current. Before the first cron tick the dataset routes return `503
-not_ready`. The full API reference (repo doc + OpenAPI page) ships in B5.
+not_ready`.
+
+Docs: `openapi.json` is the source of truth (drift-guarded by
+`test/openapi.test.js` — every served route must be documented and vice
+versa). The human-facing reference with redscript/CET snippets is
+[docs/api-reference.md](../docs/api-reference.md).
+
+## Rate limiting
+
+The read-only routes are edge-cached (`max-age=300`), so the vast majority
+of traffic never reaches the Worker, and the free tier (100k Worker
+requests/day) has a wide margin. A belt-and-braces WAF rate-limit rule is
+recommended but not code — add it in the Cloudflare dashboard:
+
+> Security → WAF → Rate limiting rules → Create, on the `nczoning.net` zone:
+> match `http.host eq "api.nczoning.net"`, **60 requests / 1 min per IP**,
+> action **Block** (or Managed Challenge). Mirror for `api-dev.nczoning.net`.
+
+Rate-limit rules are zone config, not part of `wrangler deploy`.

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -1,0 +1,223 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "NC Zoning Data API",
+    "version": "1.0.0",
+    "description": "Read-only API serving the NC Zoning Board mod registry (Cyberpunk 2077 location mods) to in-game mods and the website. Every response is wrapped in a versioned envelope. Coordinates are raw CET world values [X, Y, Z] — usable in-game with no transform. The JSON stays DTO-mappable for the in-game RedData parser: no arrays-of-arrays, property names are case-sensitive. See https://github.com/spuddeh/nc-zoning-board for the project.",
+    "contact": { "name": "NC Zoning Board", "url": "https://nczoning.net" }
+  },
+  "servers": [
+    { "url": "https://api.nczoning.net", "description": "Production" },
+    { "url": "https://api-dev.nczoning.net", "description": "Staging" }
+  ],
+  "paths": {
+    "/v1/health": {
+      "get": {
+        "summary": "Liveness + deployed version",
+        "description": "Uncached. Does not touch the dataset.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": { "application/json": { "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
+                "data": { "type": "object", "properties": {
+                  "status": { "type": "string", "const": "ok" },
+                  "version": { "type": "string", "example": "0.1.0" }
+                } } } }]
+            } } }
+          }
+        }
+      }
+    },
+    "/v1/locations": {
+      "get": {
+        "summary": "All locations (slim)",
+        "description": "The workhorse. Slim entries (no description/credits). Supports conditional GET: send If-None-Match with the last dataset_version to get a 304.",
+        "parameters": [{ "$ref": "#/components/parameters/IfNoneMatch" }],
+        "responses": {
+          "200": {
+            "description": "The full slim location array.",
+            "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
+            "content": { "application/json": { "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
+                "data": { "type": "array", "items": { "$ref": "#/components/schemas/Location" } } } }]
+            } } }
+          },
+          "304": { "$ref": "#/components/responses/NotModified" },
+          "503": { "$ref": "#/components/responses/NotReady" }
+        }
+      }
+    },
+    "/v1/locations/{id}": {
+      "get": {
+        "summary": "One location (full)",
+        "description": "Full entry including description and credits.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Location id: a UUID (manual) or nexus-<nexus_id> (auto-discovered).", "example": "nexus-27618" },
+          { "$ref": "#/components/parameters/IfNoneMatch" }
+        ],
+        "responses": {
+          "200": {
+            "description": "The full location entry.",
+            "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
+            "content": { "application/json": { "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
+                "data": { "$ref": "#/components/schemas/LocationFull" } } }]
+            } } }
+          },
+          "304": { "$ref": "#/components/responses/NotModified" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "503": { "$ref": "#/components/responses/NotReady" }
+        }
+      }
+    },
+    "/v1/districts": {
+      "get": {
+        "summary": "District/subdistrict hierarchy",
+        "description": "9 districts and their subdistricts, with centroids and FLATTENED boundary rings ([x1,y1,x2,y2,...]) in CET coordinates. Anywhere outside every district polygon is Badlands (the game default), so a location's district is never null.",
+        "parameters": [{ "$ref": "#/components/parameters/IfNoneMatch" }],
+        "responses": {
+          "200": {
+            "description": "The district hierarchy.",
+            "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
+            "content": { "application/json": { "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
+                "data": { "type": "array", "items": { "$ref": "#/components/schemas/District" } } } }]
+            } } }
+          },
+          "304": { "$ref": "#/components/responses/NotModified" },
+          "503": { "$ref": "#/components/responses/NotReady" }
+        }
+      }
+    },
+    "/v1/tags": {
+      "get": {
+        "summary": "Tag dictionary",
+        "description": "Map of tag id → human description. The allow-list a location's tags are drawn from.",
+        "parameters": [{ "$ref": "#/components/parameters/IfNoneMatch" }],
+        "responses": {
+          "200": {
+            "description": "Tag dictionary.",
+            "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
+            "content": { "application/json": { "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
+                "data": { "type": "object", "additionalProperties": { "type": "string" }, "example": { "apartment": "A residence you can enter", "corpo": "Corporate aesthetic" } } } }]
+            } } }
+          },
+          "304": { "$ref": "#/components/responses/NotModified" },
+          "503": { "$ref": "#/components/responses/NotReady" }
+        }
+      }
+    },
+    "/v1/meta": {
+      "get": {
+        "summary": "Dataset metadata",
+        "description": "Counts (total, manual, auto, per-district) and health flags. dataset_version and generated_at live on the envelope.",
+        "parameters": [{ "$ref": "#/components/parameters/IfNoneMatch" }],
+        "responses": {
+          "200": {
+            "description": "Dataset metadata.",
+            "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
+            "content": { "application/json": { "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
+                "data": { "$ref": "#/components/schemas/Meta" } } }]
+            } } }
+          },
+          "304": { "$ref": "#/components/responses/NotModified" },
+          "503": { "$ref": "#/components/responses/NotReady" }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "IfNoneMatch": {
+        "name": "If-None-Match", "in": "header", "required": false,
+        "schema": { "type": "string" },
+        "description": "The dataset_version (as a quoted ETag) from your last fetch. Returns 304 if unchanged."
+      }
+    },
+    "headers": {
+      "ETag": { "description": "The dataset_version, quoted. Use as If-None-Match next time.", "schema": { "type": "string" } },
+      "CacheControl": { "description": "public, max-age=300, stale-while-revalidate=3600", "schema": { "type": "string" } }
+    },
+    "responses": {
+      "NotModified": { "description": "Your copy is current (ETag matched). No body." },
+      "NotFound": { "description": "Unknown id or route.", "content": { "application/json": { "schema": { "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": { "data": { "type": "object", "properties": { "error": { "type": "string", "const": "not_found" } } } } }] } } } },
+      "NotReady": { "description": "The dataset has not been built yet (before the first cron tick). Retry shortly.", "content": { "application/json": { "schema": { "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": { "data": { "type": "object", "properties": { "error": { "type": "string", "const": "not_ready" } } } } }] } } } }
+    },
+    "schemas": {
+      "Envelope": {
+        "type": "object",
+        "required": ["schema", "generated_at", "dataset_version", "data"],
+        "properties": {
+          "schema": { "type": "integer", "const": 1, "description": "Envelope schema version." },
+          "generated_at": { "type": ["string", "null"], "format": "date-time", "description": "When the dataset was last built." },
+          "dataset_version": { "type": ["string", "null"], "description": "Content hash; the ETag value." },
+          "data": { "description": "Route-specific payload." }
+        }
+      },
+      "Location": {
+        "type": "object",
+        "description": "Slim location entry.",
+        "required": ["id", "name", "nexus_id", "coordinates", "category", "tags", "authors", "source", "district"],
+        "properties": {
+          "id": { "type": "string", "description": "UUID (manual) or nexus-<nexus_id> (auto).", "example": "nexus-27618" },
+          "name": { "type": "string" },
+          "nexus_id": { "type": "string", "description": "Numeric Nexus id, or WIP / Dummy.", "example": "27618" },
+          "coordinates": { "type": "array", "items": { "type": "number" }, "minItems": 2, "maxItems": 3, "description": "Raw CET world [X, Y, Z].", "example": [-2229.57, 3618.96, 12.22] },
+          "yaw": { "type": "number", "description": "Player facing in degrees (optional)." },
+          "category": { "type": "string", "enum": ["location-overhaul", "new-location", "other"] },
+          "tags": { "type": "array", "items": { "type": "string" } },
+          "authors": { "type": "array", "items": { "type": "string" } },
+          "source": { "type": "string", "enum": ["manual", "auto"] },
+          "district": { "type": "string", "description": "Never null (defaults to Badlands)." },
+          "subdistrict": { "type": ["string", "null"] }
+        }
+      },
+      "LocationFull": {
+        "allOf": [
+          { "$ref": "#/components/schemas/Location" },
+          { "type": "object", "properties": {
+            "description": { "type": "string" },
+            "credits": { "type": "string" }
+          } }
+        ]
+      },
+      "District": {
+        "type": "object",
+        "required": ["id", "name", "boundary", "subdistricts"],
+        "properties": {
+          "id": { "type": ["string", "null"] },
+          "name": { "type": "string" },
+          "centroid": { "$ref": "#/components/schemas/Point" },
+          "boundary": { "type": "array", "items": { "type": "number" }, "description": "Flattened ring [x1,y1,x2,y2,...] in CET." },
+          "subdistricts": { "type": "array", "items": { "$ref": "#/components/schemas/Subdistrict" } }
+        }
+      },
+      "Subdistrict": {
+        "type": "object",
+        "required": ["id", "name", "boundary"],
+        "properties": {
+          "id": { "type": ["string", "null"] },
+          "name": { "type": "string" },
+          "canonical": { "type": "boolean" },
+          "centroid": { "$ref": "#/components/schemas/Point" },
+          "boundary": { "type": "array", "items": { "type": "number" } }
+        }
+      },
+      "Point": { "type": ["object", "null"], "properties": { "x": { "type": "number" }, "y": { "type": "number" } } },
+      "Meta": {
+        "type": "object",
+        "properties": {
+          "counts": { "type": "object", "properties": {
+            "total": { "type": "integer" }, "manual": { "type": "integer" }, "auto": { "type": "integer" },
+            "per_district": { "type": "object", "additionalProperties": { "type": "integer" } }
+          } },
+          "discovery_stale": { "type": "boolean", "description": "True if the last Nexus refresh failed and the dataset is being served from last-known-good." },
+          "skipped": { "type": "array", "items": { "type": "object", "properties": { "nexus_id": { "type": "string" }, "name": { "type": "string" } } }, "description": "Mods tagged NCZoning whose metadata block did not parse." }
+        }
+      }
+    }
+  }
+}

--- a/worker/src/docs.js
+++ b/worker/src/docs.js
@@ -1,0 +1,29 @@
+/**
+ * Interactive API docs served from the Worker root. The OpenAPI spec
+ * (worker/openapi.json) is the source of truth; the root page renders it
+ * with Scalar (loaded from a CDN — this is a human docs page, not a
+ * CSP-restricted context). Modders browsing to api.nczoning.net land here.
+ */
+
+import openapi from '../openapi.json' with { type: 'json' };
+
+export const spec = openapi;
+
+const PAGE = `<!doctype html>
+<html>
+<head>
+  <title>NC Zoning Data API</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+  <script id="api-reference" data-url="/openapi.json"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+</body>
+</html>`;
+
+export function docsPage() {
+  return new Response(PAGE, {
+    headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'public, max-age=300' },
+  });
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -16,6 +16,7 @@
 
 import { runRefresh } from './refresh.js';
 import { KEYS } from './store.js';
+import { docsPage, spec } from './docs.js';
 
 const SCHEMA_VERSION = 1;
 
@@ -89,6 +90,11 @@ async function serveDataset(request, env, build) {
 }
 
 const routes = {
+  // Human docs (Scalar) + the machine-readable spec.
+  'GET /': () => docsPage(),
+  'GET /openapi.json': () =>
+    json(spec, { headers: { 'Cache-Control': 'public, max-age=300' } }),
+
   'GET /v1/health': (request, env) =>
     json(envelope({ status: 'ok', version: env.API_VERSION }, null)),
 

--- a/worker/test/openapi.test.js
+++ b/worker/test/openapi.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import worker from '../src/index.js';
+
+const specPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'openapi.json');
+const spec = JSON.parse(readFileSync(specPath, 'utf8'));
+
+// The concrete routes the Worker actually serves (from index.js), normalised
+// to the OpenAPI path style ({id} placeholder).
+const ROUTER_PATHS = [
+  '/v1/health', '/v1/locations', '/v1/locations/{id}',
+  '/v1/districts', '/v1/tags', '/v1/meta',
+];
+
+test('openapi.json is valid JSON with the expected top-level shape', () => {
+  assert.equal(spec.openapi, '3.1.0');
+  assert.ok(spec.info.title);
+  assert.ok(spec.paths && Object.keys(spec.paths).length > 0);
+});
+
+test('every served route is documented in the spec (no undocumented routes)', () => {
+  for (const p of ROUTER_PATHS) {
+    assert.ok(spec.paths[p], `route ${p} is served but missing from openapi.json`);
+    assert.ok(spec.paths[p].get, `route ${p} has no GET in openapi.json`);
+  }
+});
+
+test('every documented v1 path is actually served (no stale spec paths)', () => {
+  for (const p of Object.keys(spec.paths)) {
+    if (!p.startsWith('/v1/')) continue;
+    assert.ok(ROUTER_PATHS.includes(p), `openapi.json documents ${p} but the Worker does not serve it`);
+  }
+});
+
+test('GET / serves the HTML docs page', async () => {
+  const res = await worker.fetch(new Request('https://api.nczoning.net/'), { API_VERSION: '0.1.0' });
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('Content-Type'), /text\/html/);
+  const body = await res.text();
+  assert.match(body, /api-reference/); // Scalar mount point
+  assert.match(body, /\/openapi\.json/);
+});
+
+test('GET /openapi.json serves the spec', async () => {
+  const res = await worker.fetch(new Request('https://api.nczoning.net/openapi.json'), { API_VERSION: '0.1.0' });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.openapi, '3.1.0');
+  assert.deepEqual(Object.keys(body.paths).sort(), Object.keys(spec.paths).sort());
+});


### PR DESCRIPTION
## Summary

Project item **Data API B5** - the two-layer documentation.

- **`worker/openapi.json`** - OpenAPI 3.1 spec: the envelope, all six routes, full schemas (Location/LocationFull/District/Meta), the contract notes (raw CET coords, no arrays-of-arrays, `district` never null, stable ids). Served at **`GET /openapi.json`** and rendered at **`GET /`** with Scalar (interactive - route list, per-route request/response examples, a live "Test Request", client-library snippets).
- **`docs/api-reference.md`** - canonical human reference: prose, the contract rules, caching/304, and copy-paste **redscript** (RedHttpClient + `FromJson` into an `NCZLocation` DTO) + **CET** usage, including the worker-thread-callback gotcha.
- **`test/openapi.test.js`** - drift guard: every served route must be documented and every documented `/v1/` path must be served, so the spec can''t silently rot. Plus serve tests for `/` and `/openapi.json`.
- README: routes table updated; a recommended WAF rate-limit rule documented as a dashboard step (the routes are edge-cached, so it''s belt-and-braces).

## Verified

- 49 tests pass (5 new)
- `wrangler deploy --dry-run` bundles the JSON import cleanly (29 KiB)
- **Rendered in a browser** (screenshot in the session): the Scalar page loads with the production server preselected and live per-route examples - this is what a modder sees browsing to api.nczoning.net

## Note

The WAF rate-limit rule is zone config, not `wrangler deploy` - it''s documented in `worker/README.md` (60 req/min/IP on the api host) for you to add in the dashboard when you like. Low urgency given the edge caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)