### PR TITLE
Release 1.2.0 — Data API launch + site consumes /v1

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -19,11 +19,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install
         run: npm ci

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,49 @@
+name: Deploy Data API Worker
+
+# The API Worker deploys independently of the Pages site, mirroring the
+# site's main/dev split:
+#   push to main → production  (nczoning-api        @ api.nczoning.net)
+#   push to dev  → staging     (nczoning-api-staging @ api-dev.nczoning.net)
+# Path-filtered to worker/**, so unrelated pushes never redeploy the API.
+
+on:
+  push:
+    branches: [main, dev]
+    paths: ['worker/**', '.github/workflows/deploy-api.yml']
+
+concurrency:
+  group: deploy-api-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install
+        run: npm ci
+        working-directory: worker
+
+      - name: Test (gate)
+        run: npm test
+        working-directory: worker
+
+      - name: Deploy production
+        if: github.ref == 'refs/heads/main'
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: worker
+
+      - name: Deploy staging
+        if: github.ref == 'refs/heads/dev'
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: worker
+          environment: staging

--- a/.github/workflows/modify-location-submission.yml
+++ b/.github/workflows/modify-location-submission.yml
@@ -18,9 +18,9 @@ jobs:
           token: ${{ secrets.ACTIONS_PAT }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 24
 
       - name: Process Issue
         id: process

--- a/.github/workflows/monitor-api-health.yml
+++ b/.github/workflows/monitor-api-health.yml
@@ -1,0 +1,41 @@
+name: Monitor Data API Health
+
+# The site consumes /v1 with a client-side fallback (B7), and in-game mods —
+# the API's primary consumer — have NO fallback. So a silent website fallback
+# would mask an API outage. This is the independent alarm: it hits the live API
+# on a schedule and pings Discord (+ fails the run) when it isn't serving.
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'   # every 15 min — matches the dataset cron cadence
+  workflow_dispatch:          # manual trigger (testing / on demand)
+
+permissions:
+  contents: read
+
+# A slow/queued run shouldn't stack; keep only the latest.
+concurrency:
+  group: monitor-api-health
+  cancel-in-progress: true
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Probe /v1 and alert on outage
+        env:
+          # Dedicated map-alerts channel, kept separate from submissions.
+          NCZ_ALERTS_DISCORD_WEBHOOK_URL: ${{ secrets.NCZ_ALERTS_DISCORD_WEBHOOK_URL }}
+          # Both matter: prod (api.nczoning.net) is what in-game mods hit;
+          # staging (api-dev) is what the dev site consumes during the B7 bake,
+          # where an outage would otherwise be hidden by the client fallback.
+          # The script retries 3× before declaring an outage, so a momentary
+          # deploy blip won't page. Drop api-dev here if it ever gets noisy.
+          API_HEALTH_TARGETS: 'https://api.nczoning.net,https://api-dev.nczoning.net'
+        run: node scripts/monitor_api_health.js

--- a/.github/workflows/monitor-api-health.yml
+++ b/.github/workflows/monitor-api-health.yml
@@ -24,9 +24,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 24
 
       - name: Probe /v1 and alert on outage
         env:

--- a/.github/workflows/monitor-auto-discovery.yml
+++ b/.github/workflows/monitor-auto-discovery.yml
@@ -1,11 +1,11 @@
 name: Monitor Auto-Discovery Health
 
-# Auto-discovered pins are parsed client-side from live Nexus descriptions
-# that authors add at any time, and a parse failure is silent (a console
-# log nobody reads). This runs the REAL production parser
-# (assets/js/utils.js) against live Nexus data on a schedule and pings
-# Discord only when a tagged mod is missing from the map — so a broken or
-# incomplete block is caught within a day instead of when an author complains.
+# Authors add NCZoning metadata blocks to their Nexus descriptions at any time,
+# and a parse failure is silent. Since B7 the parsing runs server-side (the Data
+# API cron) and the result is exposed at /v1/meta.skipped — mods tagged NCZoning
+# that aren't excluded/manual and didn't parse. This reads that list and pings
+# Discord when it's non-empty, so a broken block is caught within a day instead
+# of when an author complains. (One source of truth: no client/server drift.)
 
 on:
   schedule:
@@ -21,9 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: 24
 
       - name: Scan NCZoning-tagged mods and alert on parse failures
         env:

--- a/.github/workflows/monitor-auto-discovery.yml
+++ b/.github/workflows/monitor-auto-discovery.yml
@@ -27,5 +27,6 @@ jobs:
 
       - name: Scan NCZoning-tagged mods and alert on parse failures
         env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          # Dedicated map-alerts channel, kept separate from submissions.
+          NCZ_ALERTS_DISCORD_WEBHOOK_URL: ${{ secrets.NCZ_ALERTS_DISCORD_WEBHOOK_URL }}
         run: node scripts/monitor_auto_discovery.js

--- a/.github/workflows/validate-mods.yml
+++ b/.github/workflows/validate-mods.yml
@@ -31,6 +31,12 @@ jobs:
             echo "data_changed=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Setup Node.js
+        if: steps.changes.outputs.data_changed == 'true'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
       - name: Build mods.json
         if: steps.changes.outputs.data_changed == 'true'
         run: node scripts/build_mods.js

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 !/docs/
 !/package.json
 !/package-lock.json
+!/worker/
 !/robots.txt
 !/sitemap.xml
 !/_headers
@@ -50,3 +51,6 @@ assets/glb-source/
 # here for `npm run build-lut`. Repo only commits the runtime asset at
 # assets/data/.
 assets/lut-source/
+
+# Wrangler local dev state
+worker/.wrangler/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2026-07-05
+
+> **Headline: the NC Zoning Data API is live for modders.** A read-only HTTPS API at `api.nczoning.net/v1/` serves the full mod registry — locations, districts and tags — to in-game mods and tools, running the same server-side merge the website used to do in the browser. The website now consumes it too.
+
+### Data API
+
+- Public read-only API at `api.nczoning.net/v1/`: `/locations` (+ `?full=1`), `/locations/{id}`, `/districts`, `/tags`, `/meta`, `/health`. Versioned envelope, `ETag`/`304` caching, and DTO-mappable JSON for the in-game RedData parser. Interactive docs at the API root; reference in `docs/api-reference.md`.
 
 ### Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Infrastructure
+
+- The website now loads the mod registry from the `/v1` Data API instead of running the Nexus auto-discovery merge in the browser; mod thumbnails moved server-side, so the browser no longer calls Nexus. Falls back to the client-side path if the API is unavailable.
+- Added a Data API health monitor (`monitor-api-health.yml`) that alerts if `/v1` stops serving. Operational alerts (API health + auto-discovery) now post to a dedicated Discord channel, separate from submissions.
+
 ## [1.1.0] - 2026-07-04
 
 ### Infrastructure

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1811,47 +1811,32 @@ async function initMap() {
 
   // 3. Fetch and Setup Data
   try {
-    const { mods, tagsDict, excludedIds } = await NCZ.fetchModData();
-
-    // Auto-discover mods tagged "NCZoning" on Nexus (manual entries win on conflict;
-    // excluded ids are never rendered, even with a valid block)
-    const existingNexusIds = new Set(
-      mods
-        .filter((m) => m.nexus_id && !["WIP", "Dummy"].includes(String(m.nexus_id)))
-        .map((m) => String(m.nexus_id)),
-    );
-    const validTagNames = new Set(Object.keys(tagsDict));
-    const { mods: autoMods, meta: autoMeta } = await NCZ.fetchNexusTaggedMods(existingNexusIds, validTagNames, excludedIds);
-    mods.push(...autoMods);
+    // B7: primary data path is the server-built Data API (/v1). It already does
+    // the manual + Nexus auto-discovery merge, district enrichment and thumbnail
+    // resolution server-side, so the browser makes no Nexus calls here. tags.json
+    // stays a local static fetch (same-origin — not the Nexus fragility this
+    // replaces). If the API is unavailable we fall back to the legacy
+    // client-side merge, so the map never regresses during the transition.
+    let mods, nexusThumbs, tagsDict;
+    try {
+      const [apiResult, localTags] = await Promise.all([
+        NCZ.fetchLocationsFromApi(),
+        fetch(NCZ.DATA_TAGS_PATH).then((r) => r.json()),
+      ]);
+      mods = apiResult.mods;
+      nexusThumbs = apiResult.nexusThumbs;
+      tagsDict = localTags;
+      console.log(`Data source: /v1 API — ${mods.length} mods`);
+    } catch (apiErr) {
+      console.warn("Data API unavailable — falling back to client-side merge:", apiErr);
+      const fb = await NCZ.fetchModDataClientSide();
+      mods = fb.mods;
+      nexusThumbs = fb.nexusThumbs;
+      tagsDict = fb.tagsDict;
+      console.log(`Data source: client-side fallback — ${mods.length} mods`);
+    }
 
     modCountEl.textContent = `(${mods.length})`;
-
-    // Pre-seed thumbnail map from auto-discovery (already fetched), then
-    // only call the API for manual mods that still need images
-    const nexusThumbs = {};
-    const manualNexusIds = [];
-    for (const mod of mods) {
-      const nid = String(mod.nexus_id);
-      if (mod._thumbnailUrl || mod._pictureUrl) {
-        nexusThumbs[nid] = { pictureUrl: mod._pictureUrl, thumbnailUrl: mod._thumbnailUrl };
-      } else if (nid && !["wip", "dummy"].includes(nid.toLowerCase()) && !autoMeta[nid]) {
-        manualNexusIds.push(nid);
-      }
-    }
-    const fetchedThumbs = await NCZ.fetchNexusThumbnails(manualNexusIds);
-    Object.assign(nexusThumbs, fetchedThumbs);
-    // Fill in metadata from auto-discovery for manual mods that are NCZoning-tagged
-    for (const [id, data] of Object.entries(autoMeta)) {
-      if (!nexusThumbs[id]) nexusThumbs[id] = data;
-    }
-
-    // Backfill _updatedAt for manual Nexus mods before sorting
-    for (const mod of mods) {
-      if (!mod._updatedAt) {
-        const thumb = nexusThumbs[String(mod.nexus_id)];
-        if (thumb?.updatedAt) mod._updatedAt = thumb.updatedAt;
-      }
-    }
 
     const sortedMods = mods.sort(NCZ.sortModsByUpdated);
     // Hand the same data set to the 3D pin layer — pins won't appear until ThreeScene

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -81,6 +81,19 @@ NCZ.NEXUS_GAME_ID = 3333; // Cyberpunk 2077
 NCZ.NEXUS_GQL_ENDPOINT = "https://api.nexusmods.com/v2/graphql";
 NCZ.NEXUS_BATCH_SIZE = 50;
 
+// Data API (B7) — the site consumes the server-built /v1 dataset instead of
+// running the Nexus auto-discovery merge client-side. Base URL is chosen by
+// hostname so environments line up with the API's: prod → prod API; everything
+// else (dev.nczoning.net, *.pages.dev previews, localhost) → staging API.
+NCZ.API_BASE =
+  location.hostname === "nczoning.net" || location.hostname === "www.nczoning.net"
+    ? "https://api.nczoning.net"
+    : "https://api-dev.nczoning.net";
+// { etag, data } for the full-locations list. Freshness is driven by the ETag
+// (If-None-Match → 304), not a TTL, so this is stored raw rather than via the
+// TTL-based cacheGet/cacheSet.
+NCZ.API_LOCATIONS_CACHE_KEY = "nc_api_locations_full";
+
 // Data paths
 NCZ.DATA_MODS_PATH = "mods.json";
 NCZ.DATA_TAGS_PATH = "data/tags.json";

--- a/assets/js/services.js
+++ b/assets/js/services.js
@@ -274,3 +274,141 @@ NCZ.fetchModData = async function () {
   }
   return { mods, tagsDict, excludedIds };
 };
+
+// ── Data API (B7) ────────────────────────────────────────────────────────────
+
+// Primary data path: fetch the whole registry from the server-built Data API
+// (/v1/locations?full=1). This replaces the client-side manual + Nexus
+// auto-discovery merge — the server already does that merge (plus district
+// enrichment and, since B7, manual-mod thumbnails), so the browser makes ZERO
+// Nexus calls here. Uses If-None-Match/304 against a localStorage-cached body.
+//
+// Returns { mods, nexusThumbs } in the same shapes the rest of app.js expects.
+// THROWS on any failure (network, non-2xx, malformed) so the caller can fall
+// back to the legacy client-side path — never a silent empty map.
+NCZ.fetchLocationsFromApi = async function () {
+  const url = `${NCZ.API_BASE}/v1/locations?full=1`;
+
+  let cached = null;
+  try {
+    cached = JSON.parse(localStorage.getItem(NCZ.API_LOCATIONS_CACHE_KEY) || "null");
+  } catch {
+    cached = null;
+  }
+
+  const headers = {};
+  if (cached?.etag) headers["If-None-Match"] = cached.etag;
+
+  const res = await fetch(url, { headers });
+
+  let rawLocations;
+  let freshEtag = null; // set only on a fresh 200 we should cache
+  if (res.status === 304 && Array.isArray(cached?.data)) {
+    console.log(`Data API: 304 Not Modified — reusing ${cached.data.length} cached locations`);
+    rawLocations = cached.data;
+  } else if (res.ok) {
+    const envelope = await res.json();
+    rawLocations = envelope?.data;
+    if (!Array.isArray(rawLocations)) {
+      throw new Error("Data API: malformed payload (envelope.data is not an array)");
+    }
+    freshEtag = res.headers.get("ETag");
+    console.log(`Data API: loaded ${rawLocations.length} locations (dataset ${String(envelope.dataset_version).slice(0, 8)})`);
+  } else {
+    throw new Error(`Data API: HTTP ${res.status}`);
+  }
+
+  // Guard against a slim payload (an API that doesn't honour ?full=1 — e.g. an
+  // older deploy still on the endpoint). Full entries always carry a
+  // `description` key; if it's missing the popups/cluster list would render
+  // empty, so treat it as unusable and let the caller fall back rather than
+  // ship a degraded map. (Zero locations is a valid dataset — don't trip on it.)
+  // Runs before caching so a rejected slim body is never stored.
+  if (rawLocations.length > 0 && !("description" in rawLocations[0])) {
+    throw new Error("Data API: slim payload (full=1 not honoured) — falling back");
+  }
+
+  if (freshEtag !== null) {
+    try {
+      localStorage.setItem(NCZ.API_LOCATIONS_CACHE_KEY, JSON.stringify({ etag: freshEtag, data: rawLocations }));
+    } catch {
+      /* localStorage quota — fine, we just won't get a 304 next load */
+    }
+  }
+
+  // Map API entries → the internal shape the rest of the app consumes. The API
+  // uses source "manual"/"auto" + snake_case image fields; the app keys off the
+  // legacy `_source` sentinel, `_updatedAt`, and a `nexusThumbs` lookup.
+  const nexusThumbs = {};
+  const mods = rawLocations.map((e) => {
+    const nid = String(e.nexus_id);
+    if (e.thumbnail_url || e.picture_url) {
+      nexusThumbs[nid] = {
+        thumbnailUrl: e.thumbnail_url || null,
+        pictureUrl: e.picture_url || null,
+        updatedAt: e.updated_at || null,
+      };
+    }
+    return {
+      ...e,
+      // Manual mods have no _source (drives the "Suggest Edit" link + no auto
+      // badge); auto mods use the "nexus-auto" sentinel the badges key off.
+      ...(e.source === "auto" ? { _source: "nexus-auto" } : {}),
+      _updatedAt: e.updated_at || null,
+    };
+  });
+
+  return { mods, nexusThumbs };
+};
+
+// Legacy client-side data path (pre-B7): load mods.json + tags.json +
+// excluded_mods.json, merge Nexus auto-discovery, fetch thumbnails via
+// modsByUid, backfill _updatedAt. Retained as the graceful FALLBACK for when
+// the Data API is unavailable; a follow-up deletes it once B7 parity has baked.
+// Returns { mods, nexusThumbs, tagsDict } — the same trio the API path yields
+// (plus tagsDict, which the API path fetches locally alongside).
+NCZ.fetchModDataClientSide = async function () {
+  const { mods, tagsDict, excludedIds } = await NCZ.fetchModData();
+
+  const existingNexusIds = new Set(
+    mods
+      .filter((m) => m.nexus_id && !["WIP", "Dummy"].includes(String(m.nexus_id)))
+      .map((m) => String(m.nexus_id)),
+  );
+  const validTagNames = new Set(Object.keys(tagsDict));
+  const { mods: autoMods, meta: autoMeta } = await NCZ.fetchNexusTaggedMods(
+    existingNexusIds,
+    validTagNames,
+    excludedIds,
+  );
+  mods.push(...autoMods);
+
+  // Pre-seed thumbnails from auto-discovery (already fetched), then only call
+  // the API for manual mods that still need images.
+  const nexusThumbs = {};
+  const manualNexusIds = [];
+  for (const mod of mods) {
+    const nid = String(mod.nexus_id);
+    if (mod._thumbnailUrl || mod._pictureUrl) {
+      nexusThumbs[nid] = { pictureUrl: mod._pictureUrl, thumbnailUrl: mod._thumbnailUrl };
+    } else if (nid && !["wip", "dummy"].includes(nid.toLowerCase()) && !autoMeta[nid]) {
+      manualNexusIds.push(nid);
+    }
+  }
+  const fetchedThumbs = await NCZ.fetchNexusThumbnails(manualNexusIds);
+  Object.assign(nexusThumbs, fetchedThumbs);
+  // Fill in metadata from auto-discovery for manual mods that are NCZoning-tagged.
+  for (const [id, data] of Object.entries(autoMeta)) {
+    if (!nexusThumbs[id]) nexusThumbs[id] = data;
+  }
+
+  // Backfill _updatedAt for manual Nexus mods before the caller sorts.
+  for (const mod of mods) {
+    if (!mod._updatedAt) {
+      const thumb = nexusThumbs[String(mod.nexus_id)];
+      if (thumb?.updatedAt) mod._updatedAt = thumb.updatedAt;
+    }
+  }
+
+  return { mods, nexusThumbs, tagsDict };
+};

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -53,7 +53,8 @@ parser:
 | --- | --- |
 | `GET /v1/health` | `{ status, version }` (uncached) |
 | `GET /v1/locations` | all locations, slim |
-| `GET /v1/locations/{id}` | one full entry (adds `description`, `credits`), or 404 |
+| `GET /v1/locations?full=1` | all locations, full (adds `description`, `credits`, image URLs) — one request for everything |
+| `GET /v1/locations/{id}` | one full entry (adds `description`, `credits`, image URLs), or 404 |
 | `GET /v1/districts` | district/subdistrict hierarchy (flat boundaries + centroids) |
 | `GET /v1/tags` | tag id → description |
 | `GET /v1/meta` | `{ counts, discovery_stale, skipped }` |
@@ -76,7 +77,13 @@ A location (slim):
 }
 ```
 
-`/v1/locations/{id}` adds `description` and (if present) `credits`.
+Full entries (`/v1/locations/{id}` or the whole list via `/v1/locations?full=1`)
+add `description`, `credits` (if present), and the Nexus image fields
+`thumbnail_url` / `picture_url` / `updated_at` (each `null` when unknown — e.g.
+WIP/Dummy entries). Images live on the full entry only; the slim list stays
+lean for the in-game RedData consumer. The `?full=1` list carries its own ETag
+(the dataset version suffixed `-full`), so caching it never collides with the
+slim list.
 
 ## Caching
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,153 @@
+# NC Zoning Data API — reference
+
+Read-only API serving the NC Zoning Board registry (Cyberpunk 2077 location
+mods) to in-game mods and the website.
+
+- **Production:** `https://api.nczoning.net`
+- **Staging:** `https://api-dev.nczoning.net` (serves the dev site's data)
+- **Interactive docs:** open the base URL in a browser (rendered from
+  [`worker/openapi.json`](../worker/openapi.json)).
+
+Everything here is GET-only, unauthenticated, HTTPS-only (TLS 1.2+), and
+CORS-open.
+
+## The envelope
+
+Every response is wrapped:
+
+```json
+{
+  "schema": 1,
+  "generated_at": "2026-07-05T00:00:00.000Z",
+  "dataset_version": "87cc60cf7332…",
+  "data": <route-specific>
+}
+```
+
+`dataset_version` is a content hash of the whole dataset. It's also the
+`ETag`, so it's how you detect changes (see [Caching](#caching)).
+
+## Contract rules (why the JSON looks the way it does)
+
+The shapes are frozen to stay parseable by the in-game **RedData** JSON
+parser:
+
+- **No arrays-of-arrays.** `coordinates` is a flat `[X, Y, Z]`; district
+  boundaries are flattened to `[x1, y1, x2, y2, …]`. This maps cleanly to
+  redscript `array<Float>`.
+- **Property names are case-sensitive** and stable — they match DTO field
+  names exactly.
+- **Coordinates are raw CET world values** — the same numbers
+  `GetWorldPosition()` returns in-game. No transform needed to teleport to
+  them or compare against the player.
+- **Stable ids:** manual entries keep a UUID; auto-discovered mods get
+  `nexus-<nexus_id>`. Safe to bookmark.
+- **`district` is never null** — anywhere outside every district polygon is
+  Badlands (the game's own default). `subdistrict` may be null.
+- **Additive versioning:** new fields may appear within `/v1/`; breaking
+  changes would ship as `/v2/`.
+
+## Routes
+
+| Route | Returns |
+| --- | --- |
+| `GET /v1/health` | `{ status, version }` (uncached) |
+| `GET /v1/locations` | all locations, slim |
+| `GET /v1/locations/{id}` | one full entry (adds `description`, `credits`), or 404 |
+| `GET /v1/districts` | district/subdistrict hierarchy (flat boundaries + centroids) |
+| `GET /v1/tags` | tag id → description |
+| `GET /v1/meta` | `{ counts, discovery_stale, skipped }` |
+
+A location (slim):
+
+```json
+{
+  "id": "nexus-27618",
+  "name": "Atari Canyon - Blade Runner",
+  "nexus_id": "27618",
+  "coordinates": [-2229.57, 3618.96, 12.22],
+  "yaw": 180.0,
+  "category": "new-location",
+  "tags": ["nczoning", "corpo"],
+  "authors": ["SomeModder"],
+  "source": "auto",
+  "district": "City Center",
+  "subdistrict": "Corpo Plaza"
+}
+```
+
+`/v1/locations/{id}` adds `description` and (if present) `credits`.
+
+## Caching
+
+Dataset routes send:
+
+```
+ETag: "87cc60cf7332…"
+Cache-Control: public, max-age=300, stale-while-revalidate=3600
+```
+
+Store the `dataset_version` from your last fetch and send it back as
+`If-None-Match`. If nothing changed you get a **`304 Not Modified`** with no
+body — the cheap path. The data changes at most a few times a day, so one
+fetch per game session (plus an optional occasional re-check) is plenty.
+
+Before the very first dataset build a route returns **`503 not_ready`** —
+retry shortly.
+
+## Using it from a mod
+
+The API is designed for the **RedHttpClient + RedData** stack (see the
+NCZoningCore framework). Minimal redscript:
+
+```swift
+import RedHttpClient.*
+import RedData.Json.*
+
+// DTO — field names match the JSON exactly (case-sensitive).
+public class NCZLocation {
+  let id: String;
+  let name: String;
+  let coordinates: array<Float>;   // [X, Y, Z] raw CET
+  let category: String;
+  let district: String;
+  let subdistrict: String;
+}
+
+public class NCZExample extends ScriptableSystem {
+  private func Fetch() {
+    let cb = HttpCallback.Create(this, n"OnLocations");
+    AsyncHttpClient.Get(cb, "https://api.nczoning.net/v1/locations");
+  }
+
+  private cb func OnLocations(response: ref<HttpResponse>) {
+    // Runs on a worker thread — parse/store here, apply game changes on the
+    // next tick via DelaySystem.
+    let root = response.GetJson();          // the envelope
+    let data = (root as JsonObject).GetKey("data") as JsonArray;
+    let i = 0u;
+    while i < data.GetSize() {
+      let loc = FromJson(data.GetItem(i) as JsonObject, n"NCZLocation") as NCZLocation;
+      FTLog(s"\(loc.name) @ \(loc.district)");
+      i += 1u;
+    }
+  }
+}
+```
+
+From **CET (Lua)**, use `NewProxy` for the callback and CET's own
+`json.decode` on `response:GetText()` if you're not using RedData.
+
+**Threading note:** RedHttpClient delivers callbacks on a worker thread, not
+the game thread. Parse and store there; bounce any game/UI mutation to the
+next tick (DelaySystem / a Codeware event). Send `If-None-Match` to avoid
+re-downloading unchanged data.
+
+## Notes
+
+- The API never talks to Nexus on your behalf at request time — a cron
+  rebuilds the dataset every 15 minutes and serves it from cache, so you're
+  shielded from Nexus API hiccups. If a refresh fails, `meta.discovery_stale`
+  is `true` and the last-known-good data is served.
+- `meta.skipped` lists mods tagged `NCZoning` whose metadata block didn't
+  parse — useful if you're a mod author debugging why yours isn't appearing.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -152,13 +152,21 @@ The auto-PR pipeline and Discord notifications require two secrets configured in
 | Secret | Value |
 | --- | --- |
 | `ACTIONS_PAT` | A GitHub Personal Access Token (fine-grained) with `Contents: Read/Write` and `Pull requests: Read/Write` on this repo |
-| `DISCORD_WEBHOOK_URL` | A Discord channel webhook URL (channel Settings → Integrations → Webhooks) |
+| `DISCORD_WEBHOOK_URL` | Webhook for the **submissions** channel — new/modified submission embeds and their PR-status edits (channel Settings → Integrations → Webhooks) |
+| `NCZ_ALERTS_DISCORD_WEBHOOK_URL` | Webhook for the dedicated **map-alerts** channel — auto-discovery parse failures and Data API health/outage alerts, kept separate from submissions |
 
 > **Why ACTIONS_PAT?** GitHub's `GITHUB_TOKEN` cannot trigger other workflow runs (a security design). Using a PAT for `create-pull-request` allows the `validate-json` check to fire automatically on the generated PR.
 
 ### Discord Notifications
 
-Two workflows handle Discord messaging:
+Two channels, two webhooks. **Submissions** (`DISCORD_WEBHOOK_URL`) — the mod
+submission lifecycle:
 
 - **`auto-pr-submission.yml`** — Posts a new embed when a submission PR is created (status: ⏳ Awaiting review). Stores the Discord message ID as a hidden comment on the issue.
-- **`notify-discord-pr-status.yml`** — When the PR is merged or closed, edits the original embed in-place to show the outcome (✅ Approved or ❌ Closed).
+- **`modify-location-submission.yml`** — Posts an embed for modification/removal requests.
+- **`notify-discord-pr-status.yml`** — When the PR is merged or closed, edits the original embed in-place to show the outcome (✅ Approved or ❌ Closed). Must use the same webhook that posted the message.
+
+**Alerts** (`NCZ_ALERTS_DISCORD_WEBHOOK_URL`) — operational health, separate channel:
+
+- **`monitor-auto-discovery.yml`** — Daily scan; alerts when a NCZoning-tagged mod fails to parse and isn't covered by a manual entry.
+- **`monitor-api-health.yml`** — Every 15 min; alerts when the Data API (`/v1`) isn't serving. The Worker's own refresh-failure alert (`worker/src/refresh.js`) posts here too (Cloudflare Worker secret, set separately via `wrangler secret put`).

--- a/docs/data-api-plan.md
+++ b/docs/data-api-plan.md
@@ -31,9 +31,13 @@ The static `mods.json` is not enough for game clients, for three reasons:
   `data/subdistricts.json` are already in CET world coordinates), then write
   to KV only when the content hash changes.
 - **Failure posture:** keep last-known-good data, set `discovery_stale=true`,
-  alert Discord (same pattern as `monitor-auto-discovery.yml`). Never serve an
+  alert Discord on the dedicated map-alerts channel
+  (`NCZ_ALERTS_DISCORD_WEBHOOK_URL`, separate from submissions). Never serve an
   empty or partial dataset. Git remains the source of truth for manual
-  entries; the Worker only reads deployed CDN artifacts.
+  entries; the Worker only reads deployed CDN artifacts. A separate
+  `monitor-api-health.yml` GitHub Action probes `/v1` every 15 min and alerts
+  on the same channel if the API stops serving (independent of the Worker's own
+  alert — catches cases where the Worker can't alert for itself).
 - **Free tier:** ~1 conditional GET per player session against a 100k req/day
   cap; KV writes at most 96/day. Passes with a huge margin.
 

--- a/docs/nczoning-auto-discovery.md
+++ b/docs/nczoning-auto-discovery.md
@@ -167,8 +167,8 @@ The format is a flat `{ "nexusId": "reason" }` object (same shape as `data/tags.
 
 An excluded id is honoured in two places:
 
-1. **Auto-discovery (`services.js`)** — the mod is never rendered as a pin, *even if its block parses correctly*. This is what stops a mistakenly-tagged mod that happens to have valid coordinates from showing up.
-2. **Health monitor (`scripts/monitor_auto_discovery.js`)** — the mod is skipped, so the daily Discord alert stops flagging it. Without this, an intentionally-excluded mod with no block would be reported every single day.
+1. **The Data API merge (`worker/src/merge.js`)** — the mod is never rendered as a pin, *even if its block parses correctly*, and it's kept out of `/v1/meta.skipped`. This is what stops a mistakenly-tagged mod that happens to have valid coordinates from showing up. (The site's client-side fallback in `services.js` honours the same list.)
+2. **Health monitor (`scripts/monitor_auto_discovery.js`)** — reads `/v1/meta.skipped`, which the API has already filtered, so an excluded mod is never flagged. Without the exclusion an intentionally-excluded mod with no block would be reported every day.
 
 To exclude a mod, add its Nexus id and a short reason to `data/excluded_mods.json` and open a PR. To re-include it later, delete the entry.
 

--- a/docs/submission-pipeline.md
+++ b/docs/submission-pipeline.md
@@ -43,6 +43,8 @@ This workflow triggers whenever the `mod-submission` label is applied to an issu
 
 Within the same `auto-pr-submission.yml` workflow, the bot reaches out to a Discord channel (using the `DISCORD_WEBHOOK_URL` secret) with an embedded message noting that a PR is awaiting review.
 
+> `DISCORD_WEBHOOK_URL` is the **submissions** channel. Operational alerts (health/monitoring) go to a separate channel via `NCZ_ALERTS_DISCORD_WEBHOOK_URL` — see [architecture.md](architecture.md#discord-notifications).
+
 **The Clever Part:**
 To allow the bot to update this exact discord message later on, the webhook returns a unique `message_id`. The bot saves this ID as a hidden HTML comment at the bottom of the original GitHub Issue `<!-- discord_message_id: XXXXX -->`.
 

--- a/scripts/monitor_api_health.js
+++ b/scripts/monitor_api_health.js
@@ -174,12 +174,15 @@ async function postDiscord(results) {
 
     if (anyOutage) {
       console.error("\nHealth check FAILED — at least one target is not serving.");
-      process.exit(1);
+      process.exitCode = 1;
+    } else {
+      console.log("\nAll targets healthy.");
     }
-    console.log("\nAll targets healthy.");
-    process.exit(0);
   } catch (err) {
     console.error("Health monitor failed (infrastructure error):", err.message);
-    process.exit(1);
+    process.exitCode = 1;
   }
 })();
+// NOTE: we set process.exitCode and let the event loop drain rather than calling
+// process.exit(), which can trip a libuv assertion on Windows when fetch's
+// keep-alive sockets are still closing.

--- a/scripts/monitor_api_health.js
+++ b/scripts/monitor_api_health.js
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * Data API health monitor.
+ *
+ * Why this exists: the website consumes /v1 with a graceful fallback to the
+ * client-side merge (B7), and the API's PRIMARY consumer — in-game mods — has
+ * NO fallback at all. So a silent website fallback would MASK an API outage:
+ * the map looks fine while the mods are broken. This is the independent alarm
+ * that closes that gap. It hits the live API on a schedule and pings Discord
+ * (+ fails the workflow run, a second visible signal) when the API isn't
+ * actually usable.
+ *
+ * What it checks per target:
+ *   1. GET /v1/health   → 200 and data.status === "ok"   (the Worker is alive)
+ *   2. GET /v1/locations → 200 and a non-empty array       (KV populated; not
+ *      503 not_ready, not an empty/wiped dataset)
+ *   3. GET /v1/meta      → discovery_stale is reported as CONTEXT only, not a
+ *      hard fail: the cron already Discord-alerts on refresh failure, and it's
+ *      still serving last-known-good, so it's a warning, not an outage.
+ *
+ * NOTE: envelope.generated_at is deliberately NOT used as a freshness/liveness
+ * signal — the cron only rewrites it when the dataset CONTENT changes (a few
+ * times a day), so a healthy-but-idle API legitimately has an hours-old
+ * generated_at. There is no served "last cron ran" timestamp to check.
+ *
+ * Run: node scripts/monitor_api_health.js
+ * Targets: API_HEALTH_TARGETS (comma-separated), default https://api.nczoning.net
+ * Alerts:  NCZ_ALERTS_DISCORD_WEBHOOK_URL — the dedicated map-alerts channel,
+ *          kept separate from the submissions webhook (prints a preview instead
+ *          of sending if unset).
+ * Exit:    0 when every target is serving; 1 on any outage or infra error
+ *          (so the Actions run goes red — a second signal beside Discord).
+ */
+
+const DEFAULT_TARGETS = ["https://api.nczoning.net"];
+const RETRIES = 3;        // transient blips shouldn't page anyone
+const RETRY_DELAY_MS = 4000;
+const FETCH_TIMEOUT_MS = 15000;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function fetchJson(url) {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal, headers: { "User-Agent": "nczoning-health-monitor" } });
+    let json = null;
+    try { json = await res.json(); } catch { /* non-JSON body — leave null */ }
+    return { ok: res.ok, status: res.status, json };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Retry a check until it passes or RETRIES is exhausted. `check` returns null
+// on success or a string describing the failure.
+async function withRetry(label, check) {
+  let last = "unknown";
+  for (let attempt = 1; attempt <= RETRIES; attempt++) {
+    try {
+      const problem = await check();
+      if (!problem) return null;
+      last = problem;
+    } catch (err) {
+      last = err.name === "AbortError" ? `timeout after ${FETCH_TIMEOUT_MS}ms` : err.message;
+    }
+    if (attempt < RETRIES) {
+      console.log(`  ${label}: attempt ${attempt} failed (${last}) — retrying`);
+      await sleep(RETRY_DELAY_MS);
+    }
+  }
+  return last;
+}
+
+async function checkTarget(base) {
+  const issues = [];   // hard failures → outage
+  const warnings = []; // soft (informational) signals
+
+  const healthProblem = await withRetry("health", async () => {
+    const { ok, status, json } = await fetchJson(`${base}/v1/health`);
+    if (!ok) return `HTTP ${status}`;
+    if (json?.data?.status !== "ok") return `status=${JSON.stringify(json?.data?.status)}`;
+    return null;
+  });
+  if (healthProblem) issues.push(`/v1/health unreachable (${healthProblem})`);
+
+  const locationsProblem = await withRetry("locations", async () => {
+    const { ok, status, json } = await fetchJson(`${base}/v1/locations`);
+    if (!ok) return status === 503 ? "503 not_ready (dataset not built)" : `HTTP ${status}`;
+    if (!Array.isArray(json?.data)) return "data is not an array";
+    if (json.data.length === 0) return "dataset is empty";
+    return null;
+  });
+  if (locationsProblem) issues.push(`/v1/locations not serving data (${locationsProblem})`);
+
+  // discovery_stale is context, not an outage — the cron self-alerts on it.
+  try {
+    const { ok, json } = await fetchJson(`${base}/v1/meta`);
+    if (ok && json?.data?.discovery_stale) {
+      warnings.push("discovery_stale=true (last Nexus refresh failed; serving last-known-good)");
+    }
+  } catch { /* meta is best-effort context */ }
+
+  return { base, issues, warnings };
+}
+
+async function postDiscord(results) {
+  const url = process.env.NCZ_ALERTS_DISCORD_WEBHOOK_URL;
+  const down = results.filter((r) => r.issues.length);
+
+  const fields = results
+    .filter((r) => r.issues.length || r.warnings.length)
+    .map((r) => ({
+      name: `${r.issues.length ? "🔴" : "🟠"} ${r.base}`,
+      value: [
+        ...r.issues.map((i) => `• **OUTAGE:** ${i}`),
+        ...r.warnings.map((w) => `• ${w}`),
+      ].join("\n"),
+    }));
+
+  const body = {
+    embeds: [
+      {
+        title: down.length
+          ? `🔴 Data API outage — ${down.length} environment${down.length === 1 ? "" : "s"} not serving`
+          : `🟠 Data API warning`,
+        description: down.length
+          ? "The API is not usable by consumers (in-game mods have no fallback). " +
+            "The website may look fine via its client-side fallback — this is that hidden failure surfacing."
+          : "The API is serving but a soft signal fired (see below).",
+        color: down.length ? 15158332 /* red */ : 15105570 /* amber */,
+        fields,
+        footer: { text: "NC Zoning Board • Data API health monitor" },
+      },
+    ],
+  };
+
+  if (!url) {
+    console.log("\n--- NCZ_ALERTS_DISCORD_WEBHOOK_URL not set — preview of payload that would be sent ---");
+    console.log(JSON.stringify(body, null, 2));
+    console.log("--- end preview (nothing was sent) ---");
+    return;
+  }
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(`Discord webhook HTTP ${res.status}: ${await res.text()}`);
+  console.log("Posted Discord health alert.");
+}
+
+(async () => {
+  try {
+    const targets = (process.env.API_HEALTH_TARGETS || DEFAULT_TARGETS.join(","))
+      .split(",")
+      .map((s) => s.trim().replace(/\/$/, ""))
+      .filter(Boolean);
+
+    console.log(`Checking ${targets.length} target(s): ${targets.join(", ")}`);
+    const results = [];
+    for (const base of targets) {
+      console.log(`\n${base}`);
+      const r = await checkTarget(base);
+      results.push(r);
+      if (r.issues.length) console.log(`  ❌ OUTAGE: ${r.issues.join("; ")}`);
+      else console.log("  ✅ serving");
+      for (const w of r.warnings) console.log(`  ⚠️  ${w}`);
+    }
+
+    const anyOutage = results.some((r) => r.issues.length);
+    const anyWarning = results.some((r) => r.warnings.length);
+    if (anyOutage || anyWarning) await postDiscord(results);
+
+    if (anyOutage) {
+      console.error("\nHealth check FAILED — at least one target is not serving.");
+      process.exit(1);
+    }
+    console.log("\nAll targets healthy.");
+    process.exit(0);
+  } catch (err) {
+    console.error("Health monitor failed (infrastructure error):", err.message);
+    process.exit(1);
+  }
+})();

--- a/scripts/monitor_auto_discovery.js
+++ b/scripts/monitor_auto_discovery.js
@@ -12,7 +12,8 @@
  * it can never drift from what users actually experience.
  *
  * Run: node scripts/monitor_auto_discovery.js
- * Posts a Discord embed (DISCORD_WEBHOOK_URL) only when ≥1 NCZoning-
+ * Posts a Discord embed (NCZ_ALERTS_DISCORD_WEBHOOK_URL — the dedicated
+ * map-alerts channel, separate from submissions) only when ≥1 NCZoning-
  * tagged mod fails to parse and isn't covered by a manual registry
  * entry. Exit 0 on a clean run OR detected-bad-mods (it's a report,
  * not a gate); exit 1 only on an infrastructure error.
@@ -138,7 +139,7 @@ async function fetchTaggedMods({ endpoint, gameId, batchSize }) {
 }
 
 async function postDiscord(failures, total, excludedCount) {
-  const url = process.env.DISCORD_WEBHOOK_URL;
+  const url = process.env.NCZ_ALERTS_DISCORD_WEBHOOK_URL;
   const MAX_PER_GROUP = 12;
   const fmt = (group) => {
     const lines = group
@@ -198,7 +199,7 @@ async function postDiscord(failures, total, excludedCount) {
   if (!url) {
     // No webhook (local run / dry run): print the exact payload that
     // would be POSTed so the alert can be reviewed without sending it.
-    console.log("\n--- DISCORD_WEBHOOK_URL not set — preview of payload that would be sent ---");
+    console.log("\n--- NCZ_ALERTS_DISCORD_WEBHOOK_URL not set — preview of payload that would be sent ---");
     console.log(JSON.stringify(body, null, 2));
     console.log("--- end preview (nothing was sent) ---");
     return;

--- a/scripts/monitor_auto_discovery.js
+++ b/scripts/monitor_auto_discovery.js
@@ -2,203 +2,57 @@
 /**
  * Auto-discovery health monitor.
  *
- * Why this exists and not a unit test: auto-discovered pins are parsed
- * client-side from *live* Nexus descriptions that authors add at any
- * time, and a parse failure is silent (a console.log nobody reads). A
- * fixture test only catches us regressing a *known* case on a parser
- * edit; it cannot catch a new author pasting a format we've never seen.
- * So this runs on a schedule against live data, importing the **real
- * production parser** (`assets/js/utils.js` → `parseNcZoningBlock`) so
- * it can never drift from what users actually experience.
+ * Purpose: catch NCZoning-tagged mods that AREN'T showing on the map because
+ * their metadata block is missing or unparseable — so a broken block is caught
+ * within a day instead of when an author complains.
+ *
+ * Since B7 the block parsing + merge runs SERVER-SIDE (the Data API cron), and
+ * the API exposes the result at `/v1/meta.skipped`: every mod tagged NCZoning
+ * that isn't excluded, isn't a manual entry, and whose block didn't parse —
+ * exactly the "tagged but not on the map" set. Reading that instead of
+ * re-parsing client-side means ONE source of truth (no client/server parser
+ * drift) and no live Nexus fetch. Before B7 this script ran the client-side
+ * `assets/js/utils.js` parser directly; that parser is now only the site's
+ * fallback, so testing it here would drift from what actually builds the map.
  *
  * Run: node scripts/monitor_auto_discovery.js
- * Posts a Discord embed (NCZ_ALERTS_DISCORD_WEBHOOK_URL — the dedicated
- * map-alerts channel, separate from submissions) only when ≥1 NCZoning-
- * tagged mod fails to parse and isn't covered by a manual registry
- * entry. Exit 0 on a clean run OR detected-bad-mods (it's a report,
- * not a gate); exit 1 only on an infrastructure error.
+ * Target: API_META_URL (default https://api.nczoning.net/v1/meta)
+ * Alerts: NCZ_ALERTS_DISCORD_WEBHOOK_URL — the dedicated map-alerts channel,
+ *         separate from submissions (prints a preview instead if unset).
+ * Exit 0 on a clean run OR flagged mods (it's a report, not a gate); exit 1
+ * only on an infrastructure error.
  */
 
-const fs = require("fs");
-const path = require("path");
-
-const ROOT = path.join(__dirname, "..");
+const API_META_URL = process.env.API_META_URL || "https://api.nczoning.net/v1/meta";
 const NEXUS_MOD_URL = (id) => `https://www.nexusmods.com/cyberpunk2077/mods/${id}`;
 
-// --- Load the real production parser (drift-proof by construction) -----------
-function loadParser() {
-  const src = fs.readFileSync(path.join(ROOT, "assets/js/utils.js"), "utf8");
-  const NCZ = {};
-  // utils.js assigns onto a bare `NCZ`; parseNcZoningBlock is self-contained
-  // (regex + the validTagNames Set), so no other NCZ members are needed.
-  new Function("NCZ", src)(NCZ);
-  if (typeof NCZ.parseNcZoningBlock !== "function") {
-    throw new Error("parseNcZoningBlock not found after loading assets/js/utils.js");
-  }
-  return NCZ.parseNcZoningBlock;
-}
-
-// --- Pull stable Nexus constants from constants.js source (no eval) ----------
-function loadNexusConstants() {
-  const src = fs.readFileSync(path.join(ROOT, "assets/js/constants.js"), "utf8");
-  const num = (name, fallback) => {
-    const m = src.match(new RegExp(`NCZ\\.${name}\\s*=\\s*(\\d+)`));
-    return m ? Number(m[1]) : fallback;
-  };
-  const str = (name, fallback) => {
-    const m = src.match(new RegExp(`NCZ\\.${name}\\s*=\\s*["']([^"']+)["']`));
-    return m ? m[1] : fallback;
-  };
-  return {
-    endpoint: str("NEXUS_GQL_ENDPOINT", "https://api.nexusmods.com/v2/graphql"),
-    gameId: num("NEXUS_GAME_ID", 3333),
-    batchSize: num("NEXUS_BATCH_SIZE", 50),
-  };
-}
-
-// --- Valid tag names (data/tags.json is a flat { id: description } object) ---
-function loadValidTagNames() {
-  const tags = JSON.parse(fs.readFileSync(path.join(ROOT, "data/tags.json"), "utf8"));
-  return new Set(Object.keys(tags));
-}
-
-// --- Manually-registered numeric nexus_ids (mirror services.js precedence) ---
-// A tagged mod that's also in the manual registry intentionally may have no
-// parseable block — manual data wins — so excluding it avoids false alarms.
-function loadManualNexusIds() {
-  const dir = path.join(ROOT, "data/locations");
-  const ids = new Set();
-  for (const file of fs.readdirSync(dir)) {
-    if (!file.endsWith(".json")) continue;
-    try {
-      const mod = JSON.parse(fs.readFileSync(path.join(dir, file), "utf8"));
-      if (/^\d+$/.test(String(mod.nexus_id))) ids.add(String(mod.nexus_id));
-    } catch {
-      /* a malformed location file is validate-mods.yml's problem, not ours */
-    }
-  }
-  return ids;
-}
-
-// --- Intentionally-excluded nexus_ids (data/excluded_mods.json) --------------
-// Mods tagged NCZoning by mistake, or too minor to map, that we deliberately
-// keep off the board. They have no manual entry and never will, so without
-// this list the monitor would flag them every single day. Flat
-// { "nexusId": "reason" } object — same shape as data/tags.json.
-function loadExcludedNexusIds() {
-  const file = path.join(ROOT, "data/excluded_mods.json");
-  try {
-    const obj = JSON.parse(fs.readFileSync(file, "utf8"));
-    return new Set(Object.keys(obj).map(String));
-  } catch {
-    // No list (or unreadable) just means nothing is excluded.
-    return new Set();
-  }
-}
-
-// --- Fetch every NCZoning-tagged mod (same query/pagination as services.js) --
-async function fetchTaggedMods({ endpoint, gameId, batchSize }) {
-  const query = `
-    query NCZoningMods($filter: ModsFilter!, $count: Int!, $offset: Int!) {
-      mods(filter: $filter, count: $count, offset: $offset) {
-        nodes { modId name description }
-        totalCount
-      }
-    }`;
-  const out = [];
-  let offset = 0;
-  let total = Infinity;
-  while (offset < total) {
-    const res = await fetch(endpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        query,
-        variables: {
-          filter: {
-            gameId: [{ value: String(gameId) }],
-            tag: [{ value: "NCZoning" }],
-          },
-          count: batchSize,
-          offset,
-        },
-      }),
-    });
-    if (!res.ok) throw new Error(`Nexus API HTTP ${res.status}`);
-    const json = await res.json();
-    if (json.errors) throw new Error(`Nexus API errors: ${JSON.stringify(json.errors)}`);
-    const page = json?.data?.mods;
-    if (!page) throw new Error("Nexus API: no mods page in response");
-    total = page.totalCount ?? 0;
-    const nodes = page.nodes || [];
-    out.push(...nodes);
-    if (nodes.length === 0 || nodes.length < batchSize) break;
-    offset += nodes.length;
-  }
-  return out;
-}
-
-async function postDiscord(failures, total, excludedCount) {
+async function postDiscord(skipped) {
   const url = process.env.NCZ_ALERTS_DISCORD_WEBHOOK_URL;
-  const MAX_PER_GROUP = 12;
-  const fmt = (group) => {
-    const lines = group
-      .slice(0, MAX_PER_GROUP)
-      .map((f) => `• [${f.name || "Unknown"}](${NEXUS_MOD_URL(f.modId)}) — \`${f.modId}\``);
-    if (group.length > MAX_PER_GROUP) lines.push(`…and ${group.length - MAX_PER_GROUP} more.`);
-    return lines.join("\n");
-  };
-
-  // Two distinct signals — keep them separate so the alert is actionable:
-  // a broken block needs the author to fix it; a missing block may just be
-  // a speculative/mistaken tag or an author who never finished setup.
-  const malformed = failures.filter((f) => f.attemptedBlock);
-  const noBlock = failures.filter((f) => !f.attemptedBlock);
-  const n = failures.length;
-
-  const fields = [];
-  if (malformed.length) {
-    fields.push({
-      name: `🔧 Malformed block — ${malformed.length}`,
-      value:
-        `Author added an \`NCZoning:\` block but it failed to parse. ` +
-        `**Action:** ask them to regenerate it with the in-app BBCode Generator.\n` +
-        fmt(malformed),
-    });
-  }
-  if (noBlock.length) {
-    fields.push({
-      name: `🏷️ Tagged, no block — ${noBlock.length}`,
-      value:
-        `Tagged \`NCZoning\` but the description has no metadata block. ` +
-        `**Action:** add a manual registry entry if it belongs on the map, ` +
-        `or add its id to \`data/excluded_mods.json\` to stop this alert.\n` +
-        fmt(noBlock),
-    });
-  }
-
-  const excludedNote = excludedCount
-    ? ` ${excludedCount} mod${excludedCount === 1 ? "" : "s"} on the exclusion list ${excludedCount === 1 ? "is" : "are"} ignored.`
-    : "";
+  const MAX = 12;
+  const n = skipped.length;
+  const lines = skipped
+    .slice(0, MAX)
+    .map((m) => `• [${m.name || "Unknown"}](${NEXUS_MOD_URL(m.nexus_id)}) — \`${m.nexus_id}\``);
+  if (n > MAX) lines.push(`…and ${n - MAX} more.`);
 
   const body = {
     embeds: [
       {
         title: `⚠️ Auto-discovery: ${n} NCZoning mod${n === 1 ? "" : "s"} tagged but not on the map`,
         description:
-          `${n} mod${n === 1 ? " is" : "s are"} tagged **NCZoning** on Nexus ` +
-          `but not showing as ${n === 1 ? "a live pin" : "live pins"}, because the ` +
-          `metadata block is missing or unreadable. Each entry below says what to do.` +
-          excludedNote,
+          `${n} mod${n === 1 ? " is" : "s are"} tagged **NCZoning** on Nexus but the ` +
+          `Data API skipped ${n === 1 ? "it" : "them"} — the metadata block is missing or ` +
+          `didn't parse. **Action:** ask the author to regenerate the block with the in-app ` +
+          `BBCode Generator, add a manual registry entry if it belongs on the map, or add the ` +
+          `id to \`data/excluded_mods.json\` to stop this alert.\n\n` +
+          lines.join("\n"),
         color: 15105570, // amber/orange — warning, not error
-        fields,
-        footer: { text: `NC Zoning Board • scanned ${total} NCZoning-tagged mod${total === 1 ? "" : "s"}` },
+        footer: { text: "NC Zoning Board • source: /v1/meta.skipped" },
       },
     ],
   };
+
   if (!url) {
-    // No webhook (local run / dry run): print the exact payload that
-    // would be POSTed so the alert can be reviewed without sending it.
     console.log("\n--- NCZ_ALERTS_DISCORD_WEBHOOK_URL not set — preview of payload that would be sent ---");
     console.log(JSON.stringify(body, null, 2));
     console.log("--- end preview (nothing was sent) ---");
@@ -209,56 +63,38 @@ async function postDiscord(failures, total, excludedCount) {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!res.ok) {
-    throw new Error(`Discord webhook HTTP ${res.status}: ${await res.text()}`);
-  }
-  console.log(`Posted Discord alert for ${failures.length} unparseable mod(s).`);
+  if (!res.ok) throw new Error(`Discord webhook HTTP ${res.status}: ${await res.text()}`);
+  console.log(`Posted Discord alert for ${n} skipped mod(s).`);
 }
 
 (async () => {
   try {
-    const parse = loadParser();
-    const consts = loadNexusConstants();
-    const validTagNames = loadValidTagNames();
-    const manualIds = loadManualNexusIds();
-    const excludedIds = loadExcludedNexusIds();
+    const res = await fetch(API_META_URL, { headers: { "User-Agent": "nczoning-auto-discovery-monitor" } });
+    if (!res.ok) throw new Error(`GET ${API_META_URL} → HTTP ${res.status}`);
+    const json = await res.json();
 
-    const mods = await fetchTaggedMods(consts);
-    console.log(
-      `Scanned ${mods.length} NCZoning-tagged mods ` +
-        `(${manualIds.size} manual, ${excludedIds.size} excluded).`,
-    );
+    const skipped = json?.data?.skipped;
+    if (!Array.isArray(skipped)) throw new Error("meta.skipped missing or not an array");
 
-    const failures = [];
-    for (const mod of mods) {
-      const id = String(mod.modId);
-      if (manualIds.has(id)) continue; // manual registry covers it
-      if (excludedIds.has(id)) continue; // intentionally kept off the map
-      if (!parse(mod.description, validTagNames)) {
-        // A `NCZoning` mention means the author attempted a block that
-        // failed to parse (actionable: fix it) vs. no block at all
-        // (a bare/mistaken tag).
-        const attemptedBlock = /NCZoning/i.test(mod.description || "");
-        failures.push({ modId: id, name: mod.name, attemptedBlock });
-      }
+    if (json.data.discovery_stale) {
+      // Still worth reporting — the last-known-good skipped list is what the map reflects.
+      console.log("Note: discovery_stale=true — the API is serving last-known-good data.");
     }
 
-    if (failures.length === 0) {
-      console.log("✅ All non-manual tagged mods parse cleanly.");
-    } else {
-      const malformed = failures.filter((f) => f.attemptedBlock);
-      const noBlock = failures.filter((f) => !f.attemptedBlock);
-      console.log(
-        `❌ ${failures.length} missing (${malformed.length} malformed block, ${noBlock.length} no block):`,
-      );
-      for (const f of failures) {
-        console.log(`   - ${f.modId}  [${f.attemptedBlock ? "malformed" : "no-block "}]  ${f.name}`);
-      }
-      await postDiscord(failures, mods.length, excludedIds.size);
+    if (skipped.length === 0) {
+      console.log("✅ No NCZoning-tagged mods skipped — all parse cleanly.");
+      return; // exitCode stays 0
     }
-    process.exit(0); // report, not a gate
+
+    console.log(`❌ ${skipped.length} tagged mod(s) skipped by the API:`);
+    for (const m of skipped) console.log(`   - ${m.nexus_id}  ${m.name}`);
+    await postDiscord(skipped);
+    // exitCode stays 0 — this is a report, not a gate.
   } catch (err) {
     console.error("Monitor failed (infrastructure error):", err.message);
-    process.exit(1);
+    process.exitCode = 1;
   }
 })();
+// NOTE: we set process.exitCode and let the event loop drain rather than calling
+// process.exit(), which can trip a libuv assertion on Windows when fetch's
+// keep-alive sockets are still closing.

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,40 @@
+# NC Zoning Data API (worker/)
+
+Cloudflare Worker serving the mod registry at `api.nczoning.net/v1/*` for
+in-game consumers (and, later, the website itself). Architecture and phase
+plan: [docs/data-api-plan.md](../docs/data-api-plan.md).
+
+Deploys independently of the Pages site. The Pages Git integration ignores
+this directory; the Worker ships via `wrangler deploy` (CI workflow arrives
+in phase B6).
+
+## Local development
+
+```bash
+cd worker
+npm install
+npm run dev          # wrangler dev on http://127.0.0.1:8787
+curl http://127.0.0.1:8787/v1/health
+```
+
+## Deploy
+
+```bash
+cd worker
+npx wrangler login   # once per machine
+npm run deploy
+```
+
+The `routes` entry in `wrangler.jsonc` binds `api.nczoning.net` as a custom
+domain on first deploy (DNS record + certificate are created automatically;
+the zone must be on the same Cloudflare account).
+
+## Routes (current)
+
+| Route | Returns |
+| --- | --- |
+| `GET /v1/health` | `{ status, version }` in the standard envelope |
+
+Every response uses the envelope
+`{ schema, generated_at, dataset_version, data }`. Contract rules live in
+the plan doc; the full API reference ships in phase B5.

--- a/worker/README.md
+++ b/worker/README.md
@@ -19,15 +19,45 @@ curl http://127.0.0.1:8787/v1/health
 
 ## Deploy
 
+One-time setup (before the first deploy):
+
 ```bash
 cd worker
-npx wrangler login   # once per machine
+npx wrangler login                       # once per machine
+npx wrangler kv namespace create DATA    # paste the id into wrangler.jsonc
+npx wrangler secret put DISCORD_WEBHOOK_URL   # optional: refresh-failure alerts
 npm run deploy
 ```
 
 The `routes` entry in `wrangler.jsonc` binds `api.nczoning.net` as a custom
-domain on first deploy (DNS record + certificate are created automatically;
-the zone must be on the same Cloudflare account).
+domain on first deploy (DNS + certificate created automatically; the zone
+must be on the same Cloudflare account). The `triggers.crons` entry starts
+the 15-minute refresh once deployed.
+
+To seed KV immediately without waiting for the first cron tick, trigger the
+scheduled handler once from the dashboard (Worker → Triggers → run) or
+redeploy.
+
+## Dataset refresh (cron)
+
+Every 15 minutes the `scheduled` handler runs `runRefresh` (`src/refresh.js`):
+fetch `mods.json` + tags + exclusions + `subdistricts.json` from
+`SITE_ORIGIN`, run the Nexus auto-discovery merge with district enrichment,
+and write to KV **only when the content hash changes**. On any source
+failure it keeps the last-known-good dataset, sets `discovery_stale` in the
+meta record, and (if configured) posts a Discord alert — it never serves an
+empty or partial dataset.
+
+KV keys: `dataset:v1` (slim), `dataset:v1:full`, `dataset:v1:districts`,
+`dataset:v1:meta`.
+
+### Test the cron locally
+
+```bash
+npm run dev
+curl "http://127.0.0.1:8787/cdn-cgi/handler/scheduled"   # trigger one refresh
+npx wrangler kv key get "dataset:v1:meta" --binding DATA --local
+```
 
 ## Routes (current)
 
@@ -36,5 +66,6 @@ the zone must be on the same Cloudflare account).
 | `GET /v1/health` | `{ status, version }` in the standard envelope |
 
 Every response uses the envelope
-`{ schema, generated_at, dataset_version, data }`. Contract rules live in
-the plan doc; the full API reference ships in phase B5.
+`{ schema, generated_at, dataset_version, data }`. The read routes that
+serve the dataset from KV (`/v1/locations`, `/v1/districts`, `/v1/meta`,
+`/v1/tags`) ship in phase B4; the full API reference in B5.

--- a/worker/README.md
+++ b/worker/README.md
@@ -99,13 +99,22 @@ versa). The human-facing reference with redscript/CET snippets is
 
 ## Rate limiting
 
-The read-only routes are edge-cached (`max-age=300`), so the vast majority
-of traffic never reaches the Worker, and the free tier (100k Worker
-requests/day) has a wide margin. A belt-and-braces WAF rate-limit rule is
-recommended but not code — add it in the Cloudflare dashboard:
+The read-only routes are edge-cached (`max-age=300`), so most traffic never
+reaches the Worker and the free tier (100k Worker requests/day) has wide
+margin. A WAF rate-limit rule is deployed as belt-and-braces (zone config,
+not `wrangler deploy`):
 
-> Security → WAF → Rate limiting rules → Create, on the `nczoning.net` zone:
-> match `http.host eq "api.nczoning.net"`, **60 requests / 1 min per IP**,
-> action **Block** (or Managed Challenge). Mirror for `api-dev.nczoning.net`.
+> Dashboard → nczoning.net → **Security → Security rules → Rate limiting
+> rules**. Rule "API rate limit": match **URI Path starts with `/v1/`**,
+> characteristic **IP**, **100 requests / 10 seconds**, action **Block**,
+> duration **10 s**.
 
-Rate-limit rules are zone config, not part of `wrangler deploy`.
+**Free-plan constraints (why it's path-based, not host-based):** the free
+rate-limiting rule only matches on **URI Path** (hostname isn't offered),
+the period is fixed at **10 seconds**, and the only action is **Block**.
+Matching `/v1/` is unaffected by this because that path only exists on the
+API — the main site has no `/v1/` routes — so one rule covers both the prod
+and staging API hosts and never touches the site. The `/` docs page and
+`/openapi.json` are intentionally left uncovered (`/` would collide with the
+site homepage). Verified by burst test: request 101 within a 10 s window
+returns `429`.

--- a/worker/README.md
+++ b/worker/README.md
@@ -59,13 +59,20 @@ curl "http://127.0.0.1:8787/cdn-cgi/handler/scheduled"   # trigger one refresh
 npx wrangler kv key get "dataset:v1:meta" --binding DATASET --local
 ```
 
-## Routes (current)
+## Routes
 
 | Route | Returns |
 | --- | --- |
-| `GET /v1/health` | `{ status, version }` in the standard envelope |
+| `GET /v1/health` | `{ status, version }` (uncached) |
+| `GET /v1/locations` | slim location array |
+| `GET /v1/locations/{id}` | one full entry (adds description/credits), or 404 |
+| `GET /v1/districts` | district/subdistrict hierarchy (flat boundaries) |
+| `GET /v1/tags` | tag dictionary |
+| `GET /v1/meta` | `{ counts, discovery_stale, skipped }` |
 
 Every response uses the envelope
-`{ schema, generated_at, dataset_version, data }`. The read routes that
-serve the dataset from KV (`/v1/locations`, `/v1/districts`, `/v1/meta`,
-`/v1/tags`) ship in phase B4; the full API reference in B5.
+`{ schema, generated_at, dataset_version, data }`. Dataset routes carry
+`ETag: "<dataset_version>"` and `Cache-Control: public, max-age=300,
+stale-while-revalidate=3600`; send `If-None-Match` to get a `304` when your
+copy is current. Before the first cron tick the dataset routes return `503
+not_ready`. The full API reference (repo doc + OpenAPI page) ships in B5.

--- a/worker/README.md
+++ b/worker/README.md
@@ -24,7 +24,7 @@ One-time setup (before the first deploy):
 ```bash
 cd worker
 npx wrangler login                       # once per machine
-npx wrangler kv namespace create DATA    # paste the id into wrangler.jsonc
+npx wrangler kv namespace create nczoning-api-dataset   # paste the id into wrangler.jsonc
 npx wrangler secret put DISCORD_WEBHOOK_URL   # optional: refresh-failure alerts
 npm run deploy
 ```
@@ -56,7 +56,7 @@ KV keys: `dataset:v1` (slim), `dataset:v1:full`, `dataset:v1:districts`,
 ```bash
 npm run dev
 curl "http://127.0.0.1:8787/cdn-cgi/handler/scheduled"   # trigger one refresh
-npx wrangler kv key get "dataset:v1:meta" --binding DATA --local
+npx wrangler kv key get "dataset:v1:meta" --binding DATASET --local
 ```
 
 ## Routes (current)

--- a/worker/README.md
+++ b/worker/README.md
@@ -62,7 +62,7 @@ meta record, and (if configured) posts a Discord alert — it never serves an
 empty or partial dataset.
 
 KV keys: `dataset:v1` (slim), `dataset:v1:full`, `dataset:v1:districts`,
-`dataset:v1:meta`.
+`dataset:v1:tags`, `dataset:v1:meta`.
 
 ### Test the cron locally
 
@@ -76,6 +76,8 @@ npx wrangler kv key get "dataset:v1:meta" --binding DATASET --local
 
 | Route | Returns |
 | --- | --- |
+| `GET /` | interactive docs (Scalar, renders `openapi.json`) |
+| `GET /openapi.json` | the OpenAPI 3.1 spec |
 | `GET /v1/health` | `{ status, version }` (uncached) |
 | `GET /v1/locations` | slim location array |
 | `GET /v1/locations/{id}` | one full entry (adds description/credits), or 404 |
@@ -88,4 +90,22 @@ Every response uses the envelope
 `ETag: "<dataset_version>"` and `Cache-Control: public, max-age=300,
 stale-while-revalidate=3600`; send `If-None-Match` to get a `304` when your
 copy is current. Before the first cron tick the dataset routes return `503
-not_ready`. The full API reference (repo doc + OpenAPI page) ships in B5.
+not_ready`.
+
+Docs: `openapi.json` is the source of truth (drift-guarded by
+`test/openapi.test.js` — every served route must be documented and vice
+versa). The human-facing reference with redscript/CET snippets is
+[docs/api-reference.md](../docs/api-reference.md).
+
+## Rate limiting
+
+The read-only routes are edge-cached (`max-age=300`), so the vast majority
+of traffic never reaches the Worker, and the free tier (100k Worker
+requests/day) has a wide margin. A belt-and-braces WAF rate-limit rule is
+recommended but not code — add it in the Cloudflare dashboard:
+
+> Security → WAF → Rate limiting rules → Create, on the `nczoning.net` zone:
+> match `http.host eq "api.nczoning.net"`, **60 requests / 1 min per IP**,
+> action **Block** (or Managed Challenge). Mirror for `api-dev.nczoning.net`.
+
+Rate-limit rules are zone config, not part of `wrangler deploy`.

--- a/worker/README.md
+++ b/worker/README.md
@@ -4,9 +4,19 @@ Cloudflare Worker serving the mod registry at `api.nczoning.net/v1/*` for
 in-game consumers (and, later, the website itself). Architecture and phase
 plan: [docs/data-api-plan.md](../docs/data-api-plan.md).
 
-Deploys independently of the Pages site. The Pages Git integration ignores
-this directory; the Worker ships via `wrangler deploy` (CI workflow arrives
-in phase B6).
+Deploys independently of the Pages site, but mirrors its main/dev split with
+two environments:
+
+| Env | Worker | Domain | Source origin | Deployed from |
+| --- | --- | --- | --- | --- |
+| production | `nczoning-api` | api.nczoning.net | nczoning.net | `main` |
+| staging | `nczoning-api-staging` | api-dev.nczoning.net | dev.nczoning.net | `dev` |
+
+CI (`.github/workflows/deploy-api.yml`) deploys production on push to `main`
+and staging on push to `dev`, path-filtered to `worker/**`. So the live site
+(main → nczoning.net → api.nczoning.net) only changes through the same
+dev→main gate that protects the site itself; dev work stays on the staging
+API.
 
 ## Local development
 
@@ -19,24 +29,27 @@ curl http://127.0.0.1:8787/v1/health
 
 ## Deploy
 
-One-time setup (before the first deploy):
+Normally you don't — CI deploys on merge (see the table above). Manual
+deploy for local iteration:
 
 ```bash
 cd worker
-npx wrangler login                       # once per machine
-npx wrangler kv namespace create nczoning-api-dataset   # paste the id into wrangler.jsonc
-npx wrangler secret put DISCORD_WEBHOOK_URL   # optional: refresh-failure alerts
-npm run deploy
+npx wrangler login                    # once per machine
+npm run deploy                        # production
+npx wrangler deploy --env staging     # staging
 ```
 
-The `routes` entry in `wrangler.jsonc` binds `api.nczoning.net` as a custom
-domain on first deploy (DNS + certificate created automatically; the zone
-must be on the same Cloudflare account). The `triggers.crons` entry starts
-the 15-minute refresh once deployed.
+CI needs one GitHub Actions secret: `CLOUDFLARE_API_TOKEN` (a token with
+Workers Scripts:Edit, Workers KV Storage:Edit, and Zone DNS:Edit on the
+nczoning.net zone — DNS is needed so the custom-domain route can be created).
+The `DISCORD_WEBHOOK_URL` Worker secret and the KV namespaces persist across
+deploys; they're set once with `wrangler secret put` / `kv namespace create`
+and are not touched by CI.
 
-To seed KV immediately without waiting for the first cron tick, trigger the
-scheduled handler once from the dashboard (Worker → Triggers → run) or
-redeploy.
+The `routes` entry binds the custom domain on first deploy (DNS + certificate
+created automatically; the zone must be on the same Cloudflare account). The
+`triggers.crons` entry starts the 15-minute refresh once deployed; a freshly
+deployed env returns `503 not_ready` until its first cron tick seeds KV.
 
 ## Dataset refresh (cron)
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -42,9 +42,12 @@ npx wrangler deploy --env staging     # staging
 CI needs one GitHub Actions secret: `CLOUDFLARE_API_TOKEN` (a token with
 Workers Scripts:Edit, Workers KV Storage:Edit, and Zone DNS:Edit on the
 nczoning.net zone — DNS is needed so the custom-domain route can be created).
-The `DISCORD_WEBHOOK_URL` Worker secret and the KV namespaces persist across
-deploys; they're set once with `wrangler secret put` / `kv namespace create`
-and are not touched by CI.
+Refresh-failure alerts post to the dedicated map-alerts channel via the
+`NCZ_ALERTS_DISCORD_WEBHOOK_URL` Worker secret (set once per environment:
+`wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL` and again with
+`--env staging`). It falls back to the legacy `DISCORD_WEBHOOK_URL` secret if
+the new one isn't set, so there's no alerting gap during the move. The secrets
+and KV namespaces persist across deploys and are not touched by CI.
 
 The `routes` entry binds the custom domain on first deploy (DNS + certificate
 created automatically; the zone must be on the same Cloudflare account). The

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -31,16 +31,19 @@
     },
     "/v1/locations": {
       "get": {
-        "summary": "All locations (slim)",
-        "description": "The workhorse. Slim entries (no description/credits). Supports conditional GET: send If-None-Match with the last dataset_version to get a 304.",
-        "parameters": [{ "$ref": "#/components/parameters/IfNoneMatch" }],
+        "summary": "All locations (slim, or full with ?full=1)",
+        "description": "The workhorse. Slim entries by default (no description/credits/images) — lean for the in-game RedData list. Pass ?full=1 to get full entries (description, credits, and Nexus image URLs) as an array in one request; that variant carries its own ETag (suffixed -full) so it can't be confused with the slim cache. Supports conditional GET: send If-None-Match with the last dataset_version to get a 304.",
+        "parameters": [
+          { "name": "full", "in": "query", "required": false, "schema": { "type": "string", "enum": ["1"] }, "description": "Set full=1 to return LocationFull entries (adds description, credits, thumbnail_url, picture_url, updated_at). Omit for the slim list." },
+          { "$ref": "#/components/parameters/IfNoneMatch" }
+        ],
         "responses": {
           "200": {
-            "description": "The full slim location array.",
+            "description": "The location array — slim Location[] by default, or LocationFull[] when ?full=1.",
             "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
             "content": { "application/json": { "schema": {
               "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
-                "data": { "type": "array", "items": { "$ref": "#/components/schemas/Location" } } } }]
+                "data": { "type": "array", "items": { "oneOf": [{ "$ref": "#/components/schemas/Location" }, { "$ref": "#/components/schemas/LocationFull" }] } } } }]
             } } }
           },
           "304": { "$ref": "#/components/responses/NotModified" },
@@ -180,7 +183,10 @@
           { "$ref": "#/components/schemas/Location" },
           { "type": "object", "properties": {
             "description": { "type": "string" },
-            "credits": { "type": "string" }
+            "credits": { "type": "string" },
+            "thumbnail_url": { "type": ["string", "null"], "description": "Nexus thumbnail image URL, or null (unknown / WIP / Dummy)." },
+            "picture_url": { "type": ["string", "null"], "description": "Nexus full-size image URL, or null." },
+            "updated_at": { "type": ["string", "null"], "format": "date-time", "description": "Nexus last-updated timestamp, or null." }
           } }
         ]
       },

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -1,0 +1,223 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "NC Zoning Data API",
+    "version": "1.0.0",
+    "description": "Read-only API serving the NC Zoning Board mod registry (Cyberpunk 2077 location mods) to in-game mods and the website. Every response is wrapped in a versioned envelope. Coordinates are raw CET world values [X, Y, Z] — usable in-game with no transform. The JSON stays DTO-mappable for the in-game RedData parser: no arrays-of-arrays, property names are case-sensitive. See https://github.com/spuddeh/nc-zoning-board for the project.",
+    "contact": { "name": "NC Zoning Board", "url": "https://nczoning.net" }
+  },
+  "servers": [
+    { "url": "https://api.nczoning.net", "description": "Production" },
+    { "url": "https://api-dev.nczoning.net", "description": "Staging" }
+  ],
+  "paths": {
+    "/v1/health": {
+      "get": {
+        "summary": "Liveness + deployed version",
+        "description": "Uncached. Does not touch the dataset.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": { "application/json": { "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
+                "data": { "type": "object", "properties": {
+                  "status": { "type": "string", "const": "ok" },
+                  "version": { "type": "string", "example": "0.1.0" }
+                } } } }]
+            } } }
+          }
+        }
+      }
+    },
+    "/v1/locations": {
+      "get": {
+        "summary": "All locations (slim)",
+        "description": "The workhorse. Slim entries (no description/credits). Supports conditional GET: send If-None-Match with the last dataset_version to get a 304.",
+        "parameters": [{ "$ref": "#/components/parameters/IfNoneMatch" }],
+        "responses": {
+          "200": {
+            "description": "The full slim location array.",
+            "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
+            "content": { "application/json": { "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
+                "data": { "type": "array", "items": { "$ref": "#/components/schemas/Location" } } } }]
+            } } }
+          },
+          "304": { "$ref": "#/components/responses/NotModified" },
+          "503": { "$ref": "#/components/responses/NotReady" }
+        }
+      }
+    },
+    "/v1/locations/{id}": {
+      "get": {
+        "summary": "One location (full)",
+        "description": "Full entry including description and credits.",
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Location id: a UUID (manual) or nexus-<nexus_id> (auto-discovered).", "example": "nexus-27618" },
+          { "$ref": "#/components/parameters/IfNoneMatch" }
+        ],
+        "responses": {
+          "200": {
+            "description": "The full location entry.",
+            "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
+            "content": { "application/json": { "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
+                "data": { "$ref": "#/components/schemas/LocationFull" } } }]
+            } } }
+          },
+          "304": { "$ref": "#/components/responses/NotModified" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "503": { "$ref": "#/components/responses/NotReady" }
+        }
+      }
+    },
+    "/v1/districts": {
+      "get": {
+        "summary": "District/subdistrict hierarchy",
+        "description": "9 districts and their subdistricts, with centroids and FLATTENED boundary rings ([x1,y1,x2,y2,...]) in CET coordinates. Anywhere outside every district polygon is Badlands (the game default), so a location's district is never null.",
+        "parameters": [{ "$ref": "#/components/parameters/IfNoneMatch" }],
+        "responses": {
+          "200": {
+            "description": "The district hierarchy.",
+            "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
+            "content": { "application/json": { "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
+                "data": { "type": "array", "items": { "$ref": "#/components/schemas/District" } } } }]
+            } } }
+          },
+          "304": { "$ref": "#/components/responses/NotModified" },
+          "503": { "$ref": "#/components/responses/NotReady" }
+        }
+      }
+    },
+    "/v1/tags": {
+      "get": {
+        "summary": "Tag dictionary",
+        "description": "Map of tag id → human description. The allow-list a location's tags are drawn from.",
+        "parameters": [{ "$ref": "#/components/parameters/IfNoneMatch" }],
+        "responses": {
+          "200": {
+            "description": "Tag dictionary.",
+            "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
+            "content": { "application/json": { "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
+                "data": { "type": "object", "additionalProperties": { "type": "string" }, "example": { "apartment": "A residence you can enter", "corpo": "Corporate aesthetic" } } } }]
+            } } }
+          },
+          "304": { "$ref": "#/components/responses/NotModified" },
+          "503": { "$ref": "#/components/responses/NotReady" }
+        }
+      }
+    },
+    "/v1/meta": {
+      "get": {
+        "summary": "Dataset metadata",
+        "description": "Counts (total, manual, auto, per-district) and health flags. dataset_version and generated_at live on the envelope.",
+        "parameters": [{ "$ref": "#/components/parameters/IfNoneMatch" }],
+        "responses": {
+          "200": {
+            "description": "Dataset metadata.",
+            "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
+            "content": { "application/json": { "schema": {
+              "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
+                "data": { "$ref": "#/components/schemas/Meta" } } }]
+            } } }
+          },
+          "304": { "$ref": "#/components/responses/NotModified" },
+          "503": { "$ref": "#/components/responses/NotReady" }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "IfNoneMatch": {
+        "name": "If-None-Match", "in": "header", "required": false,
+        "schema": { "type": "string" },
+        "description": "The dataset_version (as a quoted ETag) from your last fetch. Returns 304 if unchanged."
+      }
+    },
+    "headers": {
+      "ETag": { "description": "The dataset_version, quoted. Use as If-None-Match next time.", "schema": { "type": "string" } },
+      "CacheControl": { "description": "public, max-age=300, stale-while-revalidate=3600", "schema": { "type": "string" } }
+    },
+    "responses": {
+      "NotModified": { "description": "Your copy is current (ETag matched). No body." },
+      "NotFound": { "description": "Unknown id or route.", "content": { "application/json": { "schema": { "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": { "data": { "type": "object", "properties": { "error": { "type": "string", "const": "not_found" } } } } }] } } } },
+      "NotReady": { "description": "The dataset has not been built yet (before the first cron tick). Retry shortly.", "content": { "application/json": { "schema": { "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": { "data": { "type": "object", "properties": { "error": { "type": "string", "const": "not_ready" } } } } }] } } } }
+    },
+    "schemas": {
+      "Envelope": {
+        "type": "object",
+        "required": ["schema", "generated_at", "dataset_version", "data"],
+        "properties": {
+          "schema": { "type": "integer", "const": 1, "description": "Envelope schema version." },
+          "generated_at": { "type": ["string", "null"], "format": "date-time", "description": "When the dataset was last built." },
+          "dataset_version": { "type": ["string", "null"], "description": "Content hash; the ETag value." },
+          "data": { "description": "Route-specific payload." }
+        }
+      },
+      "Location": {
+        "type": "object",
+        "description": "Slim location entry.",
+        "required": ["id", "name", "nexus_id", "coordinates", "category", "tags", "authors", "source", "district"],
+        "properties": {
+          "id": { "type": "string", "description": "UUID (manual) or nexus-<nexus_id> (auto).", "example": "nexus-27618" },
+          "name": { "type": "string" },
+          "nexus_id": { "type": "string", "description": "Numeric Nexus id, or WIP / Dummy.", "example": "27618" },
+          "coordinates": { "type": "array", "items": { "type": "number" }, "minItems": 2, "maxItems": 3, "description": "Raw CET world [X, Y, Z].", "example": [-2229.57, 3618.96, 12.22] },
+          "yaw": { "type": "number", "description": "Player facing in degrees (optional)." },
+          "category": { "type": "string", "enum": ["location-overhaul", "new-location", "other"] },
+          "tags": { "type": "array", "items": { "type": "string" } },
+          "authors": { "type": "array", "items": { "type": "string" } },
+          "source": { "type": "string", "enum": ["manual", "auto"] },
+          "district": { "type": "string", "description": "Never null (defaults to Badlands)." },
+          "subdistrict": { "type": ["string", "null"] }
+        }
+      },
+      "LocationFull": {
+        "allOf": [
+          { "$ref": "#/components/schemas/Location" },
+          { "type": "object", "properties": {
+            "description": { "type": "string" },
+            "credits": { "type": "string" }
+          } }
+        ]
+      },
+      "District": {
+        "type": "object",
+        "required": ["id", "name", "boundary", "subdistricts"],
+        "properties": {
+          "id": { "type": ["string", "null"] },
+          "name": { "type": "string" },
+          "centroid": { "$ref": "#/components/schemas/Point" },
+          "boundary": { "type": "array", "items": { "type": "number" }, "description": "Flattened ring [x1,y1,x2,y2,...] in CET." },
+          "subdistricts": { "type": "array", "items": { "$ref": "#/components/schemas/Subdistrict" } }
+        }
+      },
+      "Subdistrict": {
+        "type": "object",
+        "required": ["id", "name", "boundary"],
+        "properties": {
+          "id": { "type": ["string", "null"] },
+          "name": { "type": "string" },
+          "canonical": { "type": "boolean" },
+          "centroid": { "$ref": "#/components/schemas/Point" },
+          "boundary": { "type": "array", "items": { "type": "number" } }
+        }
+      },
+      "Point": { "type": ["object", "null"], "properties": { "x": { "type": "number" }, "y": { "type": "number" } } },
+      "Meta": {
+        "type": "object",
+        "properties": {
+          "counts": { "type": "object", "properties": {
+            "total": { "type": "integer" }, "manual": { "type": "integer" }, "auto": { "type": "integer" },
+            "per_district": { "type": "object", "additionalProperties": { "type": "integer" } }
+          } },
+          "discovery_stale": { "type": "boolean", "description": "True if the last Nexus refresh failed and the dataset is being served from last-known-good." },
+          "skipped": { "type": "array", "items": { "type": "object", "properties": { "nexus_id": { "type": "string" }, "name": { "type": "string" } } }, "description": "Mods tagged NCZoning whose metadata block did not parse." }
+        }
+      }
+    }
+  }
+}

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,0 +1,1505 @@
+{
+  "name": "nczoning-api",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nczoning-api",
+      "version": "0.1.0",
+      "devDependencies": {
+        "wrangler": "^4.107.0"
+      }
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260701.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260701.1.tgz",
+      "integrity": "sha512-Zd9Y1bah6DwwBN2RW8vJohffQrIUazb8UXnqSNecOxM+jJLhUuvv5IOG8dbHcV83TyZAubea6gsQXo2yH1lDdw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260701.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260701.1.tgz",
+      "integrity": "sha512-yBLsjS1qCWqFyCY37qRUrYfzHHvMGvjh8zRKJ6MvUivYDhkZTzqduppK38FoqYvayLJ5KbcxH7zo5rkxGqbsaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260701.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260701.1.tgz",
+      "integrity": "sha512-vMfqSIMfoo4xmZXEuUVqLpSFS921YKjiR9q7kDXPi6Vld1PK74UHg9LZuBavT2KSyemHUCTpj9y/4JSYOEyQbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260701.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260701.1.tgz",
+      "integrity": "sha512-HRfwbKU2pK44V2NhoM0+iH0JJSj7nQ9Wv13ifIiGYCmTtDL8/zKtEhX7kQ3D4Vy/Cpjhttl0FkfqXj1aqLDPPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260701.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260701.1.tgz",
+      "integrity": "sha512-ngxCiIN9s/fM2o1IBMD0o1/mcXrv2NJVdyznh51UH8sQuvrTrXvV2nM0Uj/qU2wMwF6prgNBcdcd7AZeZGiBQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.17",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+      "integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "4.20260701.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260701.0.tgz",
+      "integrity": "sha512-L6eAAi6IKtyb/7J6L+YsH2vb1yBrJWKRXI293JYDiMl70+6nncdAgigex58w6WBd+CwvdMsqOyNyGs95Op5gWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.34.5",
+        "undici": "7.28.0",
+        "workerd": "1.20260701.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260701.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260701.1.tgz",
+      "integrity": "sha512-uF813NG09JwNRRUfJ0zBomyTslSPM810dMj9LVvkQ7RAkLrQLzAlPU8Xh/3dIqZDo2bfd7tChbf2PtqLRARRJQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260701.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260701.1",
+        "@cloudflare/workerd-linux-64": "1.20260701.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260701.1",
+        "@cloudflare/workerd-windows-64": "1.20260701.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.107.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.107.0.tgz",
+      "integrity": "sha512-fw69ThymNitZ0oIEBU2yNeq3kK59UKz/jyA3udwRrQIAIsxX57q5qLOpPTN7qc5t8n9pnUeofe0uxtMuhQZW8w==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "4.20260701.0",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260701.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20260701.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/worker/package.json
+++ b/worker/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "test": "node --test test/"
+    "test": "node --test"
   },
   "devDependencies": {
     "wrangler": "^4.107.0"

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "nczoning-api",
+  "version": "0.1.0",
+  "private": true,
+  "description": "NC Zoning Data API worker (api.nczoning.net)",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "node --test test/"
+  },
+  "devDependencies": {
+    "wrangler": "^4.107.0"
+  }
+}

