### PR TITLE
fix(api): prod cron actually 5-min + openapi version → 0.1.0

### DIFF
--- a/.github/workflows/monitor-api-health.yml
+++ b/.github/workflows/monitor-api-health.yml
@@ -7,7 +7,7 @@ name: Monitor Data API Health
 
 on:
   schedule:
-    - cron: '*/15 * * * *'   # every 15 min — matches the dataset cron cadence
+    - cron: '*/15 * * * *'   # independent uptime probe, every 15 min (need not match the dataset cron)
   workflow_dispatch:          # manual trigger (testing / on demand)
 
 permissions:

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "NC Zoning Data API",
-    "version": "1.0.0",
+    "version": "0.1.0",
     "description": "Read-only API serving the NC Zoning Board mod registry (Cyberpunk 2077 location mods) to in-game mods and the website. Every response is wrapped in a versioned envelope. Coordinates are raw CET world values [X, Y, Z] — usable in-game with no transform. The JSON stays DTO-mappable for the in-game RedData parser: no arrays-of-arrays, property names are case-sensitive. See https://github.com/spuddeh/nc-zoning-board for the project.",
     "contact": { "name": "NC Zoning Board", "url": "https://nczoning.net" }
   },

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -47,7 +47,7 @@
 	// submission). Nexus load stays well under limits — see docs/nexus-api-reference.md.
 	"triggers": {
 		"crons": [
-			"*/15 * * * *"
+			"*/5 * * * *"
 		]
 	},
 	// Refresh-failure alerts post to the dedicated map-alerts channel:


### PR DESCRIPTION
Fixes two discrepancies a codebase review surfaced.

## 1. Prod dataset cron was still `*/15`
The earlier 5-min-cron change only landed on staging — the `replace_all` edit
carried the staging block's indentation, so it matched only staging while prod
kept `*/15` and just got its comment updated (which then lied). **Prod has been
refreshing every 15 min.** Fixed prod → `*/5`.

**Knock-on (maintainer decision):** the health monitor stays `*/15` as an
independent uptime probe — reworded its comment so it no longer claims to "match
the dataset cron cadence."

## 2. openapi.json `info.version` `1.0.0` → `0.1.0`
The OpenAPI doc version disagreed with the deployed `API_VERSION` (`0.1.0`, both
envs) and even its own `/v1/health` example (`0.1.0`). Now mirrors what it
documents. (`SCHEMA_VERSION = 1` is the envelope schema — a separate concept,
left alone.)

Worker tests: pass.

> ⚠️ The prod cron fix only takes effect on prod after a **dev→main** — until
> then the live prod Worker keeps refreshing every 15 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)