### PR TITLE
feat(monitoring): Data API health monitor + dedicated alerts channel

### DIFF
--- a/.github/workflows/modify-location-submission.yml
+++ b/.github/workflows/modify-location-submission.yml
@@ -18,9 +18,9 @@ jobs:
           token: ${{ secrets.ACTIONS_PAT }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 24
 
       - name: Process Issue
         id: process

--- a/.github/workflows/monitor-api-health.yml
+++ b/.github/workflows/monitor-api-health.yml
@@ -1,0 +1,41 @@
+name: Monitor Data API Health
+
+# The site consumes /v1 with a client-side fallback (B7), and in-game mods —
+# the API's primary consumer — have NO fallback. So a silent website fallback
+# would mask an API outage. This is the independent alarm: it hits the live API
+# on a schedule and pings Discord (+ fails the run) when it isn't serving.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'   # every 15 min — matches the dataset cron cadence
+  workflow_dispatch:          # manual trigger (testing / on demand)
+
+permissions:
+  contents: read
+
+# A slow/queued run shouldn't stack; keep only the latest.
+concurrency:
+  group: monitor-api-health
+  cancel-in-progress: true
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Probe /v1 and alert on outage
+        env:
+          # Dedicated map-alerts channel, kept separate from submissions.
+          NCZ_ALERTS_DISCORD_WEBHOOK_URL: ${{ secrets.NCZ_ALERTS_DISCORD_WEBHOOK_URL }}
+          # Both matter: prod (api.nczoning.net) is what in-game mods hit;
+          # staging (api-dev) is what the dev site consumes during the B7 bake,
+          # where an outage would otherwise be hidden by the client fallback.
+          # The script retries 3× before declaring an outage, so a momentary
+          # deploy blip won't page. Drop api-dev here if it ever gets noisy.
+          API_HEALTH_TARGETS: 'https://api.nczoning.net,https://api-dev.nczoning.net'
+        run: node scripts/monitor_api_health.js

--- a/.github/workflows/monitor-api-health.yml
+++ b/.github/workflows/monitor-api-health.yml
@@ -24,9 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 24
 
       - name: Probe /v1 and alert on outage
         env:

--- a/.github/workflows/monitor-auto-discovery.yml
+++ b/.github/workflows/monitor-auto-discovery.yml
@@ -1,11 +1,11 @@
 name: Monitor Auto-Discovery Health
 
-# Auto-discovered pins are parsed client-side from live Nexus descriptions
-# that authors add at any time, and a parse failure is silent (a console
-# log nobody reads). This runs the REAL production parser
-# (assets/js/utils.js) against live Nexus data on a schedule and pings
-# Discord only when a tagged mod is missing from the map — so a broken or
-# incomplete block is caught within a day instead of when an author complains.
+# Authors add NCZoning metadata blocks to their Nexus descriptions at any time,
+# and a parse failure is silent. Since B7 the parsing runs server-side (the Data
+# API cron) and the result is exposed at /v1/meta.skipped — mods tagged NCZoning
+# that aren't excluded/manual and didn't parse. This reads that list and pings
+# Discord when it's non-empty, so a broken block is caught within a day instead
+# of when an author complains. (One source of truth: no client/server drift.)
 
 on:
   schedule:
@@ -21,9 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 24
 
       - name: Scan NCZoning-tagged mods and alert on parse failures
         env:

--- a/.github/workflows/monitor-auto-discovery.yml
+++ b/.github/workflows/monitor-auto-discovery.yml
@@ -27,5 +27,6 @@ jobs:
 
       - name: Scan NCZoning-tagged mods and alert on parse failures
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          # Dedicated map-alerts channel, kept separate from submissions.
+          NCZ_ALERTS_DISCORD_WEBHOOK_URL: ${{ secrets.NCZ_ALERTS_DISCORD_WEBHOOK_URL }}
         run: node scripts/monitor_auto_discovery.js

--- a/.github/workflows/validate-mods.yml
+++ b/.github/workflows/validate-mods.yml
@@ -31,6 +31,12 @@ jobs:
             echo "data_changed=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Setup Node.js
+        if: steps.changes.outputs.data_changed == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Build mods.json
         if: steps.changes.outputs.data_changed == 'true'
         run: node scripts/build_mods.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Infrastructure
+
+- The website now loads the mod registry from the `/v1` Data API instead of running the Nexus auto-discovery merge in the browser; mod thumbnails moved server-side, so the browser no longer calls Nexus. Falls back to the client-side path if the API is unavailable.
+- Added a Data API health monitor (`monitor-api-health.yml`) that alerts if `/v1` stops serving. Operational alerts (API health + auto-discovery) now post to a dedicated Discord channel, separate from submissions.
+
 ## [1.1.0] - 2026-07-04
 
 ### Infrastructure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,13 +152,21 @@ The auto-PR pipeline and Discord notifications require two secrets configured in
 | Secret | Value |
 | --- | --- |
 | `ACTIONS_PAT` | A GitHub Personal Access Token (fine-grained) with `Contents: Read/Write` and `Pull requests: Read/Write` on this repo |
-| `DISCORD_WEBHOOK_URL` | A Discord channel webhook URL (channel Settings → Integrations → Webhooks) |
+| `DISCORD_WEBHOOK_URL` | Webhook for the **submissions** channel — new/modified submission embeds and their PR-status edits (channel Settings → Integrations → Webhooks) |
+| `NCZ_ALERTS_DISCORD_WEBHOOK_URL` | Webhook for the dedicated **map-alerts** channel — auto-discovery parse failures and Data API health/outage alerts, kept separate from submissions |
 
 > **Why ACTIONS_PAT?** GitHub's `GITHUB_TOKEN` cannot trigger other workflow runs (a security design). Using a PAT for `create-pull-request` allows the `validate-json` check to fire automatically on the generated PR.
 
 ### Discord Notifications
 
-Two workflows handle Discord messaging:
+Two channels, two webhooks. **Submissions** (`DISCORD_WEBHOOK_URL`) — the mod
+submission lifecycle:
 
 - **`auto-pr-submission.yml`** — Posts a new embed when a submission PR is created (status: ⏳ Awaiting review). Stores the Discord message ID as a hidden comment on the issue.
-- **`notify-discord-pr-status.yml`** — When the PR is merged or closed, edits the original embed in-place to show the outcome (✅ Approved or ❌ Closed).
+- **`modify-location-submission.yml`** — Posts an embed for modification/removal requests.
+- **`notify-discord-pr-status.yml`** — When the PR is merged or closed, edits the original embed in-place to show the outcome (✅ Approved or ❌ Closed). Must use the same webhook that posted the message.
+
+**Alerts** (`NCZ_ALERTS_DISCORD_WEBHOOK_URL`) — operational health, separate channel:
+
+- **`monitor-auto-discovery.yml`** — Daily scan; alerts when a NCZoning-tagged mod fails to parse and isn't covered by a manual entry.
+- **`monitor-api-health.yml`** — Every 15 min; alerts when the Data API (`/v1`) isn't serving. The Worker's own refresh-failure alert (`worker/src/refresh.js`) posts here too (Cloudflare Worker secret, set separately via `wrangler secret put`).

--- a/docs/data-api-plan.md
+++ b/docs/data-api-plan.md
@@ -31,9 +31,13 @@ The static `mods.json` is not enough for game clients, for three reasons:
   `data/subdistricts.json` are already in CET world coordinates), then write
   to KV only when the content hash changes.
 - **Failure posture:** keep last-known-good data, set `discovery_stale=true`,