--- a/worker/src/districts.js
+++ b/worker/src/districts.js
@@ -1,0 +1,135 @@
+/**
+ * District/subdistrict assignment — server-side port of the client logic
+ * (assets/js/utils.js pointInPolygon/polygonCentroid + the resolveArea
+ * rule in assets/js/district-info.js). Polygons come from
+ * data/subdistricts.json and are in CET world coordinates, the same space
+ * as location `coordinates` — no transforms anywhere.
+ */
+
+/** Ray-casting point-in-polygon. `point` and `ring` vertices share a space. */
+export function pointInPolygon(point, ring) {
+  if (!ring || ring.length < 3) return false;
+  const [px, py] = point;
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const xi = ring[i][0], yi = ring[i][1];
+    const xj = ring[j][0], yj = ring[j][1];
+    const intersects = (yi > py) !== (yj > py) &&
+      px < ((xj - xi) * (py - yi)) / (yj - yi) + xi;
+    if (intersects) inside = !inside;
+  }
+  return inside;
+}
+
+/** Area-weighted (shoelace) centroid; vertex average for degenerate rings. */
+export function polygonCentroid(ring) {
+  if (!ring || ring.length === 0) return null;
+  let a = 0, cx = 0, cy = 0;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const cross = ring[j][0] * ring[i][1] - ring[i][0] * ring[j][1];
+    a += cross;
+    cx += (ring[j][0] + ring[i][0]) * cross;
+    cy += (ring[j][1] + ring[i][1]) * cross;
+  }
+  a *= 0.5;
+  if (Math.abs(a) < 1e-6) {
+    let sx = 0, sy = 0;
+    for (const p of ring) { sx += p[0]; sy += p[1]; }
+    return [sx / ring.length, sy / ring.length];
+  }
+  return [cx / (6 * a), cy / (6 * a)];
+}
+
+/** Absolute shoelace area — smallest containing polygon wins. */
+function polyArea(ring) {
+  let a = 0;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    a += (ring[j][0] + ring[i][0]) * (ring[j][1] - ring[i][1]);
+  }
+  return Math.abs(a) / 2;
+}
+
+/**
+ * Resolve the most specific area for a CET [x, y] point: the smallest-area
+ * subdistrict containing it (and that sub's parent district), else the
+ * smallest containing district polygon. Mirrors district-info.js
+ * resolveArea so the API and the map can never disagree.
+ *
+ * @param {number[]} pt CET [x, y]
+ * @param {Array} districts subdistricts.json `districts[]`
+ * @returns {{district: object, subdistrict: object|null}|null}
+ */
+export function resolveArea(pt, districts) {
+  let sub = null, subArea = Infinity, dist = null;
+  for (const d of districts) {
+    for (const s of d.subdistricts || []) {
+      if (s.polygon?.length && pointInPolygon(pt, s.polygon)) {
+        const a = polyArea(s.polygon);
+        if (a < subArea) { subArea = a; sub = s; dist = d; }
+      }
+    }
+  }
+  if (!sub) {
+    let dArea = Infinity;
+    for (const d of districts) {
+      if (d.polygon?.length && pointInPolygon(pt, d.polygon)) {
+        const a = polyArea(d.polygon);
+        if (a < dArea) { dArea = a; dist = d; }
+      }
+    }
+  }
+  return dist ? { district: dist, subdistrict: sub } : null;
+}
+
+/**
+ * The game's default district: anywhere outside every district polygon is
+ * Badlands (which is why it has no polygon of its own — its subdistricts
+ * are trigger areas transformed into polygons for the map, but the parent
+ * is the catch-all). The API mirrors that rule so in-game consumers and
+ * the game itself can never disagree.
+ */
+const DEFAULT_DISTRICT_ID = 'badlands';
+
+/**
+ * District/subdistrict names for a location's CET coordinates. Points
+ * outside every polygon default to Badlands (game behaviour); nulls only
+ * if the dataset has no default district at all (fixtures).
+ */
+export function assignDistrict(coordinates, districts) {
+  const hit = resolveArea([coordinates[0], coordinates[1]], districts);
+  if (hit) {
+    return {
+      district: hit.district.name,
+      subdistrict: hit.subdistrict ? hit.subdistrict.name : null,
+    };
+  }
+  const fallback = districts.find((d) => d.id === DEFAULT_DISTRICT_ID);
+  return { district: fallback ? fallback.name : null, subdistrict: null };
+}
+
+/**
+ * /v1/districts payload: hierarchy with names, centroids and FLATTENED
+ * boundaries ([x1,y1,x2,y2,...]) — the DTO contract forbids
+ * arrays-of-arrays (RedData FromJson limit).
+ */
+export function districtsPayload(districts) {
+  const flat = (ring) => ring.flat();
+  return districts.map((d) => ({
+    id: d.id ?? null,
+    name: d.name,
+    centroid: centroidObj(d.polygon),
+    boundary: flat(d.polygon || []),
+    subdistricts: (d.subdistricts || []).map((s) => ({
+      id: s.id ?? null,
+      name: s.name,
+      canonical: s.canonical !== false,
+      centroid: centroidObj(s.polygon),
+      boundary: flat(s.polygon || []),
+    })),
+  }));
+}
+
+function centroidObj(ring) {
+  const c = polygonCentroid(ring);
+  return c ? { x: c[0], y: c[1] } : null;
+}

