### PR TITLE
feat(api,site): Data API B7 — site consumes /v1, thumbnails move server-side

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1811,47 +1811,32 @@ async function initMap() {
 
   // 3. Fetch and Setup Data
   try {
-    const { mods, tagsDict, excludedIds } = await NCZ.fetchModData();
-
-    // Auto-discover mods tagged "NCZoning" on Nexus (manual entries win on conflict;
-    // excluded ids are never rendered, even with a valid block)
-    const existingNexusIds = new Set(
-      mods
-        .filter((m) => m.nexus_id && !["WIP", "Dummy"].includes(String(m.nexus_id)))
-        .map((m) => String(m.nexus_id)),
-    );
-    const validTagNames = new Set(Object.keys(tagsDict));
-    const { mods: autoMods, meta: autoMeta } = await NCZ.fetchNexusTaggedMods(existingNexusIds, validTagNames, excludedIds);
-    mods.push(...autoMods);
+    // B7: primary data path is the server-built Data API (/v1). It already does
+    // the manual + Nexus auto-discovery merge, district enrichment and thumbnail
+    // resolution server-side, so the browser makes no Nexus calls here. tags.json
+    // stays a local static fetch (same-origin — not the Nexus fragility this
+    // replaces). If the API is unavailable we fall back to the legacy
+    // client-side merge, so the map never regresses during the transition.
+    let mods, nexusThumbs, tagsDict;
+    try {
+      const [apiResult, localTags] = await Promise.all([
+        NCZ.fetchLocationsFromApi(),
+        fetch(NCZ.DATA_TAGS_PATH).then((r) => r.json()),
+      ]);
+      mods = apiResult.mods;
+      nexusThumbs = apiResult.nexusThumbs;
+      tagsDict = localTags;
+      console.log(`Data source: /v1 API — ${mods.length} mods`);
+    } catch (apiErr) {
+      console.warn("Data API unavailable — falling back to client-side merge:", apiErr);
+      const fb = await NCZ.fetchModDataClientSide();
+      mods = fb.mods;
+      nexusThumbs = fb.nexusThumbs;
+      tagsDict = fb.tagsDict;
+      console.log(`Data source: client-side fallback — ${mods.length} mods`);
+    }
 
     modCountEl.textContent = `(${mods.length})`;
-
-    // Pre-seed thumbnail map from auto-discovery (already fetched), then
-    // only call the API for manual mods that still need images
-    const nexusThumbs = {};
-    const manualNexusIds = [];
-    for (const mod of mods) {
-      const nid = String(mod.nexus_id);
-      if (mod._thumbnailUrl || mod._pictureUrl) {
-        nexusThumbs[nid] = { pictureUrl: mod._pictureUrl, thumbnailUrl: mod._thumbnailUrl };
-      } else if (nid && !["wip", "dummy"].includes(nid.toLowerCase()) && !autoMeta[nid]) {
-        manualNexusIds.push(nid);
-      }
-    }
-    const fetchedThumbs = await NCZ.fetchNexusThumbnails(manualNexusIds);
-    Object.assign(nexusThumbs, fetchedThumbs);
-    // Fill in metadata from auto-discovery for manual mods that are NCZoning-tagged
-    for (const [id, data] of Object.entries(autoMeta)) {
-      if (!nexusThumbs[id]) nexusThumbs[id] = data;
-    }
-
-    // Backfill _updatedAt for manual Nexus mods before sorting
-    for (const mod of mods) {
-      if (!mod._updatedAt) {
-        const thumb = nexusThumbs[String(mod.nexus_id)];
-        if (thumb?.updatedAt) mod._updatedAt = thumb.updatedAt;
-      }
-    }
 
     const sortedMods = mods.sort(NCZ.sortModsByUpdated);
     // Hand the same data set to the 3D pin layer — pins won't appear until ThreeScene

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -81,6 +81,19 @@ NCZ.NEXUS_GAME_ID = 3333; // Cyberpunk 2077
 NCZ.NEXUS_GQL_ENDPOINT = "https://api.nexusmods.com/v2/graphql";
 NCZ.NEXUS_BATCH_SIZE = 50;
 
+// Data API (B7) — the site consumes the server-built /v1 dataset instead of
+// running the Nexus auto-discovery merge client-side. Base URL is chosen by
+// hostname so environments line up with the API's: prod → prod API; everything
+// else (dev.nczoning.net, *.pages.dev previews, localhost) → staging API.
+NCZ.API_BASE =
+  location.hostname === "nczoning.net" || location.hostname === "www.nczoning.net"
+    ? "https://api.nczoning.net"
+    : "https://api-dev.nczoning.net";
+// { etag, data } for the full-locations list. Freshness is driven by the ETag
+// (If-None-Match → 304), not a TTL, so this is stored raw rather than via the
+// TTL-based cacheGet/cacheSet.
+NCZ.API_LOCATIONS_CACHE_KEY = "nc_api_locations_full";
+
 // Data paths
 NCZ.DATA_MODS_PATH = "mods.json";
 NCZ.DATA_TAGS_PATH = "data/tags.json";

--- a/assets/js/services.js
+++ b/assets/js/services.js
@@ -274,3 +274,141 @@ NCZ.fetchModData = async function () {
   }
   return { mods, tagsDict, excludedIds };
 };
+
+// ── Data API (B7) ────────────────────────────────────────────────────────────
+
+// Primary data path: fetch the whole registry from the server-built Data API
+// (/v1/locations?full=1). This replaces the client-side manual + Nexus
+// auto-discovery merge — the server already does that merge (plus district
+// enrichment and, since B7, manual-mod thumbnails), so the browser makes ZERO
+// Nexus calls here. Uses If-None-Match/304 against a localStorage-cached body.
+//
+// Returns { mods, nexusThumbs } in the same shapes the rest of app.js expects.
+// THROWS on any failure (network, non-2xx, malformed) so the caller can fall
+// back to the legacy client-side path — never a silent empty map.
+NCZ.fetchLocationsFromApi = async function () {
+  const url = `${NCZ.API_BASE}/v1/locations?full=1`;
+
+  let cached = null;
+  try {
+    cached = JSON.parse(localStorage.getItem(NCZ.API_LOCATIONS_CACHE_KEY) || "null");
+  } catch {
+    cached = null;
+  }
+
+  const headers = {};
+  if (cached?.etag) headers["If-None-Match"] = cached.etag;
+
+  const res = await fetch(url, { headers });
+
+  let rawLocations;
+  let freshEtag = null; // set only on a fresh 200 we should cache
+  if (res.status === 304 && Array.isArray(cached?.data)) {
+    console.log(`Data API: 304 Not Modified — reusing ${cached.data.length} cached locations`);
+    rawLocations = cached.data;
+  } else if (res.ok) {
+    const envelope = await res.json();
+    rawLocations = envelope?.data;
+    if (!Array.isArray(rawLocations)) {
+      throw new Error("Data API: malformed payload (envelope.data is not an array)");
+    }
+    freshEtag = res.headers.get("ETag");
+    console.log(`Data API: loaded ${rawLocations.length} locations (dataset ${String(envelope.dataset_version).slice(0, 8)})`);
+  } else {
+    throw new Error(`Data API: HTTP ${res.status}`);
+  }
+
+  // Guard against a slim payload (an API that doesn't honour ?full=1 — e.g. an
+  // older deploy still on the endpoint). Full entries always carry a
+  // `description` key; if it's missing the popups/cluster list would render
+  // empty, so treat it as unusable and let the caller fall back rather than
+  // ship a degraded map. (Zero locations is a valid dataset — don't trip on it.)
+  // Runs before caching so a rejected slim body is never stored.
+  if (rawLocations.length > 0 && !("description" in rawLocations[0])) {
+    throw new Error("Data API: slim payload (full=1 not honoured) — falling back");
+  }
+
+  if (freshEtag !== null) {
+    try {
+      localStorage.setItem(NCZ.API_LOCATIONS_CACHE_KEY, JSON.stringify({ etag: freshEtag, data: rawLocations }));
+    } catch {
+      /* localStorage quota — fine, we just won't get a 304 next load */
+    }
+  }
+
+  // Map API entries → the internal shape the rest of the app consumes. The API
+  // uses source "manual"/"auto" + snake_case image fields; the app keys off the
+  // legacy `_source` sentinel, `_updatedAt`, and a `nexusThumbs` lookup.
+  const nexusThumbs = {};
+  const mods = rawLocations.map((e) => {
+    const nid = String(e.nexus_id);
+    if (e.thumbnail_url || e.picture_url) {
+      nexusThumbs[nid] = {
+        thumbnailUrl: e.thumbnail_url || null,
+        pictureUrl: e.picture_url || null,
+        updatedAt: e.updated_at || null,
+      };
+    }
+    return {
+      ...e,
+      // Manual mods have no _source (drives the "Suggest Edit" link + no auto
+      // badge); auto mods use the "nexus-auto" sentinel the badges key off.
+      ...(e.source === "auto" ? { _source: "nexus-auto" } : {}),
+      _updatedAt: e.updated_at || null,
+    };
+  });
+
+  return { mods, nexusThumbs };
+};
+
+// Legacy client-side data path (pre-B7): load mods.json + tags.json +
+// excluded_mods.json, merge Nexus auto-discovery, fetch thumbnails via
+// modsByUid, backfill _updatedAt. Retained as the graceful FALLBACK for when
+// the Data API is unavailable; a follow-up deletes it once B7 parity has baked.
+// Returns { mods, nexusThumbs, tagsDict } — the same trio the API path yields
+// (plus tagsDict, which the API path fetches locally alongside).
+NCZ.fetchModDataClientSide = async function () {
+  const { mods, tagsDict, excludedIds } = await NCZ.fetchModData();
+
+  const existingNexusIds = new Set(
+    mods
+      .filter((m) => m.nexus_id && !["WIP", "Dummy"].includes(String(m.nexus_id)))
+      .map((m) => String(m.nexus_id)),
+  );
+  const validTagNames = new Set(Object.keys(tagsDict));
+  const { mods: autoMods, meta: autoMeta } = await NCZ.fetchNexusTaggedMods(
+    existingNexusIds,
+    validTagNames,
+    excludedIds,
+  );
+  mods.push(...autoMods);
+
+  // Pre-seed thumbnails from auto-discovery (already fetched), then only call
+  // the API for manual mods that still need images.
+  const nexusThumbs = {};
+  const manualNexusIds = [];
+  for (const mod of mods) {
+    const nid = String(mod.nexus_id);
+    if (mod._thumbnailUrl || mod._pictureUrl) {
+      nexusThumbs[nid] = { pictureUrl: mod._pictureUrl, thumbnailUrl: mod._thumbnailUrl };
+    } else if (nid && !["wip", "dummy"].includes(nid.toLowerCase()) && !autoMeta[nid]) {
+      manualNexusIds.push(nid);
+    }
+  }
+  const fetchedThumbs = await NCZ.fetchNexusThumbnails(manualNexusIds);
+  Object.assign(nexusThumbs, fetchedThumbs);
+  // Fill in metadata from auto-discovery for manual mods that are NCZoning-tagged.
+  for (const [id, data] of Object.entries(autoMeta)) {
+    if (!nexusThumbs[id]) nexusThumbs[id] = data;
+  }
+
+  // Backfill _updatedAt for manual Nexus mods before the caller sorts.
+  for (const mod of mods) {
+    if (!mod._updatedAt) {
+      const thumb = nexusThumbs[String(mod.nexus_id)];
+      if (thumb?.updatedAt) mod._updatedAt = thumb.updatedAt;
+    }
+  }
+
+  return { mods, nexusThumbs, tagsDict };
+};

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -53,7 +53,8 @@ parser:
 | --- | --- |
 | `GET /v1/health` | `{ status, version }` (uncached) |
 | `GET /v1/locations` | all locations, slim |
-| `GET /v1/locations/{id}` | one full entry (adds `description`, `credits`), or 404 |
+| `GET /v1/locations?full=1` | all locations, full (adds `description`, `credits`, image URLs) — one request for everything |
+| `GET /v1/locations/{id}` | one full entry (adds `description`, `credits`, image URLs), or 404 |
 | `GET /v1/districts` | district/subdistrict hierarchy (flat boundaries + centroids) |
 | `GET /v1/tags` | tag id → description |
 | `GET /v1/meta` | `{ counts, discovery_stale, skipped }` |
@@ -76,7 +77,13 @@ A location (slim):
 }
 ```
 
-`/v1/locations/{id}` adds `description` and (if present) `credits`.
+Full entries (`/v1/locations/{id}` or the whole list via `/v1/locations?full=1`)
+add `description`, `credits` (if present), and the Nexus image fields
+`thumbnail_url` / `picture_url` / `updated_at` (each `null` when unknown — e.g.
+WIP/Dummy entries). Images live on the full entry only; the slim list stays
+lean for the in-game RedData consumer. The `?full=1` list carries its own ETag
+(the dataset version suffixed `-full`), so caching it never collides with the
+slim list.
 
 ## Caching
 

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -31,16 +31,19 @@
     },
     "/v1/locations": {
       "get": {
-        "summary": "All locations (slim)",
-        "description": "The workhorse. Slim entries (no description/credits). Supports conditional GET: send If-None-Match with the last dataset_version to get a 304.",
-        "parameters": [{ "$ref": "#/components/parameters/IfNoneMatch" }],
+        "summary": "All locations (slim, or full with ?full=1)",
+        "description": "The workhorse. Slim entries by default (no description/credits/images) — lean for the in-game RedData list. Pass ?full=1 to get full entries (description, credits, and Nexus image URLs) as an array in one request; that variant carries its own ETag (suffixed -full) so it can't be confused with the slim cache. Supports conditional GET: send If-None-Match with the last dataset_version to get a 304.",
+        "parameters": [
+          { "name": "full", "in": "query", "required": false, "schema": { "type": "string", "enum": ["1"] }, "description": "Set full=1 to return LocationFull entries (adds description, credits, thumbnail_url, picture_url, updated_at). Omit for the slim list." },
+          { "$ref": "#/components/parameters/IfNoneMatch" }
+        ],
         "responses": {
           "200": {
-            "description": "The full slim location array.",
+            "description": "The location array — slim Location[] by default, or LocationFull[] when ?full=1.",
             "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
             "content": { "application/json": { "schema": {
               "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
-                "data": { "type": "array", "items": { "$ref": "#/components/schemas/Location" } } } }]
+                "data": { "type": "array", "items": { "oneOf": [{ "$ref": "#/components/schemas/Location" }, { "$ref": "#/components/schemas/LocationFull" }] } } } }]
             } } }
           },
           "304": { "$ref": "#/components/responses/NotModified" },
@@ -180,7 +183,10 @@
           { "$ref": "#/components/schemas/Location" },
           { "type": "object", "properties": {
             "description": { "type": "string" },
-            "credits": { "type": "string" }
+            "credits": { "type": "string" },
+            "thumbnail_url": { "type": ["string", "null"], "description": "Nexus thumbnail image URL, or null (unknown / WIP / Dummy)." },
+            "picture_url": { "type": ["string", "null"], "description": "Nexus full-size image URL, or null." },
+            "updated_at": { "type": ["string", "null"], "format": "date-time", "description": "Nexus last-updated timestamp, or null." }
           } }
         ]
       },

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -69,11 +69,14 @@ function notReady() {
  * receives the parsed meta and returns the response `data`, or `undefined`
  * to signal a 404 (e.g. an unknown location id).
  */
-async function serveDataset(request, env, build) {
+async function serveDataset(request, env, build, etagSuffix = '') {
   const meta = await env.DATASET.get(KEYS.meta, 'json');
   if (!meta) return notReady();
 
-  const etag = `"${meta.dataset_version}"`;
+  // The ETag is the dataset content hash. Representations that share a hash
+  // but differ in body (slim vs ?full=1) must NOT share an ETag, or a client
+  // caching one and requesting the other would get a wrong 304. Vary it.
+  const etag = `"${meta.dataset_version}${etagSuffix}"`;
   if (request.headers.get('If-None-Match') === etag) {
     return new Response(null, {
       status: 304,
@@ -98,8 +101,24 @@ const routes = {
   'GET /v1/health': (request, env) =>
     json(envelope({ status: 'ok', version: env.API_VERSION }, null)),
 
-  'GET /v1/locations': (request, env) =>
-    serveDataset(request, env, (e) => e.DATASET.get(KEYS.slim, 'json')),
+  // Slim by default (the in-game RedData workhorse list). `?full=1` returns
+  // the full entries as an array — description/credits + image URLs — for the
+  // website and any consumer that wants everything in one request.
+  'GET /v1/locations': (request, env) => {
+    const url = new URL(request.url);
+    if (url.searchParams.get('full') === '1') {
+      return serveDataset(
+        request,
+        env,
+        async (e) => {
+          const full = await e.DATASET.get(KEYS.full, 'json');
+          return full ? Object.values(full) : undefined;
+        },
+        '-full',
+      );
+    }
+    return serveDataset(request, env, (e) => e.DATASET.get(KEYS.slim, 'json'));
+  },
 
   'GET /v1/districts': (request, env) =>
     serveDataset(request, env, (e) => e.DATASET.get(KEYS.districts, 'json')),

--- a/worker/src/merge.js
+++ b/worker/src/merge.js
@@ -27,9 +27,13 @@ export const DESCRIPTION_MAX_LENGTH = 500;
  * @param {object} input.excluded     data/excluded_mods.json ({nexusId: reason})
  * @param {Array}  input.nexusNodes   raw nodes from the NCZoning GraphQL query
  * @param {Array}  input.districts    data/subdistricts.json `districts[]`
+ * @param {object} [input.manualThumbs] modsByUid image/updatedAt for manual
+ *   mods, keyed by numeric nexus_id ({pictureUrl, thumbnailUrl, updatedAt}).
+ *   Covers manual entries not tagged NCZoning (the tagged query only backfills
+ *   the tagged ones). Optional so existing callers/tests don't break.
  * @returns {{locations: Array, full: Object<string, object>, meta: object}}
  */
-export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, districts }) {
+export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs = {} }) {
   const validTagNames = new Set(Object.keys(tagsDict));
   const excludedIds = new Set(Object.keys(excluded || {}));
 
@@ -90,6 +94,28 @@ export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, distr
     ...autoEntries,
   ].sort((a, b) => a.name.localeCompare(b.name));
 
+  // Resolve image/updatedAt for a full entry. Auto mods carry theirs from the
+  // tagged node; manual mods come from the modsByUid backfill (manualThumbs),
+  // falling back to the tagged-query thumbs for manual mods that happen to be
+  // NCZoning-tagged. WIP/Dummy (non-numeric) manual entries resolve to nulls.
+  // The field is ALWAYS present (null when unknown) so the shape stays stable
+  // for DTO consumers.
+  function resolveThumbs(entry) {
+    if (entry.source === 'auto') {
+      return {
+        thumbnail_url: entry.thumbnail_url ?? null,
+        picture_url: entry.picture_url ?? null,
+        updated_at: entry.updated_at ?? null,
+      };
+    }
+    const t = manualThumbs[String(entry.nexus_id)] || nexusThumbs[String(entry.nexus_id)] || null;
+    return {
+      thumbnail_url: t?.thumbnailUrl ?? null,
+      picture_url: t?.pictureUrl ?? null,
+      updated_at: t?.updatedAt ?? null,
+    };
+  }
+
   const perDistrict = {};
   const locations = [];
   const full = {};
@@ -117,13 +143,7 @@ export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, distr
       ...locations[locations.length - 1],
       description: entry.description ?? '',
       ...(entry.credits ? { credits: entry.credits } : {}),
-      ...(entry.source === 'auto'
-        ? {
-            thumbnail_url: entry.thumbnail_url,
-            picture_url: entry.picture_url,
-            updated_at: entry.updated_at,
-          }
-        : {}),
+      ...resolveThumbs(entry),
     };
   }
 

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -82,3 +82,80 @@ export async function fetchTaggedModNodes(fetchImpl = fetch) {
 
   return nodes;
 }
+
+/** Composite UID Nexus expects for modsByUid: `${gameId}:${modId}`. */
+function toNexusUid(modId) {
+  return `${NEXUS_GAME_ID}:${modId}`;
+}
+
+const THUMBS_QUERY = `query modsByUid($uids: [ID!]!, $count: Int!) {
+  modsByUid(uids: $uids, count: $count) {
+    nodes {
+      modId
+      pictureUrl
+      thumbnailUrl
+      updatedAt
+    }
+  }
+}`;
+
+/**
+ * Fetch picture/thumbnail/updatedAt for a set of numeric mod ids via
+ * modsByUid. Unlike fetchTaggedModNodes, this NEVER throws: thumbnails are
+ * cosmetic, so a Nexus hiccup here degrades to "some images missing this
+ * cycle", not "whole dataset stale". Auto-discovered mods already carry their
+ * images from the tagged query; this covers the manual entries.
+ *
+ * Mirrors the site's chunk + single-retry pattern (large modsByUid calls
+ * silently drop a subset of nodes), see assets/js/services.js.
+ *
+ * @param {typeof fetch} fetchImpl injectable for tests
+ * @param {string[]} numericIds manual mods' numeric nexus_ids
+ * @returns {Promise<Object<string, {pictureUrl, thumbnailUrl, updatedAt}>>}
+ */
+export async function fetchModsByUidThumbs(fetchImpl = fetch, numericIds = []) {
+  const ids = [...new Set(numericIds.map(String))].filter((id) => /^\d+$/.test(id));
+  if (ids.length === 0) return {};
+
+  const postChunk = async (chunkIds) => {
+    try {
+      const res = await fetchImpl(NEXUS_GQL_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: THUMBS_QUERY,
+          variables: { uids: chunkIds.map(toNexusUid), count: chunkIds.length },
+        }),
+      });
+      if (!res.ok) return {};
+      const json = await res.json();
+      const nodes = json?.data?.modsByUid?.nodes || [];
+      const map = {};
+      for (const node of nodes) {
+        map[String(node.modId)] = {
+          pictureUrl: node.pictureUrl || null,
+          thumbnailUrl: node.thumbnailUrl || null,
+          updatedAt: node.updatedAt || null,
+        };
+      }
+      return map;
+    } catch {
+      return {}; // cosmetic — swallow and let the caller serve what it has
+    }
+  };
+
+  const fetchChunk = async (chunkIds) => {
+    const first = await postChunk(chunkIds);
+    const missing = chunkIds.filter((id) => !first[id]);
+    if (missing.length === 0) return first;
+    const retry = await postChunk(missing); // one in-flight retry for dropped UIDs
+    return { ...first, ...retry };
+  };
+
+  const chunks = [];
+  for (let i = 0; i < ids.length; i += NEXUS_BATCH_SIZE) {
+    chunks.push(ids.slice(i, i + NEXUS_BATCH_SIZE));
+  }
+  const results = await Promise.all(chunks.map(fetchChunk));
+  return Object.assign({}, ...results);
+}

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -83,9 +83,14 @@ export async function fetchTaggedModNodes(fetchImpl = fetch) {
   return nodes;
 }
 
-/** Composite UID Nexus expects for modsByUid: `${gameId}:${modId}`. */
+/**
+ * Composite UID Nexus expects for modsByUid: (gameId << 32) + modId, as a
+ * single decimal string — NOT "gameId:modId". Must match the site's
+ * NCZ.toNexusUid (assets/js/utils.js) exactly, or Nexus silently drops the
+ * UIDs and returns no images.
+ */
 function toNexusUid(modId) {
-  return `${NEXUS_GAME_ID}:${modId}`;
+  return ((BigInt(NEXUS_GAME_ID) << 32n) + BigInt(modId)).toString();
 }
 
 const THUMBS_QUERY = `query modsByUid($uids: [ID!]!, $count: Int!) {

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -13,7 +13,7 @@
  * unit-testable with a fake KV + fake fetch.
  */
 
-import { fetchTaggedModNodes } from './nexus.js';
+import { fetchTaggedModNodes, fetchModsByUidThumbs } from './nexus.js';
 import { buildDataset } from './merge.js';
 import { districtsPayload } from './districts.js';
 import { KEYS, contentHash, readMeta, writeDataset, writeMeta } from './store.js';
@@ -68,8 +68,17 @@ export async function runRefresh(env, fetchImpl = fetch) {
     const districts = subdistricts.districts;
     const nexusNodes = await fetchTaggedModNodes(fetchImpl);
 
+    // Manual-mod thumbnails: the tagged query only backfills manual mods that
+    // are themselves NCZoning-tagged, so pull the rest via modsByUid. Cosmetic
+    // and non-throwing — a failure here just leaves some images null this
+    // cycle, it never marks the dataset stale.
+    const manualNumericIds = manualMods
+      .map((m) => String(m.nexus_id))
+      .filter((id) => /^\d+$/.test(id));
+    const manualThumbs = await fetchModsByUidThumbs(fetchImpl, manualNumericIds);
+
     const { locations, full, meta } = buildDataset({
-      manualMods, tagsDict, excluded, nexusNodes, districts,
+      manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs,
     });
     const districtsOut = districtsPayload(districts);
 

--- a/worker/test/index.test.js
+++ b/worker/test/index.test.js
@@ -66,6 +66,27 @@ test('GET /v1/locations returns the slim array in an envelope with ETag', async 
   assert.ok(!('description' in body.data[0])); // slim
 });
 
+test('GET /v1/locations?full=1 returns full entries as an array, with a -full ETag', async () => {
+  const res = await worker.fetch(GET('/v1/locations?full=1'), seededEnv());
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('ETag'), '"abc123-full"'); // variant ETag, not the slim one
+  const body = await res.json();
+  assert.equal(body.data.length, 2);
+  assert.equal(body.data[0].description, 'a manual mod'); // full carries description
+});
+
+test('a slim ETag does not satisfy a ?full=1 request (distinct representations)', async () => {
+  const res = await worker.fetch(
+    GET('/v1/locations?full=1', { 'If-None-Match': '"abc123"' }), seededEnv());
+  assert.equal(res.status, 200); // slim etag ≠ full etag → fresh 200, never a wrong 304
+});
+
+test('matching -full ETag yields 304 for ?full=1', async () => {
+  const res = await worker.fetch(
+    GET('/v1/locations?full=1', { 'If-None-Match': '"abc123-full"' }), seededEnv());
+  assert.equal(res.status, 304);
+});
+
 test('matching If-None-Match yields 304 with no body', async () => {
   const res = await worker.fetch(GET('/v1/locations', { 'If-None-Match': '"abc123"' }), seededEnv());
   assert.equal(res.status, 304);

--- a/worker/test/merge.test.js
+++ b/worker/test/merge.test.js
@@ -81,6 +81,31 @@ test('manual entry wins by nexus_id; node contributes thumbnail backfill', () =>
   });
 });
 
