### PR TITLE
sync: main → dev

### DIFF
--- a/data/locations/030db42e-dbd0-46a5-8b87-ec98ceb305c5.json
+++ b/data/locations/030db42e-dbd0-46a5-8b87-ec98ceb305c5.json
@@ -1,0 +1,21 @@
+{
+    "id": "030db42e-dbd0-46a5-8b87-ec98ceb305c5",
+    "name": "Judy's Apartment Improved",
+    "authors": [
+        "ThaFunktopus"
+    ],
+    "credits": "",
+    "coordinates": [
+        -906.4348,
+        1868.7872,
+        42.36
+    ],
+    "nexus_id": "31144",
+    "description": "Vanilla themed renovation of Judy's apartment with QOL improvements for post Judy questline",
+    "category": "location-overhaul",
+    "tags": [
+        "apartment",
+        "kitsch"
+    ],
+    "yaw": -99.5407
+}


### PR DESCRIPTION
Sync `main` back into `dev` after the 1.2.0 release + the first post-release submission. Brings the new location (Judy's Apartment Improved, #799) into dev so the branches don't drift. dev keeps its in-flight #800 (5-min cron + Nexus v3 docs), which flows to main on the next release. No file overlap — clean merge.