--- a/worker/src/docs.js
+++ b/worker/src/docs.js
@@ -1,0 +1,29 @@
+/**
+ * Interactive API docs served from the Worker root. The OpenAPI spec
+ * (worker/openapi.json) is the source of truth; the root page renders it
+ * with Scalar (loaded from a CDN — this is a human docs page, not a
+ * CSP-restricted context). Modders browsing to api.nczoning.net land here.
+ */
+
+import openapi from '../openapi.json' with { type: 'json' };
+
+export const spec = openapi;
+
+const PAGE = `<!doctype html>
+<html>
+<head>
+  <title>NC Zoning Data API</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+  <script id="api-reference" data-url="/openapi.json"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+</body>
+</html>`;
+
+export function docsPage() {
+  return new Response(PAGE, {
+    headers: { 'Content-Type': 'text/html; charset=utf-8', 'Cache-Control': 'public, max-age=300' },
+  });
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -69,11 +69,14 @@ function notReady() {
  * receives the parsed meta and returns the response `data`, or `undefined`
  * to signal a 404 (e.g. an unknown location id).
  */
-async function serveDataset(request, env, build) {
+async function serveDataset(request, env, build, etagSuffix = '') {
   const meta = await env.DATASET.get(KEYS.meta, 'json');
   if (!meta) return notReady();
 
-  const etag = `"${meta.dataset_version}"`;
+  // The ETag is the dataset content hash. Representations that share a hash
+  // but differ in body (slim vs ?full=1) must NOT share an ETag, or a client
+  // caching one and requesting the other would get a wrong 304. Vary it.
+  const etag = `"${meta.dataset_version}${etagSuffix}"`;
   if (request.headers.get('If-None-Match') === etag) {
     return new Response(null, {
       status: 304,
@@ -98,8 +101,24 @@ const routes = {
   'GET /v1/health': (request, env) =>
     json(envelope({ status: 'ok', version: env.API_VERSION }, null)),
 
-  'GET /v1/locations': (request, env) =>
-    serveDataset(request, env, (e) => e.DATASET.get(KEYS.slim, 'json')),
+  // Slim by default (the in-game RedData workhorse list). `?full=1` returns
+  // the full entries as an array — description/credits + image URLs — for the
+  // website and any consumer that wants everything in one request.
+  'GET /v1/locations': (request, env) => {
+    const url = new URL(request.url);
+    if (url.searchParams.get('full') === '1') {
+      return serveDataset(
+        request,
+        env,
+        async (e) => {
+          const full = await e.DATASET.get(KEYS.full, 'json');
+          return full ? Object.values(full) : undefined;
+        },
+        '-full',
+      );
+    }
+    return serveDataset(request, env, (e) => e.DATASET.get(KEYS.slim, 'json'));
+  },
 
   'GET /v1/districts': (request, env) =>
     serveDataset(request, env, (e) => e.DATASET.get(KEYS.districts, 'json')),

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,0 +1,66 @@
+/**
+ * NC Zoning Data API — read-only Worker serving the mod registry to
+ * Cyberpunk 2077 mods (and, later, the website itself).
+ *
+ * Contract rules (frozen, see docs/data-api-plan.md):
+ * - Every response uses the envelope
+ *   { schema, generated_at, dataset_version, data }.
+ * - JSON stays DTO-mappable for the in-game RedData consumer:
+ *   no arrays-of-arrays, property names are case-sensitive.
+ * - Path-based versioning: additive changes only within /v1/.
+ */
+
+const SCHEMA_VERSION = 1;
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
+  'Access-Control-Allow-Headers': 'If-None-Match',
+};
+
+/** Wrap payload data in the versioned response envelope. */
+function envelope(data, datasetVersion = null) {
+  return {
+    schema: SCHEMA_VERSION,
+    generated_at: new Date().toISOString(),
+    dataset_version: datasetVersion,
+    data,
+  };
+}
+
+/** JSON response with CORS + content-type set. */
+function json(body, { status = 200, headers = {} } = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      ...CORS_HEADERS,
+      ...headers,
+    },
+  });
+}
+
+function notFound() {
+  return json(envelope({ error: 'not_found' }), { status: 404 });
+}
+
+const routes = {
+  '/v1/health': (request, env) =>
+    json(envelope({ status: 'ok', version: env.API_VERSION })),
+};
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: CORS_HEADERS });
+    }
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return json(envelope({ error: 'method_not_allowed' }), { status: 405 });
+    }
+
+    const handler = routes[url.pathname];
+    return handler ? handler(request, env) : notFound();
+  },
+};

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -8,9 +8,14 @@
  * - JSON stays DTO-mappable for the in-game RedData consumer:
  *   no arrays-of-arrays, property names are case-sensitive.
  * - Path-based versioning: additive changes only within /v1/.
