### PR TITLE
fix(stats): outside-polygon locations fall back to Badlands, not dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- District info panel no longer undercounts: locations outside every district/subdistrict polygon now fall back to Badlands (matching the API), instead of being dropped from all stats. Fixes Badlands count (41 → 44) and the `% of all locations` denominator (292 → 295). ([#823](https://github.com/spuddeh/nc-zoning-board/issues/823))
+
 ## [1.3.0] - 2026-07-09
 
 ### Design

--- a/assets/js/district-info.js
+++ b/assets/js/district-info.js
@@ -30,6 +30,13 @@ NCZ.DistrictInfo = (() => {
   let _stats = { districts: {}, subs: {}, total: 0 };
   let _ready = false;
   let _pendingMods = null;        // setMods() called before init() finished
+  let _defaultDistrict = null;    // the game's catch-all district (Badlands)
+
+  // The game's default district: anywhere outside every district polygon is
+  // Badlands (it has no polygon of its own — the parent is the catch-all).
+  // Mirrors DEFAULT_DISTRICT_ID in worker/src/districts.js assignDistrict()
+  // so the panel's stats and the API's `district` field can never disagree.
+  const DEFAULT_DISTRICT_ID = "badlands";
 
   // Shoelace area (absolute) — smallest matching polygon wins, so a mod inside
   // both a subdistrict and its parent district is attributed to the subdistrict.
@@ -93,6 +100,7 @@ NCZ.DistrictInfo = (() => {
           _subMeta[s.id] = { name: s.name, districtId: d.id, color };
         }
       }
+      _defaultDistrict = _districts.find(d => d.id === DEFAULT_DISTRICT_ID) || null;
       _ready = true;
       if (_pendingMods) { setMods(_pendingMods); _pendingMods = null; }
     } catch (err) {
@@ -111,8 +119,12 @@ NCZ.DistrictInfo = (() => {
     for (const m of mods || []) {
       const c = m.coordinates;
       if (!c || c.length < 2) continue;
-      const area = resolveArea([c[0], c[1]]);
-      if (!area) continue; // outside every district (e.g. open ocean) — skip
+      // Outside every polygon → the game's default district (Badlands), matching
+      // the API's assignDistrict(). Skipping these dropped them from every
+      // district's stats AND from _stats.total, so shares were computed against
+      // a denominator that was too small. See issue #823.
+      const area = resolveArea([c[0], c[1]]) || (_defaultDistrict && { dist: _defaultDistrict, sub: null });
+      if (!area) continue; // no default district at all (shouldn't happen with real data)
       const { dist, sub } = area;
 
       const catKey = (m.category in emptyBucket().cat) ? m.category : "other";


### PR DESCRIPTION
Fixes #823.

## Problem

`NCZ.DistrictInfo.setMods()` skipped any location whose coordinates fall outside every district and subdistrict polygon (`if (!area) continue;`). Those locations were dropped from **every** district's stats and from `_stats.total`, so the panel disagreed with the API.

The API's `assignDistrict()` (`worker/src/districts.js`) falls back to the default district (Badlands) for a no-polygon point — mirroring the game, where the Badlands has no polygon and is the catch-all region. The website was the one undercounting.

## Fix

Mirror the worker's fallback client-side: on a `null` resolve, attribute the location to the default district (`badlands`) instead of skipping it. The default-district id is a named constant that mirrors `DEFAULT_DISTRICT_ID` in `worker/src/districts.js`.

## Verification

Reproduced against the live `/v1/locations?full=1` payload (the same source the panel consumes):

| | total | Badlands | sum of per-district |
| --- | --- | --- | --- |
| before (skip) | 292 | 41 | 292 |
| after (fallback) | 295 | 44 | 295 |

After the fix the sum of all district counts equals the dataset size (295), and the Badlands count and `% of all locations` denominator match the API.

## Scope note

`showAt()` (the cursor-driven hover) also calls `resolveArea` but was **left unchanged** — it isn't bucketing mods, it's a hover UX decision, so hovering literal open ocean still hides the panel rather than popping up "Badlands". Only the stats-bucketing path in `setMods()` was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)