### PR TITLE
Sync main → dev: location submissions + API doc-comment fixes

### DIFF
--- a/data/locations/07ca4667-020a-4cc0-bbb6-ed21e6a37e35.json
+++ b/data/locations/07ca4667-020a-4cc0-bbb6-ed21e6a37e35.json
@@ -1,0 +1,23 @@
+{
+    "id": "07ca4667-020a-4cc0-bbb6-ed21e6a37e35",
+    "name": "Hotel Raito - Akulov Penthouse Revamped",
+    "authors": [
+        "skrittleskittie"
+    ],
+    "credits": "",
+    "coordinates": [
+        -1205.425,
+        1398.5217,
+        109.4014
+    ],
+    "nexus_id": "30980",
+    "description": "The Psycho Penthouse in Kabuki that once belonged to a Russian fixer.",
+    "category": "location-overhaul",
+    "tags": [
+        "apartment",
+        "corpo",
+        "neokitsch",
+        "quest"
+    ],
+    "yaw": -8.5066
+}

--- a/data/locations/924ea351-ab6a-4a2e-95ff-699d23e919c9.json
+++ b/data/locations/924ea351-ab6a-4a2e-95ff-699d23e919c9.json
@@ -1,0 +1,20 @@
+{
+    "id": "924ea351-ab6a-4a2e-95ff-699d23e919c9",
+    "name": "Neon Isolation",
+    "authors": [
+        "DevilDevil868"
+    ],
+    "credits": "",
+    "coordinates": [
+        -1152.6123,
+        1457.2716,
+        54.0579
+    ],
+    "nexus_id": "31233",
+    "description": "A netrunners hideout in Kabuki.",
+    "category": "new-location",
+    "tags": [
+        "apartment"
+    ],
+    "yaw": -91.6504
+}

--- a/data/locations/ee8fc5c6-089f-49fb-a881-dd9050da9950.json
+++ b/data/locations/ee8fc5c6-089f-49fb-a881-dd9050da9950.json
@@ -1,0 +1,21 @@
+{
+    "id": "ee8fc5c6-089f-49fb-a881-dd9050da9950",
+    "name": "Pacifica Hotel Pistis Sophia Apartment",
+    "authors": [
+        "hnovak1"
+    ],
+    "credits": "",
+    "coordinates": [
+        -2630.1057,
+        -2450.5002,
+        35.0366
+    ],
+    "nexus_id": "31015",
+    "description": "The same floor where Johnny takes V after the Dashi Parade, but different apartment, with great view to the Pacifica Pier.",
+    "category": "location-overhaul",
+    "tags": [
+        "apartment",
+        "quest"
+    ],
+    "yaw": -145.7413
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -101,9 +101,11 @@ const routes = {
   'GET /v1/health': (request, env) =>
     json(envelope({ status: 'ok', version: env.API_VERSION }, null)),
 
-  // Slim by default (the in-game RedData workhorse list). `?full=1` returns
-  // the full entries as an array — description/credits + image URLs — for the
-  // website and any consumer that wants everything in one request.
+  // Slim by default: the lean list, kept RedData-mappable for the in-game
+  // parser. `?full=1` returns the full entries as an array — description/credits
+  // + image URLs — in one request. Both current consumers (the website and the
+  // in-game NCZoningCore mod) fetch ?full=1; slim stays for any consumer that
+  // only needs the minimal shape.
   'GET /v1/locations': (request, env) => {
     const url = new URL(request.url);
     if (url.searchParams.get('full') === '1') {

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -9,7 +9,7 @@
  *   no arrays-of-arrays, property names are case-sensitive.
  * - Path-based versioning: additive changes only within /v1/.
  *
- * Data is served from KV (written by the 15-minute cron, see refresh.js).
+ * Data is served from KV (written by the 5-minute cron, see refresh.js).
  * ETag = dataset_version (the content hash): a client sending a matching
  * If-None-Match gets a 304 without the big data read.
  */
@@ -145,7 +145,7 @@ function locationById(request, env, id) {
 }
 
 export default {
-  // 15-minute cron: rebuild the dataset into KV (see refresh.js).
+  // 5-minute cron: rebuild the dataset into KV (see refresh.js).
   async scheduled(controller, env, ctx) {
     ctx.waitUntil(runRefresh(env));
   },

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -1,5 +1,5 @@
 /**
- * Refresh orchestrator — the body of the 15-minute cron. Fetches the CDN
+ * Refresh orchestrator — the body of the 5-minute cron. Fetches the CDN
  * source files + Nexus auto-discovery, rebuilds the dataset, and writes to
  * KV only when the content hash changes.
  *

--- a/worker/src/store.js
+++ b/worker/src/store.js
@@ -34,7 +34,7 @@ export async function readMeta(env) {
 /**
  * Persist a freshly built dataset. Writes all keys; callers only reach here
  * when the hash changed, so the per-key 1 write/s limit is never a risk
- * (cron runs every 15 min).
+ * (cron runs every 5 min).
  */
 export async function writeDataset(env, { slim, full, districts, tags, meta }) {
   await Promise.all([


### PR DESCRIPTION
Routine `main → dev` sync so staging reflects current production.

Brings into `dev`:
- 3 new location submissions merged to `main` (Neon Isolation, Pacifica Hotel Pistis Sophia Apartment, Hotel Raito - Akulov Penthouse Revamped).
- Comment-only `worker/` doc fixes (stale "15-minute cron" → "5-minute"; clarified slim-list comment). No functional code change.

Disjoint from `dev`'s brand work — clean merge, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)