+test('manual full entry carries images from the tagged-query backfill', () => {
+  const full = dataset.full['aaaa-1111']; // nexus_id 12345, also a tagged node
+  assert.equal(full.thumbnail_url, 'thumb-dup');
+  assert.equal(full.picture_url, 'pic-dup');
+  assert.equal(full.updated_at, '2026-07-01');
+});
+
+test('WIP manual entry resolves to null images (shape stays stable)', () => {
+  const full = dataset.full['bbbb-2222']; // nexus_id WIP — no Nexus page
+  assert.equal(full.thumbnail_url, null);
+  assert.equal(full.picture_url, null);
+  assert.equal(full.updated_at, null);
+});
+
+test('manualThumbs backfills manual mods that are not NCZoning-tagged (modsByUid path)', () => {
+  const ds = buildDataset({
+    manualMods: MANUAL, tagsDict: TAGS, excluded: { 777: 'x' },
+    nexusNodes: [], districts: DISTRICTS, // no tagged nodes → images can only come from modsByUid
+    manualThumbs: { 12345: { pictureUrl: 'p-mbu', thumbnailUrl: 't-mbu', updatedAt: '2026-07-09' } },
+  });
+  const full = ds.full['aaaa-1111'];
+  assert.equal(full.thumbnail_url, 't-mbu');
+  assert.equal(full.updated_at, '2026-07-09');
+});
+
 test('auto entry: authors, tags (nczoning + known only), yaw, images in full', () => {
   const auto = dataset.locations.find((l) => l.id === 'nexus-888');
   assert.deepEqual(auto.authors, ['Uploader888', 'Friend']);

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchTaggedModNodes, NEXUS_BATCH_SIZE } from '../src/nexus.js';
+import { fetchTaggedModNodes, fetchModsByUidThumbs, NEXUS_BATCH_SIZE } from '../src/nexus.js';
 
 function fakeFetch(pages) {
   let call = 0;
@@ -51,4 +51,50 @@ test('second-page failure throws rather than returning half the tag population',
     { ok: false, status: 500, json: {} },
   ]);
   await assert.rejects(() => fetchTaggedModNodes(impl), /HTTP 500/);
+});
+
+// ── fetchModsByUidThumbs (manual-mod image backfill) ────────────────────────
+
+// Queue of responses; Error entries throw (simulate a network failure).
+function uidFetch(responses) {
+  let call = 0;
+  return async () => {
+    const r = responses[call++];
+    if (r instanceof Error) throw r;
+    return { ok: r.ok ?? true, status: r.status ?? 200, json: async () => r.json };
+  };
+}
+const uidNode = (i) => ({ modId: i, pictureUrl: `p${i}`, thumbnailUrl: `t${i}`, updatedAt: `u${i}` });
+
+test('modsByUid: returns a thumb map keyed by modId', async () => {
+  const impl = uidFetch([{ json: { data: { modsByUid: { nodes: [uidNode(1), uidNode(2)] } } } }]);
+  const map = await fetchModsByUidThumbs(impl, ['1', '2']);
+  assert.deepEqual(map['1'], { pictureUrl: 'p1', thumbnailUrl: 't1', updatedAt: 'u1' });
+  assert.deepEqual(map['2'], { pictureUrl: 'p2', thumbnailUrl: 't2', updatedAt: 'u2' });
+});
+
+test('modsByUid: skips non-numeric ids and never fetches for an empty set', async () => {
+  let called = false;
+  const impl = async () => { called = true; return { ok: true, json: async () => ({}) }; };
+  assert.deepEqual(await fetchModsByUidThumbs(impl, ['WIP', 'Dummy']), {});
+  assert.equal(called, false);
+});
+
+test('modsByUid: HTTP error degrades to empty, never throws (images are cosmetic)', async () => {
+  const impl = uidFetch([{ ok: false, status: 503, json: {} }, { ok: false, status: 503, json: {} }]);
+  assert.deepEqual(await fetchModsByUidThumbs(impl, ['1']), {});
+});
+
+test('modsByUid: a thrown fetch degrades to empty, never throws', async () => {
+  const impl = uidFetch([new Error('network'), new Error('network')]);
+  assert.deepEqual(await fetchModsByUidThumbs(impl, ['1']), {});
+});
+
+test('modsByUid: retries UIDs the first call silently dropped', async () => {
+  const impl = uidFetch([
+    { json: { data: { modsByUid: { nodes: [uidNode(1)] } } } }, // drops 2
+    { json: { data: { modsByUid: { nodes: [uidNode(2)] } } } }, // retry fills 2
+  ]);
+  const map = await fetchModsByUidThumbs(impl, ['1', '2']);
+  assert.ok(map['1'] && map['2'], 'both UIDs present after the retry');
 });

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchTaggedModNodes, fetchModsByUidThumbs, NEXUS_BATCH_SIZE } from '../src/nexus.js';
+import { fetchTaggedModNodes, fetchModsByUidThumbs, NEXUS_BATCH_SIZE, NEXUS_GAME_ID } from '../src/nexus.js';
 
 function fakeFetch(pages) {
   let call = 0;
@@ -88,6 +88,19 @@ test('modsByUid: HTTP error degrades to empty, never throws (images are cosmetic
 test('modsByUid: a thrown fetch degrades to empty, never throws', async () => {
   const impl = uidFetch([new Error('network'), new Error('network')]);
   assert.deepEqual(await fetchModsByUidThumbs(impl, ['1']), {});
+});
+
+test('modsByUid: sends the composite (gameId<<32)+modId UID (not "gameId:modId")', async () => {
+  // Wire-contract guard: Nexus silently drops UIDs in the wrong format and
+  // returns no images — a bug the shape-only tests above can't catch.
+  let sentUids = null;
+  const impl = async (url, init) => {
+    sentUids = JSON.parse(init.body).variables.uids;
+    return { ok: true, json: async () => ({ data: { modsByUid: { nodes: [uidNode(28630)] } } }) };
+  };
+  await fetchModsByUidThumbs(impl, ['28630']);
+  const expected = ((BigInt(NEXUS_GAME_ID) << 32n) + 28630n).toString();
+  assert.deepEqual(sentUids, [expected]);
 });
 
 test('modsByUid: retries UIDs the first call silently dropped', async () => {

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -70,6 +70,15 @@ function fakeFetch({ failNexus = false, failMods = false, discordSink } = {}) {
     if (url.includes('/subdistricts.json')) return { ok: true, json: async () => SUBDISTRICTS };
     if (url.includes('api.nexusmods.com')) {
       if (failNexus) return { ok: false, status: 503 };
+      // Two POST shapes hit the same endpoint: the tagged-mods query and the
+      // modsByUid image backfill. Route by the query body.
+      if (JSON.parse(init.body).query.includes('modsByUid')) {
+        return { ok: true, json: async () => ({
+          data: { modsByUid: { nodes: [
+            { modId: 12345, pictureUrl: 'pm', thumbnailUrl: 'tm', updatedAt: '2026-07-08' },
+          ] } },
+        }) };
+      }
       return { ok: true, json: async () => NEXUS_PAGE };
     }
     if (url.includes('discord')) { discordSink?.push(JSON.parse(init.body)); return { ok: true }; }
@@ -89,6 +98,14 @@ test('first run writes the full dataset (changed=true)', async () => {
   assert.equal(meta.discovery_stale, false);
   assert.equal(meta.counts.total, 2);
   assert.equal(meta.dataset_version, r.version);
+});
+
+test('manual-mod images are backfilled into full via modsByUid', async () => {
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  await runRefresh(env, fakeFetch());
+  const full = await env.DATASET.get(KEYS.full, 'json');
+  assert.equal(full.m1.thumbnail_url, 'tm'); // manual mod 12345, not NCZoning-tagged
+  assert.equal(full.m1.updated_at, '2026-07-08');
 });
 
 test('unchanged content on the second run skips the write (changed=false)', async () => {


### PR DESCRIPTION
## Data API B7 — the site consumes /v1 (last Data API item)

The website now loads the whole registry from the server-built **/v1 Data API**
instead of running the Nexus auto-discovery merge in the browser. This is the
real-world verification that the API works: every page load exercises `/v1`, so
any merge bug is immediately visible on the map.

**Option B chosen** (per maintainer): thumbnails are now a first-class API field
(primary consumer is in-game mods, not just the browser), so the browser makes
**zero Nexus calls** on the happy path.

### Worker
- `GET /v1/locations?full=1` — full entries (description, credits, image URLs)
  as an array in one request. Distinct `<version>-full` ETag so its cache can't
  collide with the slim list. Slim stays lean for the in-game RedData consumer.
- Cron backfills **manual-mod** thumbnails via `modsByUid`
  (`fetchModsByUidThumbs` — chunk-by-50 + one retry per chunk, non-throwing
  since images are cosmetic). `buildDataset` now attaches
  `thumbnail_url`/`picture_url`/`updated_at` to **every** full entry (manual +
  auto), `null` when unknown.
- Fixed the composite UID (`(gameId<<32)+modId`, matching the site) — an earlier
  `"gameId:modId"` form made Nexus silently drop UIDs. Local run: manual
  thumbnail coverage **30/280 → 280/280**.
- Docs: `openapi.json` (`?full=1` param + `LocationFull` image fields),
  `docs/api-reference.md`.

### Site
- `fetchLocationsFromApi()` — `/v1/locations?full=1` with If-None-Match/304,
  maps API fields (`source`→`_source`, snake_case images→`nexusThumbs`,
  `updated_at`→`_updatedAt`). **Slim-payload guard**: if an un-upgraded API
  returns slim (no `description`), throw → fall back rather than render a
  degraded map.
- **API-primary with graceful fallback** to the legacy client-side merge
  (`fetchModDataClientSide`) — no regression during the transition. Client Nexus
  code is retained *as the fallback*; a follow-up PR deletes it once parity has
  baked on dev.
- `API_BASE` selected by hostname (prod→prod API, else staging).

### Verification (local wrangler-dev against real data)
- `?full=1` → 290 entries (281 manual + 9 auto) = slim count; all carry
  `description`+`thumbnail_url`; slim carries neither.
- Thumbnails: manual **280/280**, auto **9/9**, WIP → null (stable shape).
- ETags distinct (`…-full` vs plain); `discovery_stale: false`, `skipped: 0`.
- Worker test suite: **62 pass** (incl. `?full=1` variant/ETag, manual-thumb
  backfill, and a wire-contract UID-format guard).

### Parity to confirm on dev.nczoning.net (post-merge, CI deploys api-dev + site)
- [ ] Total pin count matches; every auto mod present; excluded honoured; manual-wins-by-nexus_id
- [ ] District Info Panel per-district counts unchanged
- [ ] Deep links (`?mod=`) resolve; 2D + 3D, filtering, clustering unaffected
- [ ] Thumbnails render on manual + auto pins; "RECENTLY UPDATED" badges correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)