### PR TITLE
feat(api): self-healing alerts — recovery all-clear after an outage

### DIFF
--- a/.github/workflows/monitor-api-health.yml
+++ b/.github/workflows/monitor-api-health.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  actions: read   # read this workflow's own run history to detect the recovery edge
 
 # A slow/queued run shouldn't stack; keep only the latest.
 concurrency:
@@ -28,10 +29,33 @@ jobs:
         with:
           node-version: 24
 
+      # The previous completed run's conclusion is the last known health state:
+      # the probe exits 1 on an outage (→ failure) and 0 when serving
+      # (→ success). Filter to success/failure so a cancelled (concurrency) or
+      # in-progress run never counts. The most recent match is "last time".
+      - name: Read previous health state
+        id: prev
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          prev=$(gh run list --workflow monitor-api-health.yml \
+            --status completed --limit 20 \
+            --json conclusion \
+            --jq '[.[] | select(.conclusion == "success" or .conclusion == "failure")][0].conclusion // ""')
+          echo "previous conclusion: '${prev:-none}'"
+          if [ "$prev" = "failure" ]; then
+            echo "prev_outage=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prev_outage=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Probe /v1 and alert on outage
         env:
           # Dedicated map-alerts channel, kept separate from submissions.
           NCZ_ALERTS_DISCORD_WEBHOOK_URL: ${{ secrets.NCZ_ALERTS_DISCORD_WEBHOOK_URL }}
+          # Was the API down last run? A clean run after a down one is the
+          # recovery edge → the script posts a green all-clear exactly once.
+          API_HEALTH_PREV_OUTAGE: ${{ steps.prev.outputs.prev_outage }}
           # Both matter: prod (api.nczoning.net) is what in-game mods hit;
           # staging (api-dev) is what the dev site consumes during the B7 bake,
           # where an outage would otherwise be hidden by the client fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Infrastructure
 
 - Data API refresh cadence 15 → 5 min, so new/updated mods propagate to the map faster after a submission. (Nexus load stays well under limits.)
+- API alerts are now self-healing: the health monitor posts a green "recovered" all-clear once the API is serving again after an outage, and the refresh cron does the same when a failed refresh next succeeds.
 
 ## [1.2.0] - 2026-07-05
 

--- a/scripts/monitor_api_health.js
+++ b/scripts/monitor_api_health.js
@@ -104,9 +104,12 @@ async function checkTarget(base) {
   return { base, issues, warnings };
 }
 
-async function postDiscord(results) {
+// `recovered` = the previous run reported an outage and this one is clean, so
+// this post is the down→up edge (a green all-clear) rather than a page.
+async function postDiscord(results, { recovered = false } = {}) {
   const url = process.env.NCZ_ALERTS_DISCORD_WEBHOOK_URL;
   const down = results.filter((r) => r.issues.length);
+  const anyWarning = results.some((r) => r.warnings.length);
 
   const fields = results
     .filter((r) => r.issues.length || r.warnings.length)
@@ -118,17 +121,34 @@ async function postDiscord(results) {
       ].join("\n"),
     }));
 