+ *
+ * Data is served from KV (written by the 15-minute cron, see refresh.js).
+ * ETag = dataset_version (the content hash): a client sending a matching
+ * If-None-Match gets a 304 without the big data read.
  */
 
 import { runRefresh } from './refresh.js';
+import { KEYS } from './store.js';
 
 const SCHEMA_VERSION = 1;
 
@@ -20,12 +25,16 @@ const CORS_HEADERS = {
   'Access-Control-Allow-Headers': 'If-None-Match',
 };
 
-/** Wrap payload data in the versioned response envelope. */
-function envelope(data, datasetVersion = null) {
+// Dataset routes are cached for 5 min at the edge/browser, with a 1-hour
+// stale-while-revalidate window so a client never blocks on a refresh.
+const DATA_CACHE = 'public, max-age=300, stale-while-revalidate=3600';
+
+/** Wrap payload data in the versioned envelope (version/time from meta). */
+function envelope(data, meta) {
   return {
     schema: SCHEMA_VERSION,
-    generated_at: new Date().toISOString(),
-    dataset_version: datasetVersion,
+    generated_at: meta?.generated_at ?? null,
+    dataset_version: meta?.dataset_version ?? null,
     data,
   };
 }
@@ -43,13 +52,70 @@ function json(body, { status = 200, headers = {} } = {}) {
 }
 
 function notFound() {
-  return json(envelope({ error: 'not_found' }), { status: 404 });
+  return json(envelope({ error: 'not_found' }, null), { status: 404 });
+}
+
+/** Before the first successful cron, KV is empty — say so, don't 404. */
+function notReady() {
+  return json(envelope({ error: 'not_ready' }, null), {
+    status: 503,
+    headers: { 'Retry-After': '60' },
+  });
+}
+
+/**
+ * Serve a dataset payload from KV with ETag/304 + cache headers. `build`
+ * receives the parsed meta and returns the response `data`, or `undefined`
+ * to signal a 404 (e.g. an unknown location id).
+ */
+async function serveDataset(request, env, build) {
+  const meta = await env.DATASET.get(KEYS.meta, 'json');
+  if (!meta) return notReady();
+
+  const etag = `"${meta.dataset_version}"`;
+  if (request.headers.get('If-None-Match') === etag) {
+    return new Response(null, {
+      status: 304,
+      headers: { ...CORS_HEADERS, ETag: etag, 'Cache-Control': DATA_CACHE },
+    });
+  }
+
+  const data = await build(env, meta);
+  if (data === undefined) return notFound();
+
+  return json(envelope(data, meta), {
+    headers: { ETag: etag, 'Cache-Control': DATA_CACHE },
+  });
 }
 
 const routes = {
-  '/v1/health': (request, env) =>
-    json(envelope({ status: 'ok', version: env.API_VERSION })),
+  'GET /v1/health': (request, env) =>
+    json(envelope({ status: 'ok', version: env.API_VERSION }, null)),
+
+  'GET /v1/locations': (request, env) =>
+    serveDataset(request, env, (e) => e.DATASET.get(KEYS.slim, 'json')),
+
+  'GET /v1/districts': (request, env) =>
+    serveDataset(request, env, (e) => e.DATASET.get(KEYS.districts, 'json')),
+
+  'GET /v1/tags': (request, env) =>
+    serveDataset(request, env, (e) => e.DATASET.get(KEYS.tags, 'json')),
+
+  'GET /v1/meta': (request, env) =>
+    serveDataset(request, env, (e, meta) => ({
+      counts: meta.counts,
+      discovery_stale: meta.discovery_stale ?? false,
+      skipped: meta.skipped ?? [],
+    })),
 };
+
+/** GET /v1/locations/{id} — full entry, or 404. */
+function locationById(request, env, id) {
+  return serveDataset(request, env, async (e) => {
+    const full = await e.DATASET.get(KEYS.full, 'json');
+    return full?.[id]; // undefined → 404
+  });
+}
 
 export default {
   // 15-minute cron: rebuild the dataset into KV (see refresh.js).
@@ -64,10 +130,17 @@ export default {
       return new Response(null, { status: 204, headers: CORS_HEADERS });
     }
     if (request.method !== 'GET' && request.method !== 'HEAD') {
-      return json(envelope({ error: 'method_not_allowed' }), { status: 405 });
+      return json(envelope({ error: 'method_not_allowed' }, null), { status: 405 });
     }
 
-    const handler = routes[url.pathname];
-    return handler ? handler(request, env) : notFound();
+    // Static routes first.
+    const handler = routes[`GET ${url.pathname}`];
+    if (handler) return handler(request, env);
+
+    // Parametric: /v1/locations/{id}
+    const locMatch = url.pathname.match(/^\/v1\/locations\/([^/]+)$/);
+    if (locMatch) return locationById(request, env, decodeURIComponent(locMatch[1]));
+
+    return notFound();
   },
 };

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -16,6 +16,7 @@
 
 import { runRefresh } from './refresh.js';
 import { KEYS } from './store.js';
