### PR TITLE
Release: prod cron actually 5-min + openapi version fix

### DIFF
--- a/.github/workflows/monitor-api-health.yml
+++ b/.github/workflows/monitor-api-health.yml
@@ -7,7 +7,7 @@ name: Monitor Data API Health
 
 on:
   schedule:
-    - cron: '*/15 * * * *'   # every 15 min — matches the dataset cron cadence
+    - cron: '*/15 * * * *'   # independent uptime probe, every 15 min (need not match the dataset cron)
   workflow_dispatch:          # manual trigger (testing / on demand)
 
 permissions:

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "NC Zoning Data API",
-    "version": "1.0.0",
+    "version": "0.1.0",
     "description": "Read-only API serving the NC Zoning Board mod registry (Cyberpunk 2077 location mods) to in-game mods and the website. Every response is wrapped in a versioned envelope. Coordinates are raw CET world values [X, Y, Z] — usable in-game with no transform. The JSON stays DTO-mappable for the in-game RedData parser: no arrays-of-arrays, property names are case-sensitive. See https://github.com/spuddeh/nc-zoning-board for the project.",
     "contact": { "name": "NC Zoning Board", "url": "https://nczoning.net" }
   },

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -47,7 +47,7 @@
 	// submission). Nexus load stays well under limits — see docs/nexus-api-reference.md.
 	"triggers": {
 		"crons": [
-			"*/15 * * * *"
+			"*/5 * * * *"
 		]
 	},
 	// Refresh-failure alerts post to the dedicated map-alerts channel:


### PR DESCRIPTION
dev → main to land the review fixes (#807) on **prod**.

- **Prod dataset cron `*/15` → `*/5`** — the live prod Worker has been refreshing
  every 15 min (the earlier change only hit staging). On merge, `deploy-api.yml`
  redeploys the prod Worker and the cron **actually becomes 5 min**.
- Health monitor stays `*/15` (independent probe; comment corrected).
- openapi `info.version` `1.0.0` → `0.1.0` to mirror the deployed `API_VERSION`.

Content diff is 3 lines. No version bump (folds into `[Unreleased]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)