### PR TITLE
Merge dev → main: shipped comment-citation cleanup

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -390,8 +390,8 @@ html.theme-preem {
     /* Preem Map theme — based on the Preem Map mod by CyanideX (permission
        granted 2026-05-01; attribution required at ship time). 3D-scene colours
        are renderer-calibrated: the eyedropped in-game Preem look inverted
-       through the measured renderer transfer (see the theme-renderer-colour-
-       calibration wiki learning). UI chrome derived from the Preem 3D palette. */
+       through the measured renderer transfer. UI chrome derived from the
+       Preem 3D palette. */
     /* UI chrome — canonical Preem material colours where one exists.
        Preem Map ships no UI inkstyle, so there is no canonical page-background
        or text colour; --primary/--dark-accent reuse Preem's dark teal map

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -300,7 +300,7 @@ NCZ.CAMERA_ROTATE_SPEED = 0.6;            // rotateSpeed     (Three.js default: 
 // single depth32float texture (the WebGPU `shadowMapping` pattern). Single map
 // for now; a CSM revisit is queued — the original "no cascades because schema
 // is ortho" rationale no longer holds since the schema camera moved to perspective
-// (FOV 25°, TweakDB-aligned), see [[align-schematic-camera-to-game]].
+// (FOV 25°, TweakDB-aligned).
 NCZ.SHADOW_MAP_SIZE      = 8192;  // px² — ~1.5 u/texel at a whole-city zoom, razor-sharp zoomed in. Always-on (interactive + showcase): the fine texels keep the showcase's fast sun from shimmering. One fixed size, not resized per-mode (maintainer call).
 NCZ.SHADOW_MAX_DISTANCE  =  8600; // CET units — cap on the footprint half-side. Matches the world half-diagonal (sqrt((WORLD_MAX_X-WORLD_MIN_X)² + (WORLD_MAX_Y-WORLD_MIN_Y)²) / 2 ≈ 8565 wu) with tiny headroom: nothing renders past the world bounds, so a larger cap just stretches texels over empty void. Trace data on PR #656 showed `half` pinned at the cap (12600 = 12000 cap + 600 margin) every showcase frame; reducing the cap shrinks the box uniformly → ~1.4× sharper texels for free at no performance cost.
 NCZ.SHADOW_GROUND_MARGIN =   600; // CET units the footprint extends past the visible ground — covers building heights / terrain relief + a sliver of just-off-screen casters. Wider off-screen-caster coverage waits on the union-frustum cull (a follow-up).

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -188,9 +188,9 @@ const ThreeScene = (() => {
   // off-screen building still in the shadow ortho box gets into the indirect
   // buffer and casts its shadow into the visible area. (Phase 2B originally
   // tested only the camera frustum, which made shadows pop in at screen
-  // edges on pan and vanish on small rotations at high zoom.) See
-  // [[webgpu-migration-execution]] risk register row for the rationale of
-  // Approach A (12-plane test) over sun-direction dilation or AABB union.
+  // edges on pan and vanish on small rotations at high zoom.) Approach A
+  // (the 12-plane test) was chosen over sun-direction dilation or an AABB
+  // union of the two frusta.
   //
   // Each plane is a vec4 packing `(normal.xyz, constant)`; the visibility
   // test against the bounding sphere is
@@ -1555,9 +1555,8 @@ const ThreeScene = (() => {
       // shows over the bay, after the road passes so it layers above both.
       //
       // LOD discard: COLOR_0 vertex attribute carries the LOD tier as one
-      // mutually-exclusive channel per vertex (per the building/metro extraction
-      // pipeline — see `[[phase3-building-rendering]]` and the metro LOD-channel
-      // mapping note in CLAUDE.md). Discard rules:
+      // mutually-exclusive channel per vertex (from the building/metro
+      // extraction pipeline). Discard rules:
       //   B=wide solid:  show only at far zoom    (zoom <= LOD_MED)
       //   G=thin solid:  show only at medium zoom (LOD_MED <= zoom <= LOD_NEAR)
       //   R=dotted:      show only at close zoom  (zoom >= LOD_NEAR)
@@ -2086,7 +2085,7 @@ const ThreeScene = (() => {
         mesh.castShadow    = true;
         mesh.receiveShadow = true;
         // Three.js's default frustum cull was already broken for our cube-
-        // at-origin setup (recon: instWiki [[iigpu-perf-investigation]]). The
+        // at-origin setup. The
         // storage-buffer pattern moves all positioning to the GPU, so the host
         // bounding sphere is even more meaningless — disable cull explicitly
         // until Phase 2B's compute pass owns visibility.
@@ -3382,8 +3381,7 @@ const ThreeScene = (() => {
   // extreme. Re-centres the sun light + its target on that footprint so the
   // shadow tracks what you see. Called on every camera change, on resize, after
   // terrain loads, on flyover frames (renderCam = the fly cam), and from
-  // startRenderLoop. Single map for now; CSM is a queued follow-up
-  // (see [[align-schematic-camera-to-game]] for the rationale shift).
+  // startRenderLoop. Single map for now; CSM is a queued follow-up.
   function updateShadowCamera(renderCam = camera) {
     if (!_dirLight || !renderCam) return;
     const shadowCam = _dirLight.shadow.camera;

--- a/scripts/monitor_api_health.js
+++ b/scripts/monitor_api_health.js
@@ -49,8 +49,7 @@ const FETCH_TIMEOUT_MS = 15000;
 // zone-wide (a /v1 rate-limit rule is the compensating control; DDoS + WAF stay
 // on). With BFM off the UA is unchallenged, so keep the honest, self-describing
 // one — and keep X-Health-Probe as a stable, spoof-resistant identifier for CF
-// logs / a future rate-limit exception. See wiki learning:
-// cloudflare-bot-fight-mode-403s-health-monitor.
+// logs / a future rate-limit exception.
 const PROBE_HEADERS = {
   "User-Agent": "nczoning-health-monitor",
   "X-Health-Probe": "nczoning-health-monitor",


### PR DESCRIPTION
Promotes the only net difference between `dev` and `main`: the shipped-comment citation cleanup from #829.

Drops internal `[[wiki]]` / `CLAUDE.md` pointers from shipped JS/CSS comments and states each rule inline. **Comments only — no executable line changed.** No changelog entry (documentation-comment cleanup).

Net diff: `theme.css`, `constants.js`, `three-scene.js`, `monitor_api_health.js` — 11 insertions, 14 deletions, all inside comments.

No CI impact: `validate-mods` (data-scoped) and `deploy-api` (`worker/**`-scoped) don't touch these files.