### PR TITLE
fix(monitor): revert to honest UA — Bot Fight Mode was the real blocker (now disabled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Data API refresh cadence 15 → 5 min, so new/updated mods propagate to the map faster after a submission. (Nexus load stays well under limits.)
 - API alerts are now self-healing: the health monitor posts a green "recovered" all-clear once the API is serving again after an outage, and the refresh cron does the same when a failed refresh next succeeds.
+- The `/v1` API no longer bot-challenges automated consumers (tools, servers, uptime checks): Cloudflare Bot Fight Mode was returning `403` to datacentre clients, including our own health monitor. Disabled it; a `/v1` rate-limit rule remains, and DDoS + WAF protection are unaffected.
 
 ## [1.2.0] - 2026-07-05
 

--- a/scripts/monitor_api_health.js
+++ b/scripts/monitor_api_health.js
@@ -39,19 +39,20 @@ const FETCH_TIMEOUT_MS = 15000;
 
 // Request headers for the probe.
 //
-// The obvious `User-Agent: nczoning-health-monitor` is exactly what got this
-// monitor 403'd: the zone runs Cloudflare's free Bot Fight Mode, which flags a
-// non-browser UA coming from a datacentre IP (the GitHub Actions runner) and
-// blocks it — a false "outage" for a fully-healthy API. Free Bot Fight Mode is
-// zone-wide and honours no WAF Skip / IP allow rule, so it can't be excepted;
-// the only lever is to not match its heuristic. Present a normal browser UA,
-// and keep the real identity in an X-Health-Probe header (visible in CF logs,
-// and ready to key a WAF allow rule to if the zone ever moves to Super Bot
-// Fight Mode). See wiki learning: cloudflare-bot-fight-mode-403s-health-monitor.
+// This monitor was once 403'd on every run: the zone ran Cloudflare's free Bot
+// Fight Mode, which managed-challenges automated clients from datacentre IPs
+// (the GitHub Actions runner, ASN 8075) — a false "outage" for a fully-healthy
+// API. It keyed on the request being non-interactive automation, NOT the UA
+// string, so a browser-UA disguise did nothing (verified: BFM still challenged
+// the Chrome UA). BFM is fundamentally incompatible with an Actions-based probe
+// and its protective value on a public read-only API is nil, so it was disabled
+// zone-wide (a /v1 rate-limit rule is the compensating control; DDoS + WAF stay
+// on). With BFM off the UA is unchallenged, so keep the honest, self-describing
+// one — and keep X-Health-Probe as a stable, spoof-resistant identifier for CF
+// logs / a future rate-limit exception. See wiki learning:
+// cloudflare-bot-fight-mode-403s-health-monitor.
 const PROBE_HEADERS = {
-  "User-Agent":
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
-    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+  "User-Agent": "nczoning-health-monitor",
   "X-Health-Probe": "nczoning-health-monitor",
 };
 


### PR DESCRIPTION
## Why

Follow-up to #805, which tried a browser User-Agent to get the health probe past the `403`. It **didn't work** — a firewall event proved Bot Fight Mode keys on non-interactive automation from a datacentre IP (ASN 8075 / Microsoft/Azure runner), not the UA string, and `managed_challenge`'d the Chrome UA identically.

Bot Fight Mode is fundamentally incompatible with an Actions-based probe, and it was `403`ing **every** datacentre consumer of the public read-only API, not just our monitor. It's been **disabled zone-wide**. Compensating controls: an existing `/v1` rate-limit rule; DDoS (L3/4 + L7, always-on) and WAF Managed Rules are unaffected.

## What

- Revert the probe to the honest `nczoning-health-monitor` UA (with BFM off it's no longer challenged), keeping `X-Health-Probe` as a stable identifier.
- Correct the now-inaccurate #805 comment.
- CHANGELOG: note the API no longer bot-challenges automated consumers.

## Verify

Confirmation run to follow once merged (BFM is now off): expect green, and since the last run was a `failure` it should post the real green **recovered** all-clear from #804.

🤖 Generated with [Claude Code](https://claude.com/claude-code)