### PR TITLE
feat(api): per-location records only — collapse slim/full, add recency, drop counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Data API now carries per-location records only.** `/v1/locations` is a single representation — the slim/full split is gone (`?full=1` is a no-op alias) — and `/v1/meta` no longer ships aggregate `counts`. Consumers derive counts by grouping records.
+- Each location carries a server-computed `recently_updated` boolean, and the response envelope publishes the `recently_updated_days` window — so the clockless in-game mod can show recency, and the website reads the bool instead of computing it.
+- The district info panel now groups stats by the API's assigned district/subdistrict labels rather than recomputing them client-side.
+
 ### Fixed
 
-- District info panel no longer undercounts: locations outside every district/subdistrict polygon now fall back to Badlands (matching the API), instead of being dropped from all stats. Fixes Badlands count (41 → 44) and the `% of all locations` denominator (292 → 295). ([#823](https://github.com/spuddeh/nc-zoning-board/issues/823))
+- District info panel no longer undercounts: locations outside every district/subdistrict polygon are now counted under Badlands (the API's assignment), instead of being dropped from all stats. Fixes Badlands count (41 → 44) and the `% of all locations` denominator (292 → 295). ([#823](https://github.com/spuddeh/nc-zoning-board/issues/823))
 
 ## [1.3.0] - 2026-07-09
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1719,7 +1719,7 @@ async function initMap() {
           <span class="cluster-mod-layout">
             ${thumbMarkup}
             <span class="cluster-mod-content">
-              <span class="cluster-mod-name">${NCZ.escapeHtml(mod.name)}${NCZ.isRecentlyUpdated(mod) ? ` <span class="badge-updated" title="Updated on Nexus within the last ${NCZ.RECENTLY_UPDATED_DAYS} days">${NCZ.UPDATED_LABEL}</span>` : ""}</span>
+              <span class="cluster-mod-name">${NCZ.escapeHtml(mod.name)}${NCZ.isRecentlyUpdated(mod) ? ` <span class="badge-updated" title="Updated on Nexus within the last ${NCZ.recentlyUpdatedDays ?? NCZ.RECENTLY_UPDATED_DAYS} days">${NCZ.UPDATED_LABEL}</span>` : ""}</span>
               <span class="cluster-mod-separator"></span>
               <span class="cluster-mod-meta">by ${NCZ.escapeHtml(mod.authors.join(", "))}</span>
               <span class="cluster-mod-tags">
@@ -1826,6 +1826,10 @@ async function initMap() {
       mods = apiResult.mods;
       nexusThumbs = apiResult.nexusThumbs;
       tagsDict = localTags;
+      // The API owns the recency window (it computes each mod's recently_updated
+      // bool against it). Adopt it so the tooltip text matches; fall back to the
+      // local constant if an older API omits it.
+      NCZ.recentlyUpdatedDays = apiResult.recentlyUpdatedDays ?? NCZ.RECENTLY_UPDATED_DAYS;
       console.log(`Data source: /v1 API — ${mods.length} mods`);
     } catch (apiErr) {
       console.warn("Data API unavailable — falling back to client-side merge:", apiErr);
@@ -1833,6 +1837,8 @@ async function initMap() {
       mods = fb.mods;
       nexusThumbs = fb.nexusThumbs;
       tagsDict = fb.tagsDict;
+      // No API envelope on the fallback path — compute recency with the constant.
+      NCZ.recentlyUpdatedDays = NCZ.RECENTLY_UPDATED_DAYS;
       console.log(`Data source: client-side fallback — ${mods.length} mods`);
     }
 
@@ -2086,7 +2092,7 @@ async function initMap() {
           ? ` <span class="nexus-auto-badge" title="Sourced automatically from Nexus Mods" aria-hidden="true"></span>`
           : "";
         const sidebarUpdatedBadge = NCZ.isRecentlyUpdated(mod)
-          ? ` <span class="badge-updated" title="Updated on Nexus within the last ${NCZ.RECENTLY_UPDATED_DAYS} days">${NCZ.UPDATED_LABEL}</span>`
+          ? ` <span class="badge-updated" title="Updated on Nexus within the last ${NCZ.recentlyUpdatedDays ?? NCZ.RECENTLY_UPDATED_DAYS} days">${NCZ.UPDATED_LABEL}</span>`
           : "";
         li.innerHTML = `
                 <div class="mod-item-header">
@@ -2247,7 +2253,7 @@ async function initMap() {
       const btn = document.createElement("button");
       btn.className = "tag-filter-btn";
       btn.textContent = NCZ.UPDATED_LABEL;
-      btn.title = `Updated on Nexus within the last ${NCZ.RECENTLY_UPDATED_DAYS} days`;
+      btn.title = `Updated on Nexus within the last ${NCZ.recentlyUpdatedDays ?? NCZ.RECENTLY_UPDATED_DAYS} days`;
       btn.dataset.tag = "updated";
       btn.addEventListener("click", () => { btn.classList.toggle("active"); applyFilters(); });
       tagsFilterContainer.appendChild(btn);

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -145,6 +145,11 @@ NCZ.CET_UNITS_PER_METER = 1;
 // LocalStorage cache keys & TTLs
 NCZ.THEME_PREFERENCE_KEY = "nc_theme_id";
 NCZ.SHOWCASE_OPTIONS_KEY = "nc_showcase_options";
+// Fallback recency window (days). The API owns this rule — it computes each
+// mod's `recently_updated` bool and publishes the window as
+// `recently_updated_days` on the response envelope, which the app adopts into
+// NCZ.recentlyUpdatedDays. This constant is only used when the API is
+// unavailable (client-side fallback path) or omits the field.
 NCZ.RECENTLY_UPDATED_DAYS = 7;
 NCZ.UPDATED_LABEL = "RECENTLY UPDATED";
 NCZ.THUMB_CACHE_KEY = "nc_nexus_thumbs";

--- a/assets/js/district-info.js
+++ b/assets/js/district-info.js
@@ -27,6 +27,8 @@ NCZ.DistrictInfo = (() => {
   let _districts = [];            // subdistricts.json districts[]
   const _districtMeta = {};       // id → { name, color }
   const _subMeta = {};            // subId → { name, districtId, color }
+  const _distIdByName = {};       // district name → id (served labels → panel ids)
+  const _subIdByName = {};        // subdistrict name → id
   let _stats = { districts: {}, subs: {}, total: 0 };
   let _ready = false;
   let _pendingMods = null;        // setMods() called before init() finished
@@ -34,8 +36,9 @@ NCZ.DistrictInfo = (() => {
 
   // The game's default district: anywhere outside every district polygon is
   // Badlands (it has no polygon of its own — the parent is the catch-all).
-  // Mirrors DEFAULT_DISTRICT_ID in worker/src/districts.js assignDistrict()
-  // so the panel's stats and the API's `district` field can never disagree.
+  // Mirrors DEFAULT_DISTRICT_ID in worker/src/districts.js assignDistrict().
+  // Used only when resolving from coordinates on the API-down fallback path;
+  // on the normal API path the served label is already "Badlands".
   const DEFAULT_DISTRICT_ID = "badlands";
 
   // Shoelace area (absolute) — smallest matching polygon wins, so a mod inside
@@ -96,8 +99,10 @@ NCZ.DistrictInfo = (() => {
       for (const d of _districts) {
         const color = NCZ.DISTRICT_COLORS[d.id] || "#ffffff";
         _districtMeta[d.id] = { name: d.name, color };
+        _distIdByName[d.name] = d.id;
         for (const s of d.subdistricts || []) {
           _subMeta[s.id] = { name: s.name, districtId: d.id, color };
+          _subIdByName[s.name] = s.id;
         }
       }
       _defaultDistrict = _districts.find(d => d.id === DEFAULT_DISTRICT_ID) || null;
@@ -108,33 +113,39 @@ NCZ.DistrictInfo = (() => {
     }
   }
 
-  // Attribute every mod to its smallest containing subdistrict (and that sub's
-  // parent district); mods outside all subs fall back to a containing district
-  // polygon. Aggregate count / category / recently-updated per area.
+  // Aggregate count / category / recently-updated per area. Normal (API) path:
+  // group by the district/subdistrict the API already assigned (served as names,
+  // mapped to panel ids) — counting the API's own labels is what keeps the panel
+  // from ever disagreeing with the API (the root of #823; the ex-ocean mods are
+  // already labelled Badlands server-side). API-down fallback path: mods carry
+  // no served label, so resolve from coordinates (with the Badlands default),
+  // exactly as the API would.
   function setMods(mods) {
     if (!_ready) { _pendingMods = mods; return; }
     const dStats = {}, sStats = {};
     let total = 0;
 
     for (const m of mods || []) {
-      const c = m.coordinates;
-      if (!c || c.length < 2) continue;
-      // Outside every polygon → the game's default district (Badlands), matching
-      // the API's assignDistrict(). Skipping these dropped them from every
-      // district's stats AND from _stats.total, so shares were computed against
-      // a denominator that was too small. See issue #823.
-      const area = resolveArea([c[0], c[1]]) || (_defaultDistrict && { dist: _defaultDistrict, sub: null });
-      if (!area) continue; // no default district at all (shouldn't happen with real data)
-      const { dist, sub } = area;
+      let distId = m.district ? _distIdByName[m.district] : undefined;
+      let subId = m.subdistrict ? (_subIdByName[m.subdistrict] ?? null) : null;
+      if (!distId) {
+        // No served label (fallback path) — resolve from coordinates.
+        const c = m.coordinates;
+        if (!c || c.length < 2) continue;
+        const area = resolveArea([c[0], c[1]]) || (_defaultDistrict && { dist: _defaultDistrict, sub: null });
+        if (!area) continue; // no default district at all (shouldn't happen with real data)
+        distId = area.dist.id;
+        subId = area.sub ? area.sub.id : null;
+      }
 
       const catKey = (m.category in emptyBucket().cat) ? m.category : "other";
       const recent = NCZ.isRecentlyUpdated(m);
       total++;
 
-      const ds = (dStats[dist.id] ||= emptyBucket());
+      const ds = (dStats[distId] ||= emptyBucket());
       ds.total++; ds.cat[catKey]++; if (recent) ds.recent++;
-      if (sub) {
-        const ss = (sStats[sub.id] ||= emptyBucket());
+      if (subId) {
+        const ss = (sStats[subId] ||= emptyBucket());
         ss.total++; ss.cat[catKey]++; if (recent) ss.recent++;
       }
     }

--- a/assets/js/services.js
+++ b/assets/js/services.js
@@ -303,15 +303,21 @@ NCZ.fetchLocationsFromApi = async function () {
 
   let rawLocations;
   let freshEtag = null; // set only on a fresh 200 we should cache
+  // The recency window, read straight off the response envelope. Cached with the
+  // data so the 304 path keeps it; null when an older API omits it (the caller
+  // falls back to NCZ.RECENTLY_UPDATED_DAYS).
+  let recentlyUpdatedDays = null;
   if (res.status === 304 && Array.isArray(cached?.data)) {
     console.log(`Data API: 304 Not Modified — reusing ${cached.data.length} cached locations`);
     rawLocations = cached.data;
+    recentlyUpdatedDays = cached.recentlyUpdatedDays ?? null;
   } else if (res.ok) {
     const envelope = await res.json();
     rawLocations = envelope?.data;
     if (!Array.isArray(rawLocations)) {
       throw new Error("Data API: malformed payload (envelope.data is not an array)");
     }
+    recentlyUpdatedDays = envelope?.recently_updated_days ?? null;
     freshEtag = res.headers.get("ETag");
     console.log(`Data API: loaded ${rawLocations.length} locations (dataset ${String(envelope.dataset_version).slice(0, 8)})`);
   } else {
@@ -330,7 +336,7 @@ NCZ.fetchLocationsFromApi = async function () {
 
   if (freshEtag !== null) {
     try {
-      localStorage.setItem(NCZ.API_LOCATIONS_CACHE_KEY, JSON.stringify({ etag: freshEtag, data: rawLocations }));
+      localStorage.setItem(NCZ.API_LOCATIONS_CACHE_KEY, JSON.stringify({ etag: freshEtag, data: rawLocations, recentlyUpdatedDays }));
     } catch {
       /* localStorage quota — fine, we just won't get a 304 next load */
     }
@@ -358,7 +364,7 @@ NCZ.fetchLocationsFromApi = async function () {
     };
   });
 
-  return { mods, nexusThumbs };
+  return { mods, nexusThumbs, recentlyUpdatedDays };
 };
 
 // Legacy client-side data path (pre-B7): load mods.json + tags.json +

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -278,10 +278,15 @@ NCZ.parseNcZoningBlock = function (description, validTagNames) {
 };
 
 // Returns true when a mod was updated on Nexus within the recent window.
+// The API computes this server-side (so the clockless in-game consumer can read
+// it too) and ships it as `recently_updated` on every record — trust that when
+// present. Only the client-side fallback path (API down, no bool) computes it
+// from the raw timestamp, using the effective window.
 NCZ.isRecentlyUpdated = function (mod) {
+  if (typeof mod.recently_updated === "boolean") return mod.recently_updated;
   if (!mod._updatedAt) return false;
-  const cutoff = Date.now() - NCZ.RECENTLY_UPDATED_DAYS * 86400000;
-  return new Date(mod._updatedAt).getTime() > cutoff;
+  const days = NCZ.recentlyUpdatedDays ?? NCZ.RECENTLY_UPDATED_DAYS;
+  return new Date(mod._updatedAt).getTime() > Date.now() - days * 86400000;
 };
 
 // CET → Three.js world coords. Game Y axis becomes -Z (both right-handed, but Y/Z are swapped).
@@ -362,7 +367,7 @@ NCZ.buildPopupHtml = function (mod, catStyle, nexusThumbs, tagsDict) {
     ? ` <span class="nexus-auto-badge" title="Sourced automatically from Nexus Mods" aria-hidden="true"></span>`
     : "";
   const updatedPopupBadge = NCZ.isRecentlyUpdated(mod)
-    ? ` <span class="badge-updated" title="Updated on Nexus within the last ${NCZ.RECENTLY_UPDATED_DAYS} days">${NCZ.UPDATED_LABEL}</span>`
+    ? ` <span class="badge-updated" title="Updated on Nexus within the last ${NCZ.recentlyUpdatedDays ?? NCZ.RECENTLY_UPDATED_DAYS} days">${NCZ.UPDATED_LABEL}</span>`
     : "";
 
   const authorsHtml = mod.authors

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -20,12 +20,19 @@ Every response is wrapped:
   "schema": 1,
   "generated_at": "2026-07-05T00:00:00.000Z",
   "dataset_version": "87cc60cf7332…",
+  "recently_updated_days": 7,
   "data": <route-specific>
 }
 ```
 
 `dataset_version` is a content hash of the whole dataset. It's also the
 `ETag`, so it's how you detect changes (see [Caching](#caching)).
+
+`recently_updated_days` is the recency window in days: a location's
+`recently_updated` bool is `true` when its Nexus update falls within this many
+days. It's published so consumers (and UI text) read the rule instead of
+hardcoding it — though a clockless in-game consumer doesn't need it: it just
+reads each record's `recently_updated` bool directly.
 
 ## Contract rules (why the JSON looks the way it does)
 
@@ -52,14 +59,19 @@ parser:
 | Route | Returns |
 | --- | --- |
 | `GET /v1/health` | `{ status, version }` (uncached) |
-| `GET /v1/locations` | all locations, slim |
-| `GET /v1/locations?full=1` | all locations, full (adds `description`, `credits`, image URLs) — one request for everything |
-| `GET /v1/locations/{id}` | one full entry (adds `description`, `credits`, image URLs), or 404 |
+| `GET /v1/locations` | all locations (full records) as an array |
+| `GET /v1/locations?full=1` | identical to `/v1/locations` — `full=1` is a no-op alias kept for older consumers |
+| `GET /v1/locations/{id}` | one location record, or 404 |
 | `GET /v1/districts` | district/subdistrict hierarchy (flat boundaries + centroids) |
 | `GET /v1/tags` | tag id → description |
-| `GET /v1/meta` | `{ counts, discovery_stale, skipped }` |
+| `GET /v1/meta` | `{ discovery_stale, skipped }` (operational health flags) |
 
-A location (slim):
+There is a **single location representation** — every record carries all fields.
+Consumers derive any aggregate (per-district counts, category breakdown, recency
+counts) by grouping these records locally; the API does not ship precomputed
+aggregates.
+
+A location record:
 
 ```json
 {
@@ -73,17 +85,22 @@ A location (slim):
   "authors": ["SomeModder"],
   "source": "auto",
   "district": "City Center",
-  "subdistrict": "Corpo Plaza"
+  "subdistrict": "Corpo Plaza",
+  "recently_updated": true,
+  "description": "…",
+  "credits": "Optional team name",
+  "thumbnail_url": "https://…",
+  "picture_url": "https://…",
+  "updated_at": "2026-07-02T12:00:00.000Z"
 }
 ```
 
-Full entries (`/v1/locations/{id}` or the whole list via `/v1/locations?full=1`)
-add `description`, `credits` (if present), and the Nexus image fields
-`thumbnail_url` / `picture_url` / `updated_at` (each `null` when unknown — e.g.
-WIP/Dummy entries). Images live on the full entry only; the slim list stays
-lean for the in-game RedData consumer. The `?full=1` list carries its own ETag
-(the dataset version suffixed `-full`), so caching it never collides with the
-slim list.
+- `recently_updated` is server-computed: `true` when `updated_at` is within
+  `recently_updated_days` (on the envelope). It's the answer a clockless in-game
+  consumer can't compute for itself, so the server provides it.
+- `credits` appears only when set; `thumbnail_url` / `picture_url` / `updated_at`
+  are `null` when unknown (e.g. WIP/Dummy entries with no Nexus page, which are
+  also never `recently_updated`).
 
 ## Caching
 
@@ -119,6 +136,7 @@ public class NCZLocation {
   let category: String;
   let district: String;
   let subdistrict: String;
+  let recently_updated: Bool;      // server-computed; no client clock needed
 }
 
 public class NCZExample extends ScriptableSystem {
@@ -153,8 +171,12 @@ re-downloading unchanged data.
 ## Notes
 
 - The API never talks to Nexus on your behalf at request time — a cron
-  rebuilds the dataset every 15 minutes and serves it from cache, so you're
+  rebuilds the dataset every 5 minutes and serves it from cache, so you're
   shielded from Nexus API hiccups. If a refresh fails, `meta.discovery_stale`
   is `true` and the last-known-good data is served.
 - `meta.skipped` lists mods tagged `NCZoning` whose metadata block didn't
   parse — useful if you're a mod author debugging why yours isn't appearing.
+- `recently_updated` rides the content hash: because it depends on the clock,
+  a location crossing the `recently_updated_days` boundary changes
+  `dataset_version` (and the `ETag`) even when nothing on Nexus changed, so a
+  conditional GET correctly sees the flip rather than a stale `304`.

--- a/docs/data-api-plan.md
+++ b/docs/data-api-plan.md
@@ -48,10 +48,10 @@ Every response uses the envelope
 
 | Route | Returns |
 | --- | --- |
-| `GET /v1/locations` | Slim list: id, name, nexus_id, coordinates, yaw, category, tags, authors, source, district, subdistrict |
-| `GET /v1/locations/{id}` | Full entry (adds description, credits) |
+| `GET /v1/locations` | Full records (one representation): id, name, nexus_id, coordinates, yaw, category, tags, authors, source, district, subdistrict, recently_updated, description, credits, image URLs. `?full=1` is a no-op alias. Consumers derive aggregates by grouping these. |
+| `GET /v1/locations/{id}` | One location record |
 | `GET /v1/districts` | District/subdistrict hierarchy with names, centroids and boundaries |
-| `GET /v1/meta` | dataset_version, generated_at, counts, discovery_stale, min_client, notices |
+| `GET /v1/meta` | discovery_stale, skipped (operational health flags; no aggregate counts). dataset_version + generated_at + recently_updated_days live on the envelope. |
 | `GET /v1/tags` | Tag dictionary |
 | `GET /v1/health` | 200 + Worker version |
 

--- a/docs/nczoning-auto-discovery.md
+++ b/docs/nczoning-auto-discovery.md
@@ -18,7 +18,7 @@ When your mod is discovered, the map reads these fields from the Nexus V2 GraphQ
 | `description` | Metadata source | Full BBCode body — only used to extract the `[NCZoning]` block, then discarded |
 | `uploader.name` | First author | Always prepended to the author list; additional authors come from `authors=` in the block |
 | `thumbnailUrl` | Thumbnail image | Displayed in the popup and sidebar entry |
-| `updatedAt` | Recently Updated badge | If within the last `NCZ.RECENTLY_UPDATED_DAYS` days, an `UPDATED` badge is shown on the pin popup, sidebar entry, and cluster flyout |
+| `updatedAt` | Recently Updated badge | Drives the server-computed `recently_updated` bool (window = the API's `recently_updated_days`); when true, an `UPDATED` badge is shown on the pin popup, sidebar entry, and cluster flyout |
 
 **Nothing else is read.** Tags, changelogs, version history, endorsements, file downloads, and all other mod fields are ignored.
 
@@ -28,7 +28,7 @@ When your mod is discovered, the map reads these fields from the Nexus V2 GraphQ
 
 When the map loads, it queries the Nexus Mods API for all Cyberpunk 2077 mods tagged with **NCZoning**. For each result it finds, it looks for a `[NCZoning]` metadata block inside the mod description. If a valid block is found, the mod is automatically added to the map as a live pin — no GitHub account or pull request required.
 
-Auto-discovered pins are identical to manually submitted ones, with a small amber **[ N ]** badge in the popup title and sidebar entry (tooltip: "Sourced automatically from Nexus Mods"). They are also automatically tagged with **nczoning**, which appears as a tag badge on their popup and can be used in the tag filter to show only auto-discovered mods. If the mod was updated on Nexus within the last `NCZ.RECENTLY_UPDATED_DAYS` days, an additional **UPDATED** badge is shown alongside the title.
+Auto-discovered pins are identical to manually submitted ones, with a small amber **[ N ]** badge in the popup title and sidebar entry (tooltip: "Sourced automatically from Nexus Mods"). They are also automatically tagged with **nczoning**, which appears as a tag badge on their popup and can be used in the tag filter to show only auto-discovered mods. If the mod is recently updated (the API's server-computed `recently_updated` bool, within the `recently_updated_days` window), an additional **UPDATED** badge is shown alongside the title.
 
 ---
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -34,7 +34,7 @@ Synthetic tags are applied automatically by the map system. They are **not** in 
 | Tag | Applied by | Description |
 | --- | --- | --- |
 | `nczoning` | Auto-discovery (`fetchNexusTaggedMods`) | Applied to every mod sourced automatically from Nexus Mods. Appears as a filter tag and as a badge on the popup and sidebar entry. |
-| `updated` | `app.js` filter setup | A virtual filter that surfaces any mod whose Nexus `updatedAt` timestamp falls within `NCZ.RECENTLY_UPDATED_DAYS` days. Not stored on the mod object — evaluated live by `isRecentlyUpdated()`. |
+| `updated` | `app.js` filter setup | A virtual filter that surfaces any recently updated mod, matched via `isRecentlyUpdated()` — which reads the API's server-computed `recently_updated` bool (or, on the API-down fallback, computes from `updatedAt` vs the recency window). Not a stored tag. |
 
 ---
 

--- a/docs/three-js-scene.md
+++ b/docs/three-js-scene.md
@@ -455,7 +455,7 @@ All in `utils.js`. Both views call these — nothing view-specific lives here.
 
 | Function | Description |
 |----------|-------------|
-| `NCZ.isRecentlyUpdated(mod)` | True if mod was updated on Nexus within `NCZ.RECENTLY_UPDATED_DAYS` |
+| `NCZ.isRecentlyUpdated(mod)` | True if mod was recently updated on Nexus. Reads the API's server-computed `recently_updated` bool; on the API-down fallback path, computes from `_updatedAt` vs the effective window (`NCZ.recentlyUpdatedDays`, default `NCZ.RECENTLY_UPDATED_DAYS`) |
 | `NCZ.cetToThree(cetX, cetY, cetZ)` | CET → Three.js `[x, y, z]` |
 | `NCZ.buildPopupHtml(mod, catStyle, nexusThumbs, tagsDict)` | Full popup HTML string, used by both views |
 | `NCZ.prepareModRenderData(mod, nexusThumbs, tagsDict)` | Returns `{ catStyle, popupHtml, thumbSrc, fullSrc, nexusUrl, nexusLabel }` |

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -31,19 +31,19 @@
     },
     "/v1/locations": {
       "get": {
-        "summary": "All locations (slim, or full with ?full=1)",
-        "description": "The workhorse. Slim entries by default (no description/credits/images) — lean for the in-game RedData list. Pass ?full=1 to get full entries (description, credits, and Nexus image URLs) as an array in one request; that variant carries its own ETag (suffixed -full) so it can't be confused with the slim cache. Supports conditional GET: send If-None-Match with the last dataset_version to get a 304.",
+        "summary": "All locations",
+        "description": "The workhorse: every location as a full record (all fields incl. description, credits, Nexus image URLs, and the recently_updated bool) in one array. There is a single representation; ?full=1 is accepted as a no-op alias for older consumers. Consumers derive any aggregate (district/category counts, recency counts) by grouping these records. Supports conditional GET: send If-None-Match with the last dataset_version to get a 304.",
         "parameters": [
-          { "name": "full", "in": "query", "required": false, "schema": { "type": "string", "enum": ["1"] }, "description": "Set full=1 to return LocationFull entries (adds description, credits, thumbnail_url, picture_url, updated_at). Omit for the slim list." },
+          { "name": "full", "in": "query", "required": false, "schema": { "type": "string", "enum": ["1"] }, "description": "Accepted as a no-op alias (the response is always the full record). Retained so existing consumers that pass full=1 keep working." },
           { "$ref": "#/components/parameters/IfNoneMatch" }
         ],
         "responses": {
           "200": {
-            "description": "The location array — slim Location[] by default, or LocationFull[] when ?full=1.",
+            "description": "The location array (LocationFull[]).",
             "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
             "content": { "application/json": { "schema": {
               "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
-                "data": { "type": "array", "items": { "oneOf": [{ "$ref": "#/components/schemas/Location" }, { "$ref": "#/components/schemas/LocationFull" }] } } } }]
+                "data": { "type": "array", "items": { "$ref": "#/components/schemas/LocationFull" } } } }]
             } } }
           },
           "304": { "$ref": "#/components/responses/NotModified" },
@@ -115,7 +115,7 @@
     "/v1/meta": {
       "get": {
         "summary": "Dataset metadata",
-        "description": "Counts (total, manual, auto, per-district) and health flags. dataset_version and generated_at live on the envelope.",
+        "description": "Operational health flags (discovery_stale, skipped). dataset_version and generated_at live on the envelope.",
         "parameters": [{ "$ref": "#/components/parameters/IfNoneMatch" }],
         "responses": {
           "200": {
@@ -152,17 +152,18 @@
     "schemas": {
       "Envelope": {
         "type": "object",
-        "required": ["schema", "generated_at", "dataset_version", "data"],
+        "required": ["schema", "generated_at", "dataset_version", "recently_updated_days", "data"],
         "properties": {
           "schema": { "type": "integer", "const": 1, "description": "Envelope schema version." },
           "generated_at": { "type": ["string", "null"], "format": "date-time", "description": "When the dataset was last built." },
           "dataset_version": { "type": ["string", "null"], "description": "Content hash; the ETag value." },
+          "recently_updated_days": { "type": "integer", "description": "The recency window in days: a location's recently_updated bool is true when its Nexus update is within this many days. Published so clock-having consumers (and UI text) read the rule instead of hardcoding it." },
           "data": { "description": "Route-specific payload." }
         }
       },
       "Location": {
         "type": "object",
-        "description": "Slim location entry.",
+        "description": "Core location record fields (shared by every representation).",
         "required": ["id", "name", "nexus_id", "coordinates", "category", "tags", "authors", "source", "district"],
         "properties": {
           "id": { "type": "string", "description": "UUID (manual) or nexus-<nexus_id> (auto).", "example": "nexus-27618" },
@@ -179,9 +180,11 @@
         }
       },
       "LocationFull": {
+        "description": "The single location representation served by /v1/locations and /v1/locations/{id}.",
         "allOf": [
           { "$ref": "#/components/schemas/Location" },
-          { "type": "object", "properties": {
+          { "type": "object", "required": ["recently_updated"], "properties": {
+            "recently_updated": { "type": "boolean", "description": "Server-computed: true when updated_at is within recently_updated_days (see envelope). Polyfill for the clockless in-game consumer; the website reads it too." },
             "description": { "type": "string" },
             "credits": { "type": "string" },
             "thumbnail_url": { "type": ["string", "null"], "description": "Nexus thumbnail image URL, or null (unknown / WIP / Dummy)." },
@@ -215,11 +218,8 @@
       "Point": { "type": ["object", "null"], "properties": { "x": { "type": "number" }, "y": { "type": "number" } } },
       "Meta": {
         "type": "object",
+        "description": "Operational health flags only. Aggregate counts were removed — consumers derive their own from the location records.",
         "properties": {
-          "counts": { "type": "object", "properties": {
-            "total": { "type": "integer" }, "manual": { "type": "integer" }, "auto": { "type": "integer" },
-            "per_district": { "type": "object", "additionalProperties": { "type": "integer" } }
-          } },
           "discovery_stale": { "type": "boolean", "description": "True if the last Nexus refresh failed and the dataset is being served from last-known-good." },
           "skipped": { "type": "array", "items": { "type": "object", "properties": { "nexus_id": { "type": "string" }, "name": { "type": "string" } } }, "description": "Mods tagged NCZoning whose metadata block did not parse." }
         }

--- a/worker/src/config.js
+++ b/worker/src/config.js
@@ -1,0 +1,12 @@
+/**
+ * Shared dataset config. Single source of truth for values that must agree
+ * across the merge (which computes the recency bool) and the request handler
+ * (which publishes the window on the envelope).
+ */
+
+// "Recently updated" window, in days. A location's recently_updated bool is
+// computed against this in merge.js; the value is published on every response
+// envelope as recently_updated_days so clock-having consumers (and humans)
+// read the rule rather than hardcoding it. The website's own constant is only
+// a fallback for when the API is unavailable.
+export const RECENTLY_UPDATED_DAYS = 7;

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -17,6 +17,7 @@
 import { runRefresh } from './refresh.js';
 import { KEYS } from './store.js';
 import { docsPage, spec } from './docs.js';
+import { RECENTLY_UPDATED_DAYS } from './config.js';
 
 const SCHEMA_VERSION = 1;
 
@@ -30,12 +31,18 @@ const CORS_HEADERS = {
 // stale-while-revalidate window so a client never blocks on a refresh.
 const DATA_CACHE = 'public, max-age=300, stale-while-revalidate=3600';
 
-/** Wrap payload data in the versioned envelope (version/time from meta). */
+/**
+ * Wrap payload data in the versioned envelope (version/time from meta).
+ * recently_updated_days publishes the recency window so clock-having consumers
+ * (and the website's tooltip text) read the rule rather than hardcoding it; the
+ * clockless in-game consumer instead reads each record's recently_updated bool.
+ */
 function envelope(data, meta) {
   return {
     schema: SCHEMA_VERSION,
     generated_at: meta?.generated_at ?? null,
     dataset_version: meta?.dataset_version ?? null,
+    recently_updated_days: RECENTLY_UPDATED_DAYS,
     data,
   };
 }
@@ -69,14 +76,13 @@ function notReady() {
  * receives the parsed meta and returns the response `data`, or `undefined`
  * to signal a 404 (e.g. an unknown location id).
  */
-async function serveDataset(request, env, build, etagSuffix = '') {
+async function serveDataset(request, env, build) {
   const meta = await env.DATASET.get(KEYS.meta, 'json');
   if (!meta) return notReady();
 
-  // The ETag is the dataset content hash. Representations that share a hash
-  // but differ in body (slim vs ?full=1) must NOT share an ETag, or a client
-  // caching one and requesting the other would get a wrong 304. Vary it.
-  const etag = `"${meta.dataset_version}${etagSuffix}"`;
+  // The ETag is the dataset content hash. There is a single location
+  // representation now, so every route derives its ETag from the same hash.
+  const etag = `"${meta.dataset_version}"`;
   if (request.headers.get('If-None-Match') === etag) {
     return new Response(null, {
       status: 304,
@@ -101,26 +107,15 @@ const routes = {
   'GET /v1/health': (request, env) =>
     json(envelope({ status: 'ok', version: env.API_VERSION }, null)),
 
-  // Slim by default: the lean list, kept RedData-mappable for the in-game
-  // parser. `?full=1` returns the full entries as an array — description/credits
-  // + image URLs — in one request. Both current consumers (the website and the
-  // in-game NCZoningCore mod) fetch ?full=1; slim stays for any consumer that
-  // only needs the minimal shape.
-  'GET /v1/locations': (request, env) => {
-    const url = new URL(request.url);
-    if (url.searchParams.get('full') === '1') {
-      return serveDataset(
-        request,
-        env,
-        async (e) => {
-          const full = await e.DATASET.get(KEYS.full, 'json');
-          return full ? Object.values(full) : undefined;
-        },
-        '-full',
-      );
-    }
-    return serveDataset(request, env, (e) => e.DATASET.get(KEYS.slim, 'json'));
-  },
+  // One representation: the full records as an array — every field the DTO
+  // consumer needs, RedData-mappable. `?full=1` is accepted as a no-op alias so
+  // existing consumers (the website and the in-game NCZoningCore mod, which both
+  // request it) keep working; there is no leaner shape to opt out to.
+  'GET /v1/locations': (request, env) =>
+    serveDataset(request, env, async (e) => {
+      const full = await e.DATASET.get(KEYS.full, 'json');
+      return full ? Object.values(full) : undefined;
+    }),
 
   'GET /v1/districts': (request, env) =>
     serveDataset(request, env, (e) => e.DATASET.get(KEYS.districts, 'json')),
@@ -128,9 +123,10 @@ const routes = {
   'GET /v1/tags': (request, env) =>
     serveDataset(request, env, (e) => e.DATASET.get(KEYS.tags, 'json')),
 
+  // Operational metadata only — health flags the monitors read. No aggregate
+  // counts: consumers derive those from the per-location records.
   'GET /v1/meta': (request, env) =>
     serveDataset(request, env, (e, meta) => ({
-      counts: meta.counts,
       discovery_stale: meta.discovery_stale ?? false,
       skipped: meta.skipped ?? [],
     })),

--- a/worker/src/merge.js
+++ b/worker/src/merge.js
@@ -17,6 +17,7 @@
 
 import { parseNcZoningBlock } from './parse.js';
 import { assignDistrict } from './districts.js';
+import { RECENTLY_UPDATED_DAYS } from './config.js';
 
 export const DESCRIPTION_MAX_LENGTH = 500;
 
@@ -31,9 +32,12 @@ export const DESCRIPTION_MAX_LENGTH = 500;
  *   mods, keyed by numeric nexus_id ({pictureUrl, thumbnailUrl, updatedAt}).
  *   Covers manual entries not tagged NCZoning (the tagged query only backfills
  *   the tagged ones). Optional so existing callers/tests don't break.
- * @returns {{locations: Array, full: Object<string, object>, meta: object}}
+ * @param {number} [input.nowMs] wall-clock (ms) the recently_updated bool is
+ *   computed against. refresh.js passes the cron tick's clock; defaults to
+ *   Date.now() so other callers still work. Tests pass a fixed value.
+ * @returns {{full: Object<string, object>, meta: object}}
  */
-export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs = {} }) {
+export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs = {}, nowMs = Date.now() }) {
   const validTagNames = new Set(Object.keys(tagsDict));
   const excludedIds = new Set(Object.keys(excluded || {}));
 
@@ -116,16 +120,25 @@ export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, distr
     };
   }
 
-  const perDistrict = {};
-  const locations = [];
+  // One representation: the full record, keyed by id (the by-id endpoint reads
+  // full[id]; the list endpoint serves Object.values(full), which keeps the
+  // alphabetical order of `all`). No separate slim array — consumers derive any
+  // aggregate (counts, category breakdown) by grouping these records locally.
+  const cutoffMs = nowMs - RECENTLY_UPDATED_DAYS * 86400000;
   const full = {};
 
   for (const entry of all) {
     const { district, subdistrict } = assignDistrict(entry.coordinates, districts);
-    const key = district || 'Outside mapped districts';
-    perDistrict[key] = (perDistrict[key] || 0) + 1;
+    const thumbs = resolveThumbs(entry);
+    // Server-computed polyfill for the clockless in-game consumer. Content ×
+    // wall-clock, so it must ride the periodically-rehashed content (refresh.js
+    // recomputes it every cron tick) — never materialize-once. NaN (bad/absent
+    // date) → false.
+    const recently_updated = thumbs.updated_at
+      ? Date.parse(thumbs.updated_at) > cutoffMs
+      : false;
 
-    locations.push({
+    full[entry.id] = {
       id: entry.id,
       name: entry.name,
       nexus_id: String(entry.nexus_id),
@@ -137,28 +150,17 @@ export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, distr
       source: entry.source,
       district,
       subdistrict,
-    });
-
-    full[entry.id] = {
-      ...locations[locations.length - 1],
+      recently_updated,
       description: entry.description ?? '',
       ...(entry.credits ? { credits: entry.credits } : {}),
-      ...resolveThumbs(entry),
+      ...thumbs,
     };
   }
 
   return {
-    locations,
     full,
-    meta: {
-      counts: {
-        manual: manualMods.length,
-        auto: autoEntries.length,
-        total: all.length,
-        per_district: perDistrict,
-      },
-      skipped,
-      nexus_thumbs: nexusThumbs,
-    },
+    // skipped = tagged mods with no valid block, surfaced on /v1/meta for the
+    // auto-discovery monitor. No aggregate counts: consumers derive their own.
+    meta: { skipped, nexus_thumbs: nexusThumbs },
   };
 }

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -110,15 +110,20 @@ export async function runRefresh(env, fetchImpl = fetch) {
       .filter((id) => /^\d+$/.test(id));
     const manualThumbs = await fetchModsByUidThumbs(fetchImpl, manualNumericIds);
 
-    const { locations, full, meta } = buildDataset({
+    const { full, meta } = buildDataset({
       manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs,
+      nowMs: Date.parse(generatedAt),
     });
     const districtsOut = districtsPayload(districts);
 
     // Hash the content that actually varies (not generated_at). Tags are
-    // included so a tags.json edit propagates through the ETag.
+    // included so a tags.json edit propagates through the ETag. `full` carries
+    // the recently_updated bool, so its clock-driven flips move the ETag —
+    // that is deliberate (a location aging past the window must invalidate
+    // caches even though nothing on Nexus changed). This is why the cron
+    // rebuilds every tick against a fresh clock, with no Nexus short-circuit.
     const version = await contentHash(
-      JSON.stringify({ locations, full, districts: districtsOut, tags: tagsDict }),
+      JSON.stringify({ full, districts: districtsOut, tags: tagsDict }),
     );
 
     const prev = await readMeta(env);
@@ -131,7 +136,6 @@ export async function runRefresh(env, fetchImpl = fetch) {
     const recovered = prev?.discovery_stale === true;
 
     await writeDataset(env, {
-      slim: locations,
       full,
       districts: districtsOut,
       tags: tagsDict,
@@ -139,7 +143,6 @@ export async function runRefresh(env, fetchImpl = fetch) {
         schema: SCHEMA_VERSION,
         generated_at: generatedAt,
         dataset_version: version,
-        counts: meta.counts,
         skipped: meta.skipped,
         discovery_stale: false,
       },

--- a/worker/src/store.js
+++ b/worker/src/store.js
@@ -1,10 +1,11 @@
 /**
  * KV storage layer for the dataset. Keys under `dataset:v1*`:
- * - dataset:v1           slim locations array (the workhorse read)
- * - dataset:v1:full      { id: fullEntry } map for /v1/locations/{id}
+ * - dataset:v1:full      { id: fullEntry } map — the one location
+ *                        representation. /v1/locations serves its values;
+ *                        /v1/locations/{id} reads full[id].
  * - dataset:v1:districts /v1/districts payload
  * - dataset:v1:tags      tag dictionary ({ tagId: description })
- * - dataset:v1:meta      { schema, generated_at, dataset_version, counts,
+ * - dataset:v1:meta      { schema, generated_at, dataset_version,
  *                          discovery_stale, skipped }
  *
  * dataset_version is a content hash: the cron writes only when it changes,
@@ -12,7 +13,6 @@
  */
 
 export const KEYS = {
-  slim: 'dataset:v1',
   full: 'dataset:v1:full',
   districts: 'dataset:v1:districts',
   tags: 'dataset:v1:tags',
@@ -36,9 +36,8 @@ export async function readMeta(env) {
  * when the hash changed, so the per-key 1 write/s limit is never a risk
  * (cron runs every 5 min).
  */
-export async function writeDataset(env, { slim, full, districts, tags, meta }) {
+export async function writeDataset(env, { full, districts, tags, meta }) {
   await Promise.all([
-    env.DATASET.put(KEYS.slim, JSON.stringify(slim)),
     env.DATASET.put(KEYS.full, JSON.stringify(full)),
     env.DATASET.put(KEYS.districts, JSON.stringify(districts)),
     env.DATASET.put(KEYS.tags, JSON.stringify(tags)),

--- a/worker/test/index.test.js
+++ b/worker/test/index.test.js
@@ -18,16 +18,14 @@ function fakeKV(entries = {}) {
 
 const META = {
   schema: 1, generated_at: '2026-07-04T00:00:00.000Z', dataset_version: 'abc123',
-  counts: { manual: 1, auto: 1, total: 2, per_district: { Watson: 2 } },
   skipped: [], discovery_stale: false,
 };
-const SLIM = [
-  { id: 'm1', name: 'Manual', nexus_id: '1', coordinates: [1, 2, 3], category: 'other', tags: [], authors: ['A'], source: 'manual', district: 'Watson', subdistrict: 'Kabuki' },
-  { id: 'nexus-2', name: 'Auto', nexus_id: '2', coordinates: [4, 5, 6], category: 'new-location', tags: ['nczoning'], authors: ['B'], source: 'auto', district: 'Watson', subdistrict: null },
-];
+// The single representation: full records keyed by id (what /v1/locations serves
+// the values of, and /v1/locations/{id} reads directly). Each carries the
+// server-computed recently_updated bool.
 const FULL = {
-  m1: { ...SLIM[0], description: 'a manual mod' },
-  'nexus-2': { ...SLIM[1], description: 'an auto mod' },
+  m1: { id: 'm1', name: 'Manual', nexus_id: '1', coordinates: [1, 2, 3], category: 'other', tags: [], authors: ['A'], source: 'manual', district: 'Watson', subdistrict: 'Kabuki', recently_updated: false, description: 'a manual mod' },
+  'nexus-2': { id: 'nexus-2', name: 'Auto', nexus_id: '2', coordinates: [4, 5, 6], category: 'new-location', tags: ['nczoning'], authors: ['B'], source: 'auto', district: 'Watson', subdistrict: null, recently_updated: true, description: 'an auto mod' },
 };
 const DISTRICTS = [{ id: 'watson', name: 'Watson', boundary: [0, 0, 10, 0, 10, 10], centroid: { x: 5, y: 5 }, subdistricts: [] }];
 const TAGS = { apartment: 'a place', corpo: 'suits' };
@@ -36,7 +34,7 @@ function seededEnv() {
   return {
     API_VERSION: '0.1.0',
     DATASET: fakeKV({
-      [KEYS.meta]: META, [KEYS.slim]: SLIM, [KEYS.full]: FULL,
+      [KEYS.meta]: META, [KEYS.full]: FULL,
       [KEYS.districts]: DISTRICTS, [KEYS.tags]: TAGS,
     }),
   };
@@ -53,7 +51,7 @@ test('GET /v1/health returns ok + version, no ETag', async () => {
   assert.equal(body.data.version, '0.1.0');
 });
 
-test('GET /v1/locations returns the slim array in an envelope with ETag', async () => {
+test('GET /v1/locations returns the full records with recently_updated + envelope window', async () => {
   const res = await worker.fetch(GET('/v1/locations'), seededEnv());
   assert.equal(res.status, 200);
   assert.equal(res.headers.get('ETag'), '"abc123"');
@@ -62,29 +60,25 @@ test('GET /v1/locations returns the slim array in an envelope with ETag', async 
   const body = await res.json();
   assert.equal(body.schema, 1);
   assert.equal(body.dataset_version, 'abc123');
+  assert.equal(body.recently_updated_days, 7); // window published on the envelope
   assert.equal(body.data.length, 2);
-  assert.ok(!('description' in body.data[0])); // slim
+  assert.equal(body.data[0].description, 'a manual mod');     // single full representation
+  assert.equal(typeof body.data[0].recently_updated, 'boolean');
 });
 
-test('GET /v1/locations?full=1 returns full entries as an array, with a -full ETag', async () => {
+test('GET /v1/locations?full=1 is a no-op alias: same body, same ETag', async () => {
   const res = await worker.fetch(GET('/v1/locations?full=1'), seededEnv());
   assert.equal(res.status, 200);
-  assert.equal(res.headers.get('ETag'), '"abc123-full"'); // variant ETag, not the slim one
+  assert.equal(res.headers.get('ETag'), '"abc123"'); // one representation → one ETag, no -full variant
   const body = await res.json();
   assert.equal(body.data.length, 2);
-  assert.equal(body.data[0].description, 'a manual mod'); // full carries description
+  assert.equal(body.data[0].description, 'a manual mod');
 });
 
-test('a slim ETag does not satisfy a ?full=1 request (distinct representations)', async () => {
+test('the base ETag satisfies a ?full=1 request (one representation, shared ETag)', async () => {
   const res = await worker.fetch(
     GET('/v1/locations?full=1', { 'If-None-Match': '"abc123"' }), seededEnv());
-  assert.equal(res.status, 200); // slim etag ≠ full etag → fresh 200, never a wrong 304
-});
-
-test('matching -full ETag yields 304 for ?full=1', async () => {
-  const res = await worker.fetch(
-    GET('/v1/locations?full=1', { 'If-None-Match': '"abc123-full"' }), seededEnv());
-  assert.equal(res.status, 304);
+  assert.equal(res.status, 304); // same hash, same body → a correct 304
 });
 
 test('matching If-None-Match yields 304 with no body', async () => {
@@ -104,6 +98,7 @@ test('GET /v1/locations/{id} returns the full entry', async () => {
   assert.equal(res.status, 200);
   const body = await res.json();
   assert.equal(body.data.description, 'an auto mod');
+  assert.equal(body.data.recently_updated, true);
 });
 
 test('GET /v1/locations/{unknown} → 404', async () => {
@@ -124,12 +119,13 @@ test('GET /v1/tags returns the dictionary', async () => {
   assert.deepEqual((await res.json()).data, TAGS);
 });
 
-test('GET /v1/meta returns counts + discovery_stale (not the raw record)', async () => {
+test('GET /v1/meta returns health flags only — no aggregate counts', async () => {
   const res = await worker.fetch(GET('/v1/meta'), seededEnv());
   const body = await res.json();
-  assert.equal(body.data.counts.total, 2);
   assert.equal(body.data.discovery_stale, false);
-  assert.ok(!('dataset_version' in body.data)); // version lives on the envelope
+  assert.deepEqual(body.data.skipped, []);
+  assert.ok(!('counts' in body.data));          // aggregates removed
+  assert.ok(!('dataset_version' in body.data));  // version lives on the envelope
 });
 
 test('empty KV (pre-first-cron) → 503 not_ready', async () => {

--- a/worker/test/merge.test.js
+++ b/worker/test/merge.test.js
@@ -59,21 +59,23 @@ const dataset = buildDataset({
   nexusNodes: NODES,
   districts: DISTRICTS,
 });
+// The list endpoint serves the values of `full` (one representation, sorted).
+const LOCS = Object.values(dataset.full);
 
 test('merges manual + auto with exclusions and duplicates handled', () => {
-  assert.equal(dataset.locations.length, 3); // 2 manual + 1 auto
-  const ids = dataset.locations.map((l) => l.id);
+  assert.equal(LOCS.length, 3); // 2 manual + 1 auto
+  const ids = LOCS.map((l) => l.id);
   assert.ok(ids.includes('nexus-888'), 'stable nexus-<id> for auto entries');
   assert.ok(!ids.some((id) => id.includes('777')), 'excluded mod absent');
 });
 
 test('sorted alphabetically by name', () => {
-  const names = dataset.locations.map((l) => l.name);
+  const names = LOCS.map((l) => l.name);
   assert.deepEqual(names, [...names].sort((a, b) => a.localeCompare(b)));
 });
 
 test('manual entry wins by nexus_id; node contributes thumbnail backfill', () => {
-  const zeta = dataset.locations.find((l) => l.nexus_id === '12345');
+  const zeta = dataset.full['aaaa-1111'];
   assert.equal(zeta.name, 'Zeta Manual Loft'); // manual name, not the Nexus page name
   assert.equal(zeta.source, 'manual');
   assert.deepEqual(dataset.meta.nexus_thumbs['12345'], {
@@ -107,39 +109,53 @@ test('manualThumbs backfills manual mods that are not NCZoning-tagged (modsByUid
 });
 
 test('auto entry: authors, tags (nczoning + known only), yaw, images in full', () => {
-  const auto = dataset.locations.find((l) => l.id === 'nexus-888');
+  const auto = dataset.full['nexus-888'];
   assert.deepEqual(auto.authors, ['Uploader888', 'Friend']);
   assert.deepEqual(auto.tags, ['nczoning', 'corpo']); // 'bogus' dropped
   assert.equal(auto.yaw, 45);
   assert.equal(auto.source, 'auto');
-  const fullAuto = dataset.full['nexus-888'];
-  assert.equal(fullAuto.credits, 'Team X');
-  assert.equal(fullAuto.thumbnail_url, 'thumb-888');
+  assert.equal(auto.credits, 'Team X');
+  assert.equal(auto.thumbnail_url, 'thumb-888');
 });
 
 test('district enrichment: subdistrict wins inside it, district elsewhere', () => {
-  const zeta = dataset.locations.find((l) => l.id === 'aaaa-1111'); // (250,250) in SW quarter
+  const zeta = dataset.full['aaaa-1111']; // (250,250) in SW quarter
   assert.equal(zeta.district, 'Testville');
   assert.equal(zeta.subdistrict, 'Little Fixture');
-  const auto = dataset.locations.find((l) => l.id === 'nexus-888'); // (600,600) outside sub
+  const auto = dataset.full['nexus-888']; // (600,600) outside sub
   assert.equal(auto.district, 'Testville');
   assert.equal(auto.subdistrict, null);
 });
 
-test('meta counts + skipped monitoring list', () => {
-  assert.deepEqual(dataset.meta.counts, {
-    manual: 2, auto: 1, total: 3,
-    per_district: { Testville: 3 },
+test('recently_updated: true inside the window, false outside, false when no date', () => {
+  const near = buildDataset({
+    manualMods: MANUAL, tagsDict: TAGS, excluded: { 777: 'x' },
+    nexusNodes: NODES, districts: DISTRICTS,
+    nowMs: Date.parse('2026-07-05T00:00:00Z'), // within 7d of the 2026-07-02 update
   });
+  assert.equal(near.full['nexus-888'].recently_updated, true);
+  assert.equal(near.full['aaaa-1111'].recently_updated, true); // updated 2026-07-01
+  assert.equal(near.full['bbbb-2222'].recently_updated, false); // WIP → no updated_at
+
+  const far = buildDataset({
+    manualMods: MANUAL, tagsDict: TAGS, excluded: { 777: 'x' },
+    nexusNodes: NODES, districts: DISTRICTS,
+    nowMs: Date.parse('2026-09-01T00:00:00Z'), // well past the window
+  });
+  assert.equal(far.full['nexus-888'].recently_updated, false);
+});
+
+test('meta carries only the skipped monitoring list — no aggregate counts', () => {
+  assert.ok(!('counts' in dataset.meta), 'aggregate counts removed');
   assert.deepEqual(dataset.meta.skipped, [{ nexus_id: '999', name: 'Blockless Mod' }]);
 });
 
-test('slim entries omit description; full carries it', () => {
-  for (const l of dataset.locations) assert.ok(!('description' in l));
+test('every record is the full shape (description present) — no slim variant', () => {
+  for (const l of LOCS) assert.ok('description' in l, `${l.id} missing description`);
   assert.equal(dataset.full['aaaa-1111'].description, 'A manual entry.');
 });
 
-test('DTO contract: no arrays-of-arrays anywhere in the slim payload', () => {
+test('DTO contract: no arrays-of-arrays anywhere in the location payload', () => {
   const walk = (v, path) => {
     if (Array.isArray(v)) {
       for (const [i, item] of v.entries()) {
@@ -150,5 +166,5 @@ test('DTO contract: no arrays-of-arrays anywhere in the slim payload', () => {
       for (const [k, val] of Object.entries(v)) walk(val, `${path}.${k}`);
     }
   };
-  walk(dataset.locations, 'locations');
+  walk(LOCS, 'locations');
 });

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -91,12 +91,14 @@ test('first run writes the full dataset (changed=true)', async () => {
   const r = await runRefresh(env, fakeFetch());
   assert.equal(r.changed, true);
   assert.ok(r.version);
-  const slim = await env.DATASET.get(KEYS.slim, 'json');
-  assert.equal(slim.length, 2); // 1 manual + 1 auto (777 excluded)
-  assert.ok(slim.every((l) => l.district));
+  const full = await env.DATASET.get(KEYS.full, 'json');
+  const locs = Object.values(full);
+  assert.equal(locs.length, 2); // 1 manual + 1 auto (777 excluded)
+  assert.ok(locs.every((l) => l.district));
+  assert.ok(locs.every((l) => typeof l.recently_updated === 'boolean'));
   const meta = await env.DATASET.get(KEYS.meta, 'json');
   assert.equal(meta.discovery_stale, false);
-  assert.equal(meta.counts.total, 2);
+  assert.ok(!('counts' in meta)); // aggregates removed — consumers derive their own
   assert.equal(meta.dataset_version, r.version);
 });
 
@@ -125,14 +127,14 @@ test('Nexus failure keeps last-known-good and flags stale + alerts Discord', asy
     NCZ_ALERTS_DISCORD_WEBHOOK_URL: 'https://discord/webhook',
   };
   await runRefresh(env, fakeFetch()); // seed good data
-  const goodSlim = await env.DATASET.get(KEYS.slim, 'json');
+  const goodFull = await env.DATASET.get(KEYS.full, 'json');
 
   const discordSink = [];
   const r = await runRefresh(env, fakeFetch({ failNexus: true, discordSink }));
   assert.equal(r.stale, true);
   assert.match(r.error, /503/);
   // Dataset preserved (not wiped).
-  assert.deepEqual(await env.DATASET.get(KEYS.slim, 'json'), goodSlim);
+  assert.deepEqual(await env.DATASET.get(KEYS.full, 'json'), goodFull);
   const meta = await env.DATASET.get(KEYS.meta, 'json');
   assert.equal(meta.discovery_stale, true);
   assert.match(meta.last_error, /503/);
@@ -145,7 +147,7 @@ test('failure with no prior dataset returns stale with null version, no crash', 
   const r = await runRefresh(env, fakeFetch({ failMods: true }));
   assert.equal(r.stale, true);
   assert.equal(r.version, null);
-  assert.equal(await env.DATASET.get(KEYS.slim, 'json'), null);
+  assert.equal(await env.DATASET.get(KEYS.full, 'json'), null);
 });
 
 test('recovery after a stale cycle rewrites and clears the stale flag', async () => {


### PR DESCRIPTION
Redesigns the Data API so it carries **per-location records only**; every consumer derives aggregates by grouping the served labels (as the in-game District Guide already did). Started from #823 (the district panel undercounting Badlands), which was a symptom of three consumers each computing stats their own way.

## Worker (`worker/`)

- **Collapse the slim/full split** into one `/v1/locations` representation. `?full=1` is a no-op alias. One ETag per dataset — the `-full` vary-hack is gone (both bodies were identical, so a shared ETag is now correct). Drops the slim KV key.
- **`recently_updated` bool per record**, server-computed against the clock and **folded into the hashed content** so a location aging past the window flips `dataset_version`/the ETag even with no Nexus change — a polyfill for the clockless in-game consumer (redscript has no OS clock). The window is published on the envelope as `recently_updated_days`.
- **Drop `meta.counts`** entirely — verified zero consumers (the website discards `/meta`, DG derives from records, the two monitors read only `discovery_stale`/`skipped`). `/v1/meta` is health flags only.
- New shared `worker/src/config.js` owns `RECENTLY_UPDATED_DAYS`.

## Website (`assets/js/`)

- `isRecentlyUpdated` reads the server `recently_updated` bool; computes from `_updatedAt` only on the API-down fallback. Tooltips show the effective window.
- **District panel groups stats by the served `district`/`subdistrict` labels** instead of re-running `resolveArea` — the structural fix for #823 (the panel can no longer disagree with the API). `resolveArea` is retained for the live hover and the fallback path (where `mods.json` has no served label).

## Verification

- Worker: **63 unit tests pass** (envelope + `recently_updated_days`, `/locations` collapse + shared ETag, per-record `recently_updated`, `/meta` without counts, deterministic recency, write path).
- Website (driven against the current live API, proving backward compatibility): recency hybrid logic correct (reads bool / computes on fallback), `NCZ.recentlyUpdatedDays` falls back to 7 when absent, **de-fork grouping yields Badlands 44 / total 295 / sum == total**, zero console errors.

## Docs + wiki

`docs/api-reference.md` (major), `data-api-plan.md`, and the recency/tags/auto-discovery mentions; wiki decision `api-per-location-records` (with rejected alternatives), a learning on time-relative fields vs content-hash-gated writes, and companion syncs.

## Coordinated (separate repos, tracked as a checklist)

`nc-zoning-core` `NCZLocation` DTO gains `recently_updated: Bool`; `nc-zoning-district-guide` can badge recency and show per-district recency counts (which it couldn't before — no clock).

Refs #823

🤖 Generated with [Claude Code](https://claude.com/claude-code)