-  alert Discord (same pattern as `monitor-auto-discovery.yml`). Never serve an
+  alert Discord on the dedicated map-alerts channel
+  (`NCZ_ALERTS_DISCORD_WEBHOOK_URL`, separate from submissions). Never serve an
   empty or partial dataset. Git remains the source of truth for manual
-  entries; the Worker only reads deployed CDN artifacts.
+  entries; the Worker only reads deployed CDN artifacts. A separate
+  `monitor-api-health.yml` GitHub Action probes `/v1` every 15 min and alerts
+  on the same channel if the API stops serving (independent of the Worker's own
+  alert — catches cases where the Worker can't alert for itself).
 - **Free tier:** ~1 conditional GET per player session against a 100k req/day
   cap; KV writes at most 96/day. Passes with a huge margin.
 

--- a/docs/nczoning-auto-discovery.md
+++ b/docs/nczoning-auto-discovery.md
@@ -167,8 +167,8 @@ The format is a flat `{ "nexusId": "reason" }` object (same shape as `data/tags.
 
 An excluded id is honoured in two places:
 
-1. **Auto-discovery (`services.js`)** — the mod is never rendered as a pin, *even if its block parses correctly*. This is what stops a mistakenly-tagged mod that happens to have valid coordinates from showing up.
-2. **Health monitor (`scripts/monitor_auto_discovery.js`)** — the mod is skipped, so the daily Discord alert stops flagging it. Without this, an intentionally-excluded mod with no block would be reported every single day.
+1. **The Data API merge (`worker/src/merge.js`)** — the mod is never rendered as a pin, *even if its block parses correctly*, and it's kept out of `/v1/meta.skipped`. This is what stops a mistakenly-tagged mod that happens to have valid coordinates from showing up. (The site's client-side fallback in `services.js` honours the same list.)
+2. **Health monitor (`scripts/monitor_auto_discovery.js`)** — reads `/v1/meta.skipped`, which the API has already filtered, so an excluded mod is never flagged. Without the exclusion an intentionally-excluded mod with no block would be reported every day.
 
 To exclude a mod, add its Nexus id and a short reason to `data/excluded_mods.json` and open a PR. To re-include it later, delete the entry.
 

--- a/docs/submission-pipeline.md
+++ b/docs/submission-pipeline.md
@@ -43,6 +43,8 @@ This workflow triggers whenever the `mod-submission` label is applied to an issu
 
 Within the same `auto-pr-submission.yml` workflow, the bot reaches out to a Discord channel (using the `DISCORD_WEBHOOK_URL` secret) with an embedded message noting that a PR is awaiting review.
 
+> `DISCORD_WEBHOOK_URL` is the **submissions** channel. Operational alerts (health/monitoring) go to a separate channel via `NCZ_ALERTS_DISCORD_WEBHOOK_URL` — see [architecture.md](architecture.md#discord-notifications).
+
 **The Clever Part:**
 To allow the bot to update this exact discord message later on, the webhook returns a unique `message_id`. The bot saves this ID as a hidden HTML comment at the bottom of the original GitHub Issue `<!-- discord_message_id: XXXXX -->`.
 

--- a/scripts/monitor_api_health.js
+++ b/scripts/monitor_api_health.js
@@ -174,12 +174,15 @@ async function postDiscord(results) {
 
     if (anyOutage) {
       console.error("\nHealth check FAILED — at least one target is not serving.");
-      process.exit(1);
+      process.exitCode = 1;
+    } else {
+      console.log("\nAll targets healthy.");
     }
-    console.log("\nAll targets healthy.");
-    process.exit(0);
   } catch (err) {
     console.error("Health monitor failed (infrastructure error):", err.message);
-    process.exit(1);
+    process.exitCode = 1;
   }
 })();
+// NOTE: we set process.exitCode and let the event loop drain rather than calling
+// process.exit(), which can trip a libuv assertion on Windows when fetch's
+// keep-alive sockets are still closing.

--- a/scripts/monitor_api_health.js
+++ b/scripts/monitor_api_health.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * Data API health monitor.
+ *
+ * Why this exists: the website consumes /v1 with a graceful fallback to the
+ * client-side merge (B7), and the API's PRIMARY consumer — in-game mods — has
+ * NO fallback at all. So a silent website fallback would MASK an API outage:
+ * the map looks fine while the mods are broken. This is the independent alarm
+ * that closes that gap. It hits the live API on a schedule and pings Discord
+ * (+ fails the workflow run, a second visible signal) when the API isn't
+ * actually usable.
+ *
+ * What it checks per target:
+ *   1. GET /v1/health   → 200 and data.status === "ok"   (the Worker is alive)
+ *   2. GET /v1/locations → 200 and a non-empty array       (KV populated; not
+ *      503 not_ready, not an empty/wiped dataset)
+ *   3. GET /v1/meta      → discovery_stale is reported as CONTEXT only, not a
+ *      hard fail: the cron already Discord-alerts on refresh failure, and it's
+ *      still serving last-known-good, so it's a warning, not an outage.
+ *
+ * NOTE: envelope.generated_at is deliberately NOT used as a freshness/liveness
+ * signal — the cron only rewrites it when the dataset CONTENT changes (a few
+ * times a day), so a healthy-but-idle API legitimately has an hours-old
+ * generated_at. There is no served "last cron ran" timestamp to check.
+ *
+ * Run: node scripts/monitor_api_health.js
+ * Targets: API_HEALTH_TARGETS (comma-separated), default https://api.nczoning.net
+ * Alerts:  NCZ_ALERTS_DISCORD_WEBHOOK_URL — the dedicated map-alerts channel,
+ *          kept separate from the submissions webhook (prints a preview instead
+ *          of sending if unset).
+ * Exit:    0 when every target is serving; 1 on any outage or infra error
+ *          (so the Actions run goes red — a second signal beside Discord).
+ */
+
+const DEFAULT_TARGETS = ["https://api.nczoning.net"];
+const RETRIES = 3;        // transient blips shouldn't page anyone
+const RETRY_DELAY_MS = 4000;
+const FETCH_TIMEOUT_MS = 15000;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function fetchJson(url) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal, headers: { "User-Agent": "nczoning-health-monitor" } });
+    let json = null;
+    try { json = await res.json(); } catch { /* non-JSON body — leave null */ }
+    return { ok: res.ok, status: res.status, json };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Retry a check until it passes or RETRIES is exhausted. `check` returns null
+// on success or a string describing the failure.
+async function withRetry(label, check) {
+  let last = "unknown";
+  for (let attempt = 1; attempt <= RETRIES; attempt++) {
+    try {
+      const problem = await check();
+      if (!problem) return null;
+      last = problem;
+    } catch (err) {
+      last = err.name === "AbortError" ? `timeout after ${FETCH_TIMEOUT_MS}ms` : err.message;
+    }
+    if (attempt < RETRIES) {
+      console.log(`  ${label}: attempt ${attempt} failed (${last}) — retrying`);
+      await sleep(RETRY_DELAY_MS);
+    }
+  }
+  return last;
+}
+
+async function checkTarget(base) {
+  const issues = [];   // hard failures → outage
+  const warnings = []; // soft (informational) signals
+
+  const healthProblem = await withRetry("health", async () => {
+    const { ok, status, json } = await fetchJson(`${base}/v1/health`);
+    if (!ok) return `HTTP ${status}`;
+    if (json?.data?.status !== "ok") return `status=${JSON.stringify(json?.data?.status)}`;
+    return null;
+  });
+  if (healthProblem) issues.push(`/v1/health unreachable (${healthProblem})`);
+
+  const locationsProblem = await withRetry("locations", async () => {
+    const { ok, status, json } = await fetchJson(`${base}/v1/locations`);
+    if (!ok) return status === 503 ? "503 not_ready (dataset not built)" : `HTTP ${status}`;
+    if (!Array.isArray(json?.data)) return "data is not an array";
+    if (json.data.length === 0) return "dataset is empty";
+    return null;
+  });
+  if (locationsProblem) issues.push(`/v1/locations not serving data (${locationsProblem})`);
+
+  // discovery_stale is context, not an outage — the cron self-alerts on it.
+  try {
+    const { ok, json } = await fetchJson(`${base}/v1/meta`);
+    if (ok && json?.data?.discovery_stale) {
+      warnings.push("discovery_stale=true (last Nexus refresh failed; serving last-known-good)");
+    }
+  } catch { /* meta is best-effort context */ }
+
+  return { base, issues, warnings };
+}
+
+async function postDiscord(results) {
+  const url = process.env.NCZ_ALERTS_DISCORD_WEBHOOK_URL;
+  const down = results.filter((r) => r.issues.length);
+
+  const fields = results
+    .filter((r) => r.issues.length || r.warnings.length)
+    .map((r) => ({
+      name: `${r.issues.length ? "🔴" : "🟠"} ${r.base}`,
+      value: [
+        ...r.issues.map((i) => `• **OUTAGE:** ${i}`),
+        ...r.warnings.map((w) => `• ${w}`),
+      ].join("\n"),
+    }));
+
+  const body = {
+    embeds: [
+      {
+        title: down.length
+          ? `🔴 Data API outage — ${down.length} environment${down.length === 1 ? "" : "s"} not serving`
+          : `🟠 Data API warning`,
+        description: down.length
+          ? "The API is not usable by consumers (in-game mods have no fallback). " +
+            "The website may look fine via its client-side fallback — this is that hidden failure surfacing."
+          : "The API is serving but a soft signal fired (see below).",
+        color: down.length ? 15158332 /* red */ : 15105570 /* amber */,
+        fields,
+        footer: { text: "NC Zoning Board • Data API health monitor" },
+      },
+    ],
+  };
+
+  if (!url) {
+    console.log("\n--- NCZ_ALERTS_DISCORD_WEBHOOK_URL not set — preview of payload that would be sent ---");
+    console.log(JSON.stringify(body, null, 2));
+    console.log("--- end preview (nothing was sent) ---");
+    return;
+  }
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`Discord webhook HTTP ${res.status}: ${await res.text()}`);
+  console.log("Posted Discord health alert.");
+}
+
+(async () => {
+  try {
+    const targets = (process.env.API_HEALTH_TARGETS || DEFAULT_TARGETS.join(","))
+      .split(",")
+      .map((s) => s.trim().replace(/\/$/, ""))
+      .filter(Boolean);
+
+    console.log(`Checking ${targets.length} target(s): ${targets.join(", ")}`);
+    const results = [];
+    for (const base of targets) {
+      console.log(`\n${base}`);
+      const r = await checkTarget(base);
+      results.push(r);
+      if (r.issues.length) console.log(`  ❌ OUTAGE: ${r.issues.join("; ")}`);
+      else console.log("  ✅ serving");
+      for (const w of r.warnings) console.log(`  ⚠️  ${w}`);
+    }
+
+    const anyOutage = results.some((r) => r.issues.length);
+    const anyWarning = results.some((r) => r.warnings.length);
+    if (anyOutage || anyWarning) await postDiscord(results);
+
+    if (anyOutage) {
+      console.error("\nHealth check FAILED — at least one target is not serving.");
+      process.exit(1);
+    }
+    console.log("\nAll targets healthy.");
+    process.exit(0);
+  } catch (err) {
+    console.error("Health monitor failed (infrastructure error):", err.message);
+    process.exit(1);
+  }
+})();

--- a/scripts/monitor_auto_discovery.js
+++ b/scripts/monitor_auto_discovery.js
@@ -12,7 +12,8 @@
  * it can never drift from what users actually experience.
  *
  * Run: node scripts/monitor_auto_discovery.js
- * Posts a Discord embed (DISCORD_WEBHOOK_URL) only when ≥1 NCZoning-
+ * Posts a Discord embed (NCZ_ALERTS_DISCORD_WEBHOOK_URL — the dedicated
+ * map-alerts channel, separate from submissions) only when ≥1 NCZoning-
  * tagged mod fails to parse and isn't covered by a manual registry
  * entry. Exit 0 on a clean run OR detected-bad-mods (it's a report,
  * not a gate); exit 1 only on an infrastructure error.
@@ -138,7 +139,7 @@ async function fetchTaggedMods({ endpoint, gameId, batchSize }) {
 }
 
 async function postDiscord(failures, total, excludedCount) {
-  const url = process.env.DISCORD_WEBHOOK_URL;
+  const url = process.env.NCZ_ALERTS_DISCORD_WEBHOOK_URL;
   const MAX_PER_GROUP = 12;
   const fmt = (group) => {
     const lines = group
@@ -198,7 +199,7 @@ async function postDiscord(failures, total, excludedCount) {
   if (!url) {
     // No webhook (local run / dry run): print the exact payload that
     // would be POSTed so the alert can be reviewed without sending it.
-    console.log("\n--- DISCORD_WEBHOOK_URL not set — preview of payload that would be sent ---");
+    console.log("\n--- NCZ_ALERTS_DISCORD_WEBHOOK_URL not set — preview of payload that would be sent ---");
     console.log(JSON.stringify(body, null, 2));
     console.log("--- end preview (nothing was sent) ---");
     return;

--- a/scripts/monitor_auto_discovery.js
+++ b/scripts/monitor_auto_discovery.js
@@ -2,203 +2,57 @@
 /**
  * Auto-discovery health monitor.
  *
- * Why this exists and not a unit test: auto-discovered pins are parsed
- * client-side from *live* Nexus descriptions that authors add at any
- * time, and a parse failure is silent (a console.log nobody reads). A
- * fixture test only catches us regressing a *known* case on a parser
- * edit; it cannot catch a new author pasting a format we've never seen.
- * So this runs on a schedule against live data, importing the **real
- * production parser** (`assets/js/utils.js` → `parseNcZoningBlock`) so
- * it can never drift from what users actually experience.
+ * Purpose: catch NCZoning-tagged mods that AREN'T showing on the map because
+ * their metadata block is missing or unparseable — so a broken block is caught
+ * within a day instead of when an author complains.
+ *
+ * Since B7 the block parsing + merge runs SERVER-SIDE (the Data API cron), and
+ * the API exposes the result at `/v1/meta.skipped`: every mod tagged NCZoning
+ * that isn't excluded, isn't a manual entry, and whose block didn't parse —
+ * exactly the "tagged but not on the map" set. Reading that instead of
+ * re-parsing client-side means ONE source of truth (no client/server parser
+ * drift) and no live Nexus fetch. Before B7 this script ran the client-side
+ * `assets/js/utils.js` parser directly; that parser is now only the site's
+ * fallback, so testing it here would drift from what actually builds the map.
  *
  * Run: node scripts/monitor_auto_discovery.js
- * Posts a Discord embed (NCZ_ALERTS_DISCORD_WEBHOOK_URL — the dedicated
- * map-alerts channel, separate from submissions) only when ≥1 NCZoning-
- * tagged mod fails to parse and isn't covered by a manual registry
- * entry. Exit 0 on a clean run OR detected-bad-mods (it's a report,
- * not a gate); exit 1 only on an infrastructure error.
+ * Target: API_META_URL (default https://api.nczoning.net/v1/meta)
+ * Alerts: NCZ_ALERTS_DISCORD_WEBHOOK_URL — the dedicated map-alerts channel,
+ *         separate from submissions (prints a preview instead if unset).
+ * Exit 0 on a clean run OR flagged mods (it's a report, not a gate); exit 1
+ * only on an infrastructure error.
  */
 
-const fs = require("fs");
-const path = require("path");
-
-const ROOT = path.join(__dirname, "..");
+const API_META_URL = process.env.API_META_URL || "https://api.nczoning.net/v1/meta";
 const NEXUS_MOD_URL = (id) => `https://www.nexusmods.com/cyberpunk2077/mods/${id}`;
 
-// --- Load the real production parser (drift-proof by construction) -----------
-function loadParser() {
-  const src = fs.readFileSync(path.join(ROOT, "assets/js/utils.js"), "utf8");
-  const NCZ = {};
-  // utils.js assigns onto a bare `NCZ`; parseNcZoningBlock is self-contained
-  // (regex + the validTagNames Set), so no other NCZ members are needed.
-  new Function("NCZ", src)(NCZ);
-  if (typeof NCZ.parseNcZoningBlock !== "function") {
-    throw new Error("parseNcZoningBlock not found after loading assets/js/utils.js");
-  }
-  return NCZ.parseNcZoningBlock;
-}
-
-// --- Pull stable Nexus constants from constants.js source (no eval) ----------
-function loadNexusConstants() {
-  const src = fs.readFileSync(path.join(ROOT, "assets/js/constants.js"), "utf8");
-  const num = (name, fallback) => {
-    const m = src.match(new RegExp(`NCZ\\.${name}\\s*=\\s*(\\d+)`));
-    return m ? Number(m[1]) : fallback;
-  };
-  const str = (name, fallback) => {
-    const m = src.match(new RegExp(`NCZ\\.${name}\\s*=\\s*["']([^"']+)["']`));
-    return m ? m[1] : fallback;
-  };
-  return {
-    endpoint: str("NEXUS_GQL_ENDPOINT", "https://api.nexusmods.com/v2/graphql"),
-    gameId: num("NEXUS_GAME_ID", 3333),
-    batchSize: num("NEXUS_BATCH_SIZE", 50),
-  };
-}
-
-// --- Valid tag names (data/tags.json is a flat { id: description } object) ---
-function loadValidTagNames() {
-  const tags = JSON.parse(fs.readFileSync(path.join(ROOT, "data/tags.json"), "utf8"));
-  return new Set(Object.keys(tags));
-}
-
-// --- Manually-registered numeric nexus_ids (mirror services.js precedence) ---
-// A tagged mod that's also in the manual registry intentionally may have no
-// parseable block — manual data wins — so excluding it avoids false alarms.
-function loadManualNexusIds() {
-  const dir = path.join(ROOT, "data/locations");
-  const ids = new Set();
-  for (const file of fs.readdirSync(dir)) {
-    if (!file.endsWith(".json")) continue;
-    try {
-      const mod = JSON.parse(fs.readFileSync(path.join(dir, file), "utf8"));
-      if (/^\d+$/.test(String(mod.nexus_id))) ids.add(String(mod.nexus_id));
-    } catch {
-      /* a malformed location file is validate-mods.yml's problem, not ours */
-    }
-  }
-  return ids;
-}
-
-// --- Intentionally-excluded nexus_ids (data/excluded_mods.json) --------------
-// Mods tagged NCZoning by mistake, or too minor to map, that we deliberately
-// keep off the board. They have no manual entry and never will, so without
-// this list the monitor would flag them every single day. Flat
-// { "nexusId": "reason" } object — same shape as data/tags.json.
-function loadExcludedNexusIds() {
-  const file = path.join(ROOT, "data/excluded_mods.json");
-  try {
-    const obj = JSON.parse(fs.readFileSync(file, "utf8"));
-    return new Set(Object.keys(obj).map(String));
-  } catch {
-    // No list (or unreadable) just means nothing is excluded.
-    return new Set();
-  }
-}
-
-// --- Fetch every NCZoning-tagged mod (same query/pagination as services.js) --
-async function fetchTaggedMods({ endpoint, gameId, batchSize }) {
-  const query = `
-    query NCZoningMods($filter: ModsFilter!, $count: Int!, $offset: Int!) {
-      mods(filter: $filter, count: $count, offset: $offset) {
-        nodes { modId name description }
-        totalCount
-      }
-    }`;
-  const out = [];
-  let offset = 0;
-  let total = Infinity;
-  while (offset < total) {
-    const res = await fetch(endpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        query,
-        variables: {
-          filter: {
-            gameId: [{ value: String(gameId) }],
-            tag: [{ value: "NCZoning" }],
-          },
-          count: batchSize,
-          offset,
-        },
-      }),
-    });
-    if (!res.ok) throw new Error(`Nexus API HTTP ${res.status}`);
-    const json = await res.json();
-    if (json.errors) throw new Error(`Nexus API errors: ${JSON.stringify(json.errors)}`);
-    const page = json?.data?.mods;
-    if (!page) throw new Error("Nexus API: no mods page in response");
-    total = page.totalCount ?? 0;
-    const nodes = page.nodes || [];
-    out.push(...nodes);
-    if (nodes.length === 0 || nodes.length < batchSize) break;
-    offset += nodes.length;
-  }
-  return out;
-}
-
-async function postDiscord(failures, total, excludedCount) {
+async function postDiscord(skipped) {
   const url = process.env.NCZ_ALERTS_DISCORD_WEBHOOK_URL;
-  const MAX_PER_GROUP = 12;
-  const fmt = (group) => {
-    const lines = group
-      .slice(0, MAX_PER_GROUP)
-      .map((f) => `• [${f.name || "Unknown"}](${NEXUS_MOD_URL(f.modId)}) — \`${f.modId}\``);
-    if (group.length > MAX_PER_GROUP) lines.push(`…and ${group.length - MAX_PER_GROUP} more.`);
-    return lines.join("\n");
-  };
-
-  // Two distinct signals — keep them separate so the alert is actionable:
-  // a broken block needs the author to fix it; a missing block may just be
-  // a speculative/mistaken tag or an author who never finished setup.
-  const malformed = failures.filter((f) => f.attemptedBlock);
-  const noBlock = failures.filter((f) => !f.attemptedBlock);
-  const n = failures.length;
-
-  const fields = [];
-  if (malformed.length) {
-    fields.push({
-      name: `🔧 Malformed block — ${malformed.length}`,
-      value:
-        `Author added an \`NCZoning:\` block but it failed to parse. ` +
-        `**Action:** ask them to regenerate it with the in-app BBCode Generator.\n` +
-        fmt(malformed),
-    });
-  }
-  if (noBlock.length) {
-    fields.push({
-      name: `🏷️ Tagged, no block — ${noBlock.length}`,
-      value:
-        `Tagged \`NCZoning\` but the description has no metadata block. ` +
-        `**Action:** add a manual registry entry if it belongs on the map, ` +
-        `or add its id to \`data/excluded_mods.json\` to stop this alert.\n` +
-        fmt(noBlock),
-    });
-  }
-
-  const excludedNote = excludedCount
-    ? ` ${excludedCount} mod${excludedCount === 1 ? "" : "s"} on the exclusion list ${excludedCount === 1 ? "is" : "are"} ignored.`
-    : "";
+  const MAX = 12;
+  const n = skipped.length;
+  const lines = skipped
+    .slice(0, MAX)
+    .map((m) => `• [${m.name || "Unknown"}](${NEXUS_MOD_URL(m.nexus_id)}) — \`${m.nexus_id}\``);
+  if (n > MAX) lines.push(`…and ${n - MAX} more.`);
 
   const body = {
     embeds: [
       {
         title: `⚠️ Auto-discovery: ${n} NCZoning mod${n === 1 ? "" : "s"} tagged but not on the map`,
         description:
-          `${n} mod${n === 1 ? " is" : "s are"} tagged **NCZoning** on Nexus ` +
-          `but not showing as ${n === 1 ? "a live pin" : "live pins"}, because the ` +
-          `metadata block is missing or unreadable. Each entry below says what to do.` +
-          excludedNote,
+          `${n} mod${n === 1 ? " is" : "s are"} tagged **NCZoning** on Nexus but the ` +
+          `Data API skipped ${n === 1 ? "it" : "them"} — the metadata block is missing or ` +
+          `didn't parse. **Action:** ask the author to regenerate the block with the in-app ` +
+          `BBCode Generator, add a manual registry entry if it belongs on the map, or add the ` +
+          `id to \`data/excluded_mods.json\` to stop this alert.\n\n` +
+          lines.join("\n"),
         color: 15105570, // amber/orange — warning, not error
-        fields,
-        footer: { text: `NC Zoning Board • scanned ${total} NCZoning-tagged mod${total === 1 ? "" : "s"}` },
+        footer: { text: "NC Zoning Board • source: /v1/meta.skipped" },
       },
     ],
   };
+
   if (!url) {
-    // No webhook (local run / dry run): print the exact payload that
-    // would be POSTed so the alert can be reviewed without sending it.
     console.log("\n--- NCZ_ALERTS_DISCORD_WEBHOOK_URL not set — preview of payload that would be sent ---");
     console.log(JSON.stringify(body, null, 2));
     console.log("--- end preview (nothing was sent) ---");
@@ -209,56 +63,38 @@ async function postDiscord(failures, total, excludedCount) {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!res.ok) {
-    throw new Error(`Discord webhook HTTP ${res.status}: ${await res.text()}`);
-  }
-  console.log(`Posted Discord alert for ${failures.length} unparseable mod(s).`);
+  if (!res.ok) throw new Error(`Discord webhook HTTP ${res.status}: ${await res.text()}`);
+  console.log(`Posted Discord alert for ${n} skipped mod(s).`);
 }
 
 (async () => {
   try {
-    const parse = loadParser();
-    const consts = loadNexusConstants();
-    const validTagNames = loadValidTagNames();
-    const manualIds = loadManualNexusIds();
-    const excludedIds = loadExcludedNexusIds();
+    const res = await fetch(API_META_URL, { headers: { "User-Agent": "nczoning-auto-discovery-monitor" } });
+    if (!res.ok) throw new Error(`GET ${API_META_URL} → HTTP ${res.status}`);
+    const json = await res.json();
 
-    const mods = await fetchTaggedMods(consts);
-    console.log(
-      `Scanned ${mods.length} NCZoning-tagged mods ` +
-        `(${manualIds.size} manual, ${excludedIds.size} excluded).`,
-    );
+    const skipped = json?.data?.skipped;
+    if (!Array.isArray(skipped)) throw new Error("meta.skipped missing or not an array");
 
-    const failures = [];
-    for (const mod of mods) {
-      const id = String(mod.modId);
-      if (manualIds.has(id)) continue; // manual registry covers it
-      if (excludedIds.has(id)) continue; // intentionally kept off the map
-      if (!parse(mod.description, validTagNames)) {
-        // A `NCZoning` mention means the author attempted a block that
-        // failed to parse (actionable: fix it) vs. no block at all
-        // (a bare/mistaken tag).
-        const attemptedBlock = /NCZoning/i.test(mod.description || "");
-        failures.push({ modId: id, name: mod.name, attemptedBlock });
-      }
+    if (json.data.discovery_stale) {
+      // Still worth reporting — the last-known-good skipped list is what the map reflects.
+      console.log("Note: discovery_stale=true — the API is serving last-known-good data.");
     }
 
-    if (failures.length === 0) {
-      console.log("✅ All non-manual tagged mods parse cleanly.");
-    } else {
-      const malformed = failures.filter((f) => f.attemptedBlock);
-      const noBlock = failures.filter((f) => !f.attemptedBlock);
-      console.log(
-        `❌ ${failures.length} missing (${malformed.length} malformed block, ${noBlock.length} no block):`,
-      );
-      for (const f of failures) {
-        console.log(`   - ${f.modId}  [${f.attemptedBlock ? "malformed" : "no-block "}]  ${f.name}`);
-      }
-      await postDiscord(failures, mods.length, excludedIds.size);
+    if (skipped.length === 0) {
+      console.log("✅ No NCZoning-tagged mods skipped — all parse cleanly.");
+      return; // exitCode stays 0
     }
-    process.exit(0); // report, not a gate
+
+    console.log(`❌ ${skipped.length} tagged mod(s) skipped by the API:`);
+    for (const m of skipped) console.log(`   - ${m.nexus_id}  ${m.name}`);
+    await postDiscord(skipped);
+    // exitCode stays 0 — this is a report, not a gate.
   } catch (err) {
     console.error("Monitor failed (infrastructure error):", err.message);
-    process.exit(1);
+    process.exitCode = 1;
   }
 })();
+// NOTE: we set process.exitCode and let the event loop drain rather than calling
+// process.exit(), which can trip a libuv assertion on Windows when fetch's
+// keep-alive sockets are still closing.

--- a/worker/README.md
+++ b/worker/README.md
@@ -42,9 +42,12 @@ npx wrangler deploy --env staging     # staging
 CI needs one GitHub Actions secret: `CLOUDFLARE_API_TOKEN` (a token with
 Workers Scripts:Edit, Workers KV Storage:Edit, and Zone DNS:Edit on the
 nczoning.net zone — DNS is needed so the custom-domain route can be created).
-The `DISCORD_WEBHOOK_URL` Worker secret and the KV namespaces persist across
-deploys; they're set once with `wrangler secret put` / `kv namespace create`
-and are not touched by CI.
+Refresh-failure alerts post to the dedicated map-alerts channel via the
+`NCZ_ALERTS_DISCORD_WEBHOOK_URL` Worker secret (set once per environment:
+`wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL` and again with
+`--env staging`). It falls back to the legacy `DISCORD_WEBHOOK_URL` secret if
+the new one isn't set, so there's no alerting gap during the move. The secrets
+and KV namespaces persist across deploys and are not touched by CI.
 
 The `routes` entry binds the custom domain on first deploy (DNS + certificate
 created automatically; the zone must be on the same Cloudflare account). The

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -27,11 +27,18 @@ async function fetchJson(fetchImpl, origin, path) {
   return res.json();
 }
 
-/** Post a failure embed to Discord if a webhook is configured. */
+/**
+ * Post a failure embed to Discord if a webhook is configured. Prefers the
+ * dedicated map-alerts channel (NCZ_ALERTS_DISCORD_WEBHOOK_URL), falling back
+ * to the legacy submissions webhook so there's no alerting gap until the new
+ * Cloudflare Worker secret is set (`wrangler secret put
+ * NCZ_ALERTS_DISCORD_WEBHOOK_URL` for BOTH the prod and staging Workers).
+ */
 async function alertDiscord(env, fetchImpl, reason) {
-  if (!env.DISCORD_WEBHOOK_URL) return;
+  const webhook = env.NCZ_ALERTS_DISCORD_WEBHOOK_URL || env.DISCORD_WEBHOOK_URL;
+  if (!webhook) return;
   try {
-    await fetchImpl(env.DISCORD_WEBHOOK_URL, {
+    await fetchImpl(webhook, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -121,7 +121,8 @@ test('unchanged content on the second run skips the write (changed=false)', asyn
 test('Nexus failure keeps last-known-good and flags stale + alerts Discord', async () => {
   const env = {
     DATASET: fakeKV(), SITE_ORIGIN: 'https://x',
-    DISCORD_WEBHOOK_URL: 'https://discord/webhook',
+    // Dedicated alerts channel (preferred over the legacy DISCORD_WEBHOOK_URL).
+    NCZ_ALERTS_DISCORD_WEBHOOK_URL: 'https://discord/webhook',
   };
   await runRefresh(env, fakeFetch()); // seed good data
   const goodSlim = await env.DATASET.get(KEYS.slim, 'json');

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -49,8 +49,12 @@
 			"*/15 * * * *"
 		]
 	},
-	// DISCORD_WEBHOOK_URL is a secret (wrangler secret put DISCORD_WEBHOOK_URL),
-	// not committed here. Optional — refresh runs without it.
+	// Refresh-failure alerts post to the dedicated map-alerts channel:
+	//   wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL           (production)
+	//   wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL --env staging
+	// Falls back to the legacy DISCORD_WEBHOOK_URL secret if the new one isn't
+	// set (no alerting gap during the move). Secrets aren't committed here.
+	// Optional — refresh runs without either.
 
 	"env": {
 		// Staging: pulls source files from the dev site, writes to a separate


### PR DESCRIPTION
Follow-up to B7 (PR #794). Adds an independent health alarm for the Data API and
separates operational **alerts** from **submission** notifications.

## Why
B7 gave the site a client-side fallback; in-game mods (the API's primary
consumer) have none. A silent site fallback could **mask an API outage** — the
map looks fine while the mods are broken. This is the independent signal that
closes that gap during the fallback bake period (we remove the client-side path
in ~1 week).

## What
- **`scripts/monitor_api_health.js` + `monitor-api-health.yml`** — every 15 min,
  probe `/v1/health` (Worker alive) + `/v1/locations` (KV populated; not
  `503`/empty) for prod + staging. Retries 3× to absorb blips; Discord-alerts
  **and fails the run** on an outage. (`generated_at` is intentionally *not* a
  liveness signal — the cron only rewrites it on content change.)
- **Webhook split** — alerts (this monitor, `monitor-auto-discovery`, and the
  Worker's refresh-failure alert) now use **`NCZ_ALERTS_DISCORD_WEBHOOK_URL`**;
  submission embeds + their PR-status edits stay on `DISCORD_WEBHOOK_URL`.
  `refresh.js` prefers the new secret, falling back to the old — no alerting gap.
- Docs: `architecture.md` (two-channel table + notifications), `worker/README.md`,
  `wrangler.jsonc`.

## Verified
- `node scripts/monitor_api_health.js` → prod + staging both `✅ serving`, exit 0.
- Simulated outage → 3 retries → red alert embed (naming the fallback-masking
  risk) → exit 1.
- Worker tests: **62 pass**.

## ⚠️ Manual follow-up (Cloudflare, not GitHub)
The Worker's refresh alert reads a **Cloudflare Worker secret**, not the GH
Actions secret. To move it to the alerts channel:
```
wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL              # prod worker
wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL --env staging
```
Until then it falls back to the existing `DISCORD_WEBHOOK_URL` Worker secret (no gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)