+import { docsPage, spec } from './docs.js';
 
 const SCHEMA_VERSION = 1;
 
@@ -89,6 +90,11 @@ async function serveDataset(request, env, build) {
 }
 
 const routes = {
+  // Human docs (Scalar) + the machine-readable spec.
+  'GET /': () => docsPage(),
+  'GET /openapi.json': () =>
+    json(spec, { headers: { 'Cache-Control': 'public, max-age=300' } }),
+
   'GET /v1/health': (request, env) =>
     json(envelope({ status: 'ok', version: env.API_VERSION }, null)),
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -10,6 +10,8 @@
  * - Path-based versioning: additive changes only within /v1/.
  */
 
+import { runRefresh } from './refresh.js';
+
 const SCHEMA_VERSION = 1;
 
 const CORS_HEADERS = {
@@ -50,6 +52,11 @@ const routes = {
 };
 
 export default {
+  // 15-minute cron: rebuild the dataset into KV (see refresh.js).
+  async scheduled(controller, env, ctx) {
+    ctx.waitUntil(runRefresh(env));
+  },
+
   async fetch(request, env) {
     const url = new URL(request.url);
 

--- a/worker/src/merge.js
+++ b/worker/src/merge.js
@@ -1,0 +1,144 @@
+/**
+ * Dataset builder — the server-side version of the merge the browser does
+ * in assets/js/services.js (fetchNexusTaggedMods) + app.js concat.
+ *
+ * Pure function: all inputs are plain data, no fetching, no KV. The cron
+ * handler (B3) feeds it CDN files + Nexus nodes; tests feed it fixtures.
+ *
+ * Precedence rules (must match the site):
+ * - excluded_mods.json entries never appear, even with a valid block
+ * - manual entries win by nexus_id; the Nexus node only contributes
+ *   image/updatedAt metadata for thumbnail backfill
+ * - auto entries need a valid [NCZoning] block (coords + category)
+ *
+ * Contract rules (frozen): auto entries get stable id `nexus-<nexus_id>`;
+ * every location carries source ("manual"|"auto") and district/subdistrict.
+ */
+
+import { parseNcZoningBlock } from './parse.js';
+import { assignDistrict } from './districts.js';
+
+export const DESCRIPTION_MAX_LENGTH = 500;
+
+/**
+ * @param {object} input
+ * @param {Array}  input.manualMods   compiled mods.json array
+ * @param {object} input.tagsDict     data/tags.json ({tag: definition})
+ * @param {object} input.excluded     data/excluded_mods.json ({nexusId: reason})
+ * @param {Array}  input.nexusNodes   raw nodes from the NCZoning GraphQL query
+ * @param {Array}  input.districts    data/subdistricts.json `districts[]`
+ * @returns {{locations: Array, full: Object<string, object>, meta: object}}
+ */
+export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, districts }) {
+  const validTagNames = new Set(Object.keys(tagsDict));
+  const excludedIds = new Set(Object.keys(excluded || {}));
+
+  // Numeric nexus_ids of manual entries (WIP/Dummy have no Nexus page).
+  const existingNexusIds = new Set(
+    manualMods
+      .map((m) => String(m.nexus_id))
+      .filter((id) => !['wip', 'dummy'].includes(id.toLowerCase())),
+  );
+
+  const nexusThumbs = {}; // manual-entry image/updatedAt backfill, keyed by nexus_id
+  const autoEntries = [];
+  const skipped = []; // tagged mods with no valid block — surfaced for monitoring
+
+  for (const node of nexusNodes || []) {
+    const nexusId = String(node.modId);
+    if (excludedIds.has(nexusId)) continue;
+    if (existingNexusIds.has(nexusId)) {
+      nexusThumbs[nexusId] = {
+        pictureUrl: node.pictureUrl || null,
+        thumbnailUrl: node.thumbnailUrl || null,
+        updatedAt: node.updatedAt || null,
+      };
+      continue;
+    }
+
+    const parsed = parseNcZoningBlock(node.description, validTagNames);
+    if (!parsed) {
+      skipped.push({ nexus_id: nexusId, name: node.name || 'Unknown Mod' });
+      continue;
+    }
+
+    const uploaderName = node.uploader?.name || 'Unknown';
+    const summary = node.summary || '';
+    autoEntries.push({
+      id: `nexus-${nexusId}`,
+      name: node.name || 'Unknown Mod',
+      authors: [uploaderName, ...parsed.additionalAuthors],
+      ...(parsed.credits ? { credits: parsed.credits } : {}),
+      coordinates: parsed.coordinates,
+      ...(parsed.yaw !== null ? { yaw: parsed.yaw } : {}),
+      nexus_id: nexusId,
+      description:
+        summary.length > DESCRIPTION_MAX_LENGTH
+          ? summary.slice(0, DESCRIPTION_MAX_LENGTH - 3) + '...'
+          : summary,
+      category: parsed.category,
+      tags: ['nczoning', ...parsed.tags],
+      source: 'auto',
+      thumbnail_url: node.thumbnailUrl || null,
+      picture_url: node.pictureUrl || null,
+      updated_at: node.updatedAt || null,
+    });
+  }
+
+  const all = [
+    ...manualMods.map((m) => ({ ...m, source: 'manual' })),
+    ...autoEntries,
+  ].sort((a, b) => a.name.localeCompare(b.name));
+
+  const perDistrict = {};
+  const locations = [];
+  const full = {};
+
+  for (const entry of all) {
+    const { district, subdistrict } = assignDistrict(entry.coordinates, districts);
+    const key = district || 'Outside mapped districts';
+    perDistrict[key] = (perDistrict[key] || 0) + 1;
+
+    locations.push({
+      id: entry.id,
+      name: entry.name,
+      nexus_id: String(entry.nexus_id),
+      coordinates: entry.coordinates,
+      ...(entry.yaw !== undefined && entry.yaw !== null ? { yaw: entry.yaw } : {}),
+      category: entry.category,
+      tags: entry.tags,
+      authors: entry.authors,
+      source: entry.source,
+      district,
+      subdistrict,
+    });
+
+    full[entry.id] = {
+      ...locations[locations.length - 1],
+      description: entry.description ?? '',
+      ...(entry.credits ? { credits: entry.credits } : {}),
+      ...(entry.source === 'auto'
+        ? {
+            thumbnail_url: entry.thumbnail_url,
+            picture_url: entry.picture_url,
+            updated_at: entry.updated_at,
+          }
+        : {}),
+    };
+  }
+
+  return {
+    locations,
+    full,
+    meta: {
+      counts: {
+        manual: manualMods.length,
+        auto: autoEntries.length,
+        total: all.length,
+        per_district: perDistrict,
+      },
+      skipped,
+      nexus_thumbs: nexusThumbs,
+    },
+  };
+}

--- a/worker/src/merge.js
+++ b/worker/src/merge.js
@@ -27,9 +27,13 @@ export const DESCRIPTION_MAX_LENGTH = 500;
  * @param {object} input.excluded     data/excluded_mods.json ({nexusId: reason})
  * @param {Array}  input.nexusNodes   raw nodes from the NCZoning GraphQL query
  * @param {Array}  input.districts    data/subdistricts.json `districts[]`
+ * @param {object} [input.manualThumbs] modsByUid image/updatedAt for manual
+ *   mods, keyed by numeric nexus_id ({pictureUrl, thumbnailUrl, updatedAt}).
+ *   Covers manual entries not tagged NCZoning (the tagged query only backfills
+ *   the tagged ones). Optional so existing callers/tests don't break.
  * @returns {{locations: Array, full: Object<string, object>, meta: object}}
  */
-export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, districts }) {
+export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs = {} }) {
   const validTagNames = new Set(Object.keys(tagsDict));
   const excludedIds = new Set(Object.keys(excluded || {}));
 
@@ -90,6 +94,28 @@ export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, distr
     ...autoEntries,
   ].sort((a, b) => a.name.localeCompare(b.name));
 
+  // Resolve image/updatedAt for a full entry. Auto mods carry theirs from the
+  // tagged node; manual mods come from the modsByUid backfill (manualThumbs),
+  // falling back to the tagged-query thumbs for manual mods that happen to be
+  // NCZoning-tagged. WIP/Dummy (non-numeric) manual entries resolve to nulls.
+  // The field is ALWAYS present (null when unknown) so the shape stays stable
+  // for DTO consumers.
+  function resolveThumbs(entry) {
+    if (entry.source === 'auto') {
+      return {
+        thumbnail_url: entry.thumbnail_url ?? null,
+        picture_url: entry.picture_url ?? null,
+        updated_at: entry.updated_at ?? null,
+      };
+    }
+    const t = manualThumbs[String(entry.nexus_id)] || nexusThumbs[String(entry.nexus_id)] || null;
+    return {
+      thumbnail_url: t?.thumbnailUrl ?? null,
+      picture_url: t?.pictureUrl ?? null,
+      updated_at: t?.updatedAt ?? null,
+    };
+  }
+
   const perDistrict = {};
   const locations = [];
   const full = {};
@@ -117,13 +143,7 @@ export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, distr
       ...locations[locations.length - 1],
       description: entry.description ?? '',
       ...(entry.credits ? { credits: entry.credits } : {}),
-      ...(entry.source === 'auto'
-        ? {
-            thumbnail_url: entry.thumbnail_url,
-            picture_url: entry.picture_url,
-            updated_at: entry.updated_at,
-          }
-        : {}),
+      ...resolveThumbs(entry),
     };
   }
 

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -1,0 +1,84 @@
+/**
+ * Nexus V2 GraphQL auto-discovery fetch — server-side port of the
+ * pagination loop in assets/js/services.js fetchNexusTaggedMods, minus
+ * the merge (that lives in merge.js) and the localStorage cache (KV plays
+ * that role, in the B3 cron).
+ *
+ * The V2 API is technically unsupported (see docs/nexus-api-reference.md);
+ * callers must treat failures as "keep last-known-good", never as "empty
+ * dataset".
+ */
+
+export const NEXUS_GQL_ENDPOINT = 'https://api.nexusmods.com/v2/graphql';
+export const NEXUS_GAME_ID = 3333; // Cyberpunk 2077
+export const NEXUS_BATCH_SIZE = 50;
+
+const QUERY = `
+  query NCZoningMods($filter: ModsFilter!, $count: Int!, $offset: Int!) {
+    mods(filter: $filter, count: $count, offset: $offset) {
+      nodes {
+        modId
+        name
+        summary
+        description
+        pictureUrl
+        thumbnailUrl
+        updatedAt
+        uploader {
+          name
+        }
+      }
+      totalCount
+    }
+  }
+`;
+
+/**
+ * Fetch every mod tagged NCZoning for CP2077. Throws on any page failure —
+ * a partial node list must never be mistaken for the full tag population
+ * (missing mods would be dropped from the map).
+ *
+ * @param {typeof fetch} fetchImpl injectable for tests
+ * @returns {Promise<Array>} raw GraphQL nodes
+ */
+export async function fetchTaggedModNodes(fetchImpl = fetch) {
+  const nodes = [];
+  let offset = 0;
+  let totalCount = Infinity;
+
+  while (offset < totalCount) {
+    const res = await fetchImpl(NEXUS_GQL_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: QUERY,
+        variables: {
+          filter: {
+            gameId: [{ value: String(NEXUS_GAME_ID) }],
+            tag: [{ value: 'NCZoning' }],
+          },
+          count: NEXUS_BATCH_SIZE,
+          offset,
+        },
+      }),
+    });
+    if (!res.ok) throw new Error(`Nexus GraphQL HTTP ${res.status}`);
+
+    const json = await res.json();
+    const page = json?.data?.mods;
+    if (!page) {
+      throw new Error(
+        `Nexus GraphQL: no mods page in response${json?.errors ? ` (${JSON.stringify(json.errors).slice(0, 200)})` : ''}`,
+      );
+    }
+
+    totalCount = page.totalCount ?? 0;
+    const pageNodes = page.nodes || [];
+    if (pageNodes.length === 0) break;
+    nodes.push(...pageNodes);
+    offset += pageNodes.length;
+    if (pageNodes.length < NEXUS_BATCH_SIZE) break; // last page
+  }
+
+  return nodes;
+}

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -82,3 +82,80 @@ export async function fetchTaggedModNodes(fetchImpl = fetch) {
 
   return nodes;
 }
+
+/** Composite UID Nexus expects for modsByUid: `${gameId}:${modId}`. */
+function toNexusUid(modId) {
+  return `${NEXUS_GAME_ID}:${modId}`;
+}
+
+const THUMBS_QUERY = `query modsByUid($uids: [ID!]!, $count: Int!) {
+  modsByUid(uids: $uids, count: $count) {
+    nodes {
+      modId
+      pictureUrl
+      thumbnailUrl
+      updatedAt
+    }
+  }
+}`;
+
+/**
+ * Fetch picture/thumbnail/updatedAt for a set of numeric mod ids via
+ * modsByUid. Unlike fetchTaggedModNodes, this NEVER throws: thumbnails are
+ * cosmetic, so a Nexus hiccup here degrades to "some images missing this
+ * cycle", not "whole dataset stale". Auto-discovered mods already carry their
+ * images from the tagged query; this covers the manual entries.
+ *
+ * Mirrors the site's chunk + single-retry pattern (large modsByUid calls
+ * silently drop a subset of nodes), see assets/js/services.js.
+ *
+ * @param {typeof fetch} fetchImpl injectable for tests
+ * @param {string[]} numericIds manual mods' numeric nexus_ids
+ * @returns {Promise<Object<string, {pictureUrl, thumbnailUrl, updatedAt}>>}
+ */
+export async function fetchModsByUidThumbs(fetchImpl = fetch, numericIds = []) {
+  const ids = [...new Set(numericIds.map(String))].filter((id) => /^\d+$/.test(id));
+  if (ids.length === 0) return {};
+
+  const postChunk = async (chunkIds) => {
+    try {
+      const res = await fetchImpl(NEXUS_GQL_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          query: THUMBS_QUERY,
+          variables: { uids: chunkIds.map(toNexusUid), count: chunkIds.length },
+        }),
+      });
+      if (!res.ok) return {};
+      const json = await res.json();
+      const nodes = json?.data?.modsByUid?.nodes || [];
+      const map = {};
+      for (const node of nodes) {
+        map[String(node.modId)] = {
+          pictureUrl: node.pictureUrl || null,
+          thumbnailUrl: node.thumbnailUrl || null,
+          updatedAt: node.updatedAt || null,
+        };
+      }
+      return map;
+    } catch {
+      return {}; // cosmetic — swallow and let the caller serve what it has
+    }
+  };
+
+  const fetchChunk = async (chunkIds) => {
+    const first = await postChunk(chunkIds);
+    const missing = chunkIds.filter((id) => !first[id]);
+    if (missing.length === 0) return first;
+    const retry = await postChunk(missing); // one in-flight retry for dropped UIDs
+    return { ...first, ...retry };
+  };
+
+  const chunks = [];
+  for (let i = 0; i < ids.length; i += NEXUS_BATCH_SIZE) {
+    chunks.push(ids.slice(i, i + NEXUS_BATCH_SIZE));
+  }
+  const results = await Promise.all(chunks.map(fetchChunk));
+  return Object.assign({}, ...results);
+}

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -83,9 +83,14 @@ export async function fetchTaggedModNodes(fetchImpl = fetch) {
   return nodes;
 }
 