+  // Three headlines: outage (page), recovery (all-clear edge), warning (soft).
+  // Outage wins if anything is currently down — recovery only applies when
+  // this run is fully clean.
+  let title, description, color;
+  if (down.length) {
+    title = `🔴 Data API outage — ${down.length} environment${down.length === 1 ? "" : "s"} not serving`;
+    description =
+      "The API is not usable by consumers (in-game mods have no fallback). " +
+      "The website may look fine via its client-side fallback — this is that hidden failure surfacing.";
+    color = 15158332; /* red */
+  } else if (recovered) {
+    title = `✅ Data API recovered — serving normally again`;
+    description =
+      "The earlier outage has cleared: every target is serving again." +
+      (anyWarning ? " One soft signal is still active (see below)." : "");
+    color = 3066993; /* green */
+  } else {
+    title = `🟠 Data API warning`;
+    description = "The API is serving but a soft signal fired (see below).";
+    color = 15105570; /* amber */
+  }
+
   const body = {
     embeds: [
       {
-        title: down.length
-          ? `🔴 Data API outage — ${down.length} environment${down.length === 1 ? "" : "s"} not serving`
-          : `🟠 Data API warning`,
-        description: down.length
-          ? "The API is not usable by consumers (in-game mods have no fallback). " +
-            "The website may look fine via its client-side fallback — this is that hidden failure surfacing."
-          : "The API is serving but a soft signal fired (see below).",
-        color: down.length ? 15158332 /* red */ : 15105570 /* amber */,
+        title,
+        description,
+        color,
         fields,
         footer: { text: "NC Zoning Board • Data API health monitor" },
       },
@@ -170,13 +190,24 @@ async function postDiscord(results) {
 
     const anyOutage = results.some((r) => r.issues.length);
     const anyWarning = results.some((r) => r.warnings.length);
-    if (anyOutage || anyWarning) await postDiscord(results);
+
+    // The previous run's conclusion IS the last health state: this script
+    // exits 1 on an outage (Actions run → failure) and 0 when serving
+    // (→ success). The workflow reads that conclusion and passes it in, so a
+    // clean run that follows a failed one is the recovery edge — announce the
+    // all-clear ONCE (next run sees success and stays quiet). A prior infra
+    // error also lands here as "was down"; a reassuring green after it is
+    // harmless. Absent the flag (local run, first ever run) → no false edge.
+    const prevOutage = process.env.API_HEALTH_PREV_OUTAGE === "true";
+    const recovered = prevOutage && !anyOutage;
+
+    if (anyOutage || anyWarning || recovered) await postDiscord(results, { recovered });
 
     if (anyOutage) {
       console.error("\nHealth check FAILED — at least one target is not serving.");
       process.exitCode = 1;
     } else {
-      console.log("\nAll targets healthy.");
+      console.log(recovered ? "\nAll targets healthy — recovered from prior outage." : "\nAll targets healthy.");
     }
   } catch (err) {
     console.error("Health monitor failed (infrastructure error):", err.message);

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -56,6 +56,32 @@ async function alertDiscord(env, fetchImpl, reason) {
 }
 
 /**
+ * Post a recovery embed: the previous cycle marked the dataset discovery_stale
+ * and this cycle rebuilt it cleanly, so this is the down→up edge. Fires once
+ * (the next successful cycle sees discovery_stale=false and stays quiet).
+ */
+async function alertDiscordRecovered(env, fetchImpl) {
+  const webhook = env.NCZ_ALERTS_DISCORD_WEBHOOK_URL || env.DISCORD_WEBHOOK_URL;
+  if (!webhook) return;
+  try {
+    await fetchImpl(webhook, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        embeds: [{
+          title: '✅ Data API refresh recovered',
+          description: 'A refresh succeeded after an earlier failure — the dataset is fresh again (discovery_stale=false).',
+          color: 0x2ecc71,
+          footer: { text: 'NC Zoning Board • Data API refresh' },
+        }],
+      }),
+    });
+  } catch {
+    // A missed all-clear is not worth throwing over.
+  }
+}
+
+/**
  * Run one refresh cycle.
  * @param {object} env  Worker env (DATASET KV binding, SITE_ORIGIN?, DISCORD_WEBHOOK_URL?)
  * @param {typeof fetch} fetchImpl  injectable
@@ -100,6 +126,10 @@ export async function runRefresh(env, fetchImpl = fetch) {
       return { changed: false, version, stale: false };
     }
 
+    // Recovery edge: last cycle failed (discovery_stale) and this one rebuilt
+    // cleanly. Announce the all-clear after the write actually lands.
+    const recovered = prev?.discovery_stale === true;
+
     await writeDataset(env, {
       slim: locations,
       full,
@@ -114,7 +144,8 @@ export async function runRefresh(env, fetchImpl = fetch) {
         discovery_stale: false,
       },
     });
-    return { changed: true, version, stale: false };
+    if (recovered) await alertDiscordRecovered(env, fetchImpl);
+    return { changed: true, version, stale: false, recovered };
   } catch (err) {
     // Keep last-known-good; flag stale; alert. Never wipe the dataset.
     const prev = await readMeta(env);

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -155,5 +155,25 @@ test('recovery after a stale cycle rewrites and clears the stale flag', async ()
   assert.equal((await env.DATASET.get(KEYS.meta, 'json')).discovery_stale, true);
   const r = await runRefresh(env, fakeFetch());
   assert.equal(r.changed, true); // stale flag forces a rewrite even if hash matches
+  assert.equal(r.recovered, true);
   assert.equal((await env.DATASET.get(KEYS.meta, 'json')).discovery_stale, false);
+});
+
+test('recovery posts a recovery alert exactly once (edge, not every cycle)', async () => {
+  const env = {
+    DATASET: fakeKV(), SITE_ORIGIN: 'https://x',
+    NCZ_ALERTS_DISCORD_WEBHOOK_URL: 'https://discord/webhook',
+  };
+  const discordSink = [];
+  await runRefresh(env, fakeFetch({ discordSink }));                  // seed good
+  await runRefresh(env, fakeFetch({ failNexus: true, discordSink })); // fail → stale + alert
+  const r = await runRefresh(env, fakeFetch({ discordSink }));        // recover → all-clear
+  assert.equal(r.recovered, true);
+  const titles = discordSink.map((m) => m.embeds[0].title);
+  assert.deepEqual(titles, ['⚠️ Data API refresh failed', '✅ Data API refresh recovered']);
+
+  // A subsequent healthy cycle must NOT re-announce recovery.
+  const r2 = await runRefresh(env, fakeFetch({ discordSink }));
+  assert.equal(r2.recovered ?? false, false);
+  assert.equal(discordSink.length, 2); // still just the fail + the one recovery
 });


### PR DESCRIPTION
## Why

Both API alert sources could announce a failure but never that it cleared, so an outage embed sat unresolved in the Discord alerts channel until someone manually re-checked. This adds the missing down→up edge to both.

## What

**Health monitor** (`scripts/monitor_api_health.js` + `monitor-api-health.yml`)
- The workflow reads its own *previous* completed run conclusion via `gh run list` (the probe exits `1` on outage → `failure`, `0` when serving → `success`, so the run conclusion already **is** the health state) and passes `API_HEALTH_PREV_OUTAGE` into the script.
- A clean run following a failed one posts a green **"Data API recovered"** embed, exactly once (the next run sees `success` and stays quiet).
- Cancelled (concurrency) and in-progress runs are filtered out so they can't be mistaken for the last state. Needs `actions: read`.

**Refresh cron** (`worker/src/refresh.js`)
- When a refresh succeeds after a `discovery_stale` cycle, it posts a **"Data API refresh recovered"** embed once (fires on the edge; a later healthy cycle stays quiet). New `refresh.test.js` coverage; full worker suite green (63/63).

## Design note

State lives in the run conclusion / the existing `discovery_stale` meta flag — no new store (GitHub Actions cache or KV writes from an external prober were both considered and rejected). Nothing to keep in sync because the existing signal already encodes "was it down".

## Test

- `worker` suite: 63/63 pass.
- Local smoke test of the recovery branch against live prod (`API_HEALTH_PREV_OUTAGE=true`, no webhook → preview) rendered the green all-clear correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)