### PR TITLE
docs(api): correct stale worker comments (slim-list consumer + 15-min cron)

### DIFF
--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -101,9 +101,11 @@ const routes = {
   'GET /v1/health': (request, env) =>
     json(envelope({ status: 'ok', version: env.API_VERSION }, null)),
 
-  // Slim by default (the in-game RedData workhorse list). `?full=1` returns
-  // the full entries as an array — description/credits + image URLs — for the
-  // website and any consumer that wants everything in one request.
+  // Slim by default: the lean list, kept RedData-mappable for the in-game
+  // parser. `?full=1` returns the full entries as an array — description/credits
+  // + image URLs — in one request. Both current consumers (the website and the
+  // in-game NCZoningCore mod) fetch ?full=1; slim stays for any consumer that
+  // only needs the minimal shape.
   'GET /v1/locations': (request, env) => {
     const url = new URL(request.url);
     if (url.searchParams.get('full') === '1') {

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -9,7 +9,7 @@
  *   no arrays-of-arrays, property names are case-sensitive.
  * - Path-based versioning: additive changes only within /v1/.
  *
- * Data is served from KV (written by the 15-minute cron, see refresh.js).
+ * Data is served from KV (written by the 5-minute cron, see refresh.js).
  * ETag = dataset_version (the content hash): a client sending a matching
  * If-None-Match gets a 304 without the big data read.
  */
@@ -145,7 +145,7 @@ function locationById(request, env, id) {
 }
 
 export default {
-  // 15-minute cron: rebuild the dataset into KV (see refresh.js).
+  // 5-minute cron: rebuild the dataset into KV (see refresh.js).
   async scheduled(controller, env, ctx) {
     ctx.waitUntil(runRefresh(env));
   },

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -1,5 +1,5 @@
 /**
- * Refresh orchestrator — the body of the 15-minute cron. Fetches the CDN
+ * Refresh orchestrator — the body of the 5-minute cron. Fetches the CDN
  * source files + Nexus auto-discovery, rebuilds the dataset, and writes to
  * KV only when the content hash changes.
  *

--- a/worker/src/store.js
+++ b/worker/src/store.js
@@ -34,7 +34,7 @@ export async function readMeta(env) {
 /**
  * Persist a freshly built dataset. Writes all keys; callers only reach here
  * when the hash changed, so the per-key 1 write/s limit is never a risk
- * (cron runs every 15 min).
+ * (cron runs every 5 min).
  */
 export async function writeDataset(env, { slim, full, districts, tags, meta }) {
   await Promise.all([


### PR DESCRIPTION
Two comment-only corrections in `worker/` (no behaviour change):

1. **slim-list comment** (`index.js`): it called the slim list "the in-game RedData workhorse list", but the shipped in-game consumer (NCZoningCore) fetches `/v1/locations?full=1` once per launch, same as the website. Reworded to keep the RedData-mappable rationale for the slim shape without implying the mod consumes it.
2. **stale "15-minute cron" comments** (`index.js` x2, `refresh.js`, `store.js`): the dataset cron has run every **5 minutes** since the cron fix (PR #807); these comments still said 15. Updated to match `wrangler.jsonc`.

Both were surfaced while authoring the NC Zoning Academy Data API course against these files. Comment-only, so tests are unaffected; merging redeploys the prod Worker with identical behaviour (`API_VERSION` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)