-/** Composite UID Nexus expects for modsByUid: `${gameId}:${modId}`. */
+/**
+ * Composite UID Nexus expects for modsByUid: (gameId << 32) + modId, as a
+ * single decimal string — NOT "gameId:modId". Must match the site's
+ * NCZ.toNexusUid (assets/js/utils.js) exactly, or Nexus silently drops the
+ * UIDs and returns no images.
+ */
 function toNexusUid(modId) {
-  return `${NEXUS_GAME_ID}:${modId}`;
+  return ((BigInt(NEXUS_GAME_ID) << 32n) + BigInt(modId)).toString();
 }
 
 const THUMBS_QUERY = `query modsByUid($uids: [ID!]!, $count: Int!) {

--- a/worker/src/parse.js
+++ b/worker/src/parse.js
@@ -1,0 +1,68 @@
+/**
+ * NCZoning metadata-block parser — server-side port of
+ * assets/js/utils.js NCZ.parseNcZoningBlock (keep the two in sync; the
+ * client version's comment block documents the real-world breakage this
+ * strategy survives).
+ *
+ * Strategy: strip all BBCode, then treat `NCZoning:` as a token that can
+ * appear anywhere (not a whole line). Every occurrence is tried as a
+ * candidate; the first one whose following lines yield valid coords +
+ * category wins, so the coords/category validation — not the sentinel's
+ * position — is what disambiguates the real block from prose.
+ */
+
+const RECOGNIZED = new Set(['coords', 'category', 'tags', 'yaw', 'credits', 'authors']);
+const VALID_CATEGORIES = ['location-overhaul', 'new-location', 'other'];
+
+/**
+ * @param {string} description Raw Nexus mod description (BBCode).
+ * @param {Set<string>} validTagNames Known tag ids; unknown tags are dropped.
+ * @returns {{coordinates: number[], category: string, tags: string[],
+ *   credits: string|null, additionalAuthors: string[], yaw: number|null}|null}
+ */
+export function parseNcZoningBlock(description, validTagNames) {
+  if (!description) return null;
+
+  const text = description
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/\[\/?[a-z][^\]]*\]/gi, '');
+
+  const finalize = (data) => {
+    if (!data.coords) return null;
+    // coords: two or three comma-separated numbers [X, Y] or [X, Y, Z].
+    const coordParts = data.coords.split(',').map((s) => parseFloat(s.trim()));
+    if (coordParts.length < 2 || coordParts.length > 3 || coordParts.some(Number.isNaN)) return null;
+    if (!data.category || !VALID_CATEGORIES.includes(data.category)) return null;
+
+    return {
+      coordinates: coordParts,
+      category: data.category,
+      tags: data.tags
+        ? data.tags.split(',').map((t) => t.trim()).filter((t) => validTagNames.has(t))
+        : [],
+      credits: data.credits || null,
+      additionalAuthors: data.authors
+        ? data.authors.split(',').map((a) => a.trim()).filter(Boolean)
+        : [],
+      yaw: data.yaw && !Number.isNaN(parseFloat(data.yaw)) ? parseFloat(data.yaw) : null,
+    };
+  };
+
+  const sentinel = /NCZoning[ \t]*:/gi;
+  let m;
+  while ((m = sentinel.exec(text)) !== null) {
+    const data = {};
+    for (const raw of text.slice(m.index + m[0].length).split('\n')) {
+      const line = raw.trim();
+      if (!line) continue;
+      const eqIdx = line.indexOf('=');
+      const key = eqIdx === -1 ? '' : line.slice(0, eqIdx).trim().toLowerCase();
+      if (!RECOGNIZED.has(key)) break;
+      const value = line.slice(eqIdx + 1).trim();
+      if (value && !(key in data)) data[key] = value;
+    }
+    const parsed = finalize(data);
+    if (parsed) return parsed;
+  }
+  return null;
+}

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -27,11 +27,18 @@ async function fetchJson(fetchImpl, origin, path) {
   return res.json();
 }
 
-/** Post a failure embed to Discord if a webhook is configured. */
+/**
+ * Post a failure embed to Discord if a webhook is configured. Prefers the
+ * dedicated map-alerts channel (NCZ_ALERTS_DISCORD_WEBHOOK_URL), falling back
+ * to the legacy submissions webhook so there's no alerting gap until the new
+ * Cloudflare Worker secret is set (`wrangler secret put
+ * NCZ_ALERTS_DISCORD_WEBHOOK_URL` for BOTH the prod and staging Workers).
+ */
 async function alertDiscord(env, fetchImpl, reason) {
-  if (!env.DISCORD_WEBHOOK_URL) return;
+  const webhook = env.NCZ_ALERTS_DISCORD_WEBHOOK_URL || env.DISCORD_WEBHOOK_URL;
+  if (!webhook) return;
   try {
-    await fetchImpl(env.DISCORD_WEBHOOK_URL, {
+    await fetchImpl(webhook, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -13,7 +13,7 @@
  * unit-testable with a fake KV + fake fetch.
  */
 
-import { fetchTaggedModNodes } from './nexus.js';
+import { fetchTaggedModNodes, fetchModsByUidThumbs } from './nexus.js';
 import { buildDataset } from './merge.js';
 import { districtsPayload } from './districts.js';
 import { KEYS, contentHash, readMeta, writeDataset, writeMeta } from './store.js';
@@ -68,8 +68,17 @@ export async function runRefresh(env, fetchImpl = fetch) {
     const districts = subdistricts.districts;
     const nexusNodes = await fetchTaggedModNodes(fetchImpl);
 
+    // Manual-mod thumbnails: the tagged query only backfills manual mods that
+    // are themselves NCZoning-tagged, so pull the rest via modsByUid. Cosmetic
+    // and non-throwing — a failure here just leaves some images null this
+    // cycle, it never marks the dataset stale.
+    const manualNumericIds = manualMods
+      .map((m) => String(m.nexus_id))
+      .filter((id) => /^\d+$/.test(id));
+    const manualThumbs = await fetchModsByUidThumbs(fetchImpl, manualNumericIds);
+
     const { locations, full, meta } = buildDataset({
-      manualMods, tagsDict, excluded, nexusNodes, districts,
+      manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs,
     });
     const districtsOut = districtsPayload(districts);
 

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -50,7 +50,7 @@ async function alertDiscord(env, fetchImpl, reason) {
 
 /**
  * Run one refresh cycle.
- * @param {object} env  Worker env (DATA KV binding, SITE_ORIGIN?, DISCORD_WEBHOOK_URL?)
+ * @param {object} env  Worker env (DATASET KV binding, SITE_ORIGIN?, DISCORD_WEBHOOK_URL?)
  * @param {typeof fetch} fetchImpl  injectable
  * @returns {Promise<{changed:boolean, version:string|null, stale:boolean, error?:string}>}
  */

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -73,9 +73,10 @@ export async function runRefresh(env, fetchImpl = fetch) {
     });
     const districtsOut = districtsPayload(districts);
 
-    // Hash the content that actually varies (not generated_at).
+    // Hash the content that actually varies (not generated_at). Tags are
+    // included so a tags.json edit propagates through the ETag.
     const version = await contentHash(
-      JSON.stringify({ locations, full, districts: districtsOut }),
+      JSON.stringify({ locations, full, districts: districtsOut, tags: tagsDict }),
     );
 
     const prev = await readMeta(env);
@@ -87,6 +88,7 @@ export async function runRefresh(env, fetchImpl = fetch) {
       slim: locations,
       full,
       districts: districtsOut,
+      tags: tagsDict,
       meta: {
         schema: SCHEMA_VERSION,
         generated_at: generatedAt,

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -1,0 +1,121 @@
+/**
+ * Refresh orchestrator — the body of the 15-minute cron. Fetches the CDN
+ * source files + Nexus auto-discovery, rebuilds the dataset, and writes to
+ * KV only when the content hash changes.
+ *
+ * Failure posture (the load-bearing rule): if Nexus (or any source) fails,
+ * KEEP the last-known-good dataset, mark meta.discovery_stale, alert
+ * Discord, and never serve an empty/partial dataset. A partial Nexus page
+ * already throws in nexus.js, so a truncated tag population can't slip
+ * through as "complete".
+ *
+ * Pure-ish: all I/O is injected (fetchImpl, env), so the whole thing is
+ * unit-testable with a fake KV + fake fetch.
+ */
+
+import { fetchTaggedModNodes } from './nexus.js';
+import { buildDataset } from './merge.js';
+import { districtsPayload } from './districts.js';
+import { KEYS, contentHash, readMeta, writeDataset, writeMeta } from './store.js';
+
+const SCHEMA_VERSION = 1;
+
+/** Fetch a JSON file from the site origin; throws on non-200. */
+async function fetchJson(fetchImpl, origin, path) {
+  const res = await fetchImpl(`${origin}${path}`);
+  if (!res.ok) throw new Error(`GET ${path} → HTTP ${res.status}`);
+  return res.json();
+}
+
+/** Post a failure embed to Discord if a webhook is configured. */
+async function alertDiscord(env, fetchImpl, reason) {
+  if (!env.DISCORD_WEBHOOK_URL) return;
+  try {
+    await fetchImpl(env.DISCORD_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        embeds: [{
+          title: '⚠️ Data API refresh failed',
+          description: String(reason).slice(0, 1500),
+          color: 0xffb300,
+          footer: { text: 'Serving last-known-good dataset (discovery_stale=true)' },
+        }],
+      }),
+    });
+  } catch {
+    // Alerting must never mask the original failure.
+  }
+}
+
+/**
+ * Run one refresh cycle.
+ * @param {object} env  Worker env (DATA KV binding, SITE_ORIGIN?, DISCORD_WEBHOOK_URL?)
+ * @param {typeof fetch} fetchImpl  injectable
+ * @returns {Promise<{changed:boolean, version:string|null, stale:boolean, error?:string}>}
+ */
+export async function runRefresh(env, fetchImpl = fetch) {
+  const origin = env.SITE_ORIGIN || 'https://nczoning.net';
+  const generatedAt = new Date().toISOString();
+
+  try {
+    const [manualMods, tagsDict, excluded, subdistricts] = await Promise.all([
+      fetchJson(fetchImpl, origin, '/mods.json'),
+      fetchJson(fetchImpl, origin, '/data/tags.json'),
+      fetchJson(fetchImpl, origin, '/data/excluded_mods.json').catch(() => ({})),
+      fetchJson(fetchImpl, origin, '/data/subdistricts.json'),
+    ]);
+    const districts = subdistricts.districts;
+    const nexusNodes = await fetchTaggedModNodes(fetchImpl);
+
+    const { locations, full, meta } = buildDataset({
+      manualMods, tagsDict, excluded, nexusNodes, districts,
+    });
+    const districtsOut = districtsPayload(districts);
+
+    // Hash the content that actually varies (not generated_at).
+    const version = await contentHash(
+      JSON.stringify({ locations, full, districts: districtsOut }),
+    );
+
+    const prev = await readMeta(env);
+    if (prev && prev.dataset_version === version && !prev.discovery_stale) {
+      return { changed: false, version, stale: false };
+    }
+
+    await writeDataset(env, {
+      slim: locations,
+      full,
+      districts: districtsOut,
+      meta: {
+        schema: SCHEMA_VERSION,
+        generated_at: generatedAt,
+        dataset_version: version,
+        counts: meta.counts,
+        skipped: meta.skipped,
+        discovery_stale: false,
+      },
+    });
+    return { changed: true, version, stale: false };
+  } catch (err) {
+    // Keep last-known-good; flag stale; alert. Never wipe the dataset.
+    const prev = await readMeta(env);
+    if (prev) {
+      await writeMeta(env, {
+        ...prev,
+        discovery_stale: true,
+        last_error: String(err).slice(0, 300),
+        last_error_at: generatedAt,
+      });
+    }
+    await alertDiscord(env, fetchImpl, err);
+    return {
+      changed: false,
+      version: prev?.dataset_version ?? null,
+      stale: true,
+      error: String(err),
+    };
+  }
+}
+
+export { KEYS };

--- a/worker/src/store.js
+++ b/worker/src/store.js
@@ -3,17 +3,19 @@
  * - dataset:v1           slim locations array (the workhorse read)
  * - dataset:v1:full      { id: fullEntry } map for /v1/locations/{id}
  * - dataset:v1:districts /v1/districts payload
+ * - dataset:v1:tags      tag dictionary ({ tagId: description })
  * - dataset:v1:meta      { schema, generated_at, dataset_version, counts,
  *                          discovery_stale, skipped }
  *
  * dataset_version is a content hash: the cron writes only when it changes,
- * and it doubles as the ETag for the read path (B4).
+ * and it doubles as the ETag for the read path.
  */
 
 export const KEYS = {
   slim: 'dataset:v1',
   full: 'dataset:v1:full',
   districts: 'dataset:v1:districts',
+  tags: 'dataset:v1:tags',
   meta: 'dataset:v1:meta',
 };
 
@@ -30,15 +32,16 @@ export async function readMeta(env) {
 }
 
 /**
- * Persist a freshly built dataset. Writes all four keys; callers only reach
- * here when the hash changed, so the per-key 1 write/s limit is never a risk
+ * Persist a freshly built dataset. Writes all keys; callers only reach here
+ * when the hash changed, so the per-key 1 write/s limit is never a risk
  * (cron runs every 15 min).
  */
-export async function writeDataset(env, { slim, full, districts, meta }) {
+export async function writeDataset(env, { slim, full, districts, tags, meta }) {
   await Promise.all([
     env.DATASET.put(KEYS.slim, JSON.stringify(slim)),
     env.DATASET.put(KEYS.full, JSON.stringify(full)),
     env.DATASET.put(KEYS.districts, JSON.stringify(districts)),
+    env.DATASET.put(KEYS.tags, JSON.stringify(tags)),
     env.DATASET.put(KEYS.meta, JSON.stringify(meta)),
   ]);
 }

--- a/worker/src/store.js
+++ b/worker/src/store.js
@@ -26,7 +26,7 @@ export async function contentHash(str) {
 
 /** Read the current meta record (or null before the first successful cron). */
 export async function readMeta(env) {
-  return env.DATA.get(KEYS.meta, 'json');
+  return env.DATASET.get(KEYS.meta, 'json');
 }
 
 /**
@@ -36,14 +36,14 @@ export async function readMeta(env) {
  */
 export async function writeDataset(env, { slim, full, districts, meta }) {
   await Promise.all([
-    env.DATA.put(KEYS.slim, JSON.stringify(slim)),
-    env.DATA.put(KEYS.full, JSON.stringify(full)),
-    env.DATA.put(KEYS.districts, JSON.stringify(districts)),
-    env.DATA.put(KEYS.meta, JSON.stringify(meta)),
+    env.DATASET.put(KEYS.slim, JSON.stringify(slim)),
+    env.DATASET.put(KEYS.full, JSON.stringify(full)),
+    env.DATASET.put(KEYS.districts, JSON.stringify(districts)),
+    env.DATASET.put(KEYS.meta, JSON.stringify(meta)),
   ]);
 }
 
 /** Update only the meta record (last-known-good touch on a failed refresh). */
 export async function writeMeta(env, meta) {
-  await env.DATA.put(KEYS.meta, JSON.stringify(meta));
+  await env.DATASET.put(KEYS.meta, JSON.stringify(meta));
 }

--- a/worker/src/store.js
+++ b/worker/src/store.js
@@ -1,0 +1,49 @@
+/**
+ * KV storage layer for the dataset. Keys under `dataset:v1*`:
+ * - dataset:v1           slim locations array (the workhorse read)
+ * - dataset:v1:full      { id: fullEntry } map for /v1/locations/{id}
+ * - dataset:v1:districts /v1/districts payload
+ * - dataset:v1:meta      { schema, generated_at, dataset_version, counts,
+ *                          discovery_stale, skipped }
+ *
+ * dataset_version is a content hash: the cron writes only when it changes,
+ * and it doubles as the ETag for the read path (B4).
+ */
+
+export const KEYS = {
+  slim: 'dataset:v1',
+  full: 'dataset:v1:full',
+  districts: 'dataset:v1:districts',
+  meta: 'dataset:v1:meta',
+};
+
+/** SHA-256 hex of a string, via Web Crypto (Workers + Node 24). */
+export async function contentHash(str) {
+  const bytes = new TextEncoder().encode(str);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/** Read the current meta record (or null before the first successful cron). */
+export async function readMeta(env) {
+  return env.DATA.get(KEYS.meta, 'json');
+}
+
+/**
+ * Persist a freshly built dataset. Writes all four keys; callers only reach
+ * here when the hash changed, so the per-key 1 write/s limit is never a risk
+ * (cron runs every 15 min).
+ */
+export async function writeDataset(env, { slim, full, districts, meta }) {
+  await Promise.all([
+    env.DATA.put(KEYS.slim, JSON.stringify(slim)),
+    env.DATA.put(KEYS.full, JSON.stringify(full)),
+    env.DATA.put(KEYS.districts, JSON.stringify(districts)),
+    env.DATA.put(KEYS.meta, JSON.stringify(meta)),
+  ]);
+}
+
+/** Update only the meta record (last-known-good touch on a failed refresh). */
+export async function writeMeta(env, meta) {
+  await env.DATA.put(KEYS.meta, JSON.stringify(meta));
+}

--- a/worker/test/districts.test.js
+++ b/worker/test/districts.test.js
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  pointInPolygon, polygonCentroid, resolveArea, assignDistrict, districtsPayload,
+} from '../src/districts.js';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const { districts } = JSON.parse(
+  readFileSync(join(repoRoot, 'data', 'subdistricts.json'), 'utf8'),
+);
+
+// Deterministic interior point: walk from the centroid toward a vertex
+// until the ray-cast test agrees the point is inside (handles concave rings).
+function interiorPoint(ring) {
+  const c = polygonCentroid(ring);
+  if (pointInPolygon(c, ring)) return c;
+  for (const v of ring) {
+    for (const t of [0.5, 0.25, 0.75, 0.9]) {
+      const p = [c[0] + (v[0] - c[0]) * t, c[1] + (v[1] - c[1]) * t];
+      if (pointInPolygon(p, ring)) return p;
+    }
+  }
+  throw new Error('no interior point found');
+}
+
+test('real subdistricts.json loads with the expected shape', () => {
+  assert.ok(districts.length >= 8, `expected >=8 districts, got ${districts.length}`);
+  for (const d of districts) {
+    assert.equal(typeof d.name, 'string');
+    // Badlands has no parent polygon — only subdistrict polygons.
+    const hasOwnRing = Array.isArray(d.polygon) && d.polygon.length >= 3;
+    const hasSubRings = (d.subdistricts || []).some(
+      (s) => Array.isArray(s.polygon) && s.polygon.length >= 3,
+    );
+    assert.ok(hasOwnRing || hasSubRings, `${d.name}: no polygons at all`);
+  }
+});
+
+test('an interior point of every subdistrict resolves to that subdistrict', () => {
+  for (const d of districts) {
+    for (const s of d.subdistricts || []) {
+      const p = interiorPoint(s.polygon);
+      const hit = resolveArea(p, districts);
+      assert.ok(hit, `${s.name}: no area resolved`);
+      // Smallest containing subdistrict wins; overlapping rings mean the hit
+      // may legitimately be a smaller neighbour, but the common case is exact.
+      assert.ok(hit.subdistrict, `${s.name}: resolved district-only`);
+    }
+  }
+});
+
+test('outside every polygon defaults to Badlands (game rule)', () => {
+  assert.deepEqual(assignDistrict([99999, 99999, 0], districts), {
+    district: 'Badlands',
+    subdistrict: null,
+  });
+});
+
+test('every real location gets a district (Badlands catch-all included)', () => {
+  const locDir = join(repoRoot, 'data', 'locations');
+  const files = readdirSync(locDir).filter((f) => f.endsWith('.json'));
+  assert.ok(files.length > 200, `expected >200 location files, got ${files.length}`);
+  let assigned = 0, subs = 0;
+  for (const f of files) {
+    const mod = JSON.parse(readFileSync(join(locDir, f), 'utf8'));
+    const { district, subdistrict } = assignDistrict(mod.coordinates, districts);
+    if (district) assigned++;
+    if (subdistrict) subs++;
+  }
+  assert.equal(assigned, files.length, 'district must never be null on real data');
+  assert.ok(subs / files.length > 0.6,
+    `only ${subs}/${files.length} locations got a subdistrict`);
+});
+
+test('districtsPayload flattens boundaries (DTO rule: no arrays-of-arrays)', () => {
+  const payload = districtsPayload(districts);
+  for (const d of payload) {
+    assert.ok(d.boundary.every((n) => typeof n === 'number'), `${d.name}: non-flat boundary`);
+    assert.equal(d.boundary.length % 2, 0);
+    if (d.centroid) {
+      assert.equal(typeof d.centroid.x, 'number');
+      assert.equal(typeof d.centroid.y, 'number');
+    }
+    for (const s of d.subdistricts) {
+      assert.ok(s.boundary.every((n) => typeof n === 'number'), `${s.name}: non-flat boundary`);
+      assert.equal(typeof s.canonical, 'boolean');
+    }
+  }
+});

--- a/worker/test/index.test.js
+++ b/worker/test/index.test.js
@@ -66,6 +66,27 @@ test('GET /v1/locations returns the slim array in an envelope with ETag', async 
   assert.ok(!('description' in body.data[0])); // slim
 });
 
+test('GET /v1/locations?full=1 returns full entries as an array, with a -full ETag', async () => {
+  const res = await worker.fetch(GET('/v1/locations?full=1'), seededEnv());
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('ETag'), '"abc123-full"'); // variant ETag, not the slim one
+  const body = await res.json();
+  assert.equal(body.data.length, 2);
+  assert.equal(body.data[0].description, 'a manual mod'); // full carries description
+});
+
+test('a slim ETag does not satisfy a ?full=1 request (distinct representations)', async () => {
+  const res = await worker.fetch(
+    GET('/v1/locations?full=1', { 'If-None-Match': '"abc123"' }), seededEnv());
+  assert.equal(res.status, 200); // slim etag ≠ full etag → fresh 200, never a wrong 304
+});
+
+test('matching -full ETag yields 304 for ?full=1', async () => {
+  const res = await worker.fetch(
+    GET('/v1/locations?full=1', { 'If-None-Match': '"abc123-full"' }), seededEnv());
+  assert.equal(res.status, 304);
+});
+
 test('matching If-None-Match yields 304 with no body', async () => {
   const res = await worker.fetch(GET('/v1/locations', { 'If-None-Match': '"abc123"' }), seededEnv());
   assert.equal(res.status, 304);

--- a/worker/test/index.test.js
+++ b/worker/test/index.test.js
@@ -1,0 +1,137 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import worker from '../src/index.js';
+import { KEYS } from '../src/store.js';
+
+// In-memory KV seeded with a full dataset (matches what the cron writes).
+function fakeKV(entries = {}) {
+  const store = new Map(Object.entries(entries).map(([k, v]) => [k, JSON.stringify(v)]));
+  return {
+    async get(key, type) {
+      const v = store.get(key);
+      if (v === undefined) return null;
+      return type === 'json' ? JSON.parse(v) : v;
+    },
+    async put(key, value) { store.set(key, value); },
+  };
+}
+
+const META = {
+  schema: 1, generated_at: '2026-07-04T00:00:00.000Z', dataset_version: 'abc123',
+  counts: { manual: 1, auto: 1, total: 2, per_district: { Watson: 2 } },
+  skipped: [], discovery_stale: false,
+};
+const SLIM = [
+  { id: 'm1', name: 'Manual', nexus_id: '1', coordinates: [1, 2, 3], category: 'other', tags: [], authors: ['A'], source: 'manual', district: 'Watson', subdistrict: 'Kabuki' },
+  { id: 'nexus-2', name: 'Auto', nexus_id: '2', coordinates: [4, 5, 6], category: 'new-location', tags: ['nczoning'], authors: ['B'], source: 'auto', district: 'Watson', subdistrict: null },
+];
+const FULL = {
+  m1: { ...SLIM[0], description: 'a manual mod' },
+  'nexus-2': { ...SLIM[1], description: 'an auto mod' },
+};
+const DISTRICTS = [{ id: 'watson', name: 'Watson', boundary: [0, 0, 10, 0, 10, 10], centroid: { x: 5, y: 5 }, subdistricts: [] }];
+const TAGS = { apartment: 'a place', corpo: 'suits' };
+
+function seededEnv() {
+  return {
+    API_VERSION: '0.1.0',
+    DATASET: fakeKV({
+      [KEYS.meta]: META, [KEYS.slim]: SLIM, [KEYS.full]: FULL,
+      [KEYS.districts]: DISTRICTS, [KEYS.tags]: TAGS,
+    }),
+  };
+}
+
+const GET = (path, headers) => new Request(`https://api.nczoning.net${path}`, { headers });
+
+test('GET /v1/health returns ok + version, no ETag', async () => {
+  const res = await worker.fetch(GET('/v1/health'), seededEnv());
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('ETag'), null);
+  const body = await res.json();
+  assert.equal(body.data.status, 'ok');
+  assert.equal(body.data.version, '0.1.0');
+});
+
+test('GET /v1/locations returns the slim array in an envelope with ETag', async () => {
+  const res = await worker.fetch(GET('/v1/locations'), seededEnv());
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('ETag'), '"abc123"');
+  assert.match(res.headers.get('Cache-Control'), /max-age=300/);
+  assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
+  const body = await res.json();
+  assert.equal(body.schema, 1);
+  assert.equal(body.dataset_version, 'abc123');
+  assert.equal(body.data.length, 2);
+  assert.ok(!('description' in body.data[0])); // slim
+});
+
+test('matching If-None-Match yields 304 with no body', async () => {
+  const res = await worker.fetch(GET('/v1/locations', { 'If-None-Match': '"abc123"' }), seededEnv());
+  assert.equal(res.status, 304);
+  assert.equal(res.headers.get('ETag'), '"abc123"');
+  assert.equal(await res.text(), '');
+});
+
+test('stale If-None-Match yields a fresh 200', async () => {
+  const res = await worker.fetch(GET('/v1/locations', { 'If-None-Match': '"old"' }), seededEnv());
+  assert.equal(res.status, 200);
+});
+
+test('GET /v1/locations/{id} returns the full entry', async () => {
+  const res = await worker.fetch(GET('/v1/locations/nexus-2'), seededEnv());
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.data.description, 'an auto mod');
+});
+
+test('GET /v1/locations/{unknown} → 404', async () => {
+  const res = await worker.fetch(GET('/v1/locations/nope'), seededEnv());
+  assert.equal(res.status, 404);
+  assert.equal((await res.json()).data.error, 'not_found');
+});
+
+test('GET /v1/districts returns the hierarchy with flat boundaries', async () => {
+  const res = await worker.fetch(GET('/v1/districts'), seededEnv());
+  const body = await res.json();
+  assert.equal(body.data[0].name, 'Watson');
+  assert.ok(body.data[0].boundary.every((n) => typeof n === 'number'));
+});
+
+test('GET /v1/tags returns the dictionary', async () => {
+  const res = await worker.fetch(GET('/v1/tags'), seededEnv());
+  assert.deepEqual((await res.json()).data, TAGS);
+});
+
+test('GET /v1/meta returns counts + discovery_stale (not the raw record)', async () => {
+  const res = await worker.fetch(GET('/v1/meta'), seededEnv());
+  const body = await res.json();
+  assert.equal(body.data.counts.total, 2);
+  assert.equal(body.data.discovery_stale, false);
+  assert.ok(!('dataset_version' in body.data)); // version lives on the envelope
+});
+
+test('empty KV (pre-first-cron) → 503 not_ready', async () => {
+  const env = { API_VERSION: '0.1.0', DATASET: fakeKV() };
+  const res = await worker.fetch(GET('/v1/locations'), env);
+  assert.equal(res.status, 503);
+  assert.equal(res.headers.get('Retry-After'), '60');
+});
+
+test('OPTIONS preflight → 204 with CORS', async () => {
+  const res = await worker.fetch(
+    new Request('https://api.nczoning.net/v1/locations', { method: 'OPTIONS' }), seededEnv());
+  assert.equal(res.status, 204);
+  assert.equal(res.headers.get('Access-Control-Allow-Methods'), 'GET, HEAD, OPTIONS');
+});
+
+test('POST → 405', async () => {
+  const res = await worker.fetch(
+    new Request('https://api.nczoning.net/v1/locations', { method: 'POST' }), seededEnv());
+  assert.equal(res.status, 405);
+});
+
+test('unknown route → 404', async () => {
+  const res = await worker.fetch(GET('/v1/nope'), seededEnv());
+  assert.equal(res.status, 404);
+});

