### PR TITLE
docs(changelog): release 1.4.0 — API per-location records redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-16
+
 ### Changed
 
 - **Data API now carries per-location records only.** `/v1/locations` is a single representation — the slim/full split is gone (`?full=1` is a no-op alias) — and `/v1/meta` no longer ships aggregate `counts`. Consumers derive counts by grouping records.


### PR DESCRIPTION
Cuts the **1.4.0** version heading in the changelog for the API per-location-records release (the `dev → main` promotion in #827).

Moves the existing `[Unreleased]` entries (the API redesign + the #823 fix) under `## [1.4.0] - 2026-07-16`, leaving a fresh empty `[Unreleased]`. Content-only — no code change.

**Versioning:** minor bump after 1.3.0 — the `/v1` API is path-versioned and every change is additive-safe (records only gained fields; `?full=1` still works; the dropped `/meta` counts had no consumers), and there's no breaking site change.

Merge this into `dev` first; #827 (`dev → main`) then carries 1.4.0 into production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)