--- a/worker/test/merge.test.js
+++ b/worker/test/merge.test.js
@@ -1,0 +1,129 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildDataset } from '../src/merge.js';
+
+// One square district (0,0)-(1000,1000) with a subdistrict in its SW quarter.
+const DISTRICTS = [
+  {
+    id: 50, name: 'Testville',
+    polygon: [[0, 0], [1000, 0], [1000, 1000], [0, 1000]],
+    subdistricts: [
+      { id: 54, name: 'Little Fixture', polygon: [[0, 0], [500, 0], [500, 500], [0, 500]] },
+    ],
+  },
+];
+
+const TAGS = { apartment: 'a place', corpo: 'suits' };
+
+const MANUAL = [
+  {
+    id: 'aaaa-1111', name: 'Zeta Manual Loft', authors: ['Spud'],
+    coordinates: [250, 250, 10], yaw: 90, nexus_id: '12345',
+    description: 'A manual entry.', category: 'new-location', tags: ['apartment'],
+  },
+  {
+    id: 'bbbb-2222', name: 'Alpha WIP Spot', authors: ['Spud'],
+    coordinates: [750, 750], nexus_id: 'WIP',
+    description: 'Not on Nexus yet.', category: 'other', tags: [],
+  },
+];
+
+const NODES = [
+  { // duplicate of the manual entry — must only contribute thumbs
+    modId: 12345, name: 'Zeta Manual Loft (Nexus page)', summary: 'dup',
+    description: 'NCZoning:\ncoords=1,1\ncategory=other',
+    pictureUrl: 'pic-dup', thumbnailUrl: 'thumb-dup', updatedAt: '2026-07-01',
+    uploader: { name: 'Spud' },
+  },
+  { // excluded — never appears even with a valid block
+    modId: 777, name: 'Mistagged Mod', summary: 'oops',
+    description: 'NCZoning:\ncoords=2,2\ncategory=other',
+    uploader: { name: 'Someone' },
+  },
+  { // valid auto-discovered mod
+    modId: 888, name: 'Mango Auto Bar', summary: 'An auto entry.',
+    description: '[code]NCZoning:\ncoords=600,600,5\nyaw=45\ncategory=location-overhaul\ntags=corpo,bogus\ncredits=Team X\nauthors=Friend[/code]',
+    pictureUrl: 'pic-888', thumbnailUrl: 'thumb-888', updatedAt: '2026-07-02',
+    uploader: { name: 'Uploader888' },
+  },
+  { // tagged but no valid block — skipped, surfaced in meta
+    modId: 999, name: 'Blockless Mod', summary: 'no block',
+    description: 'Just prose.', uploader: { name: 'Nobody' },
+  },
+];
+
+const dataset = buildDataset({
+  manualMods: MANUAL,
+  tagsDict: TAGS,
+  excluded: { 777: 'tagged by mistake' },
+  nexusNodes: NODES,
+  districts: DISTRICTS,
+});
+
+test('merges manual + auto with exclusions and duplicates handled', () => {
+  assert.equal(dataset.locations.length, 3); // 2 manual + 1 auto
+  const ids = dataset.locations.map((l) => l.id);
+  assert.ok(ids.includes('nexus-888'), 'stable nexus-<id> for auto entries');
+  assert.ok(!ids.some((id) => id.includes('777')), 'excluded mod absent');
+});
+
+test('sorted alphabetically by name', () => {
+  const names = dataset.locations.map((l) => l.name);
+  assert.deepEqual(names, [...names].sort((a, b) => a.localeCompare(b)));
+});
+
+test('manual entry wins by nexus_id; node contributes thumbnail backfill', () => {
+  const zeta = dataset.locations.find((l) => l.nexus_id === '12345');
+  assert.equal(zeta.name, 'Zeta Manual Loft'); // manual name, not the Nexus page name
+  assert.equal(zeta.source, 'manual');
+  assert.deepEqual(dataset.meta.nexus_thumbs['12345'], {
+    pictureUrl: 'pic-dup', thumbnailUrl: 'thumb-dup', updatedAt: '2026-07-01',
+  });
+});
+
+test('auto entry: authors, tags (nczoning + known only), yaw, images in full', () => {
+  const auto = dataset.locations.find((l) => l.id === 'nexus-888');
+  assert.deepEqual(auto.authors, ['Uploader888', 'Friend']);
+  assert.deepEqual(auto.tags, ['nczoning', 'corpo']); // 'bogus' dropped
+  assert.equal(auto.yaw, 45);
+  assert.equal(auto.source, 'auto');
+  const fullAuto = dataset.full['nexus-888'];
+  assert.equal(fullAuto.credits, 'Team X');
+  assert.equal(fullAuto.thumbnail_url, 'thumb-888');
+});
+
+test('district enrichment: subdistrict wins inside it, district elsewhere', () => {
+  const zeta = dataset.locations.find((l) => l.id === 'aaaa-1111'); // (250,250) in SW quarter
+  assert.equal(zeta.district, 'Testville');
+  assert.equal(zeta.subdistrict, 'Little Fixture');
+  const auto = dataset.locations.find((l) => l.id === 'nexus-888'); // (600,600) outside sub
+  assert.equal(auto.district, 'Testville');
+  assert.equal(auto.subdistrict, null);
+});
+
+test('meta counts + skipped monitoring list', () => {
+  assert.deepEqual(dataset.meta.counts, {
+    manual: 2, auto: 1, total: 3,
+    per_district: { Testville: 3 },
+  });
+  assert.deepEqual(dataset.meta.skipped, [{ nexus_id: '999', name: 'Blockless Mod' }]);
+});
+
+test('slim entries omit description; full carries it', () => {
+  for (const l of dataset.locations) assert.ok(!('description' in l));
+  assert.equal(dataset.full['aaaa-1111'].description, 'A manual entry.');
+});
+
+test('DTO contract: no arrays-of-arrays anywhere in the slim payload', () => {
+  const walk = (v, path) => {
+    if (Array.isArray(v)) {
+      for (const [i, item] of v.entries()) {
+        assert.ok(!Array.isArray(item), `nested array at ${path}[${i}]`);
+        walk(item, `${path}[${i}]`);
+      }
+    } else if (v && typeof v === 'object') {
+      for (const [k, val] of Object.entries(v)) walk(val, `${path}.${k}`);
+    }
+  };
+  walk(dataset.locations, 'locations');
+});

--- a/worker/test/merge.test.js
+++ b/worker/test/merge.test.js
@@ -81,6 +81,31 @@ test('manual entry wins by nexus_id; node contributes thumbnail backfill', () =>
   });
 });
 
+test('manual full entry carries images from the tagged-query backfill', () => {
+  const full = dataset.full['aaaa-1111']; // nexus_id 12345, also a tagged node
+  assert.equal(full.thumbnail_url, 'thumb-dup');
+  assert.equal(full.picture_url, 'pic-dup');
+  assert.equal(full.updated_at, '2026-07-01');
+});
+
+test('WIP manual entry resolves to null images (shape stays stable)', () => {
+  const full = dataset.full['bbbb-2222']; // nexus_id WIP — no Nexus page
+  assert.equal(full.thumbnail_url, null);
+  assert.equal(full.picture_url, null);
+  assert.equal(full.updated_at, null);
+});
+
+test('manualThumbs backfills manual mods that are not NCZoning-tagged (modsByUid path)', () => {
+  const ds = buildDataset({
+    manualMods: MANUAL, tagsDict: TAGS, excluded: { 777: 'x' },
+    nexusNodes: [], districts: DISTRICTS, // no tagged nodes → images can only come from modsByUid
+    manualThumbs: { 12345: { pictureUrl: 'p-mbu', thumbnailUrl: 't-mbu', updatedAt: '2026-07-09' } },
+  });
+  const full = ds.full['aaaa-1111'];
+  assert.equal(full.thumbnail_url, 't-mbu');
+  assert.equal(full.updated_at, '2026-07-09');
+});
+
 test('auto entry: authors, tags (nczoning + known only), yaw, images in full', () => {
   const auto = dataset.locations.find((l) => l.id === 'nexus-888');
   assert.deepEqual(auto.authors, ['Uploader888', 'Friend']);

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fetchTaggedModNodes, NEXUS_BATCH_SIZE } from '../src/nexus.js';
+
+function fakeFetch(pages) {
+  let call = 0;
+  const calls = [];
+  const impl = async (url, init) => {
+    const body = JSON.parse(init.body);
+    calls.push(body.variables.offset);
+    const page = pages[call++];
+    if (page instanceof Error) throw page;
+    return {
+      ok: page.ok ?? true,
+      status: page.status ?? 200,
+      json: async () => page.json,
+    };
+  };
+  impl.calls = calls;
+  return impl;
+}
+
+const node = (i) => ({ modId: i, name: `Mod ${i}` });
+
+test('paginates until the short page', async () => {
+  const first = Array.from({ length: NEXUS_BATCH_SIZE }, (_, i) => node(i));
+  const second = Array.from({ length: 10 }, (_, i) => node(100 + i));
+  const impl = fakeFetch([
+    { json: { data: { mods: { nodes: first, totalCount: 60 } } } },
+    { json: { data: { mods: { nodes: second, totalCount: 60 } } } },
+  ]);
+  const nodes = await fetchTaggedModNodes(impl);
+  assert.equal(nodes.length, 60);
+  assert.deepEqual(impl.calls, [0, NEXUS_BATCH_SIZE]);
+});
+
+test('HTTP error throws (partial results must not look complete)', async () => {
+  const impl = fakeFetch([{ ok: false, status: 503, json: {} }]);
+  await assert.rejects(() => fetchTaggedModNodes(impl), /HTTP 503/);
+});
+
+test('missing mods page throws with error detail', async () => {
+  const impl = fakeFetch([{ json: { errors: [{ message: 'boom' }] } }]);
+  await assert.rejects(() => fetchTaggedModNodes(impl), /no mods page/);
+});
+
+test('second-page failure throws rather than returning half the tag population', async () => {
+  const first = Array.from({ length: NEXUS_BATCH_SIZE }, (_, i) => node(i));
+  const impl = fakeFetch([
+    { json: { data: { mods: { nodes: first, totalCount: 60 } } } },
+    { ok: false, status: 500, json: {} },
+  ]);
+  await assert.rejects(() => fetchTaggedModNodes(impl), /HTTP 500/);
+});

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchTaggedModNodes, NEXUS_BATCH_SIZE } from '../src/nexus.js';
+import { fetchTaggedModNodes, fetchModsByUidThumbs, NEXUS_BATCH_SIZE } from '../src/nexus.js';
 
 function fakeFetch(pages) {
   let call = 0;
@@ -51,4 +51,50 @@ test('second-page failure throws rather than returning half the tag population',
     { ok: false, status: 500, json: {} },
   ]);
   await assert.rejects(() => fetchTaggedModNodes(impl), /HTTP 500/);
+});
+
+// ── fetchModsByUidThumbs (manual-mod image backfill) ────────────────────────
+
+// Queue of responses; Error entries throw (simulate a network failure).
+function uidFetch(responses) {
+  let call = 0;
+  return async () => {
+    const r = responses[call++];
+    if (r instanceof Error) throw r;
+    return { ok: r.ok ?? true, status: r.status ?? 200, json: async () => r.json };
+  };
+}
+const uidNode = (i) => ({ modId: i, pictureUrl: `p${i}`, thumbnailUrl: `t${i}`, updatedAt: `u${i}` });
+
+test('modsByUid: returns a thumb map keyed by modId', async () => {
+  const impl = uidFetch([{ json: { data: { modsByUid: { nodes: [uidNode(1), uidNode(2)] } } } }]);
+  const map = await fetchModsByUidThumbs(impl, ['1', '2']);
+  assert.deepEqual(map['1'], { pictureUrl: 'p1', thumbnailUrl: 't1', updatedAt: 'u1' });
+  assert.deepEqual(map['2'], { pictureUrl: 'p2', thumbnailUrl: 't2', updatedAt: 'u2' });
+});
+
+test('modsByUid: skips non-numeric ids and never fetches for an empty set', async () => {
+  let called = false;
+  const impl = async () => { called = true; return { ok: true, json: async () => ({}) }; };
+  assert.deepEqual(await fetchModsByUidThumbs(impl, ['WIP', 'Dummy']), {});
+  assert.equal(called, false);
+});
+
+test('modsByUid: HTTP error degrades to empty, never throws (images are cosmetic)', async () => {
+  const impl = uidFetch([{ ok: false, status: 503, json: {} }, { ok: false, status: 503, json: {} }]);
+  assert.deepEqual(await fetchModsByUidThumbs(impl, ['1']), {});
+});
+
+test('modsByUid: a thrown fetch degrades to empty, never throws', async () => {
+  const impl = uidFetch([new Error('network'), new Error('network')]);
+  assert.deepEqual(await fetchModsByUidThumbs(impl, ['1']), {});
+});
+
+test('modsByUid: retries UIDs the first call silently dropped', async () => {
+  const impl = uidFetch([
+    { json: { data: { modsByUid: { nodes: [uidNode(1)] } } } }, // drops 2
+    { json: { data: { modsByUid: { nodes: [uidNode(2)] } } } }, // retry fills 2
+  ]);
+  const map = await fetchModsByUidThumbs(impl, ['1', '2']);
+  assert.ok(map['1'] && map['2'], 'both UIDs present after the retry');
 });

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchTaggedModNodes, fetchModsByUidThumbs, NEXUS_BATCH_SIZE } from '../src/nexus.js';
+import { fetchTaggedModNodes, fetchModsByUidThumbs, NEXUS_BATCH_SIZE, NEXUS_GAME_ID } from '../src/nexus.js';
 
 function fakeFetch(pages) {
   let call = 0;
@@ -88,6 +88,19 @@ test('modsByUid: HTTP error degrades to empty, never throws (images are cosmetic
 test('modsByUid: a thrown fetch degrades to empty, never throws', async () => {
   const impl = uidFetch([new Error('network'), new Error('network')]);
   assert.deepEqual(await fetchModsByUidThumbs(impl, ['1']), {});
+});
+
+test('modsByUid: sends the composite (gameId<<32)+modId UID (not "gameId:modId")', async () => {
+  // Wire-contract guard: Nexus silently drops UIDs in the wrong format and
+  // returns no images — a bug the shape-only tests above can't catch.
+  let sentUids = null;
+  const impl = async (url, init) => {
+    sentUids = JSON.parse(init.body).variables.uids;
+    return { ok: true, json: async () => ({ data: { modsByUid: { nodes: [uidNode(28630)] } } }) };
+  };
+  await fetchModsByUidThumbs(impl, ['28630']);
+  const expected = ((BigInt(NEXUS_GAME_ID) << 32n) + 28630n).toString();
+  assert.deepEqual(sentUids, [expected]);
 });
 
 test('modsByUid: retries UIDs the first call silently dropped', async () => {

--- a/worker/test/openapi.test.js
+++ b/worker/test/openapi.test.js
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import worker from '../src/index.js';
+
+const specPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'openapi.json');
+const spec = JSON.parse(readFileSync(specPath, 'utf8'));
+
+// The concrete routes the Worker actually serves (from index.js), normalised
+// to the OpenAPI path style ({id} placeholder).
+const ROUTER_PATHS = [
+  '/v1/health', '/v1/locations', '/v1/locations/{id}',
+  '/v1/districts', '/v1/tags', '/v1/meta',
+];
+
+test('openapi.json is valid JSON with the expected top-level shape', () => {
+  assert.equal(spec.openapi, '3.1.0');
+  assert.ok(spec.info.title);
+  assert.ok(spec.paths && Object.keys(spec.paths).length > 0);
+});
+
+test('every served route is documented in the spec (no undocumented routes)', () => {
+  for (const p of ROUTER_PATHS) {
+    assert.ok(spec.paths[p], `route ${p} is served but missing from openapi.json`);
+    assert.ok(spec.paths[p].get, `route ${p} has no GET in openapi.json`);
+  }
+});
+
+test('every documented v1 path is actually served (no stale spec paths)', () => {
+  for (const p of Object.keys(spec.paths)) {
+    if (!p.startsWith('/v1/')) continue;
+    assert.ok(ROUTER_PATHS.includes(p), `openapi.json documents ${p} but the Worker does not serve it`);
+  }
+});
+
+test('GET / serves the HTML docs page', async () => {
+  const res = await worker.fetch(new Request('https://api.nczoning.net/'), { API_VERSION: '0.1.0' });
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('Content-Type'), /text\/html/);
+  const body = await res.text();
+  assert.match(body, /api-reference/); // Scalar mount point
+  assert.match(body, /\/openapi\.json/);
+});
+
+test('GET /openapi.json serves the spec', async () => {
+  const res = await worker.fetch(new Request('https://api.nczoning.net/openapi.json'), { API_VERSION: '0.1.0' });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.openapi, '3.1.0');
+  assert.deepEqual(Object.keys(body.paths).sort(), Object.keys(spec.paths).sort());
+});

--- a/worker/test/parse.test.js
+++ b/worker/test/parse.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseNcZoningBlock } from '../src/parse.js';
+
+const TAGS = new Set(['apartment', 'corpo', 'neokitsch']);
+
+test('parses a clean [code]-wrapped block', () => {
+  const desc = `My cool mod.
+[code]
+NCZoning:
+coords=-1234.5,678.9,12.3
+yaw=180.0
+category=new-location
+tags=apartment,neokitsch
+credits=Team NC
+authors=CoAuthor1,CoAuthor2
+[/code]`;
+  const p = parseNcZoningBlock(desc, TAGS);
+  assert.deepEqual(p.coordinates, [-1234.5, 678.9, 12.3]);
+  assert.equal(p.category, 'new-location');
+  assert.deepEqual(p.tags, ['apartment', 'neokitsch']);
+  assert.equal(p.credits, 'Team NC');
+  assert.deepEqual(p.additionalAuthors, ['CoAuthor1', 'CoAuthor2']);
+  assert.equal(p.yaw, 180.0);
+});
+
+test('survives lost [code] wrapper and per-line styling tags', () => {
+  const desc = `[size=4]Great mod![/size]
+NCZoning:
+[b]coords=100,200[/b]
+[color=red]category=other[/color]`;
+  const p = parseNcZoningBlock(desc, TAGS);
+  assert.deepEqual(p.coordinates, [100, 200]);
+  assert.equal(p.category, 'other');
+});
+
+test('sentinel glued to prose still parses', () => {
+  const desc = `Check it out — it's Preem, Making![code]NCZoning:
+coords=1,2,3
+category=location-overhaul[/code]`;
+  const p = parseNcZoningBlock(desc, TAGS);
+  assert.deepEqual(p.coordinates, [1, 2, 3]);
+});
+
+test('false-positive NCZoning mention earlier; real block later wins', () => {
+  const desc = `I love NCZoning: it is a great map.
+
+[code]
+NCZoning:
+coords=5,6
+category=other
+[/code]`;
+  const p = parseNcZoningBlock(desc, TAGS);
+  assert.deepEqual(p.coordinates, [5, 6]);
+});
+
+test('missing category → null', () => {
+  const p = parseNcZoningBlock('NCZoning:\ncoords=1,2,3', TAGS);
+  assert.equal(p, null);
+});
+
+test('bad coords rejected: too few, too many, NaN', () => {
+  for (const coords of ['1', '1,2,3,4', '1,abc']) {
+    assert.equal(parseNcZoningBlock(`NCZoning:\ncoords=${coords}\ncategory=other`, TAGS), null);
+  }
+});
+
+test('unknown tags silently dropped, yaw optional', () => {
+  const p = parseNcZoningBlock(
+    'NCZoning:\ncoords=1,2\ncategory=other\ntags=apartment,unknowntag', TAGS);
+  assert.deepEqual(p.tags, ['apartment']);
+  assert.equal(p.yaw, null);
+});
+
+test('empty/absent description → null', () => {
+  assert.equal(parseNcZoningBlock('', TAGS), null);
+  assert.equal(parseNcZoningBlock(null, TAGS), null);
+});
+
+test('html <br> line breaks are normalised', () => {
+  const p = parseNcZoningBlock('NCZoning:<br>coords=9,8,7<br/>category=other', TAGS);
+  assert.deepEqual(p.coordinates, [9, 8, 7]);
+});

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -1,0 +1,141 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { runRefresh } from '../src/refresh.js';
+import { KEYS } from '../src/store.js';
+
+// Minimal in-memory KV: get(key, 'json') + put(key, string).
+function fakeKV(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    async get(key, type) {
+      const v = store.get(key);
+      if (v === undefined) return null;
+      return type === 'json' ? JSON.parse(v) : v;
+    },
+    async put(key, value) { store.set(key, value); },
+    _dump: () => Object.fromEntries(store),
+  };
+}
+
+const TAGS = { apartment: 'a place', corpo: 'suits' };
+const EXCLUDED = { 777: 'mistagged' };
+const SUBDISTRICTS = {
+  districts: [
+    {
+      id: 'testville', name: 'Testville',
+      polygon: [[0, 0], [1000, 0], [1000, 1000], [0, 1000]],
+      subdistricts: [
+        { id: 'little', name: 'Little Fixture', polygon: [[0, 0], [500, 0], [500, 500], [0, 500]] },
+      ],
+    },
+    { id: 'badlands', name: 'Badlands', subdistricts: [] },
+  ],
+};
+const MODS = [
+  {
+    id: 'm1', name: 'Manual Loft', authors: ['Spud'], coordinates: [250, 250, 10],
+    nexus_id: '12345', description: 'x', category: 'new-location', tags: ['apartment'],
+  },
+];
+
+// GraphQL response with one valid auto mod (888) and the excluded 777.
+const NEXUS_PAGE = {
+  data: {
+    mods: {
+      nodes: [
+        {
+          modId: 888, name: 'Auto Bar', summary: 'auto',
+          description: 'NCZoning:\ncoords=600,600\ncategory=other',
+          uploader: { name: 'Up888' },
+        },
+        {
+          modId: 777, name: 'Mistagged', summary: 'no',
+          description: 'NCZoning:\ncoords=1,1\ncategory=other',
+          uploader: { name: 'X' },
+        },
+      ],
+      totalCount: 2,
+    },
+  },
+};
+
+// fetch stub keyed by URL substring; nexus POST returns the page.
+function fakeFetch({ failNexus = false, failMods = false, discordSink } = {}) {
+  return async (url, init) => {
+    if (url.includes('/mods.json')) {
+      return failMods ? { ok: false, status: 500 } : { ok: true, json: async () => MODS };
+    }
+    if (url.includes('/tags.json')) return { ok: true, json: async () => TAGS };
+    if (url.includes('/excluded_mods.json')) return { ok: true, json: async () => EXCLUDED };
+    if (url.includes('/subdistricts.json')) return { ok: true, json: async () => SUBDISTRICTS };
+    if (url.includes('api.nexusmods.com')) {
+      if (failNexus) return { ok: false, status: 503 };
+      return { ok: true, json: async () => NEXUS_PAGE };
+    }
+    if (url.includes('discord')) { discordSink?.push(JSON.parse(init.body)); return { ok: true }; }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+}
+
+test('first run writes the full dataset (changed=true)', async () => {
+  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const r = await runRefresh(env, fakeFetch());
+  assert.equal(r.changed, true);
+  assert.ok(r.version);
+  const slim = await env.DATA.get(KEYS.slim, 'json');
+  assert.equal(slim.length, 2); // 1 manual + 1 auto (777 excluded)
+  assert.ok(slim.every((l) => l.district));
+  const meta = await env.DATA.get(KEYS.meta, 'json');
+  assert.equal(meta.discovery_stale, false);
+  assert.equal(meta.counts.total, 2);
+  assert.equal(meta.dataset_version, r.version);
+});
+
+test('unchanged content on the second run skips the write (changed=false)', async () => {
+  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  await runRefresh(env, fakeFetch());
+  const before = (await env.DATA.get(KEYS.meta, 'json')).generated_at;
+  const r2 = await runRefresh(env, fakeFetch());
+  assert.equal(r2.changed, false);
+  // generated_at unchanged because we didn't rewrite.
+  assert.equal((await env.DATA.get(KEYS.meta, 'json')).generated_at, before);
+});
+
+test('Nexus failure keeps last-known-good and flags stale + alerts Discord', async () => {
+  const env = {
+    DATA: fakeKV(), SITE_ORIGIN: 'https://x',
+    DISCORD_WEBHOOK_URL: 'https://discord/webhook',
+  };
+  await runRefresh(env, fakeFetch()); // seed good data
+  const goodSlim = await env.DATA.get(KEYS.slim, 'json');
+
+  const discordSink = [];
+  const r = await runRefresh(env, fakeFetch({ failNexus: true, discordSink }));
+  assert.equal(r.stale, true);
+  assert.match(r.error, /503/);
+  // Dataset preserved (not wiped).
+  assert.deepEqual(await env.DATA.get(KEYS.slim, 'json'), goodSlim);
+  const meta = await env.DATA.get(KEYS.meta, 'json');
+  assert.equal(meta.discovery_stale, true);
+  assert.match(meta.last_error, /503/);
+  assert.equal(discordSink.length, 1);
+  assert.match(discordSink[0].embeds[0].title, /refresh failed/);
+});
+
+test('failure with no prior dataset returns stale with null version, no crash', async () => {
+  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const r = await runRefresh(env, fakeFetch({ failMods: true }));
+  assert.equal(r.stale, true);
+  assert.equal(r.version, null);
+  assert.equal(await env.DATA.get(KEYS.slim, 'json'), null);
+});
+
+test('recovery after a stale cycle rewrites and clears the stale flag', async () => {
+  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  await runRefresh(env, fakeFetch());
+  await runRefresh(env, fakeFetch({ failNexus: true }));
+  assert.equal((await env.DATA.get(KEYS.meta, 'json')).discovery_stale, true);
+  const r = await runRefresh(env, fakeFetch());
+  assert.equal(r.changed, true); // stale flag forces a rewrite even if hash matches
+  assert.equal((await env.DATA.get(KEYS.meta, 'json')).discovery_stale, false);
+});

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -121,7 +121,8 @@ test('unchanged content on the second run skips the write (changed=false)', asyn
 test('Nexus failure keeps last-known-good and flags stale + alerts Discord', async () => {
   const env = {
     DATASET: fakeKV(), SITE_ORIGIN: 'https://x',
-    DISCORD_WEBHOOK_URL: 'https://discord/webhook',
+    // Dedicated alerts channel (preferred over the legacy DISCORD_WEBHOOK_URL).
+    NCZ_ALERTS_DISCORD_WEBHOOK_URL: 'https://discord/webhook',
   };
   await runRefresh(env, fakeFetch()); // seed good data
   const goodSlim = await env.DATASET.get(KEYS.slim, 'json');

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -70,6 +70,15 @@ function fakeFetch({ failNexus = false, failMods = false, discordSink } = {}) {
     if (url.includes('/subdistricts.json')) return { ok: true, json: async () => SUBDISTRICTS };
     if (url.includes('api.nexusmods.com')) {
       if (failNexus) return { ok: false, status: 503 };
+      // Two POST shapes hit the same endpoint: the tagged-mods query and the
+      // modsByUid image backfill. Route by the query body.
+      if (JSON.parse(init.body).query.includes('modsByUid')) {
+        return { ok: true, json: async () => ({
+          data: { modsByUid: { nodes: [
+            { modId: 12345, pictureUrl: 'pm', thumbnailUrl: 'tm', updatedAt: '2026-07-08' },
+          ] } },
+        }) };
+      }
       return { ok: true, json: async () => NEXUS_PAGE };
     }
     if (url.includes('discord')) { discordSink?.push(JSON.parse(init.body)); return { ok: true }; }
@@ -89,6 +98,14 @@ test('first run writes the full dataset (changed=true)', async () => {
   assert.equal(meta.discovery_stale, false);
   assert.equal(meta.counts.total, 2);
   assert.equal(meta.dataset_version, r.version);
+});
+
+test('manual-mod images are backfilled into full via modsByUid', async () => {
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  await runRefresh(env, fakeFetch());
+  const full = await env.DATASET.get(KEYS.full, 'json');
+  assert.equal(full.m1.thumbnail_url, 'tm'); // manual mod 12345, not NCZoning-tagged
+  assert.equal(full.m1.updated_at, '2026-07-08');
 });
 
 test('unchanged content on the second run skips the write (changed=false)', async () => {

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -78,44 +78,44 @@ function fakeFetch({ failNexus = false, failMods = false, discordSink } = {}) {
 }
 
 test('first run writes the full dataset (changed=true)', async () => {
-  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
   const r = await runRefresh(env, fakeFetch());
   assert.equal(r.changed, true);
   assert.ok(r.version);
-  const slim = await env.DATA.get(KEYS.slim, 'json');
+  const slim = await env.DATASET.get(KEYS.slim, 'json');
   assert.equal(slim.length, 2); // 1 manual + 1 auto (777 excluded)
   assert.ok(slim.every((l) => l.district));
-  const meta = await env.DATA.get(KEYS.meta, 'json');
+  const meta = await env.DATASET.get(KEYS.meta, 'json');
   assert.equal(meta.discovery_stale, false);
   assert.equal(meta.counts.total, 2);
   assert.equal(meta.dataset_version, r.version);
 });
 
 test('unchanged content on the second run skips the write (changed=false)', async () => {
-  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
   await runRefresh(env, fakeFetch());
-  const before = (await env.DATA.get(KEYS.meta, 'json')).generated_at;
+  const before = (await env.DATASET.get(KEYS.meta, 'json')).generated_at;
   const r2 = await runRefresh(env, fakeFetch());
   assert.equal(r2.changed, false);
   // generated_at unchanged because we didn't rewrite.
-  assert.equal((await env.DATA.get(KEYS.meta, 'json')).generated_at, before);
+  assert.equal((await env.DATASET.get(KEYS.meta, 'json')).generated_at, before);
 });
 
 test('Nexus failure keeps last-known-good and flags stale + alerts Discord', async () => {
   const env = {
-    DATA: fakeKV(), SITE_ORIGIN: 'https://x',
+    DATASET: fakeKV(), SITE_ORIGIN: 'https://x',
     DISCORD_WEBHOOK_URL: 'https://discord/webhook',
   };
   await runRefresh(env, fakeFetch()); // seed good data
-  const goodSlim = await env.DATA.get(KEYS.slim, 'json');
+  const goodSlim = await env.DATASET.get(KEYS.slim, 'json');
 
   const discordSink = [];
   const r = await runRefresh(env, fakeFetch({ failNexus: true, discordSink }));
   assert.equal(r.stale, true);
   assert.match(r.error, /503/);
   // Dataset preserved (not wiped).
-  assert.deepEqual(await env.DATA.get(KEYS.slim, 'json'), goodSlim);
-  const meta = await env.DATA.get(KEYS.meta, 'json');
+  assert.deepEqual(await env.DATASET.get(KEYS.slim, 'json'), goodSlim);
+  const meta = await env.DATASET.get(KEYS.meta, 'json');
   assert.equal(meta.discovery_stale, true);
   assert.match(meta.last_error, /503/);
   assert.equal(discordSink.length, 1);
@@ -123,19 +123,19 @@ test('Nexus failure keeps last-known-good and flags stale + alerts Discord', asy
 });
 
 test('failure with no prior dataset returns stale with null version, no crash', async () => {
-  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
   const r = await runRefresh(env, fakeFetch({ failMods: true }));
   assert.equal(r.stale, true);
   assert.equal(r.version, null);
-  assert.equal(await env.DATA.get(KEYS.slim, 'json'), null);
+  assert.equal(await env.DATASET.get(KEYS.slim, 'json'), null);
 });
 
 test('recovery after a stale cycle rewrites and clears the stale flag', async () => {
-  const env = { DATA: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
   await runRefresh(env, fakeFetch());
   await runRefresh(env, fakeFetch({ failNexus: true }));
-  assert.equal((await env.DATA.get(KEYS.meta, 'json')).discovery_stale, true);
+  assert.equal((await env.DATASET.get(KEYS.meta, 'json')).discovery_stale, true);
   const r = await runRefresh(env, fakeFetch());
   assert.equal(r.changed, true); // stale flag forces a rewrite even if hash matches
-  assert.equal((await env.DATA.get(KEYS.meta, 'json')).discovery_stale, false);
+  assert.equal((await env.DATASET.get(KEYS.meta, 'json')).discovery_stale, false);
 });

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -15,6 +15,10 @@
 	"name": "nczoning-api",
 	"main": "src/index.js",
 	"compatibility_date": "2026-07-04",
+	// Set so CI's scoped API token doesn't need User→Memberships→Read to
+	// discover the account (wrangler skips the /memberships lookup). Account
+	// IDs are not secret. Inherited by all environments.
+	"account_id": "ab7ff2fad6832c2db0a25d22e3287227",
 	// Custom domain: deploying creates the DNS record + cert on the zone
 	// automatically (the zone must be on the same Cloudflare account).
 	"routes": [

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -1,0 +1,24 @@
+// NC Zoning Data API — Cloudflare Worker config.
+// Deploys independently of the Pages site; shares only the nczoning.net zone.
+// See docs/data-api-plan.md for the architecture.
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "nczoning-api",
+  "main": "src/index.js",
+  "compatibility_date": "2026-07-04",
+
+  // Custom domain: deploying creates the DNS record + cert on the zone
+  // automatically (the zone must be on the same Cloudflare account).
+  "routes": [
+    { "pattern": "api.nczoning.net", "custom_domain": true }
+  ],
+
+  "vars": {
+    // Bumped manually on releases; reported by /v1/health.
+    "API_VERSION": "0.1.0"
+  }
+
+  // B3 will add:
+  // - "kv_namespaces": [{ "binding": "DATA", "id": "..." }]
+  // - "triggers": { "crons": ["*/15 * * * *"] }
+}

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -2,36 +2,40 @@
 // Deploys independently of the Pages site; shares only the nczoning.net zone.
 // See docs/data-api-plan.md for the architecture.
 {
-  "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "nczoning-api",
-  "main": "src/index.js",
-  "compatibility_date": "2026-07-04",
-
-  // Custom domain: deploying creates the DNS record + cert on the zone
-  // automatically (the zone must be on the same Cloudflare account).
-  "routes": [
-    { "pattern": "api.nczoning.net", "custom_domain": true }
-  ],
-
-  "vars": {
-    // Bumped manually on releases; reported by /v1/health.
-    "API_VERSION": "0.1.0",
-    // Origin the cron pulls source files from (mods.json, tags, subdistricts).
-    "SITE_ORIGIN": "https://nczoning.net"
-  },
-
-  // Dataset store. Create with:
-  //   npx wrangler kv namespace create DATA
-  // then paste the returned id below (and a preview_id for `wrangler dev`).
-  "kv_namespaces": [
-    { "binding": "DATA", "id": "REPLACE_WITH_KV_ID" }
-  ],
-
-  // Rebuild the dataset every 15 minutes.
-  "triggers": {
-    "crons": ["*/15 * * * *"]
-  }
-
-  // DISCORD_WEBHOOK_URL is a secret (wrangler secret put DISCORD_WEBHOOK_URL),
-  // not committed here. Optional — refresh runs without it.
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "nczoning-api",
+	"main": "src/index.js",
+	"compatibility_date": "2026-07-04",
+	// Custom domain: deploying creates the DNS record + cert on the zone
+	// automatically (the zone must be on the same Cloudflare account).
+	"routes": [
+		{
+			"pattern": "api.nczoning.net",
+			"custom_domain": true
+		}
+	],
+	"vars": {
+		// Bumped manually on releases; reported by /v1/health.
+		"API_VERSION": "0.1.0",
+		// Origin the cron pulls source files from (mods.json, tags, subdistricts).
+		"SITE_ORIGIN": "https://nczoning.net"
+	},
+	// Dataset store (dashboard title: nczoning-api-dataset). Recreate with:
+	//   npx wrangler kv namespace create nczoning-api-dataset
+	// then paste the returned id below. Content is fully derived (rebuilt by
+	// the cron), so the namespace can be recreated at any time.
+	"kv_namespaces": [
+		{
+			"binding": "DATASET",
+			"id": "d86735e00790417e948e423c3df01d68"
+		}
+	],
+	// Rebuild the dataset every 15 minutes.
+	"triggers": {
+		"crons": [
+			"*/15 * * * *"
+		]
+	}
+	// DISCORD_WEBHOOK_URL is a secret (wrangler secret put DISCORD_WEBHOOK_URL),
+	// not committed here. Optional — refresh runs without it.
 }

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -1,6 +1,15 @@
 // NC Zoning Data API — Cloudflare Worker config.
 // Deploys independently of the Pages site; shares only the nczoning.net zone.
 // See docs/data-api-plan.md for the architecture.
+//
+// Two environments mirror the site's main/dev split:
+//   `wrangler deploy`                 → PRODUCTION (top-level config below)
+//                                       nczoning-api @ api.nczoning.net
+//   `wrangler deploy --env staging`   → STAGING (env.staging)
+//                                       nczoning-api-staging @ api-dev.nczoning.net
+// CI (.github/workflows/deploy-api.yml) deploys prod from `main`, staging
+// from `dev`. Named environments do NOT inherit vars/kv/routes/triggers —
+// each is declared in full.
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "nczoning-api",
@@ -35,7 +44,37 @@
 		"crons": [
 			"*/15 * * * *"
 		]
-	}
+	},
 	// DISCORD_WEBHOOK_URL is a secret (wrangler secret put DISCORD_WEBHOOK_URL),
 	// not committed here. Optional — refresh runs without it.
+
+	"env": {
+		// Staging: pulls source files from the dev site, writes to a separate
+		// KV namespace, serves the dev site (B7). Isolated from production.
+		"staging": {
+			"name": "nczoning-api-staging",
+			"routes": [
+				{
+					"pattern": "api-dev.nczoning.net",
+					"custom_domain": true
+				}
+			],
+			"vars": {
+				"API_VERSION": "0.1.0",
+				"SITE_ORIGIN": "https://dev.nczoning.net"
+			},
+			// dashboard title: nczoning-api-dataset-staging
+			"kv_namespaces": [
+				{
+					"binding": "DATASET",
+					"id": "ac85bf5c0b6f47afac35085408857d4b"
+				}
+			],
+			"triggers": {
+				"crons": [
+					"*/15 * * * *"
+				]
+			}
+		}
+	}
 }

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -15,10 +15,23 @@
 
   "vars": {
     // Bumped manually on releases; reported by /v1/health.
-    "API_VERSION": "0.1.0"
+    "API_VERSION": "0.1.0",
+    // Origin the cron pulls source files from (mods.json, tags, subdistricts).
+    "SITE_ORIGIN": "https://nczoning.net"
+  },
+
+  // Dataset store. Create with:
+  //   npx wrangler kv namespace create DATA
+  // then paste the returned id below (and a preview_id for `wrangler dev`).
+  "kv_namespaces": [
+    { "binding": "DATA", "id": "REPLACE_WITH_KV_ID" }
+  ],
+
+  // Rebuild the dataset every 15 minutes.
+  "triggers": {
+    "crons": ["*/15 * * * *"]
   }
 
-  // B3 will add:
-  // - "kv_namespaces": [{ "binding": "DATA", "id": "..." }]
-  // - "triggers": { "crons": ["*/15 * * * *"] }
+  // DISCORD_WEBHOOK_URL is a secret (wrangler secret put DISCORD_WEBHOOK_URL),
+  // not committed here. Optional — refresh runs without it.
 }

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -49,8 +49,12 @@
 			"*/15 * * * *"
 		]
 	},
-	// DISCORD_WEBHOOK_URL is a secret (wrangler secret put DISCORD_WEBHOOK_URL),
-	// not committed here. Optional — refresh runs without it.
+	// Refresh-failure alerts post to the dedicated map-alerts channel:
+	//   wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL           (production)
+	//   wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL --env staging
+	// Falls back to the legacy DISCORD_WEBHOOK_URL secret if the new one isn't
+	// set (no alerting gap during the move). Secrets aren't committed here.
+	// Optional — refresh runs without either.
 
 	"env": {
 		// Staging: pulls source files from the dev site, writes to a separate


### PR DESCRIPTION
Promotes `dev` → `main` for the **1.2.0** release. This is the first time the
whole Data API lands on main.

## Ships
- **Data API (B1–B7)** — `worker/` is new to main. Read-only API at
  `api.nczoning.net/v1/` (locations/districts/tags/meta/health, `?full=1`,
  ETag/304, RedData-mappable). Modder docs at the API root + `docs/api-reference.md`.
- **Site consumes `/v1`** — `nczoning.net` flips from the client-side Nexus
  merge to the API (with a graceful client-side fallback retained for now).
  Thumbnails resolved server-side; the browser no longer calls Nexus.
- **Monitoring** — `monitor-api-health.yml` + the reworked
  `monitor-auto-discovery.yml` (reads `/v1/meta.skipped`); Discord alerts split
  onto a dedicated channel, separate from submissions.

## Effects on merge
1. `deploy-api.yml` runs on `main` → `npm test` (62) gate → **prod Worker**
   (`api.nczoning.net`) redeploys with B7 (`?full=1` + manual thumbnails). KV
   persists.
2. Cloudflare Pages rebuilds `nczoning.net` from main → **prod site becomes
   API-primary**.
3. Scheduled monitors begin running (GitHub Actions schedules only fire from the
   default branch).

## Risk / rollback
- Low: Worker deploys are atomic (KV intact, prod already serving); the site
  keeps its fallback; `/v1` is contract-frozen + additive.
- The client-side fallback stays this release — removed in a follow-up after
  ~1 week of prod bake.

CHANGELOG: `[1.2.0] - 2026-07-05`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)