### PR TITLE
docs: house-style pass (no em-dashes, Australian English, plainer voice)

### DIFF
--- a/docs/3d-map-lighting.md
+++ b/docs/3d-map-lighting.md
@@ -1,8 +1,8 @@
-# 3D Map — Lighting & Colour Pipeline
+# 3D Map: Lighting & Colour Pipeline
 
 How the Three.js 3D schematic map reproduces Cyberpunk 2077's in-game 3D
-world-map look. Everything here is decoded from game files; the few values that
-can't be is called out under [Calibration](#calibration).
+world-map look. Everything here is decoded from game files; the few that
+can't are called out under [Calibration](#calibration).
 
 ## Source of truth
 
@@ -33,63 +33,63 @@ writes a normal). We reproduce the same chain.
   `renderer.outputColorSpace = SRGBColorSpace`.
 - Theme `--scene-*` albedo is authored as sRGB hex, read into a linear `THREE.Color`.
 - The tone-mapping function returns **linear** display values; Three.js applies
-  the sRGB OETF at output — so the function must not sRGB-encode its result.
+  the sRGB OETF at output, so the function must not sRGB-encode its result.
 - The braindance LUT is `sRGB`-indexed, `Linear`-output (per the envparam
   `ColorGradingLutParams`): the grade pass encodes to sRGB before the lookup,
   and the sampled result is linear.
 
-## Lighting — `three-scene.js`
+## Lighting: `three-scene.js`
 
 Decoded from `3dmap.envparam`:
 
-- **Sun** — `DirectionalLight`, colour `(0.975, 0.869, 0.774)` (warm white,
+- **Sun**: `DirectionalLight`, colour `(0.975, 0.869, 0.774)` (warm white,
   linear), a fixed low south-west direction (azimuth 107°, elevation 7°). The
-  time-of-day slider moves only the *direction*; the colour is fixed — the
+  time-of-day slider moves only the *direction*; the colour is fixed: the
   in-game map has no time-of-day variation.
-- **Ambient** — `HemisphereLight`: sky `(0.796, 0.895, 1.0)`, ground
-  `(0.566, 0.766, 1.0)` — the decoded 6-direction ambient cube collapsed to a
+- **Ambient**, a `HemisphereLight`: sky `(0.796, 0.895, 1.0)`, ground
+  `(0.566, 0.766, 1.0)`, the decoded 6-direction ambient cube collapsed to a
   hemisphere (bright cool dome, dim blue floor).
 - Cast shadows are an intentional artistic layer; the in-game map's own
   shadows are subtle.
 
-## Tonemap — `aces-tonemap.js`
+## Tonemap: `aces-tonemap.js`
 
 The game tonemaps with `TonemappingModeACES`. `aces-tonemap.js` implements the
-**ACES SSTS** (Single-Stage Tone Scale) — the parametric ACES Output Transform
-tone curve — ported verbatim from the ACES 1.3 reference (`ACESlib.SSTS.ctl`),
+**ACES SSTS** (Single-Stage Tone Scale), the parametric ACES Output Transform
+tone curve, ported verbatim from the ACES 1.3 reference (`ACESlib.SSTS.ctl`),
 parametrised by the decoded `STonemappingACESParams` (`minStops -7`,
 `maxStops 9`, `midGrayScale 1`, `desaturate 0`, …).
 
 It is registered as a custom WebGPU tone-mapping function via
 `renderer.library.addToneMapping(fn, CP2077_ACES_TONE_MAPPING)` and selected
 with `renderer.toneMapping`. (Three.js r184 has no `renderer.toneMappingNode`;
-`addToneMapping` is the supported extension point — every built-in tonemap is
+`addToneMapping` is the supported extension point: every built-in tonemap is
 registered the same way. Three's built-in `ACESFilmicToneMapping` is the
 Narkowicz *approximation* and is **not** used.)
 
-## Colour grade + LUT — `aces-tonemap.js`, gated by `--scene-grade`
+## Colour grade + LUT: `aces-tonemap.js`, gated by `--scene-grade`
 
 From the envparam `ColorGradingAreaSettings`:
 
-- contrast 1.1 about pivot 0.435, gain (R 1.0, G/B 1.3), luminance gamma 0.96 —
+- contrast 1.1 about pivot 0.435, gain (R 1.0, G/B 1.3), luminance gamma 0.96,
   applied in display (sRGB) space (the 0.435 pivot is display-referred)
-- the **braindance LUT** — `cube_cp_braindance_v001`, a 32×32×32 RGBA-float cube
+- the **braindance LUT**: `cube_cp_braindance_v001`, a 32×32×32 RGBA-float cube
 
 `scripts/build_lut.js` extracts the LUT from a WolvenKit **`.cube`** export →
 `assets/data/braindance-lut.bin`; the app loads it into a `THREE.Data3DTexture`
 and samples it trilinearly. **Do not** use WolvenKit's *DDS* export of this
-texture — for a 3D float volume it re-lays-out the slices incorrectly (its
+texture: for a 3D float volume it re-lays-out the slices incorrectly (its
 texel 0 differs from the raw `.xbm` bytes; the `.cube` export is faithful).
 
 The grade + LUT are the game's *specific creative grade*. They are gated by the
 `--scene-grade` CSS custom property: **on for the Game theme**, off for the five
-stylised themes — which keep their own colour identity and get only the
+stylised themes, which keep their own colour identity and get only the
 (theme-agnostic) ACES tonemap.
 
 ## Theme colours
 
 The Game theme's `--scene-*` are the **exact extracted material
-`BaseColorScale`** values — buildings `#c97e87`, terrain/cliffs `#566c88`,
+`BaseColorScale`** values: buildings `#c97e87`, terrain/cliffs `#566c88`,
 landmarks `#f2919c`, edge `#ff99a5`, grid `#6d8ab0`. Water shares the terrain
 albedo `#566c88` with a 0.7 brightness multiply on the water material
 (`3dmap_water.mi`'s `Brightness` override).
@@ -106,13 +106,13 @@ engine-specific:
 | Constant (`constants.js`) | Why it can't be decoded |
 | --- | --- |
 | `SUN_INTENSITY` | the envparam's sun `Alpha` is a REDengine HDR unit, no 1:1 Three.js mapping |
-| `AMBIENT_INTENSITY` | likewise — the ambient cube's `Alpha 2000` is a REDengine HDR unit |
-| `SCENE_TONEMAP_EXPOSURE` | the game's exposure is runtime auto-metered (`ExposureAreaSettings`) — no fixed value exists in any file |
+| `AMBIENT_INTENSITY` | likewise: the ambient cube's `Alpha 2000` is a REDengine HDR unit |
+| `SCENE_TONEMAP_EXPOSURE` | the game's exposure is runtime auto-metered (`ExposureAreaSettings`): no fixed value exists in any file |
 
 `SUN_INTENSITY` and `AMBIENT_INTENSITY` are **calibrated** against the usage
-envelope (default load, whole-city, zoomed-out, tilted-close) — not a single
+envelope (default load, whole-city, zoomed-out, tilted-close), not a single
 frame. Current values: sun `3.0`, ambient `0.405` (sun:ambient ≈ 7.4:1).
-Exposure is no longer a single constant — see below.
+Exposure is no longer a single constant (see below).
 
 This is the only tuning in the pipeline: every colour, the tone curve, the
 grade and the LUT are exact decoded game data; only the brightness scalars are
@@ -123,11 +123,11 @@ fit.
 The in-game map's exposure is runtime auto-metered (`ExposureAreaSettings`) and
 its sun is a fixed artistic choice. Ours is **real SunCalc sun data**, so without
 help the scene crushes to black at dawn/dusk. But the goal is **not** constant
-brightness — the map should still read like real-world light (bright midday, dim
+brightness: the map should still read like real-world light (bright midday, dim
 and atmospheric at sunrise/sunset). So `NCZ.SCENE_EXPOSURE_CURVE` is a gentle
 **"floor the darkness"** curve, **keyed on sun elevation**: exposure holds at the
 calibrated midday base for most of the day (letting the sun's own N·L falloff
-carry the natural variation) and only opens up near the horizon — **capped** — so
+carry the natural variation) and only opens up near the horizon (**capped**), so
 low sun stays atmospheric without going unusably black.
 
 > An earlier version *solved* the curve to hold the default view at one fixed
@@ -140,7 +140,7 @@ clamped to the endpoints. Tune the two ends: the first row is the horizon cap
 (sunrise/sunset), the last is the midday base. Because it's keyed on elevation,
 **both** the time-of-day slider (`applySunTime`) and the showcase flyover
 (`updateFlyoverSun`) drive it through the same function,
-`NCZ.exposureForSunElevation` (in `utils.js`) — the flyover animates the sun
+`NCZ.exposureForSunElevation` (in `utils.js`): the flyover animates the sun
 directly, so it must apply exposure itself or it freezes at one brightness.
 
 `SCENE_EXPOSURE` survives as the init fallback and the fixed `?gamelight`
@@ -150,11 +150,11 @@ drift).
 ## Edge glow (Settings toggle + per-theme default)
 
 When on, the building edge highlight is also written to `emissiveNode`, so it
-stays lit regardless of sun/shadow — a self-lit neon look (no bloom pass needed;
+stays lit regardless of sun/shadow, a self-lit neon look (no bloom pass needed;
 a true soft halo would need bloom). It's **binary** (no intensity slider): the
 on-value is the fixed `NCZ.EDGE_GLOW_INTENSITY` (`0.3`).
 
-`--scene-edge-glow` (`>0` = on) is the per-theme **default** — **Synthwave is
+`--scene-edge-glow` (`>0` = on) is the per-theme **default**: **Synthwave is
 the only theme on**. The Settings modal has an **"Edge glow"** toggle
 (`setEdgeGlowEnabled` / `getEdgeGlowEnabled`) that overrides the default for the
 session; a theme switch resets it. Because the building materials load *after*
@@ -164,10 +164,10 @@ from scene state.
 
 **Showcase:** in `cycle` mode the beat path tweens colours directly (bypassing
 `updateMaterials`), so it applies each beat-theme's edge-glow **and** grade
-defaults explicitly via `getBeatToggles()` — otherwise the gates would freeze at
+defaults explicitly via `getBeatToggles()`; otherwise the gates would freeze at
 the opening theme for the whole showcase.
 
-## Colour grade (LUT) — default + runtime toggle
+## Colour grade (LUT): default + runtime toggle
 
 The ACES grade + braindance LUT are gated per theme by `--scene-grade` (1 =
 on): **on for the Game and Preem map-replica themes, off for the stylised
@@ -176,29 +176,29 @@ themes** by default. The Settings modal has a **"Colour grade (LUT)"** toggle
 for the session so any theme can be previewed with the grade; switching themes
 resets the override to the new theme's default and the checkbox re-syncs.
 
-## Metering harness — `scripts/measure_lighting.js`
+## Metering harness: `scripts/measure_lighting.js`
 
 Automated brightness QA. Drives an installed Chrome (puppeteer-core, WebGPU)
-across the envelope in `scripts/lighting-envelope.json` — 8 approved camera
-poses × 7 sun times × the 2 calibrated themes — screenshots the 3D canvas, and
+across the envelope in `scripts/lighting-envelope.json` (8 approved camera
+poses × 7 sun times × the 2 calibrated themes), screenshots the 3D canvas, and
 computes per-frame luminance stats (median / p5 / p95 / black% / clip%) with
 sharp. Flags frames outside the calibrated `bounds`; exits non-zero so it can
 gate lighting changes. `--quick` runs a smoke subset. Emits `report.json` +
 labelled contact sheets. (`--solve` exists from the earlier hold-constant
-exposure model and is no longer used to author the curve — the floor curve is
+exposure model and is no longer used to author the curve: the floor curve is
 hand-shaped at its two ends and verified by the sweep.)
 
 The `bounds.medianMin` floor is `0.035`: deep-shadow dense-tower canyons
-legitimately sit at median ~0.04 (dim but legible, 0% crushed) — accepted as
+legitimately sit at median ~0.04 (dim but legible, 0% crushed), accepted as
 correct rather than brightened. Note the floor is a *lower* guard against true
 black; with the floor exposure curve, dawn/dusk are intentionally dim, so some
 near-horizon terrain frames sit close to it by design.
 
 ## Not (yet) replicated
 
-- **Bloom** — the envparam has `BloomAreaSettings`. The in-game buildings'
+- **Bloom**: the envparam has `BloomAreaSettings`. The in-game buildings'
   "glow" (and the visible structure of their decoded edge highlight at
-  zoomed-out scale) comes from it. Not implemented — tracked as a follow-up.
+  zoomed-out scale) comes from it. Not implemented, tracked as a follow-up.
 
 ## Key files
 
@@ -207,10 +207,10 @@ near-horizon terrain frames sit close to it by design.
 | `assets/js/aces-tonemap.js` | ACES SSTS tonemap + colour grade + braindance LUT |
 | `scripts/build_lut.js` | `.cube` → `assets/data/braindance-lut.bin` |
 | `assets/js/three-scene.js` | sun/ambient setup, tonemap registration, LUT load, `setSceneExposure`, edge-glow + grade gates |
-| `assets/js/utils.js` | `NCZ.exposureForSunElevation` — the shared exposure-curve lookup |
+| `assets/js/utils.js` | `NCZ.exposureForSunElevation`, the shared exposure-curve lookup |
 | `assets/js/app.js` | `applySunTime` (sun dir + exposure), Settings LUT toggle wiring |
-| `assets/js/flyover.js` | `updateFlyoverSun` — animates the sun + applies the exposure curve |
+| `assets/js/flyover.js` | `updateFlyoverSun`, animates the sun + applies the exposure curve |
 | `assets/js/constants.js` | `SUN_*`, `AMBIENT_*`, `SCENE_EXPOSURE`, `SCENE_EXPOSURE_CURVE` |
 | `assets/css/theme.css` | per-theme `--scene-*` albedo, `--scene-grade`, `--scene-edge-glow` |
-| `scripts/measure_lighting.js` | metering harness — sweep, `--solve`, contact sheets |
+| `scripts/measure_lighting.js` | metering harness: sweep, `--solve`, contact sheets |
 | `scripts/lighting-envelope.json` | approved poses, sun sweep, calibrated bounds |

--- a/docs/3dmap-asset-reference.md
+++ b/docs/3dmap-asset-reference.md
@@ -16,14 +16,14 @@ All files are exported from the game archive using WolvenKit. The table below co
 
 | File | Type | In ent JSON | Pipeline status | Notes |
 | --- | --- | --- | --- | --- |
-| `3dmap_view.ent.json` | Entity template | — | **Used** | Master component hierarchy; defines all transforms, triggers, and mesh placements |
-| `3dmap_triangle_soup.glb` | Visual mesh | Yes | **Used** | District-colored fill mesh; 8 `meshAppearance` variants (one per district) |
+| `3dmap_view.ent.json` | Entity template | n/a | **Used** | Master component hierarchy; defines all transforms, triggers, and mesh placements |
+| `3dmap_triangle_soup.glb` | Visual mesh | Yes | **Used** | District-coloured fill mesh; 8 `meshAppearance` variants (one per district) |
 | `3dmap_roads.glb` | Visual mesh | Yes | **Used** | Road surface mesh (~56k faces); rendered as low-opacity fill |
 | `3dmap_metro.glb` | Visual mesh | Yes | **Used** | Metro track mesh; rendered as boundary edges (edges with exactly 1 face) |
-| `3dmap_roads_borders.glb` | Visual mesh | Yes | Not used | In-game UI road border overlay — **not district boundaries**; same geometry class as roads |
+| `3dmap_roads_borders.glb` | Visual mesh | Yes | Not used | In-game UI road border overlay, **not district boundaries**; same geometry class as roads |
 | `3dmap_terrain.glb` | Visual mesh | Yes | Excluded | Full terrain mesh (247k verts); too large for 2D projection, dark background serves the same purpose |
 | `3dmap_water.glb` | Visual mesh | Yes | Excluded | World-scale flat plane; projects to fill the entire canvas |
-| `3dmap_cliffs.glb` | Visual mesh | Yes | Excluded | Terrain geometry — overwhelms the Dogtown/Badlands border area at 2D projection scale |
+| `3dmap_cliffs.glb` | Visual mesh | Yes | Excluded | Terrain geometry: overwhelms the Dogtown/Badlands border area at 2D projection scale |
 | `3dmap_obelisk.glb` | Landmark mesh | Yes | **Rendered** | Dogtown obelisk; written to `landmarks.svg` / `data/landmarks.json` |
 | `3dmap_statue_splash_a.glb` | Landmark mesh | Yes | **Rendered** | Dogtown statue on the plaza |
 | `3dmap_ext_monument_av_building_b.glb` | Landmark mesh | Yes | **Rendered** | Dogtown AV building monument |
@@ -36,12 +36,12 @@ All files are exported from the game archive using WolvenKit. The table below co
 | `3dmap_coll_buildings2.glb` | Collision mesh | Yes | Skip | As above |
 | `3dmap_coll_buildings3.glb` | Collision mesh | Yes | Skip | As above |
 | `3dmap_coll_roads.glb` | Collision mesh | Yes | Skip | Road collision hull; no visual data |
-| `3dmap_coll_santo.glb` | Collision mesh | **No** | Skip | On disk but **not referenced anywhere in `3dmap_view.ent.json`** — see anomaly note below |
-| `3dmap_mesh_static.mi.json` | Material instance | Yes (resolvedDeps) | Reference only | Shader parameter overrides for the triangle soup mesh — see material files section |
+| `3dmap_coll_santo.glb` | Collision mesh | **No** | Skip | On disk but **not referenced anywhere in `3dmap_view.ent.json`**, see anomaly note below |
+| `3dmap_mesh_static.mi.json` | Material instance | Yes (resolvedDeps) | Reference only | Shader parameter overrides for the triangle soup mesh, see material files section |
 | `3dmap_terrain.mi.json` | Material instance | Yes | Reference only | Shader params for terrain |
 | `3dmap_water.mi.json` | Material instance | Yes | Reference only | Shader params for water |
-| `3dmap_highlight_off.effect.json` | Visual effect | Yes | Skip | District de-highlight animation — see effect files section |
-| `3dmap_highlight_on.effect.json` | Visual effect | Yes | Skip | District highlight animation — see effect files section |
+| `3dmap_highlight_off.effect.json` | Visual effect | Yes | Skip | District de-highlight animation, see effect files section |
+| `3dmap_highlight_on.effect.json` | Visual effect | Yes | Skip | District highlight animation, see effect files section |
 
 ## Building Instance Textures
 
@@ -58,7 +58,7 @@ Each district has two textures:
 | `*_data.xbm` / `*_data.dds` | DXGI_FORMAT_R16G16B16A16_UNORM (16-bit RGBA) | Per-instance position, rotation, scale. Three 1:1 horizontal blocks: Position \| Rotation \| Scale. Each pixel row = one building. |
 | `*_m.xbm` / `*_m.dds` | DXGI_FORMAT_R8_UNORM (8-bit greyscale) | Surface detail baked top-down view of the district. Applied to building cube surfaces via world-space planar UV. |
 
-The `*_data` textures use the `3d_map_cubes.mt` GPU instancing shader. The decode parameters (CubeSize, TransMin, TransMax) are in `3dmap_triangle_soup.Material.json` — one entry per district.
+The `*_data` textures use the `3d_map_cubes.mt` GPU instancing shader. The decode parameters (CubeSize, TransMin, TransMax) are in `3dmap_triangle_soup.Material.json`, one entry per district.
 
 **`*_data.dds` block layout** (blockW = width / 3):
 
@@ -68,27 +68,27 @@ The `*_data` textures use the `3d_map_cubes.mt` GPU instancing shader. The decod
 | Rotation | blockW..2×blockW | RGBA = quaternion XYZw, remapped [0,1] → [-1,1] |
 | Scale | 2×blockW..3×blockW | RGB = XYZ half-extents × cubeSize |
 
-**sw5 / nw4 — legacy:** `sw1_data.xbm` (used by `sw5` material) has no TransMin/TransMax in `3dmap_triangle_soup.Material.json` and is not referenced in `3dmap_view.ent.json`. `nw4_data.xbm` is similarly unreferenced. Both are considered legacy and are not decoded by the current pipeline.
+**sw5 / nw4 (legacy):** `sw1_data.xbm` (used by `sw5` material) has no TransMin/TransMax in `3dmap_triangle_soup.Material.json` and is not referenced in `3dmap_view.ent.json`. `nw4_data.xbm` is similarly unreferenced. Both are considered legacy and are not decoded by the current pipeline.
 
 **Export format:** WolvenKit exports `*_data.xbm` as DDS with a DX10 extended header (128 byte standard header + 20 byte DX10 extension = 148 bytes before pixel data). Use `Uint16Array(buffer, 148)` to access raw pixel values.
 
 ## Effect Files (`.effect.json`)
 
-`3dmap_highlight_on.effect.json` and `3dmap_highlight_off.effect.json` define the animated district highlight that plays in the in-game minimap UI when the player enters or leaves a district zone. They drive opacity and color transitions on the triangle soup mesh appearances.
+`3dmap_highlight_on.effect.json` and `3dmap_highlight_off.effect.json` define the animated district highlight that plays in the in-game minimap UI when the player enters or leaves a district zone. They drive opacity and colour transitions on the triangle soup mesh appearances.
 
-**These are not useful for static map generation.** The pipeline applies district colors directly in Python — the in-engine animation system is bypassed entirely.
+**These are not useful for static map generation.** The pipeline applies district colours directly in Python: the in-engine animation system is bypassed entirely.
 
 ## Material Instance Files (`.mi.json`)
 
-Material Instance (`.mi`) files are shader parameter overrides. They reference a base shader and specify texture maps, colors, opacity values, and other render properties. In-engine, `3dmap_mesh_static.mi` provides the visual style for the triangle soup district fills — translucent colored faces over the map canvas.
+Material Instance (`.mi`) files are shader parameter overrides. They reference a base shader and specify texture maps, colours, opacity values, and other render properties. In-engine, `3dmap_mesh_static.mi` provides the visual style for the triangle soup district fills: translucent coloured faces over the map canvas.
 
-**These are not needed for the Python extraction pipeline.** Colors are applied directly when rendering to the 8k canvas; there is no shader system to configure.
+**These are not needed for the Python extraction pipeline.** Colours are applied directly when rendering to the 8k canvas; there is no shader system to configure.
 
-If you ever need to match the exact in-game visual style (e.g. for a tile set that closely mirrors the game's own minimap), these files contain the color and opacity values used by the original renderer.
+If you ever need to match the exact in-game visual style (e.g. for a tile set that closely mirrors the game's own minimap), these files contain the colour and opacity values used by the original renderer.
 
 ## Collision Meshes
 
-All `3dmap_coll_*.glb` files are simplified collision hulls used by the game's physics system to detect player position for the minimap zoom transitions. They contain no vertex color or visual data — skip them entirely.
+All `3dmap_coll_*.glb` files are simplified collision hulls used by the game's physics system to detect player position for the minimap zoom transitions. They contain no vertex colour or visual data: skip them entirely.
 
 ### The `3dmap_coll_santo.glb` Anomaly
 
@@ -102,29 +102,29 @@ Possible explanations:
 
 It is a non-visual collision mesh regardless, so it can be safely skipped.
 
-## Landmark Meshes — Pipeline Status
+## Landmark Meshes: Pipeline Status
 
 The landmark GLBs are decorative 3D models placed at recognisable locations on the in-game minimap. All are now rendered by the extraction pipeline as filled top-down silhouettes composited **over buildings and under district borders** in `combined_8k.png`.
 
-All landmarks are written to single combined outputs (`scripts/output/landmarks.svg`, `data/landmarks.json`). Each landmark gets a fill group `<g id="{label}">` and an outline group `<g id="{label}_outline">` in the SVG. The JSON uses `{label: {"faces": [...], "edges": [...]}}` — faces for fill polygons, edges for boundary outline segments.
+All landmarks are written to single combined outputs (`scripts/output/landmarks.svg`, `data/landmarks.json`). Each landmark gets a fill group `<g id="{label}">` and an outline group `<g id="{label}_outline">` in the SVG. The JSON uses `{label: {"faces": [...], "edges": [...]}}`: faces for fill polygons, edges for boundary outline segments.
 
 **Landmark colours** are not hardcoded. At render time, each landmark's world CET position is tested against the district trigger polygons via `classify_district()`, and the matching district colour from `DISTRICT_COLORS` is used for both fill (alpha 200) and outline (alpha 240). This means landmarks blend visually with the district they sit in rather than standing out as a separate layer.
 
 World placement and orientation are extracted automatically from `3dmap_view.ent.json` by `load_mesh_transforms()`. Run `--list-landmarks` to print all `entMeshComponent` names with resolved world CET positions and yaw angles.
 
-**Full 3D rotation is applied**: the quaternion from each component's `localTransform.Orientation` is accumulated through the parent chain (Hamilton products) and applied to vertices as a 3×3 rotation matrix in CET space before projection. This correctly handles pitch and roll, not just yaw — the collapsed ferris wheel lying on its side is one example where this matters.
+**Full 3D rotation is applied**: the quaternion from each component's `localTransform.Orientation` is accumulated through the parent chain (Hamilton products) and applied to vertices as a 3×3 rotation matrix in CET space before projection. This correctly handles pitch and roll, not just yaw: the collapsed ferris wheel lying on its side is one example where this matters.
 
 | Mesh | ent component name | Location | Pipeline status | Notes |
 | --- | --- | --- | --- | --- |
-| `3dmap_obelisk.glb` | `obelisk` | Dogtown | **Rendered** | Tall obelisk near the center |
+| `3dmap_obelisk.glb` | `obelisk` | Dogtown | **Rendered** | Tall obelisk near the centre |
 | `3dmap_statue_splash_a.glb` | `statue_splash_a` | Dogtown | **Rendered** | Dogtown statue on the plaza |
 | `3dmap_ext_monument_av_building_b.glb` | `ext_monument_av_building_b` | Dogtown | **Rendered** | AV building silhouette |
 | `northoak_sign_a.glb` | `northoak_sign_a` | North Oak (Westbrook) | **Rendered** | Entrance arch gate; has ~33° world yaw |
-| `rcr_park_ferris_wheel.glb` | `ferris_wheel_pacifica` | Pacifica | **Rendered** | Upright ferris wheel; parented to Pacifica hierarchy — `localTransform` is local, not world space |
+| `rcr_park_ferris_wheel.glb` | `ferris_wheel_pacifica` | Pacifica | **Rendered** | Upright ferris wheel; parented to Pacifica hierarchy, `localTransform` is local, not world space |
 | `rcr_park_ferris_wheel.glb` | `ferris_wheel_collapsed` | Santo Domingo border | **Rendered** | Collapsed (on its side); world position (445, -1672) |
 | `monument_ave_pyramid.glb` | `monument_ave_pyramid` | Dogtown | **Rendered** | Monument Avenue pyramid |
 | `cz_cz_building_h_icosphere.glb` | `cz_cz_building_h_icosphere` | Dogtown | **Rendered** | Icosphere on a landmark building |
-| `3dmap_cliffs.glb` | `3dmap_cliffs` | Dogtown/Badlands border | **Excluded** | Terrain geometry — overwhelms the border area at 2D projection scale and adds no landmark value |
+| `3dmap_cliffs.glb` | `3dmap_cliffs` | Dogtown/Badlands border | **Excluded** | Terrain geometry: overwhelms the border area at 2D projection scale and adds no landmark value |
 
 **Composite layer order** (bottom to top in `combined_8k.png`):
 
@@ -137,11 +137,11 @@ World placement and orientation are extracted automatically from `3dmap_view.ent
 
 - `-GLB_X` → CET_X
 - `+GLB_Z` → CET_Y
-- `+GLB_Y` → CET_Z (height — projected out, but participates in 3D rotation before projection)
+- `+GLB_Y` → CET_Z (height: projected out, but participates in 3D rotation before projection)
 
 ## Why `3dmap_roads_borders.glb` Is Not District Borders
 
-A common point of confusion: `3dmap_roads_borders.glb` sounds like it should contain district boundary outlines, but it does not. It is the road border overlay — a slightly wider version of the road geometry used by the in-game renderer to paint a darker edge around road surfaces for visual depth.
+A common point of confusion: `3dmap_roads_borders.glb` sounds like it should contain district boundary outlines, but it does not. It is the road border overlay, a slightly wider version of the road geometry used by the in-game renderer to paint a darker edge around road surfaces for visual depth.
 
 **True district boundaries** come from the `gameStaticTriggerAreaComponent` entries in `3dmap_view.ent.json`. These trigger areas define the polygonal regions the game uses to detect which district the player is in. The extraction pipeline converts these to world-space polygons (with full parent chain resolution) and exports them as `district_borders.svg` and `data/subdistricts.json`.
 
@@ -172,11 +172,11 @@ ncx_trigger
       → Transform5641     root (identity)
 ```
 
-NCX and Morro Rock share the same outline polygon — they represent the same physical area.
+NCX and Morro Rock share the same outline polygon: they represent the same physical area.
 
 ### Dogtown
 
-`dogtown_transform` position: `(2422.441, 2368.156)`, parent: `pacifica_transform_fix`. Note that this is the exact negation of `pacifica_data0633`'s offset, which is intentional — Dogtown's coordinate space is the inverse of Pacifica's.
+`dogtown_transform` position: `(2422.441, 2368.156)`, parent: `pacifica_transform_fix`. Note that this is the exact negation of `pacifica_data0633`'s offset, which is intentional: Dogtown's coordinate space is the inverse of Pacifica's.
 
 ### Quaternion Yaw Extraction
 

--- a/docs/3dmap-fixed-assets.md
+++ b/docs/3dmap-fixed-assets.md
@@ -1,4 +1,4 @@
-# 3D World Map Fixed — asset integration
+# 3D World Map Fixed: asset integration
 
 How NC Zoning Board integrates **malgalad's "3D World Map Fixed"** mod
 ([Nexus #26500](https://www.nexusmods.com/cyberpunk2077/mods/26500), author
@@ -17,20 +17,20 @@ The exported mod (`3d_map_fixed_export/`) contains **three distinct building
 representations**, encoded differently. Understanding which is which is the key
 to the integration:
 
-1. **Fixed per-district textures** —
+1. **Fixed per-district textures**:
    `base/fx/textures/3dmap/static/<district>_data.xbm` for 7 districts
    (city_center, heywood, pacifica, santo_domingo, watson, westbrook,
-   ep1_dogtown — **no spaceport**). These sit at the **vanilla depot paths** and
+   ep1_dogtown, **no spaceport**). These sit at the **vanilla depot paths** and
    are the same dimensions as the base-game textures (DX10 header byte-identical;
    only the pixel data differs). They **remove** the game's broken blocks but do
    **not** add replacements.
-2. **`my_district` — combined corrections overlay** — `my_district.xbm`, a
+2. **`my_district`, the combined corrections overlay**: `my_district.xbm`, a
    single world-space point cloud (~19k buildings spread across the whole city)
    rendered by the mod's own entity (`3dmap_view.ent` → `3dmap_triangle_soup.mesh`).
-   This is **sparse** — it holds malgalad's *corrected/added* buildings (e.g. the
+   This is **sparse**: it holds malgalad's *corrected/added* buildings (e.g. the
    Corpo Plaza cluster), filling the gaps the per-district pass left. It is **not**
    a full dense city; it overlays on top of the per-district base.
-3. **`ugly_building` add-on** — malgalad's optional *"returns the ugly building
+3. **`ugly_building` add-on**: malgalad's optional *"returns the ugly building
    to Watson"* download. A tiny standalone cloud (`ugly_building.xbm`, 72×24) at
    its own world position.
 
@@ -42,7 +42,7 @@ the replacement cluster exactly there.
 ### Surface texture
 
 `my_district` and `ugly_building` reference `c_pacifica_m.xbm` as their surface
-(`BaseColor`) — the game's stock Pacifica surface, which malgalad reuses for his
+(`BaseColor`): the game's stock Pacifica surface, which malgalad reuses for his
 additions (he hasn't cracked the edge-highlight texture). In this repo that file
 already exists as `assets/dds/pacifica_m.dds` (the `c_` prefix was dropped when
 it was first added); the two are byte-identical, so the overlays **reuse
@@ -52,16 +52,16 @@ it was first added); the two are byte-identical, so the overlays **reuse
 
 All in `assets/js/three-scene.js` (`DISTRICT_META` + `loadBuildings()`):
 
-- **`DISTRICT_META.dataDdsFixed`** — the 7 per-district entries gain a
+- **`DISTRICT_META.dataDdsFixed`**: the 7 per-district entries gain a
   `dataDdsFixed` path (`assets/dds/fixed/<district>_data.dds`) alongside the
   base-game `dataDds`. `ep1_spaceport` has no fixed version → it stays on
   `dataDds` in both sets.
 - **`my_district` and `ugly_building`** are extra `DISTRICT_META` entries flagged
-  `fixedOnly: true` — loaded only when the Fixed set is active. Their `offset` is
+  `fixedOnly: true`, loaded only when the Fixed set is active. Their `offset` is
   the **entity world position** decoded from the mod's `.ent`
   (`my_district` = `[-828, -531]`, `ugly_building` = `[-1630, 1404]`; CP2077
   `FixedPoint` WorldPosition → divide `Bits` by `131072`).
-- **Asset-set selection** — `loadBuildings()` reads `localStorage[NCZ.ASSET_SET_KEY]`
+- **Asset-set selection**: `loadBuildings()` reads `localStorage[NCZ.ASSET_SET_KEY]`
   (`'fixed'` default, `'cdpr'` = base game). For each district it picks
   `dataDdsFixed` when Fixed is active, else `dataDds`; `fixedOnly` entries are
   skipped entirely in CDPR mode. The Settings → **Map data → Fixed building
@@ -74,7 +74,7 @@ The point-cloud decode skips empty grid cells. Base-game textures mark empties
 with near-zero position **alpha**; malgalad's fixed textures keep alpha full and
 mark empties by **zero scale** instead. `loadBuildings()` therefore skips a cell
 when its alpha is below `NCZ.DDS_ALPHA_THRESH` **OR** its scale is ~0 on all
-three axes — correct for both encodings (on base-game data the two sets of
+three axes, correct for both encodings (on base-game data the two sets of
 empties coincide, so it's a no-op there). Without the scale test, the fixed
 textures would render thousands of degenerate zero-scale cubes.
 
@@ -83,12 +83,12 @@ textures would render thousands of degenerate zero-scale cubes.
 The mod is in active development (more districts / fixes planned). To refresh:
 
 1. Open the updated `.archive` in WolvenKit; export the changed
-   `*_data.xbm` as **DDS** (16-bit, default settings — see
+   `*_data.xbm` as **DDS** (16-bit, default settings; see
    [`docs/3dmap-asset-reference.md`](3dmap-asset-reference.md) for the building
    texture format).
 2. Copy into `assets/dds/fixed/` (per-district keeps the repo basename, e.g.
    `ep1_dogtown_data.xbm` → `dogtown_data.dds`).
-3. Run the validator: `node scripts/validate_3dmap_assets.js` — checks each
+3. Run the validator: `node scripts/validate_3dmap_assets.js`, which checks each
    fixed DDS's DX10 dimensions, asserts `width % 3 === 0`, derives the block
    height, and reports it against the matching `DISTRICT_META` entry. Catches a
    bad export or a dimension/bounds change before it ships.
@@ -115,6 +115,6 @@ About panel. See `ASSETS.md`.
 
 ## Debugging
 
-`?only=<district>` renders a single cloud in isolation — `?only=my_district`
+`?only=<district>` renders a single cloud in isolation: `?only=my_district`
 shows just the corrections overlay, `?only=ugly_building` just the add-on. See
 [`docs/url-parameters.md`](url-parameters.md).

--- a/docs/3dmap-lighting-shadows.md
+++ b/docs/3dmap-lighting-shadows.md
@@ -1,10 +1,10 @@
-# 3D Map — Lighting and Shadows
+# 3D Map: Lighting and Shadows
 
 Reference for the sun/shadow/lighting system in the Three.js schematic view.
 
 > **Renderer:** this scene runs on `WebGPURenderer` (three r184) with TSL node
 > materials. There is **no `onBeforeCompile` / GLSL-chunk injection** and no
-> `MeshLambertMaterial` — every material is a `*NodeMaterial`. Shadow state lives on
+> `MeshLambertMaterial`: every material is a `*NodeMaterial`. Shadow state lives on
 > the **light** (`light.shadow.*`), not on `renderer.shadowMap` (which under WebGPU
 > only carries `{ enabled, transmitted, type }`).
 
@@ -16,14 +16,14 @@ Lighting is calibrated to the in-game 3D map's environment file
 (`base/weather/24h_basic/3dmap.envparam`), which lights the world map with a fixed
 low sun + a 6-direction ambient cube through an ACES tonemap. We reproduce that with
 **one `DirectionalLight` (sun) + one `HemisphereLight` (ambient)**, both at fixed,
-calibrated colour and intensity — the in-game map has no time-of-day variation.
+calibrated colour and intensity: the in-game map has no time-of-day variation.
 
 ```javascript
-// Sun — warm white, fixed intensity (envparam LightAreaSettings.sunColor)
+// Sun - warm white, fixed intensity (envparam LightAreaSettings.sunColor)
 _dirLight = new THREE.DirectionalLight(0xffffff, NCZ.SUN_INTENSITY); // 3.00
 _dirLight.color.setRGB(...NCZ.SUN_COLOR_RGB, THREE.LinearSRGBColorSpace); // [0.975, 0.869, 0.774]
 
-// Ambient — the envparam ambient cube collapses to a hemisphere:
+// Ambient - the envparam ambient cube collapses to a hemisphere:
 // 5 bright cool-white faces (sky+sides) over 1 dim blue face (ground)
 _hemiLight = new THREE.HemisphereLight(0xffffff, 0xffffff, NCZ.AMBIENT_INTENSITY); // 0.405
 _hemiLight.color.setRGB(...NCZ.AMBIENT_SKY_RGB, THREE.LinearSRGBColorSpace);    // [0.796, 0.895, 1.0]
@@ -31,18 +31,18 @@ _hemiLight.groundColor.setRGB(...NCZ.AMBIENT_GROUND_RGB, THREE.LinearSRGBColorSp
 ```
 
 Sun : ambient ≈ 7.4 : 1 (envelope-fit). Cast shadows are layered on top as an
-intentional artistic choice — the in-game map has them disabled.
+intentional artistic choice: the in-game map has them disabled.
 
 ### Updating sun position
 
 `NCZ.ThreeScene.setSunPosition(azimuthRad, altitudeRad)` moves **only the sun's
-direction** — colour and intensity are fixed at construction. The slider/showcase
+direction**: colour and intensity are fixed at construction. The slider/showcase
 sweep the direction so shadows move and faces relight; the look stays calibrated.
 
 It:
 
 - Stores the requested az/el in `_sunAz` / `_sunEl` **before** the lights-exist guard
-  (so an early call before `init()` still propagates to the UI-sync poll — see
+  (so an early call before `init()` still propagates to the UI-sync poll; see
   PR #733, the cold-load sun-init race)
 - Recomputes `_sunDir` and re-places the light `SUN_DIST` up the sun ray from the
   shadow camera's target (orthographic ⇒ only direction matters for shading)
@@ -77,7 +77,7 @@ ample depth precision, so the old WebGL RGBA8-packed-depth cushion (`-0.0005`) i
 longer needed. The geometric self-shadow (a shadow texel covering a depth range) is
 handled entirely by the **normal bias** instead.
 
-### Shadow render-on-demand (WebGPU) — the gate is on the *light*
+### Shadow render-on-demand (WebGPU): the gate is on the *light*
 
 > ⚠️ Under `WebGPURenderer`, `renderer.shadowMap` only carries `{ enabled, transmitted,
 > type }`. **`renderer.shadowMap.autoUpdate` and `.needsUpdate` are inert** (silent no-ops).
@@ -87,16 +87,16 @@ handled entirely by the **normal bias** instead.
 So shadow render-on-demand is driven on the light:
 
 ```javascript
-_dirLight.shadow.autoUpdate = false;            // permanent — the real WebGPU gate
+_dirLight.shadow.autoUpdate = false;            // permanent - the real WebGPU gate
 
 function flagShadowUpdate() {                    // single chokepoint
   if (_shadowsOn && _dirLight) _dirLight.shadow.needsUpdate = true;
 }
 ```
 
-`flagShadowUpdate()` is called only when the shadow silhouette actually changes —
+`flagShadowUpdate()` is called only when the shadow silhouette actually changes:
 `setSunPosition()` (sun moved), `updateShadowCamera()` (camera/resize/terrain/flyover/
-re-enable), and **the async caster loads** (`loadBuildings`, `loadLandmarks` — they finish
+re-enable), and **the async caster loads** (`loadBuildings`, `loadLandmarks`, which finish
 after the post-terrain refit, so nothing else flags them). It is **not** called on
 theme/colour transitions (shadow depth is geometry-only). The result: the 4096² depth pass
 re-renders only on shadow-relevant frames, and the **Shadows toggle off** simply stops
@@ -109,10 +109,10 @@ casters stop being drawn into the main pass. (PR #751.)
 
 The single shadow camera (an `OrthographicCamera`) is **re-fitted every camera change**
 in `updateShadowCamera(renderCam = camera)` to concentrate the 4096² map on exactly the
-visible-ground footprint — far sharper shadows when zoomed in. Two fit paths, because the
+visible-ground footprint: far sharper shadows when zoomed in. Two fit paths, because the
 camera shapes differ too much to share one:
 
-- **Schema cam** (interactive top-down perspective): **rect-fit** — ray-cast the view's
+- **Schema cam** (interactive top-down perspective): **rect-fit**, ray-cast the view's
   NDC corners to the `Y=0` ground plane, take the bbox. Tight and sharp; always succeeds
   because `controls` constrain tilt below horizontal.
 - **Showcase fly cam** (cinematic, often near-horizontal): **fixed-size box** centred
@@ -131,7 +131,7 @@ function updateShadowCamera(renderCam = camera) {
   shadowCam.far  = NCZ.SHADOW_CAM_FAR;
   shadowCam.updateProjectionMatrix();
 
-  // normalBias in WORLD units = N texels × (2·half / mapSize) — constant texel
+  // normalBias in WORLD units = N texels × (2·half / mapSize) - constant texel
   // offset at every zoom (a constant world bias is too small zoomed out → acne,
   // too large zoomed in → shadows detach)
   _dirLight.shadow.normalBias = NCZ.SHADOW_NORMAL_BIAS_TEXELS * (2 * half / NCZ.SHADOW_MAP_SIZE);
@@ -153,8 +153,8 @@ Key constants:
 | `SHADOW_MAX_DISTANCE` | 8600 | Cap on the footprint half-side (≈ world half-diagonal; nothing renders past the world bounds) |
 | `SHADOW_GROUND_MARGIN` | 600 | Footprint extends this far past the visible ground (building heights + a sliver of off-screen casters) |
 | `SHADOW_CAM_NEAR` | 1 | Shadow camera near clip |
-| `SHADOW_CAM_FAR` | 40000 | Far clip — the camera sits `SUN_DIST` up the sun ray, so this must reach the far edge even at a low sun (orthographic ⇒ wide range is free) |
-| `SHADOW_BIAS` | 0 | Depth bias — native `depth32float` + reverse-Z need none |
+| `SHADOW_CAM_FAR` | 40000 | Far clip: the camera sits `SUN_DIST` up the sun ray, so this must reach the far edge even at a low sun (orthographic ⇒ wide range is free) |
+| `SHADOW_BIAS` | 0 | Depth bias: native `depth32float` + reverse-Z need none |
 | `SHADOW_NORMAL_BIAS_TEXELS` | 2.5 | Receiver-sample offset along the surface normal, in shadow-texel widths (→ world units per-frame) |
 | `SUN_DIST` | 22000 | How far up the sun ray the light + shadow camera sit from the footprint centre |
 
@@ -162,13 +162,13 @@ Key constants:
 
 | Object | castShadow | receiveShadow | Material | Notes |
 | --- | --- | --- | --- | --- |
-| Terrain | — | ✓ | `MeshLambertNodeMaterial` + `flatShading` | `frustumCulled=false`; faceted look is intentional (community vote — see PR #748) |
-| Water | — | ✓ | `MeshLambertNodeMaterial` (terrain material, brightness 0.7) | Receives terrain shadows |
+| Terrain | ✗ | ✓ | `MeshLambertNodeMaterial` + `flatShading` | `frustumCulled=false`; faceted look is intentional (community vote, see PR #748) |
+| Water | ✗ | ✓ | `MeshLambertNodeMaterial` (terrain material, brightness 0.7) | Receives terrain shadows |
 | Cliffs | ✓ | ✓ | `MeshLambertNodeMaterial` + `flatShading` | `frustumCulled=false` |
 | Landmarks | ✓ | ✓ | `MeshLambertNodeMaterial` | Dogtown structures etc. |
 | Buildings | ✓ | ✓ | `MeshLambertNodeMaterial` + TSL nodes | Instanced; stencil=1 |
-| Roads | — | — | `MeshBasicNodeMaterial` (additive) | Overlay layer; no shadow |
-| Metro | — | — | `MeshBasicNodeMaterial` (additive) | Overlay layer; no shadow |
+| Roads | ✗ | ✗ | `MeshBasicNodeMaterial` (additive) | Overlay layer; no shadow |
+| Metro | ✗ | ✗ | `MeshBasicNodeMaterial` (additive) | Overlay layer; no shadow |
 
 **Note on `frustumCulled=false`:** terrain and cliffs are always included in the shadow
 pass regardless of the dynamic shadow camera position.
@@ -184,20 +184,20 @@ need them.
 
 Buildings use `MeshLambertNodeMaterial` driven by **TSL nodes** (no `onBeforeCompile`).
 Standard Three.js handles shadow casting/receiving (`castShadow`/`receiveShadow = true`)
-via the engine's depth pass — no `customDepthMaterial` needed. Per-district values that
+via the engine's depth pass: no `customDepthMaterial` needed. Per-district values that
 the WebGL build passed as `onBeforeCompile` uniforms are now plain TSL `uniform()` nodes.
 
 The material wires three nodes:
 
-1. **`normalNode`** — per-instance view-space normals. The instance matrix is applied to
+1. **`normalNode`**: per-instance view-space normals. The instance matrix is applied to
    the local normal (inverse-transpose form, for non-uniform building scale) → world, then
    `transformNormalToView()` → view. `NodeMaterial.setupNormal()` consumes `normalNode`
    *directly* for lighting, so it must already be in view space.
-2. **`colorNode`** — `_m.dds` surface modulation (`0.4 + 0.5·m`, the decoded
+2. **`colorNode`**: `_m.dds` surface modulation (`0.4 + 0.5·m`, the decoded
    `3d_map_cubes.mt` value) applied to the albedo, plus the procedural **edge highlight**
    (`saturate(pow(max(|1-2u|,|1-2v|), EdgeSharpnessPower))` over a synthesised per-face UV,
    `lerp`'d onto albedo pre-lighting) with `fwidth` anti-aliasing.
-3. **`emissiveNode`** (optional) — when **edge glow** is on, the edge term is also written
+3. **`emissiveNode`** (optional): when **edge glow** is on, the edge term is also written
    to emissive so it stays self-lit regardless of sun/shadow. Binary on/off at
    `NCZ.EDGE_GLOW_INTENSITY`; per-theme default from `--scene-edge-glow`, overridable in
    Settings.
@@ -229,11 +229,11 @@ NCZ.ThreeScene.setCameraState(JSON.parse('...'));
 
 Two generations preceded the current pipeline:
 
-- **Gen 2 — `RawShaderMaterial`** (`gl_InstanceID` + `texelFetch()`): required
+- **Gen 2: `RawShaderMaterial`** (`gl_InstanceID` + `texelFetch()`): required
   `customDepthMaterial`, identity matrices for the bounding sphere, `frustumCulled=false`,
   and exact `packDepthToRGBA` matching Three.js's `modf`-based implementation. Replaced by
   the DDS + CPU-matrix instancing pipeline.
-- **Gen 3 (WebGL/r170) — `MeshLambertMaterial` + `onBeforeCompile`**: the planar UV,
+- **Gen 3 (WebGL/r170), `MeshLambertMaterial` + `onBeforeCompile`**: the planar UV,
   `_m` modulation and edge highlight were injected as GLSL chunk replacements
   (`project_vertex`, `color_fragment`, `outgoingLight`). The WebGPU migration ported all
   of these to TSL `colorNode`/`normalNode`/`emissiveNode` on `MeshLambertNodeMaterial`;

--- a/docs/adding-mods.md
+++ b/docs/adding-mods.md
@@ -1,6 +1,6 @@
 # Adding Mods to the Map
 
-> **Looking for the easiest way to add your mod?** Use [NCZoning Auto-Discovery](nczoning-auto-discovery.md) — tag your mod on Nexus and paste a metadata block into your description. No GitHub required.
+> **Looking for the easiest way to add your mod?** Use [NCZoning Auto-Discovery](nczoning-auto-discovery.md): tag your mod on Nexus and paste a metadata block into your description. No GitHub required.
 >
 > This guide covers the GitHub issue and manual PR methods for permanent, manually curated entries.
 
@@ -24,20 +24,20 @@ Each mod entry is stored in its own file in `data/locations/<UUID>.json`. The sc
 
 | Field | Type | Rules |
 | --- | --- | --- |
-| `id` | string | UUID v4 — **auto-generated**, do not set manually |
+| `id` | string | UUID v4 (**auto-generated**, do not set manually) |
 | `name` | string | Min 3 characters |
 | `authors` | array[string] | Array of modding aliases |
-| `coordinates` | [number, number, number] | `[CET_X, CET_Y, CET_Z]` — in-game coordinates from CET (X=east/west, Y=north/south, Z=height) |
+| `coordinates` | [number, number, number] | `[CET_X, CET_Y, CET_Z]`, in-game coordinates from CET (X=east/west, Y=north/south, Z=height) |
 | `yaw` | number | (Optional) Player facing direction in degrees from CET |
 | `nexus_id` | string | Numeric Nexus ID (Used to automatically fetch thumbnails/images via API), or "WIP" / "Dummy" |
 | `category` | string | `location-overhaul`, `new-location`, or `other` |
-| `tags` | array[string] | Tags from `data/tags.json` — see [Tag Registry](tags.md) for the full list |
+| `tags` | array[string] | Tags from `data/tags.json` (see [Tag Registry](tags.md) for the full list) |
 | `description` | string | Max 500 characters |
-| `credits` | string | (Optional) Team name or secondary acknowledgments |
+| `credits` | string | (Optional) Team name or secondary acknowledgements |
 
 ### Important: Coordinate Order
 
-Coordinates are stored as **`[X, Y, Z]`** — matching the order CET reports them. Z (height/elevation) is required for new submissions.
+Coordinates are stored as **`[X, Y, Z]`**, matching the order CET reports them. Z (height/elevation) is required for new submissions.
 
 ## Getting Your Coordinates
 
@@ -68,7 +68,7 @@ Best for modders who don't use Git:
 1. Go to the [Issues tab](https://github.com/spuddeh/nc-zoning-board/issues)
 2. Click **New Issue** → **"📍 Submit a New Mod Location"**
 3. Fill in the form fields
-4. Submit — the automated bot creates a PR (with `validate-json` running automatically)
+4. Submit. The automated bot creates a PR (with `validate-json` running automatically)
 5. A maintainer reviews and merges → **the issue closes automatically**, pin appears on the map
 
 ### Method 2: Manual Pull Request

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,4 +1,4 @@
-# NC Zoning Data API — reference
+# NC Zoning Data API reference
 
 Read-only API serving the NC Zoning Board registry (Cyberpunk 2077 location
 mods) to in-game mods and the website.
@@ -35,14 +35,14 @@ parser:
 - **No arrays-of-arrays.** `coordinates` is a flat `[X, Y, Z]`; district
   boundaries are flattened to `[x1, y1, x2, y2, …]`. This maps cleanly to
   redscript `array<Float>`.
-- **Property names are case-sensitive** and stable — they match DTO field
+- **Property names are case-sensitive** and stable: they match DTO field
   names exactly.
-- **Coordinates are raw CET world values** — the same numbers
+- **Coordinates are raw CET world values**: the same numbers
   `GetWorldPosition()` returns in-game. No transform needed to teleport to
   them or compare against the player.
 - **Stable ids:** manual entries keep a UUID; auto-discovered mods get
   `nexus-<nexus_id>`. Safe to bookmark.
-- **`district` is never null** — anywhere outside every district polygon is
+- **`district` is never null**: anywhere outside every district polygon is
   Badlands (the game's own default). `subdistrict` may be null.
 - **Additive versioning:** new fields may appear within `/v1/`; breaking
   changes would ship as `/v2/`.
@@ -53,7 +53,7 @@ parser:
 | --- | --- |
 | `GET /v1/health` | `{ status, version }` (uncached) |
 | `GET /v1/locations` | all locations, slim |
-| `GET /v1/locations?full=1` | all locations, full (adds `description`, `credits`, image URLs) — one request for everything |
+| `GET /v1/locations?full=1` | all locations, full (adds `description`, `credits`, image URLs): one request for everything |
 | `GET /v1/locations/{id}` | one full entry (adds `description`, `credits`, image URLs), or 404 |
 | `GET /v1/districts` | district/subdistrict hierarchy (flat boundaries + centroids) |
 | `GET /v1/tags` | tag id → description |
@@ -79,7 +79,7 @@ A location (slim):
 
 Full entries (`/v1/locations/{id}` or the whole list via `/v1/locations?full=1`)
 add `description`, `credits` (if present), and the Nexus image fields
-`thumbnail_url` / `picture_url` / `updated_at` (each `null` when unknown — e.g.
+`thumbnail_url` / `picture_url` / `updated_at` (each `null` when unknown, e.g.
 WIP/Dummy entries). Images live on the full entry only; the slim list stays
 lean for the in-game RedData consumer. The `?full=1` list carries its own ETag
 (the dataset version suffixed `-full`), so caching it never collides with the
@@ -96,10 +96,10 @@ Cache-Control: public, max-age=300, stale-while-revalidate=3600
 
 Store the `dataset_version` from your last fetch and send it back as
 `If-None-Match`. If nothing changed you get a **`304 Not Modified`** with no
-body — the cheap path. The data changes at most a few times a day, so one
+body: the cheap path. The data changes at most a few times a day, so one
 fetch per game session (plus an optional occasional re-check) is plenty.
 
-Before the very first dataset build a route returns **`503 not_ready`** —
+Before the very first dataset build a route returns **`503 not_ready`**:
 retry shortly.
 
 ## Using it from a mod
@@ -111,7 +111,7 @@ NCZoningCore framework). Minimal redscript:
 import RedHttpClient.*
 import RedData.Json.*
 
-// DTO — field names match the JSON exactly (case-sensitive).
+// DTO - field names match the JSON exactly (case-sensitive).
 public class NCZLocation {
   let id: String;
   let name: String;
@@ -128,7 +128,7 @@ public class NCZExample extends ScriptableSystem {
   }
 
   private cb func OnLocations(response: ref<HttpResponse>) {
-    // Runs on a worker thread — parse/store here, apply game changes on the
+    // Runs on a worker thread - parse/store here, apply game changes on the
     // next tick via DelaySystem.
     let root = response.GetJson();          // the envelope
     let data = (root as JsonObject).GetKey("data") as JsonArray;
@@ -152,9 +152,9 @@ re-downloading unchanged data.
 
 ## Notes
 
-- The API never talks to Nexus on your behalf at request time — a cron
+- The API never talks to Nexus on your behalf at request time: a cron
   rebuilds the dataset every 15 minutes and serves it from cache, so you're
   shielded from Nexus API hiccups. If a refresh fails, `meta.discovery_stale`
   is `true` and the last-known-good data is served.
 - `meta.skipped` lists mods tagged `NCZoning` whose metadata block didn't
-  parse — useful if you're a mod author debugging why yours isn't appearing.
+  parse: useful if you're a mod author debugging why yours isn't appearing.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document explains how the NC Zoning Board is organized and how data flows through the system. **If you're new here:** Start with the [Project Overview](../README.md) — then read this to understand how the pieces fit together. You don't need to know every detail to contribute, but this gives you the full picture of where things live and how they interact.
+This document explains how the NC Zoning Board is organised and how data flows through the system. **If you're new here:** Start with the [Project Overview](../README.md), then read this to understand how the pieces fit together. You don't need to know every detail to contribute, but this gives you the full picture of where things live and how they interact.
 
 ---
 
@@ -32,7 +32,7 @@ nc-zoning-board/
 │   ├── validate_tags.js    # Validates tags in data/ against tags.json
 │   └── generate_tiles.js   # Slices 16k source image into 256×256 WebP tiles
 │
-├── raw maps/               # Source map images (not committed — too large)
+├── raw maps/               # Source map images (not committed - too large)
 │   ├── 4k/night_city.png   # 4096×4096, 27 MB
 │   ├── 8k/night_city.png   # 8192×8192, 108 MB (archive)
 │   ├── 16k/night_city_16k.png  # 16384×16384, 529 MB (current tile source)
@@ -97,10 +97,10 @@ The core frontend JS is four files loaded via `<script>` tags (no ES modules, no
 
 | File | Role |
 | --- | --- |
-| `constants.js` | All config values — category styles, API endpoints, cache keys, UI sizing, 3D scene constants |
-| `utils.js` | Pure functions — `escapeHtml`, `cetToLeaflet`, `cetToThree`, positioning algorithm, BBCode parser |
-| `services.js` | Fetch functions — Nexus thumbnail API, auto-discovery, `fetchModData()` |
-| `app.js` | DOM logic — map init, sidebar, cluster panel, modals, image gallery, view switching |
+| `constants.js` | All config values: category styles, API endpoints, cache keys, UI sizing, 3D scene constants |
+| `utils.js` | Pure functions: `escapeHtml`, `cetToLeaflet`, `cetToThree`, positioning algorithm, BBCode parser |
+| `services.js` | Fetch functions: Nexus thumbnail API, auto-discovery, `fetchModData()` |
+| `app.js` | DOM logic: map init, sidebar, cluster panel, modals, image gallery, view switching |
 
 Load order on `main`: `constants.js` → `utils.js` → `services.js` → `app.js`
 
@@ -110,8 +110,8 @@ Load order on `main`: `constants.js` → `utils.js` → `services.js` → `app.j
 | --- | --- |
 | `overlay.js` | District/subdistrict GeoJSON border overlays for the satellite view |
 | `three-scene.js` | Three.js scene: renderer, camera, GLBs, buildings, sun/shadows (`NCZ.ThreeScene`) |
-| `three-markers.js` | 3D pin/popup/tooltip/cluster layer — interactive parity with Leaflet (`NCZ.ThreeMarkers`). See [three-markers.md](three-markers.md) for the full architecture. |
-| `flyover.js` | Optional cinematic flyover showcase — include/exclude via `<script>` tag |
+| `three-markers.js` | 3D pin/popup/tooltip/cluster layer: interactive parity with Leaflet (`NCZ.ThreeMarkers`). See [three-markers.md](three-markers.md) for the full architecture. |
+| `flyover.js` | Optional cinematic flyover showcase, include/exclude via `<script>` tag |
 
 Load order on `dev`/feature branches: `constants.js` → `utils.js` → `services.js` → `overlay.js` → `three-scene.js` (module) → `three-markers.js` (module) → `app.js` → `[flyover.js optional]`
 
@@ -124,16 +124,16 @@ Load order on `dev`/feature branches: `constants.js` → `utils.js` → `service
 
 ### Coordinate Transform (`utils.js`)
 
-- `NCZ.cetToLeaflet(x, y)` — converts CET game coordinates to Leaflet `[lat, lng]`
-- Exact linear mapping derived from `NCZ.WORLD_MIN/MAX_X/Y` constants (from the Realistic Map mod terrain quad UV mapping) — not a calibrated approximation
-- `NCZ.cetToThree(x, y, z)` — converts CET coordinates to Three.js scene space (`[x, z||0, -y]`)
+- `NCZ.cetToLeaflet(x, y)` converts CET game coordinates to Leaflet `[lat, lng]`
+- Exact linear mapping derived from `NCZ.WORLD_MIN/MAX_X/Y` constants (from the Realistic Map mod terrain quad UV mapping), not a calibrated approximation
+- `NCZ.cetToThree(x, y, z)` converts CET coordinates to Three.js scene space (`[x, z||0, -y]`)
 - See [Coordinate System](coordinate-system.md) for full details
 
 ### Mod Data (`data/locations/*.json`)
 
 - Individual JSON files per mod to prevent merge conflicts.
 - **Attributes**: `id` (UUID), `name`, `authors` (array), `coordinates` ([X, Y]), `nexus_id` (ID string, "WIP", or "Dummy"), `category`, `tags` (array), and `description`.
-- **Credits**: Optional field for team-based acknowledgments.
+- **Credits**: Optional field for team-based acknowledgements.
 - **Validation**: Individual tags are checked against `data/tags.json` and the final compiled `mods.json` is validated against `mods.schema.json` in CI.
 
 ### Styling (`style.css`)
@@ -143,7 +143,7 @@ Load order on `dev`/feature branches: `constants.js` → `utils.js` → `service
 - Colour palette: `--primary` (#0a192f), `--secondary` (#00f0ff), `--tertiary` (#ffb300), `--white` (#e6f1ff), `--gray` (#8892b0)
 - Custom Leaflet popup, tooltip, and cluster styling
 - MarkerCluster CSS is inlined (no external CDN dependency)
-- Uses native CSS nesting — see [browser support](https://caniuse.com/css-nesting)
+- Uses native CSS nesting; see [browser support](https://caniuse.com/css-nesting)
 
 ## Repo Setup (for new maintainers)
 
@@ -152,21 +152,21 @@ The auto-PR pipeline and Discord notifications require two secrets configured in
 | Secret | Value |
 | --- | --- |
 | `ACTIONS_PAT` | A GitHub Personal Access Token (fine-grained) with `Contents: Read/Write` and `Pull requests: Read/Write` on this repo |
-| `DISCORD_WEBHOOK_URL` | Webhook for the **submissions** channel — new/modified submission embeds and their PR-status edits (channel Settings → Integrations → Webhooks) |
-| `NCZ_ALERTS_DISCORD_WEBHOOK_URL` | Webhook for the dedicated **map-alerts** channel — auto-discovery parse failures and Data API health/outage alerts, kept separate from submissions |
+| `DISCORD_WEBHOOK_URL` | Webhook for the **submissions** channel: new/modified submission embeds and their PR-status edits (channel Settings → Integrations → Webhooks) |
+| `NCZ_ALERTS_DISCORD_WEBHOOK_URL` | Webhook for the dedicated **map-alerts** channel: auto-discovery parse failures and Data API health/outage alerts, kept separate from submissions |
 
 > **Why ACTIONS_PAT?** GitHub's `GITHUB_TOKEN` cannot trigger other workflow runs (a security design). Using a PAT for `create-pull-request` allows the `validate-json` check to fire automatically on the generated PR.
 
 ### Discord Notifications
 
-Two channels, two webhooks. **Submissions** (`DISCORD_WEBHOOK_URL`) — the mod
+Two channels, two webhooks. **Submissions** (`DISCORD_WEBHOOK_URL`) covers the mod
 submission lifecycle:
 
-- **`auto-pr-submission.yml`** — Posts a new embed when a submission PR is created (status: ⏳ Awaiting review). Stores the Discord message ID as a hidden comment on the issue.
-- **`modify-location-submission.yml`** — Posts an embed for modification/removal requests.
-- **`notify-discord-pr-status.yml`** — When the PR is merged or closed, edits the original embed in-place to show the outcome (✅ Approved or ❌ Closed). Must use the same webhook that posted the message.
+- **`auto-pr-submission.yml`**: Posts a new embed when a submission PR is created (status: ⏳ Awaiting review). Stores the Discord message ID as a hidden comment on the issue.
+- **`modify-location-submission.yml`**: Posts an embed for modification/removal requests.
+- **`notify-discord-pr-status.yml`**: When the PR is merged or closed, edits the original embed in-place to show the outcome (✅ Approved or ❌ Closed). Must use the same webhook that posted the message.
 
-**Alerts** (`NCZ_ALERTS_DISCORD_WEBHOOK_URL`) — operational health, separate channel:
+**Alerts** (`NCZ_ALERTS_DISCORD_WEBHOOK_URL`) covers operational health on a separate channel:
 
-- **`monitor-auto-discovery.yml`** — Daily scan; alerts when a NCZoning-tagged mod fails to parse and isn't covered by a manual entry.
-- **`monitor-api-health.yml`** — Every 15 min; alerts when the Data API (`/v1`) isn't serving. The Worker's own refresh-failure alert (`worker/src/refresh.js`) posts here too (Cloudflare Worker secret, set separately via `wrangler secret put`).
+- **`monitor-auto-discovery.yml`**: Daily scan; alerts when a NCZoning-tagged mod fails to parse and isn't covered by a manual entry.
+- **`monitor-api-health.yml`**: Every 15 min; alerts when the Data API (`/v1`) isn't serving. The Worker's own refresh-failure alert (`worker/src/refresh.js`) posts here too (Cloudflare Worker secret, set separately via `wrangler secret put`).

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -1,15 +1,15 @@
-# NC Zoning Board — Brand Guidelines
+# NC Zoning Board: Brand Guidelines
 
 ## 1. Lore & Background (Night Corp Interface)
 
-> *"What IS Night Corporation? Richard Night's legacy. The foundation stone of Night City. Its silent, watchful guardian."* — Night Corp netsite
+> *"What IS Night Corporation? Richard Night's legacy. The foundation stone of Night City. Its silent, watchful guardian."* (Night Corp netsite)
 
-The **NC Zoning Board** map is presented as an internal tool operated by **Night Corp**, the megacorporation dedicated to preserving and executing Richard Night's original vision for the city. Founded by Miriam Night after Richard's death, Night Corp acts as the largest contractor of public procurements within Night City—building roads, bridges, tunnels, and overseeing all civic development. 
+The **NC Zoning Board** map is presented as an internal tool operated by **Night Corp**, the megacorporation dedicated to preserving and executing Richard Night's original vision for the city. Founded by Miriam Night after Richard's death, Night Corp acts as the largest contractor of public procurements within Night City: building roads, bridges, tunnels, and overseeing all civic development. 
 
 As a Night Corp interface, the application should feel:
 - **Bureaucratic but High-Tech:** Clean lines, structured data, and an undeniable corporate authority. It's the silent, watchful guardian of the city's infrastructure.
 - **Civic-Minded:** Designed "for the public good". We manage the city's growth, infrastructure, and zoning.
-- **Secretive & Protected:** Night Corp is known for its tight security and secretive policies. The interface should feel strictly authorized.
+- **Secretive & Protected:** Night Corp is known for its tight security and secretive policies. The interface should feel strictly authorised.
 
 ### Voice & Tone
 - *In UI Copy:* Official, authoritative, and slightly sterile. 
@@ -20,7 +20,7 @@ As a Night Corp interface, the application should feel:
 
 ---
 
-## 2. Color Palette
+## 2. Colour Palette
 
 Night Corp's aesthetic relies on conveying trust, stability, and control, contrasting with the neon-drenched chaos of the rest of the city.
 
@@ -33,7 +33,7 @@ Night Corp's aesthetic relies on conveying trust, stability, and control, contra
 | **Warning Amber (Alerts)** | `#ffb300` | Warning states, overlaps, or critical alerts (like the "New Location" category). CSS: `--tertiary`. |
 | **Approval Green (Success)** | `#00ff9d` | Success states, verified locations, or "Safe" zones. |
 
-*Note: The map pins should utilize this palette, with specific colors assigned to different zoning categories (e.g., Apartments, Overhauls, New Structures).*
+*Note: The map pins should utilise this palette, with specific colours assigned to different zoning categories (e.g., Apartments, Overhauls, New Structures).*
 
 ---
 
@@ -41,10 +41,10 @@ Night Corp's aesthetic relies on conveying trust, stability, and control, contra
 
 A four-tier scale. The tiers are additive: the display face sits **above** Orbitron, it does not replace it.
 
-- **Tier 0 — Display / Brand:** `Night Corp Display` (local `@font-face`, derived from the logo; caps-only A-Z, 0-9, punctuation). CSS token `--font-nightcorp`. Reserve for the shortest, biggest, most branded moments only — wordmarks and boot/splash hero text. Rule of thumb: under ~20 characters, all-caps, and ≥28px. Never body copy, never a full sentence. Currently used on: the header wordmark (`NC ZONING BOARD`) and the welcome-modal splash.
-- **Tier 1 — Heading:** `Orbitron` (Google Fonts). CSS token `--font-heading`. Screen titles, card headers, stat labels, nav, modal headers — all the structural lifting. More legible at small sizes and has the lowercase the display face lacks.
-- **Tier 2 — Body & Data:** `Rajdhani` (Google Fonts). CSS token `--font-body`. Tooltips, descriptions, lists. Squarish but highly legible for dense data.
-- **Tier 3 — Monospace (Logs/Coords):** `Fira Code` or generic `monospace` for coordinates and system outputs.
+- **Tier 0, Display / Brand:** `Night Corp Display` (local `@font-face`, derived from the logo; caps-only A-Z, 0-9, punctuation). CSS token `--font-nightcorp`. Reserve for the shortest, biggest, most branded moments only: wordmarks and boot/splash hero text. Rule of thumb: under ~20 characters, all-caps, and ≥28px. Never body copy, never a full sentence. Currently used on: the header wordmark (`NC ZONING BOARD`) and the welcome-modal splash.
+- **Tier 1, Heading:** `Orbitron` (Google Fonts). CSS token `--font-heading`. Screen titles, card headers, stat labels, nav, modal headers: all the structural lifting. More legible at small sizes and has the lowercase the display face lacks.
+- **Tier 2, Body & Data:** `Rajdhani` (Google Fonts). CSS token `--font-body`. Tooltips, descriptions, lists. Squarish but highly legible for dense data.
+- **Tier 3, Monospace (Logs/Coords):** `Fira Code` or generic `monospace` for coordinates and system outputs.
 
 ---
 
@@ -52,12 +52,12 @@ A four-tier scale. The tiers are additive: the display face sits **above** Orbit
 
 ### Logos & Branding
 - **Primary Logo:** `assets/img/nightcorp-logo.svg` (fill `#e6f1ff` so it reads on the navy header). Used in the `night-corp` theme header. Each theme swaps in its own logo file.
-- **Favicon:** The Cyan favicon set in `assets/img/favicon/` — SVG + `.ico` + 16/32px PNG + apple-touch + `site.webmanifest`.
+- **Favicon:** The Cyan favicon set in `assets/img/favicon/`: SVG + `.ico` + 16/32px PNG + apple-touch + `site.webmanifest`.
 - **Parked / source assets:** `assets/brand/` holds brand assets not currently wired into the site (the compact monogram, candidate shard icons, an unused Gold favicon set). Kept version-controlled but out of the runtime `assets/img/` path. See `assets/brand/README.md`.
 
 ### Buttons & Toggles
 - Sharp corners, no border radius (0px). Night Corp doesn't do "soft."
-- Hover states should feel responsive, perhaps with a subtle glitch effect or a sharp color inversion (e.g., from Dark Navy with Cyan border to solid Cyan background with Navy text).
+- Hover states should feel responsive, perhaps with a subtle glitch effect or a sharp colour inversion (e.g., from Dark Navy with Cyan border to solid Cyan background with Navy text).
 
 ### Windows & Popups (The Map Overlay)
 - **Borders:** Thin, 1px solid borders using the Cyan accent or a muted gray, perhaps with subtle "corner brackets" (e.g., `[ ]`) framing the corners.

--- a/docs/caching-strategy.md
+++ b/docs/caching-strategy.md
@@ -10,16 +10,16 @@ Cloudflare migration.
 For `_headers` to be honoured at all, the `nczoning.net` Cloudflare **zone** must
 have **Caching → Configuration → Browser Cache TTL** set to **"Respect Existing
 Headers."** This is a zone-level setting, so it covers every Pages project in the
-zone (prod and dev) — but a fresh zone, or a project moved to a new zone, needs it
+zone (prod and dev), but a fresh zone, or a project moved to a new zone, needs it
 set explicitly.
 
 If it's set to a fixed value instead (the default is often "4 hours"), Cloudflare
-**overrides** the `Cache-Control` we send — but only in the "extend caching"
+**overrides** the `Cache-Control` we send, but only in the "extend caching"
 direction, and only for its default-cacheable file extensions. The symptom is
 subtle and easy to miss: tiles (`immutable`, longer than the setting) look fine,
 `.dds`/`.glb` (not default-cacheable) look fine, but `.js`/`.css` silently come
 back as `Cache-Control: public, max-age=14400` instead of `no-cache`. That means
-a deploy's code wouldn't reach returning browsers for up to 4 hours — the exact
+a deploy's code wouldn't reach returning browsers for up to 4 hours, the exact
 failure `no-cache` exists to prevent.
 
 Verify from the command line (any tier; `.js` is the canary):
@@ -38,9 +38,9 @@ the stale header until it expires or a hard-refresh.
 There are **two independent caches**, and only one of them is under your control
 after the fact:
 
-1. **Cloudflare's edge cache** — shared, on Cloudflare's servers. You can **purge**
+1. **Cloudflare's edge cache**: shared, on Cloudflare's servers. You can **purge**
    it from the dashboard or API at any time.
-2. **The visitor's browser cache** — private, on their machine. You **cannot**
+2. **The visitor's browser cache**: private, on their machine. You **cannot**
    reach it. It obeys the `Cache-Control` header that was sent *when the file was
    downloaded*, until that instruction expires.
 
@@ -54,7 +54,7 @@ So the rule that drives everything here:
 `no-cache` does **not** mean "don't cache". It means "cache it, but revalidate
 before reusing". The browser keeps the file and sends a conditional request; if
 unchanged, Cloudflare (using an auto-generated content `ETag`) replies `304 Not
-Modified` — a few hundred bytes, no re-download. If changed, it sends the new
+Modified` (a few hundred bytes, no re-download). If changed, it sends the new
 file. This gives **automatic correctness on update** with almost no bandwidth
 cost, which is why it's the default for anything that can change.
 
@@ -63,7 +63,7 @@ cost, which is why it's the default for anything that can change.
 | Path | Policy | Why |
 | --- | --- | --- |
 | `/assets/tiles/*` | `immutable`, 1 year | Thousands of files, content-stable at a fixed path. `immutable` skips even the revalidation round-trip. The *only* class that needs a manual bust on change. |
-| `/assets/dds/*` | `no-cache` | Building data textures. Change occasionally as new fixed assets land. ETag revalidation auto-refreshes browsers on deploy — nothing to remember. |
+| `/assets/dds/*` | `no-cache` | Building data textures. Change occasionally as new fixed assets land. ETag revalidation auto-refreshes browsers on deploy, nothing to remember. |
 | `/assets/glb-meshopt/*` | `no-cache` | Meshes. Same reasoning as DDS. |
 | `/assets/js/*`, `/assets/css/*`, `/index.html` | `no-cache` | Un-hashed filenames that change every deploy. Must revalidate or users run stale code. |
 
@@ -82,7 +82,7 @@ bytes automatically. This is the whole point of putting these on `no-cache`.
 ### Regenerating tiles
 
 This is the **only** case that needs manual action, because tiles are
-`immutable` — browsers that already downloaded them will never re-check on their
+`immutable`: browsers that already downloaded them will never re-check on their
 own. Two steps, both required:
 
 1. **Bump the version token** in the tile URL. In
@@ -106,19 +106,19 @@ Step 1 fixes returning browsers; step 2 fixes the edge. You need both.
 ## Dev vs prod caching
 
 The same [`_headers`](../_headers) applies to both the production site and the
-dev site (`dev.nczoning.net`), and that's intentional — it keeps the rules a
+dev site (`dev.nczoning.net`), and that's intentional: it keeps the rules a
 single source of truth with no per-branch divergence to drift.
 
 This is fine for dev in practice: everything you iterate on (JS, CSS, DDS, GLB)
 is `no-cache`, so it always revalidates and you never see stale code or textures.
 The only hard-cached class is tiles (`immutable`), which you rarely regenerate on
-dev — and DevTools "Disable cache" overrides all of it during active development
+dev, and DevTools "Disable cache" overrides all of it during active development
 anyway.
 
 **If** stale tiles ever become a problem on dev, the fix is a **Cloudflare
 Response Header Transform Rule scoped to `dev.nczoning.net`** that overrides
 `Cache-Control` to `no-cache` for all responses. Keep this at the dashboard
-(platform) layer — do **not** give the `dev` branch a different `_headers` than
+(platform) layer: do **not** give the `dev` branch a different `_headers` than
 `main`, as that reintroduces the exact drift this file exists to prevent. It must
 be a *response header* transform, not a cache-bypass rule: bypassing the edge
 cache doesn't change the `Cache-Control` the browser receives, so the browser
@@ -126,6 +126,6 @@ would still honour `immutable`.
 
 ## Where the config lives
 
-- [`_headers`](../_headers) — the actual Cloudflare Pages rules.
-- [`assets/js/app.js`](../assets/js/app.js) — the tile `?v=` bust token (with an
+- [`_headers`](../_headers): the actual Cloudflare Pages rules.
+- [`assets/js/app.js`](../assets/js/app.js): the tile `?v=` bust token (with an
   inline comment pointing back here).

--- a/docs/coordinate-system-3d.md
+++ b/docs/coordinate-system-3d.md
@@ -1,4 +1,4 @@
-# Three.js 3D Scene — Coordinate System Reference
+# Three.js 3D Scene: Coordinate System Reference
 
 Everything discovered about how CP2077's 3D map assets relate to CET game coordinates and how they should map into Three.js.
 
@@ -10,15 +10,15 @@ What `GetPlayer():GetWorldPosition()` returns. What mod authors use. What our lo
 - **Y** = north/south  
 - **Z** = height above sea level (elevation)
 - World extent: X[-6298, 5815], Y[-7684, 4427], Z[0, ~500]
-- This is our **source of truth** — all NC Zoning Board data uses CET coordinates.
+- This is our **source of truth**: all NC Zoning Board data uses CET coordinates.
 
 ### B. GLB / Engine Rendering Coordinates
 What the WolvenKit-exported GLB meshes (terrain, roads, water, cliffs, metro) use internally.
 - **GLB_X** = CET_X (east/west, same axis, same units, same origin)
 - **GLB_Z** = -CET_Y (north/south, negated)
-- **GLB_Y** = elevation (height) — positive Y is upward (correct rendering)
+- **GLB_Y** = elevation (height): positive Y is upward (correct rendering)
 - Terrain bbox: X[-8000, 8000], Y[-99, 879], Z[-8000, 8001]
-- The terrain covers MORE area than the CET world bounds (extra ocean and outer badlands). CET coordinates sit inside the terrain's XZ range at 1:1 scale — **there is no scaling factor**, the terrain just extends further.
+- The terrain covers MORE area than the CET world bounds (extra ocean and outer badlands). CET coordinates sit inside the terrain's XZ range at 1:1 scale: **there is no scaling factor**, the terrain just extends further.
 
 ### C. Building Instance Texture Coordinates
 Decoded from `*_data.png` textures via `TRANS_MIN/MAX` and `CUBE_SIZE` values.
@@ -27,7 +27,7 @@ Decoded from `*_data.png` textures via `TRANS_MIN/MAX` and `CUBE_SIZE` values.
 - Position: `cetZ = TRANS_MIN_Z + (TRANS_MAX_Z - TRANS_MIN_Z) * B_channel` (no Z offset)
 - Scale: `half_width = R_scale * CUBE_SIZE`, `half_depth = G_scale * CUBE_SIZE`, `half_height = B_scale * CUBE_SIZE`
 - Rotation: quaternion from Block 2, used for yaw extraction
-- These decode directly to **CET coordinates** — verified against player CET Z positions (within 1–6 units).
+- These decode directly to **CET coordinates**: verified against player CET Z positions (within 1–6 units).
 
 ## Coordinate System Validation
 
@@ -63,12 +63,12 @@ All five samples agree within ±6m. The delta is consistent with:
 
 #### Earlier (incorrect) measurement
 
-A previous version of this doc listed an "elevation gap" of 7–23m between CET Z and terrain GLB Y, derived from samples at the Pier, Koi Fish, and Nash Hideout. Those readings were taken on top of buildings/platforms, not on bare terrain — they measured infrastructure height, not a coordinate-space mismatch. Findings retracted.
+A previous version of this doc listed an "elevation gap" of 7–23m between CET Z and terrain GLB Y, derived from samples at the Pier, Koi Fish, and Nash Hideout. Those readings were taken on top of buildings/platforms, not on bare terrain: they measured infrastructure height, not a coordinate-space mismatch. Findings retracted.
 
-Validated 2026-05-01 by an in-game teleport experiment to six bare-terrain points across the map; all five usable samples landed within ±6m of terrain GLB Y, mean delta −0.17m. CET Z and terrain GLB Y are in the same coordinate space — `pinYFor(cetZ)` works without a raycast.
+Validated 2026-05-01 by an in-game teleport experiment to six bare-terrain points across the map; all five usable samples landed within ±6m of terrain GLB Y, mean delta −0.17m. CET Z and terrain GLB Y are in the same coordinate space: `pinYFor(cetZ)` works without a raycast.
 
 ### Building Rotation
-Buildings have per-instance quaternion rotations (Block 2 of instance texture). All four components (qx, qy, qz, qw) are kept — pitch and roll are used by the game shader to form non-upright primitives (wedges, ramps, bridges, gap-fillers), not just upright buildings.
+Buildings have per-instance quaternion rotations (Block 2 of instance texture). All four components (qx, qy, qz, qw) are kept: pitch and roll are used by the game shader to form non-upright primitives (wedges, ramps, bridges, gap-fillers), not just upright buildings.
 
 Applied in Three.js with CET→Three.js axis remapping:
 
@@ -79,7 +79,7 @@ dummy.quaternion.set(gQx, gQz, -gQy, gQw);
 // CET Y → Three.js -Z (CET north becomes Three.js -forward)
 ```
 
-Verified: yaw-only case (gQx≈0, gQy≈0) reduces to `set(0, sin(θ/2), 0, cos(θ/2))` — a pure Three.js Y rotation matching the previously verified Biotechnica Flats orientation.
+Verified: yaw-only case (gQx≈0, gQy≈0) reduces to `set(0, sin(θ/2), 0, cos(θ/2))`, a pure Three.js Y rotation matching the previously verified Biotechnica Flats orientation.
 
 ## The HLSL Shader (`minimap_instance_shader.hlsl`)
 
@@ -107,7 +107,7 @@ In `map_data_export/source/raw/base/worlds/03_night_city/sectors/`:
 
 | File | Size | Format | Description |
 |------|------|--------|-------------|
-| `world_map_albedo.png` | 2.1 MB | 1008×1016 RGBA | Base color texture |
+| `world_map_albedo.png` | 2.1 MB | 1008×1016 RGBA | Base colour texture |
 | `world_map_depth.png` | 243 KB | 1008×1016 Greyscale | Height/elevation map |
 | `world_map_normal.png` | 1.5 MB | 1008×1016 RGBA | Normal map |
 
@@ -122,12 +122,12 @@ From `cyberpunk-decompiled-scripts/cyberpunk/UI/fullscreen/map/worldMap.swift`:
 - Zoom range: 800 (in) to 15000 (out), default 3000
 - District view states: None, Districts, SubDistricts
 
-## Data Pipeline — Evolution
+## Data Pipeline: Evolution
 
 ### Generation 1 (obsolete): Python script → JSON → InstancedMesh
 
 ```
-*_data.png (WolvenKit 8-bit PNG export — precision loss from 16-bit source)
+*_data.png (WolvenKit 8-bit PNG export - precision loss from 16-bit source)
     ↓ scripts/build_buildings_3d.py
     ↓   Decodes position/rotation/scale; samples _m.png for per-instance brightness
     ↓
@@ -146,7 +146,7 @@ problem, and was later removed.
 ### Generation 2 (obsolete): xbm.json → GPU instancing via DataTexture
 
 ```
-*_data.xbm.json (WolvenKit JSON sidecar — 16-bit RGBA base64 in textureData.Bytes)
+*_data.xbm.json (WolvenKit JSON sidecar - 16-bit RGBA base64 in textureData.Bytes)
     ↓ loadXbmDataTexture() → Uint16 → Float32 → THREE.DataTexture
     ↓
 RawShaderMaterial BUILDING_VERT reads via gl_InstanceID + texelFetch()
@@ -168,7 +168,7 @@ Three.js's exact algorithm, identity matrix workarounds for shadow bounding sphe
 ### Generation 3 (current): DDS binary → CPU matrices → MeshLambertMaterial
 
 ```
-assets/dds/*_data.dds  (DXGI_FORMAT_R16G16B16A16_UNORM — raw binary, DX10 header)
+assets/dds/*_data.dds  (DXGI_FORMAT_R16G16B16A16_UNORM - raw binary, DX10 header)
     ↓ loadDataDds() → fetch → Uint16Array (skip 148-byte DX10 header)
     ↓ CPU decode: position / quaternion / scale per valid pixel
     ↓ setMatrixAt() → InstancedMesh with correct bounding sphere
@@ -178,7 +178,7 @@ MeshLambertMaterial + onBeforeCompile
     → Correct bounding sphere → frustum culling works automatically
     → onBeforeCompile patches: world-space planar UV, _m texture, edge highlight
 
-assets/dds/*_m.dds  (DXGI_FORMAT_R8_UNORM — 8-bit greyscale, DX10 header)
+assets/dds/*_m.dds  (DXGI_FORMAT_R8_UNORM - 8-bit greyscale, DX10 header)
     ↓ loadMDds() → Uint8Array (mip 0) → DataTexture (RedFormat, generateMipmaps)
     ↓
 Fragment shader samples surface detail via world-space planar UV

--- a/docs/coordinate-system.md
+++ b/docs/coordinate-system.md
@@ -4,10 +4,10 @@
 
 The map uses two coordinate systems that are linked by a simple linear transform:
 
-1. **CET Coordinates** — the in-game `[X, Y, Z]` values from Cyber Engine Tweaks (X=east/west, Y=north/south, Z=height)
-2. **Leaflet Coordinates** — the `[lat, lng]` values used internally by the map
+1. **CET Coordinates**: the in-game `[X, Y, Z]` values from Cyber Engine Tweaks (X=east/west, Y=north/south, Z=height)
+2. **Leaflet Coordinates**: the `[lat, lng]` values used internally by the map
 
-**Note:** The 2D map placement uses only X and Y coordinates. The Z (height/elevation) coordinate is stored for reference and future features (like teleport scripts or 3D visualization). 
+**Note:** The 2D map placement uses only X and Y coordinates. The Z (height/elevation) coordinate is stored for reference and future features (like teleport scripts or 3D visualisation). 
 
 Mod authors only need to know CET coordinates. The app handles the conversion automatically.
 
@@ -49,7 +49,7 @@ eyJjYXRlZ29yaWVzIjpbeyJuYW1lIjoiTkMgWm9uaW5nIiwiaWNvbiI6IkZsb29yUGxhbiJ9LHsibmFt
 
 ### Formulas
 
-The mapping is a simple linear transform with **decoupled axes** — latitude depends only on CET Y, and longitude depends only on CET X:
+The mapping is a simple linear transform with **decoupled axes**: latitude depends only on CET Y, and longitude depends only on CET X:
 
 ```
 Leaflet lat = 0.02101335 × CET_Y − 93.68566
@@ -63,7 +63,7 @@ CET_X = (lng − 132.80160) / 0.02086230
 CET_Y = (lat + 93.68566) / 0.02101335
 ```
 
-These coefficients were derived from a **16-point uniform grid calibration** — see below.
+These coefficients were derived from a **16-point uniform grid calibration** (see below).
 
 ### Implementation
 
@@ -85,7 +85,7 @@ function leafletToCet(lat, lng) {
 
 ### Leaflet Coordinate Space
 
-The map uses `L.CRS.Simple` — a flat, non-geographic coordinate reference system. The 8192×8192px image is mapped by `map.unproject()` at zoom level 5 to:
+The map uses `L.CRS.Simple`, a flat, non-geographic coordinate reference system. The 8192×8192px image is mapped by `map.unproject()` at zoom level 5 to:
 
 - **Latitude:** −256 (bottom/south) to 0 (top/north)
 - **Longitude:** 0 (left/west) to 256 (right/east)
@@ -126,7 +126,7 @@ The transform was calibrated by placing 16 markers in a 4×4 grid on the Leaflet
 
 If the map image changes (new source, different crop, etc.), you'll need to recalibrate:
 
-1. **Enable the calibration grid** in `app.js` — uncomment the `CALIBRATION GRID` block
+1. **Enable the calibration grid** in `app.js`: uncomment the `CALIBRATION GRID` block
 2. **Place markers** at known Leaflet positions on the map
 3. **Import the SLM preset** (above) or manually visit each marker location in-game
 4. **Record CET coordinates** for each grid point

--- a/docs/creating-a-new-district.md
+++ b/docs/creating-a-new-district.md
@@ -2,15 +2,15 @@
 
 This guide explains how to add a new district or subdistrict to the in-game map.
 
-It uses the **North Oaks Casino** as a worked example — a cut-content area between North Oak, Red Peaks, and Rocky Ridge that the NC Zoning Board has computed a boundary polygon for.
+It uses the **North Oaks Casino** as a worked example, a cut-content area between North Oak, Red Peaks, and Rocky Ridge that the NC Zoning Board has computed a boundary polygon for.
 
 ---
 
 ## What You Need
 
-- **WolvenKit** — the main modding tool for CP2077 files
-- A **boundary polygon** — a list of X, Y coordinates in CET world-space that form the outline of your district
-- A **TweakDB record** — configuration for the district (name, parent, colors, etc.)
+- **WolvenKit**: the main modding tool for CP2077 files
+- A **boundary polygon**: a list of X, Y coordinates in CET world-space that form the outline of your district
+- A **TweakDB record**: configuration for the district (name, parent, colours, etc.)
 
 The NC Zoning Board has already computed the boundary polygon for North Oaks Casino. See [Step 1](#step-1-the-boundary-polygon) below.
 
@@ -20,7 +20,7 @@ The NC Zoning Board has already computed the boundary polygon for North Oaks Cas
 
 **CET world coordinates** are the same coordinates you see when you use the Cyber Engine Tweaks console in-game. X increases to the east, Y increases to the north.
 
-**TweakDB** is the game's database of configuration records. Districts are stored here with their names, colors, and parent relationships.
+**TweakDB** is the game's database of configuration records. Districts are stored here with their names, colours, and parent relationships.
 
 **`gameStaticTriggerAreaComponent`** is the game object that detects when the player enters an area. Each district has one, with a polygon outline defining its shape.
 
@@ -90,13 +90,13 @@ Districts.NorthOaksCasino:
 | `$type: gamedataDistrict_Record` | Tells the game this is a district record. Do not change this. |
 | `localizedName: LocKey#NorthOaksCasino` | The display name (we will set the actual text in Step 2.2). |
 | `parentDistrict: Districts.NorthOaks` | North Oaks is the parent. The game uses this for the district hierarchy. |
-| `uiState: Westbrook` | Uses Westbrook's orange color (`#ff5100`) on the map. Change if you want a different color (see color list below). |
+| `uiState: Westbrook` | Uses Westbrook's orange colour (`#ff5100`) on the map. Change if you want a different colour (see colour list below). |
 | `uiIcon: None` | No map icon. Set to `ico_district_westbrook_large` or similar if you add an icon. |
 | `isQuestDistrict: False` | Set to `True` if quests reference this district. |
 
-**Available `uiState` values and their colors:**
+**Available `uiState` values and their colours:**
 
-| uiState | Color | Hex |
+| uiState | Colour | Hex |
 | ------- | ----- | --- |
 | `CityCenter` | Yellow | #ffd741 |
 | `Watson` | Red | #ff3e34 |
@@ -107,9 +107,9 @@ Districts.NorthOaksCasino:
 | `Dogtown` | Dark green | #00a32c |
 | `MorroRock` | Teal | #349197 |
 
-### 2.2 Add the localized name
+### 2.2 Add the localised name
 
-Create a file called `north_oaks_casino_loc.json` in your mod's `r6/tweaks/` folder (or use an existing localization file):
+Create a file called `north_oaks_casino_loc.json` in your mod's `r6/tweaks/` folder (or use an existing localisation file):
 
 ```json
 {
@@ -123,7 +123,7 @@ Create a file called `north_oaks_casino_loc.json` in your mod's `r6/tweaks/` fol
 }
 ```
 
-> **Note:** CP2077 localization uses "femaleVariant" for the default text. Leave "maleVariant" empty to use the same text for everyone.
+> **Note:** CP2077 localisation uses "femaleVariant" for the default text. Leave "maleVariant" empty to use the same text for everyone.
 
 ---
 
@@ -228,11 +228,11 @@ In JSON format (WolvenKit can import this), the structure looks like this:
 **Key things to check:**
 
 - The `"$value": "Districts.NorthOaksCasino"` in the `districtID` must match exactly the TweakDB path you defined in Step 2.1.
-- The `"Z": 0` on each point is fine — the game extends the trigger volume up and down automatically.
+- The `"Z": 0` on each point is fine: the game extends the trigger volume up and down automatically.
 
 ### 3.3 Set the entity's world position
 
-The trigger component polygon points are in **world space** (they already include the absolute CET coordinates). Set the entity's root transform to position `(0, 0, 0)` with no rotation. Do not add an offset — the polygon coordinates already place it in the correct location.
+The trigger component polygon points are in **world space** (they already include the absolute CET coordinates). Set the entity's root transform to position `(0, 0, 0)` with no rotation. Do not add an offset: the polygon coordinates already place it in the correct location.
 
 ---
 
@@ -263,7 +263,7 @@ streaming:
 
 You can add the entity directly to a streaming sector that covers the North Oak area:
 
-- The relevant sector is near grid coordinates (0, 0) — look for exterior sectors around that area
+- The relevant sector is near grid coordinates (0, 0): look for exterior sectors around that area
 - Add your entity as a new node in the sector's `nodes` array
 
 ---
@@ -278,21 +278,21 @@ You can add the entity directly to a streaming sector that covers the North Oak 
 If the HUD does not update:
 - Check that `Districts.NorthOaksCasino` in the trigger's `districtID` exactly matches the TweakDB record path
 - Check that the entity is loaded (use CET console: `GetPlayer():GetCurrentDistrict()` to query the active district)
-- Check that the polygon points are correct — use CET to print your current position (`print(GetPlayer():GetWorldPosition())`) and verify you are inside the expected coordinate range: X[397, 1565] Y[1219, 2069]
+- Check that the polygon points are correct: use CET to print your current position (`print(GetPlayer():GetWorldPosition())`) and verify you are inside the expected coordinate range: X[397, 1565] Y[1219, 2069]
 
 ---
 
 ## Coordinate Reference
 
-These are the approximate boundary positions between North Oaks Casino and its neighbors:
+These are the approximate boundary positions between North Oaks Casino and its neighbours:
 
-| Neighbor | Shared border direction |
+| Neighbour | Shared border direction |
 | -------- | ---------------------- |
 | North Oak (Westbrook) | West and north edge |
 | Red Peaks (Badlands) | South edge |
 | Rocky Ridge (Badlands) | East edge |
 
-The approximate center of the casino area is around **(880, 1640)** in CET world-space.
+The approximate centre of the casino area is around **(880, 1640)** in CET world-space.
 
 ---
 
@@ -301,15 +301,15 @@ The approximate center of the casino area is around **(880, 1640)** in CET world
 | File | Location | Purpose |
 | ---- | -------- | ------- |
 | `north_oaks_casino.yaml` | `r6/tweaks/` | TweakDB district record |
-| `north_oaks_casino_loc.json` | `r6/tweaks/` | Localized display name |
+| `north_oaks_casino_loc.json` | `r6/tweaks/` | Localised display name |
 | `north_oaks_casino_district.ent` | `your_mod/districts/` | Trigger area entity |
 
 ---
 
 ## About the Boundary Polygon
 
-The 50-point polygon in this document was computed mathematically by the NC Zoning Board project. It was not hand-traced — it was generated by finding the geometric area that is simultaneously within 1200 CET units of all three surrounding districts (North Oak, Red Peaks, Rocky Ridge), minus those districts themselves.
+The 50-point polygon in this document was computed mathematically by the NC Zoning Board project. It was not hand-traced: it was generated by finding the geometric area that is simultaneously within 1200 CET units of all three surrounding districts (North Oak, Red Peaks, Rocky Ridge), minus those districts themselves.
 
-This gives the natural "pocket" shape of the cut-content zone. If you need to adjust edges — for example if your mod adds geometry that changes where the district boundary should be — you can modify individual points in the polygon freely.
+This gives the natural "pocket" shape of the cut-content zone. If you need to adjust edges (for example if your mod adds geometry that changes where the district boundary should be), you can modify individual points in the polygon freely.
 
 The polygon is stored in `data/subdistricts.json` in the NC Zoning Board repository with `"canonical": false`, which means it is included in the map data but hidden by default in the public map unless a user specifically enables it. When the North Oaks Casino mod releases, this flag can be updated.

--- a/docs/data-api-plan.md
+++ b/docs/data-api-plan.md
@@ -37,7 +37,7 @@ The static `mods.json` is not enough for game clients, for three reasons:
   entries; the Worker only reads deployed CDN artifacts. A separate
   `monitor-api-health.yml` GitHub Action probes `/v1` every 15 min and alerts
   on the same channel if the API stops serving (independent of the Worker's own
-  alert — catches cases where the Worker can't alert for itself).
+  alert: catches cases where the Worker can't alert for itself).
 - **Free tier:** ~1 conditional GET per player session against a 100k req/day
   cap; KV writes at most 96/day. Passes with a huge margin.
 

--- a/docs/dev-branch-maintainer-guide.md
+++ b/docs/dev-branch-maintainer-guide.md
@@ -1,10 +1,10 @@
-# Dev Branch — Maintainer Guide
+# Dev Branch: Maintainer Guide
 
 This document covers what the `dev` branch contains, why it exists, and how to contribute to the Three.js 3D map migration happening on it. For infrastructure details (Cloudflare Pages setup, build config), see [`dev-environment.md`](dev-environment.md).
 
 ## Why the dev branch exists
 
-The NC Zoning Board site at [nczoning.net](https://nczoning.net) is currently a 2D Leaflet map with a rasterised terrain image. The `dev` branch is the long-running integration branch for the **Three.js 3D map migration** — a 7-phase project that replaces the 2D schematic view with a live 3D scene rendering the game's actual terrain, roads, metro, buildings, and landmarks.
+The NC Zoning Board site at [nczoning.net](https://nczoning.net) is currently a 2D Leaflet map with a rasterised terrain image. The `dev` branch is the long-running integration branch for the **Three.js 3D map migration**: a 7-phase project that replaces the 2D schematic view with a live 3D scene rendering the game's actual terrain, roads, metro, buildings, and landmarks.
 
 The migration happens on `dev` (not directly on `main`) because:
 
@@ -22,7 +22,7 @@ The dev branch exists from **before Phase 0 started** through the eventual merge
 | Production | `main` | [nczoning.net](https://nczoning.net) | Cloudflare Pages (native Git integration) |
 | Staging | `dev` | [dev.nczoning.net](https://dev.nczoning.net) | Cloudflare Pages (native Git integration) |
 
-Both environments are separate Cloudflare Pages projects on the same repo (prod builds `main`, staging builds `dev`). Cloudflare runs `node scripts/build_mods.js` on every push to the project's branch and deploys the result. No GitHub Actions secrets or tokens needed — Cloudflare's GitHub integration handles authentication itself.
+Both environments are separate Cloudflare Pages projects on the same repo (prod builds `main`, staging builds `dev`). Cloudflare runs `node scripts/build_mods.js` on every push to the project's branch and deploys the result. No GitHub Actions secrets or tokens needed. Cloudflare's GitHub integration handles authentication itself.
 
 ## Contributing to a phase
 
@@ -40,18 +40,18 @@ Create the phase branch off `dev`, not `main`. This picks up all completed prior
 
 ### Working on a phase
 
-1. **Read the migration plan section for your phase** — it lists the specific files to create/modify and the expected output.
+1. **Read the migration plan section for your phase**: it lists the specific files to create/modify and the expected output.
 2. **Read the relevant reference docs**:
-   - [`three-js-scene.md`](three-js-scene.md) — current Three.js scene implementation reference
-   - [`coordinate-system-3d.md`](coordinate-system-3d.md) — CET / GLB / building instance coordinate system details
-   - [`3dmap-asset-reference.md`](3dmap-asset-reference.md) — asset inventory and transform chains
+   - [`three-js-scene.md`](three-js-scene.md): current Three.js scene implementation reference
+   - [`coordinate-system-3d.md`](coordinate-system-3d.md): CET / GLB / building instance coordinate system details
+   - [`3dmap-asset-reference.md`](3dmap-asset-reference.md): asset inventory and transform chains
 3. **Keep `dev` merged in periodically** if the phase is long-running, so you pick up upstream bugfixes and new location data:
    ```bash
    git fetch origin
    git merge origin/dev
    ```
-4. **Test locally** — `node scripts/build_mods.js` then `npx serve .`
-5. **Update the changelog** — add entries under `## [Unreleased]` in `CHANGELOG.md` describing what the phase adds
+4. **Test locally**: `node scripts/build_mods.js` then `npx serve .`
+5. **Update the changelog**: add entries under `## [Unreleased]` in `CHANGELOG.md` describing what the phase adds
 6. **Update `three-js-scene.md`** if you change any architectural decisions, add new GLB assets, or change the data pipeline
 
 ### Finishing a phase
@@ -62,9 +62,9 @@ Create the phase branch off `dev`, not `main`. This picks up all completed prior
    ```
 2. Open a PR **targeting `dev`** (not `main`):
    ```bash
-   gh pr create --base dev --title "feat(3d): Phase N — <summary>"
+   gh pr create --base dev --title "feat(3d): Phase N - <summary>"
    ```
-3. Cloudflare Pages will build a preview deployment for the PR branch — use it to verify visual correctness on the staging URL
+3. Cloudflare Pages will build a preview deployment for the PR branch: use it to verify visual correctness on the staging URL
 4. Merge when ready. Cloudflare redeploys `dev.nczoning.net` automatically.
 
 ### What NOT to do
@@ -91,9 +91,9 @@ git merge origin/main --no-edit         # Merge main's changes
 git push origin dev
 ```
 
-Do this **ad-hoc, whenever `main` has changes `dev` needs** — a Leaflet/satellite-view bugfix, new location JSONs, tooling, or docs. There is **no fixed cadence**: no weekly schedule, no per-phase requirement. Sync on demand.
+Do this **ad-hoc, whenever `main` has changes `dev` needs**: a Leaflet/satellite-view bugfix, new location JSONs, tooling, or docs. There is **no fixed cadence**: no weekly schedule, no per-phase requirement. Sync on demand.
 
-Merge conflicts are **almost always limited to `CHANGELOG.md`**, and the conflict is structural: `dev` carries a long-lived `[Unreleased]` block (the 3D-map changelog) that `main` doesn't have, while `main` accumulates released `[0.3.x]` sections `dev` doesn't have. **Resolve by union, in order:** keep dev's entire `[Unreleased]` body, then place main's released `[0.3.x]` sections immediately below it (above the previously-newest released version). Drop neither side — a correct resolution just removes the `<<<<<<<` / `=======` / `>>>>>>>` markers with both blocks intact.
+Merge conflicts are **almost always limited to `CHANGELOG.md`**, and the conflict is structural: `dev` carries a long-lived `[Unreleased]` block (the 3D-map changelog) that `main` doesn't have, while `main` accumulates released `[0.3.x]` sections `dev` doesn't have. **Resolve by union, in order:** keep dev's entire `[Unreleased]` body, then place main's released `[0.3.x]` sections immediately below it (above the previously-newest released version). Drop neither side: a correct resolution just removes the `<<<<<<<` / `=======` / `>>>>>>>` markers with both blocks intact.
 
 ## Phase status
 
@@ -104,10 +104,10 @@ As of the last update to this document:
 | 0 | View-agnostic data layer | ✅ Merged to main + dev | #567 |
 | 1 | Terrain scene + view switching | ✅ Merged to dev | #572 |
 | 2 | Roads, metro, district borders | ✅ Merged to dev | #573 |
-| 3 | Buildings as instanced cubes | 🟡 In progress | — |
-| 4 | Location pins in 3D | ⏳ Not started | — |
-| 5 | Landmarks | ⏳ Not started | — |
-| 6 | Polish and integration | ⏳ Not started | — |
+| 3 | Buildings as instanced cubes | 🟡 In progress | - |
+| 4 | Location pins in 3D | ⏳ Not started | - |
+| 5 | Landmarks | ⏳ Not started | - |
+| 6 | Polish and integration | ⏳ Not started | - |
 
 Check `CHANGELOG.md` and recent PRs for the current state.
 
@@ -117,30 +117,30 @@ Check `CHANGELOG.md` and recent PRs for the current state.
 
 ```
 assets/js/
-  three-scene.js       — Three.js scene: renderer, camera, GLB loading, buildings
-  three-markers.js     — CSS2D pins and clustering (Phase 4)
-  overlay.js           — Leaflet district border overlay (shared with SAT view)
+  three-scene.js       - Three.js scene: renderer, camera, GLB loading, buildings
+  three-markers.js     - CSS2D pins and clustering (Phase 4)
+  overlay.js           - Leaflet district border overlay (shared with SAT view)
 
 assets/glb/
-  3dmap_terrain.glb    — Terrain surface mesh (18 MB)
-  3dmap_water.glb      — Water plane
-  3dmap_cliffs.glb     — Dogtown cliffs
-  3dmap_roads.glb      — Road surfaces
-  3dmap_metro.glb      — Metro tracks
+  3dmap_terrain.glb    - Terrain surface mesh (18 MB)
+  3dmap_water.glb      - Water plane
+  3dmap_cliffs.glb     - Dogtown cliffs
+  3dmap_roads.glb      - Road surfaces
+  3dmap_metro.glb      - Metro tracks
 
 data/
-  buildings_3d.json    — 254k building instances (cetX, cetY, surfaceY, width, depth, height, brightness, districtIdx, yaw)
-  subdistricts.json    — District/subdistrict polygon data in CET coordinates
+  buildings_3d.json    - 254k building instances (cetX, cetY, surfaceY, width, depth, height, brightness, districtIdx, yaw)
+  subdistricts.json    - District/subdistrict polygon data in CET coordinates
 
 scripts/
-  build_buildings_3d.py      — Extracts buildings from WolvenKit _data.png textures
-  fix_building_heights.py    — Raycasts terrain GLB to set building surface Y
-  minimap_instance_shader.hlsl — Reference: the game's own instance shader
+  build_buildings_3d.py      - Extracts buildings from WolvenKit _data.png textures
+  fix_building_heights.py    - Raycasts terrain GLB to set building surface Y
+  minimap_instance_shader.hlsl - Reference: the game's own instance shader
 ```
 
 ### Coordinate systems in one sentence
 
-CET (game world) and GLB (terrain mesh) share the same XZ coordinate space at 1:1 scale. CET Z (elevation) does NOT match GLB Y — use `fix_building_heights.py` to raycast terrain for actual surface Y at each building. Full details in [`coordinate-system-3d.md`](coordinate-system-3d.md).
+CET (game world) and GLB (terrain mesh) share the same XZ coordinate space at 1:1 scale. CET Z (elevation) does NOT match GLB Y. Use `fix_building_heights.py` to raycast terrain for actual surface Y at each building. Full details in [`coordinate-system-3d.md`](coordinate-system-3d.md).
 
 ### Building data pipeline
 
@@ -179,22 +179,22 @@ node scripts/build_mods.js   # Rebuild mods.json from data/locations/*.json firs
 npx serve .                   # Serve the repo root
 ```
 
-Always rebuild `mods.json` before testing — it's gitignored and won't exist on a fresh clone.
+Always rebuild `mods.json` before testing: it's gitignored and won't exist on a fresh clone.
 
 ## Troubleshooting
 
 **Buildings don't appear**
 - Check the browser console for errors in `loadBuildings()`
 - Verify `data/buildings_3d.json` exists and has ~254k instances: `node -e "console.log(require('./data/buildings_3d.json').instances.length)"`
-- Check that `fix_building_heights.py` was run after `build_buildings_3d.py` — the field at index 2 should be the terrain surface Y, not the original CET Z
+- Check that `fix_building_heights.py` was run after `build_buildings_3d.py`: the field at index 2 should be the terrain surface Y, not the original CET Z
 
 **Terrain and buildings don't align**
-- Districts are the reference truth — they're drawn from `subdistricts.json` in CET coordinates
+- Districts are the reference truth: they're drawn from `subdistricts.json` in CET coordinates
 - If districts align with terrain but not buildings, check building XY extraction in `build_buildings_3d.py`
-- If nothing aligns, check `DISTRICT_OFFSETS` in `build_buildings_3d.py` — these translate district-local coordinates to CET world coordinates
+- If nothing aligns, check `DISTRICT_OFFSETS` in `build_buildings_3d.py`: these translate district-local coordinates to CET world coordinates
 
 **Camera behaves oddly when tilting**
-- The camera uses `up=(0,1,0)` (standard Three.js up). Do NOT change this to `(0,0,-1)` — that causes a Y-axis inversion bug where buildings appear upside down when tilted. This was Phase 3's blocker and the one-line fix was restoring the standard up vector.
+- The camera uses `up=(0,1,0)` (standard Three.js up). Do NOT change this to `(0,0,-1)`: that causes a Y-axis inversion bug where buildings appear upside down when tilted. This was Phase 3's blocker and the one-line fix was restoring the standard up vector.
 
 **Cloudflare Pages build fails**
 - Check the build log in the Cloudflare dashboard (Workers & Pages → nc-zoning-board-dev → Deployments)
@@ -213,14 +213,14 @@ When all 7 phases are complete and verified on `dev.nczoning.net`:
 2. Run the full local test suite: `npx serve .`, click every view toggle, every overlay, every filter
 3. Take screenshots of the before/after for the PR description
 4. Open the final PR: `gh pr create --base main --title "feat(3d): Three.js 3D schematic map"`
-5. Merge — GitHub Actions deploys to nczoning.net
-6. Delete the `dev` branch (no longer needed) — or keep it for the next major feature
+5. Merge: GitHub Actions deploys to nczoning.net
+6. Delete the `dev` branch (no longer needed), or keep it for the next major feature
 
 ## Related documentation
 
-- [GitHub Project](https://github.com/users/spuddeh/projects/1) — current phase-by-phase work, organised by Stream (WebGPU Migration / Three.js Parity / Roadmap / Bugs) and Release (Schema map / Post schema map / Future / Ongoing)
-- [`three-js-scene.md`](three-js-scene.md) — Current implementation reference
-- [`coordinate-system-3d.md`](coordinate-system-3d.md) — CET/GLB/instance texture coordinate details
-- [`3dmap-asset-reference.md`](3dmap-asset-reference.md) — Game asset inventory and transform chains
-- [`map-data-extraction.md`](map-data-extraction.md) — How texture data becomes JSON
-- [`dev-environment.md`](dev-environment.md) — Infrastructure setup (Cloudflare Pages)
+- [GitHub Project](https://github.com/users/spuddeh/projects/1): current phase-by-phase work, organised by Stream (WebGPU Migration / Three.js Parity / Roadmap / Bugs) and Release (Schema map / Post schema map / Future / Ongoing)
+- [`three-js-scene.md`](three-js-scene.md): Current implementation reference
+- [`coordinate-system-3d.md`](coordinate-system-3d.md): CET/GLB/instance texture coordinate details
+- [`3dmap-asset-reference.md`](3dmap-asset-reference.md): Game asset inventory and transform chains
+- [`map-data-extraction.md`](map-data-extraction.md): How texture data becomes JSON
+- [`dev-environment.md`](dev-environment.md): Infrastructure setup (Cloudflare Pages)

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -10,8 +10,8 @@ The project has two deployment environments:
 
 | Environment | Branch | URL | Purpose |
 |-------------|--------|-----|---------|
-| Production | `main` | [nczoning.net](https://nczoning.net) | Live site — always fully functional |
-| Staging | `dev` | [dev.nczoning.net](https://dev.nczoning.net) | In-progress Three.js work — may be incomplete |
+| Production | `main` | [nczoning.net](https://nczoning.net) | Live site, always fully functional |
+| Staging | `dev` | [dev.nczoning.net](https://dev.nczoning.net) | In-progress Three.js work, may be incomplete |
 
 Both environments deploy via Cloudflare Pages Git integration: production on
 every push to `main`, staging on every push to `dev` (separate Pages projects on
@@ -33,7 +33,7 @@ main ─────────────────────────
 
 - **Phase feature branches** (e.g. `feat/three-js-phase-1`) branch off `dev` and PR back into `dev`
 - `main` is only touched when a complete, fully-tested feature is ready to ship
-- `dev` may be broken or incomplete at any point — that's expected
+- `dev` may be broken or incomplete at any point; that's expected
 
 ---
 
@@ -58,7 +58,7 @@ No GitHub Actions secrets or API tokens are required. Cloudflare's native Git in
 1. Cloudflare detects the push via GitHub webhook
 2. Clones the repository at the pushed commit
 3. Runs `npm clean-install` (installs dependencies from `package.json`)
-4. Runs `node scripts/build_mods.js` — generates `mods.json` from `data/locations/*.json`
+4. Runs `node scripts/build_mods.js`: generates `mods.json` from `data/locations/*.json`
 5. Uploads all files (including the generated `mods.json`) to Cloudflare's global network
 6. Site is live at `dev.nczoning.net` within ~60 seconds of pushing
 
@@ -90,7 +90,7 @@ git checkout -b feat/three-js-phase-N
 2. Open a PR targeting `dev` (not `main`)
 3. Verify the preview looks correct locally with `npx serve .` after running `node scripts/build_mods.js`
 4. Merge the PR into `dev`
-5. Cloudflare automatically deploys — verify at `dev.nczoning.net`
+5. Cloudflare automatically deploys: verify at `dev.nczoning.net`
 
 ### Keeping dev in sync with main
 
@@ -109,7 +109,7 @@ Do this periodically, especially after any data backfill PRs merge to `main`.
 Once all phases of the Three.js migration are complete and verified on `dev.nczoning.net`:
 
 1. Open a PR from `dev` → `main`
-2. Merge — GitHub Actions deploys to `nczoning.net` automatically
+2. Merge: GitHub Actions deploys to `nczoning.net` automatically
 
 ---
 
@@ -122,7 +122,7 @@ node scripts/build_mods.js
 npx serve .
 ```
 
-`mods.json` is gitignored and is never committed — it is built fresh on every Cloudflare deploy and must be built manually for local testing.
+`mods.json` is gitignored and is never committed: it is built fresh on every Cloudflare deploy and must be built manually for local testing.
 
 ---
 
@@ -130,4 +130,4 @@ npx serve .
 
 The `dev` branch exists specifically to support the Three.js 3D map migration. Each phase ships as a PR into `dev`. The full feature will not touch `main` until all phases are complete and verified.
 
-Current phase-by-phase work is tracked in the [GitHub Project](https://github.com/users/spuddeh/projects/1) — see the **WebGPU Migration** and **Three.js Parity** streams. For the current implementation reference see [`three-js-scene.md`](three-js-scene.md).
+Current phase-by-phase work is tracked in the [GitHub Project](https://github.com/users/spuddeh/projects/1): see the **WebGPU Migration** and **Three.js Parity** streams. For the current implementation reference see [`three-js-scene.md`](three-js-scene.md).

--- a/docs/district-hierarchy.md
+++ b/docs/district-hierarchy.md
@@ -3,11 +3,11 @@
 Full district hierarchy extracted from TweakDB `District_Record` entries (132 records).
 Source: `scripts/extract_tweakdb_map.wscript` run in WolvenKit.
 
-## District Outline Colors
+## District Outline Colours
 
 From `world_map_style.inkstyle` → `MainColors` in `main_colors.inkstyle`:
 
-| District | UiState | Ink Color | HDR RGBA | RGB | Hex |
+| District | UiState | Ink Colour | HDR RGBA | RGB | Hex |
 |----------|---------|-----------|----------|-----|-----|
 | Default (base) | Default | MainColors.White | [1, 1, 1, 1] | (255, 255, 255) | #ffffff |
 | City Center | CityCenter | MainColors.Yellow | [1.119, 0.844, 0.257, 1] | (255, 215, 65) | #ffd741 |
@@ -39,7 +39,7 @@ All levels use FOV=25 and Yaw=-85 rotation.
 
 ## Map Bounds
 
-### Render Extent (authoritative — used for tile/overlay projection)
+### Render Extent (authoritative: used for tile/overlay projection)
 
 From the Realistic Map mod terrain quad UV mapping (see `docs/coordinate-system.md`):
 
@@ -53,9 +53,9 @@ From the Realistic Map mod terrain quad UV mapping (see `docs/coordinate-system.
 | Height | 12111 CET units |
 | Centre | (-242, -1628) |
 
-### In-Game Pan Limit (TweakDB — NOT the render extent)
+### In-Game Pan Limit (TweakDB, NOT the render extent)
 
-From TweakDB `WorldMap.DefaultSettings` — defines how far the player can scroll the map in-game, not what is rendered:
+From TweakDB `WorldMap.DefaultSettings` (defines how far the player can scroll the map in-game, not what is rendered):
 
 | Parameter | Value |
 |-----------|-------|
@@ -65,13 +65,13 @@ From TweakDB `WorldMap.DefaultSettings` — defines how far the player can scrol
 ## Full Hierarchy
 
 Legend:
-- **Bold** = has UiState color (rendered on map)
+- **Bold** = has UiState colour (rendered on map)
 - `[Q]` = isQuestDistrict
 - Gang affiliations shown where applicable
 
 ### Night City Districts
 
-#### **City Center** `[Q]` — UiState: CityCenter (Yellow #ffd741)
+#### **City Center** `[Q]`, UiState: CityCenter (Yellow #ffd741)
 - Corpo Plaza `[Q]`
   - Arasaka Tower Atrium
   - Arasaka Tower CEO Floor
@@ -88,7 +88,7 @@ Legend:
   - Jinguji
   - The Hammer
 
-#### **Watson** `[Q]` — UiState: Watson (CombatRed #ff3e34) — Maelstrom
+#### **Watson** `[Q]`, UiState: Watson (CombatRed #ff3e34), Maelstrom
 - Arasaka Waterfront
   - Abandoned Warehouse
   - Konpeki Plaza
@@ -111,11 +111,11 @@ Legend:
   - Totentanz
   - WNS
 
-#### **Westbrook** `[Q]` — UiState: Westbrook (Orange #ff5100)
+#### **Westbrook** `[Q]`, UiState: Westbrook (Orange #ff5100)
 - Charter Hill
   - Au Cabanon
   - Power Plant
-- Japantown — Tyger Claws
+- Japantown (Tyger Claws)
   - Clouds
   - Dark Matter
   - Fingers
@@ -131,7 +131,7 @@ Legend:
   - Denny's Estate
   - Kerry's Estate
 
-#### **Heywood** `[Q]` — UiState: Heywood (Green #1ded83) — Valentinos
+#### **Heywood** `[Q]`, UiState: Heywood (Green #1ded83), Valentinos
 - The Glen
   - Embers
   - Glen Apartment
@@ -145,7 +145,7 @@ Legend:
   - La Catrina
 - Wellsprings
 
-#### **Santo Domingo** `[Q]` — UiState: SantoDomingo (Blue #5ef6ff) — 6th Street
+#### **Santo Domingo** `[Q]`, UiState: SantoDomingo (Blue #5ef6ff), 6th Street
 - Arroyo
   - Arasaka Warehouse
   - Claire's Garage
@@ -162,8 +162,8 @@ Legend:
   - Softsys
   - Stylishly
 
-#### **Pacifica** `[Q]` — UiState: Pacifica (Red #ff6158) — Voodoo Boys
-- Coastview — Voodoo Boys
+#### **Pacifica** `[Q]`, UiState: Pacifica (Red #ff6158), Voodoo Boys
+- Coastview (Voodoo Boys)
   - Batty's Hotel
   - Butcher Shop
   - Grand Imperial Mall
@@ -171,9 +171,9 @@ Legend:
   - VDB Chapel
   - VDB Maglev
   - q110 Cyberspace
-- West Wind Estate — Animals
+- West Wind Estate (Animals)
 
-#### **Dogtown** `[Q]` — UiState: Dogtown (DarkGreen #00a32c) — Barghest
+#### **Dogtown** `[Q]`, UiState: Dogtown (DarkGreen #00a32c), Barghest
 - Akebono
 - Capitan Caliente
 - Cynosure Facility
@@ -181,12 +181,12 @@ Legend:
 - Hideout
 - Worldmap Sub
 
-#### **Morro Rock** — UiState: MorroRock (MildBlue #349197)
+#### **Morro Rock**, UiState: MorroRock (MildBlue #349197)
 - NCX (Spaceport)
 
-### Badlands — UiState: None (no map border)
+### Badlands, UiState: None (no map border)
 
-#### Badlands `[Q]` — Aldecaldos
+#### Badlands `[Q]` (Aldecaldos)
 - Biotechnica Flats
 - ~~Dry Creek~~ *(nomad lifepath start, not on world map)*
 - Jackson Plains
@@ -215,7 +215,7 @@ Legend:
 - q201 Space Station
 
 ### Other
-- Brooklyn (Dogtown sub, orphaned — parentDistrict: None in TweakDB)
+- Brooklyn (Dogtown sub, orphaned; parentDistrict: None in TweakDB)
 - q307 Langley Clinic (orphaned)
 
 ## Boundary Data Sources

--- a/docs/map-data-extraction.md
+++ b/docs/map-data-extraction.md
@@ -6,7 +6,7 @@ The game's 3D minimap renders Night City using a GPU instancing shader. Building
 
 This pipeline was inspired by [a Reddit post](https://www.reddit.com/r/cyberpunk2077mods/comments/1rzqh2m/in_game_minimap_extraction/) that decoded the same textures into 3D OBJ meshes for 3D printing. Our version skips the 3D boolean union and projects everything to 2D instead.
 
-> **Note:** This document covers `scripts/cp2077_extract_footprints.py` — the **2D extraction pipeline** used for district borders, roads, metro, and landmark SVGs. The **Three.js 3D building rendering** uses a completely separate pipeline that reads DDS files directly and renders via `MeshLambertMaterial`. See [`coordinate-system-3d.md`](coordinate-system-3d.md) for the 3D pipeline.
+> **Note:** This document covers `scripts/cp2077_extract_footprints.py`: the **2D extraction pipeline** used for district borders, roads, metro, and landmark SVGs. The **Three.js 3D building rendering** uses a completely separate pipeline that reads DDS files directly and renders via `MeshLambertMaterial`. See [`coordinate-system-3d.md`](coordinate-system-3d.md) for the 3D pipeline.
 
 ## Prerequisites
 
@@ -25,7 +25,7 @@ All source files must be exported from the game archive using [WolvenKit](https:
 GLB_DIR = r"<your WolvenKit export path>\base\entities\cameras\3dmap"
 ```
 
-The scripts expect files at `<export root>\base\...` — point `GLB_DIR` and the texture/entity paths at the top of each script to wherever WolvenKit wrote the exports on your machine.
+The scripts expect files at `<export root>\base\...`. Point `GLB_DIR` and the texture/entity paths at the top of each script to wherever WolvenKit wrote the exports on your machine.
 
 **Required exports:**
 
@@ -37,7 +37,7 @@ The scripts expect files at `<export root>\base\...` — point `GLB_DIR` and the
 | Road/metro meshes | `base\entities\cameras\3dmap\3dmap_roads.mesh`, `3dmap_metro.mesh` | Export as GLB |
 | District icons | `base\gameplay\gui\common\icons\district_icons.xbm` + `.inkatlas` | Export PNG + convert inkatlas to JSON |
 
-> **Warning:** Do NOT open/re-save the exported PNGs in Photoshop or any colour-managed tool. The pixel values encode coordinates — any gamma or sRGB correction will corrupt them. The script uses pypng which reads raw bytes and ignores colour profile chunks.
+> **Warning:** Do NOT open/re-save the exported PNGs in Photoshop or any colour-managed tool. The pixel values encode coordinates: any gamma or sRGB correction will corrupt them. The script uses pypng which reads raw bytes and ignores colour profile chunks.
 
 ## Scripts
 
@@ -46,16 +46,16 @@ The scripts expect files at `<export root>\base\...` — point `GLB_DIR` and the
 Main extraction script. Decodes building textures, renders overlays, and produces all output files.
 
 ```bash
-# Pass 1 — Analyze building positions (fast, no rendering)
+# Pass 1: Analyze building positions (fast, no rendering)
 python scripts/cp2077_extract_footprints.py --analyze
 
-# Pass 2 — Full output (buildings.png, buildings.svg, buildings.json, etc.)
+# Pass 2: Full output (buildings.png, buildings.svg, buildings.json, etc.)
 python scripts/cp2077_extract_footprints.py
 ```
 
 **Pass 1 (`--analyze`)** decodes centre positions only and outputs:
-- `scripts/output/analysis.txt` — per-district position ranges
-- `scripts/output/analysis_scatter.png` — scatter plot of all building positions
+- `scripts/output/analysis.txt`: per-district position ranges
+- `scripts/output/analysis_scatter.png`: scatter plot of all building positions
 
 Use this to verify the world extent constants (`WORLD_MIN/MAX_X/Y`) before running the full pipeline.
 
@@ -71,7 +71,7 @@ python scripts/regenerate_subdistricts.py
 
 ### `scripts/cp2077_3dmap_to_manifold.py` (reference)
 
-Original Reddit script for 3D printing. Not used in the pipeline — kept as reference for the texture decoding logic.
+Original Reddit script for 3D printing. Not used in the pipeline. Kept as reference for the texture decoding logic.
 
 ## How It Works
 
@@ -127,7 +127,7 @@ component → parentTransform.bindName → parent → grandparent → ...
 
 At each level: **rotate** points by the component's yaw, then **translate** by its position.
 
-Example — Pacifica's chain:
+Example (Pacifica's chain):
 ```
 pacifica_trigger (offset, no rotation)
   → pacifica_transform (65° yaw + offset)  ← THIS ROTATION IS CRITICAL
@@ -138,7 +138,7 @@ pacifica_trigger (offset, no rotation)
 
 Without walking the full chain, Pacifica's trigger polygon is oriented ~65° wrong.
 
-Example — NCX/Spaceport's chain:
+Example (NCX/Spaceport's chain):
 ```
 ncx_trigger (no offset)
   → ncx_transform (identity)
@@ -150,28 +150,28 @@ ncx_trigger (no offset)
 
 GLB meshes are rendered in two separate passes via `render_glb_base_layer()`, which is called twice in `run_full_output()`:
 
-1. **Roads + metro pass** (`GLB_LAYERS[:2]`) — composited under buildings
-2. **Landmark pass** (`GLB_LAYERS[2:]`, `combined_label="landmarks"`) — composited over buildings, under district borders
+1. **Roads + metro pass** (`GLB_LAYERS[:2]`): composited under buildings
+2. **Landmark pass** (`GLB_LAYERS[2:]`, `combined_label="landmarks"`): composited over buildings, under district borders
 
 The `combined_label` parameter controls SVG/JSON output grouping. When set, all layers are written to a single file per type. Each landmark gets its own `<g id="{label}">` (fill) and `<g id="{label}_outline">` (boundary edges) group in the SVG. The JSON uses the structure `{label: {"faces": [...], "edges": [...]}}`. When `None` (roads/metro), each layer writes its own flat file.
 
 World placement and orientation are read from the ent JSON via `load_mesh_transforms()`.
 
-**Axis mapping** (determined empirically — roads 180° from buildings without this):
+**Axis mapping** (determined empirically: roads 180° from buildings without this):
 - `-GLB_X` → CET_X (X is negated; corrects for coordinate handedness difference)
 - `+GLB_Z` → CET_Y (Z maps directly to north-south)
-- `+GLB_Y` → CET_Z (height — projected out, but used during 3D rotation)
+- `+GLB_Y` → CET_Z (height: projected out, but used during 3D rotation)
 
 **Orientation:** `load_mesh_transforms()` walks the full `parentTransform` chain for each `entMeshComponent` and accumulates the world-space orientation as a quaternion (Hamilton product up the chain). For rendering, the full quaternion is converted to a 3×3 rotation matrix and applied to the GLB vertices in CET space before projection. This correctly handles pitch and roll (e.g. the collapsed ferris wheel lying on its side) not just yaw.
 
-**Roads/metro orientation exception:** The road and metro meshes have a **116.6° world yaw** in the ent (confirmed from entity quaternion: both instances of 3dmap_roads.mesh and 3dmap_metro.mesh). The net effect of this rotation when projected top-down is equivalent to negating the X axis, so the projection formula uses `-GLB_X` = `CET_X`. This was confirmed empirically — roads appear 180° mirrored from buildings without the negation. These meshes use `offset_key=None` in `GLB_LAYERS`, which suppresses the ent quaternion so it isn't double-applied.
+**Roads/metro orientation exception:** The road and metro meshes have a **116.6° world yaw** in the ent (confirmed from entity quaternion: both instances of 3dmap_roads.mesh and 3dmap_metro.mesh). The net effect of this rotation when projected top-down is equivalent to negating the X axis, so the projection formula uses `-GLB_X` = `CET_X`. This was confirmed empirically: roads appear 180° mirrored from buildings without the negation. These meshes use `offset_key=None` in `GLB_LAYERS`, which suppresses the ent quaternion so it isn't double-applied.
 
 **Rendering approaches per mesh type:**
-- **Roads:** Fill faces at low opacity — shows grey road areas between buildings
-- **Metro:** Boundary edges only (edges belonging to exactly 1 face) — clean track lines without interior mesh tessellation
-- **Landmarks:** Fill faces + boundary edge outline, both using the district colour resolved from the landmark's world CET position via `classify_district()`. Alpha 200/255 for fill, 240/255 for outline — matching building visual style. Each landmark's colour is looked up at render time so it blends with the surrounding district rather than being visually distinct
-- **Water:** Excluded — world-scale flat plane floods the entire canvas
-- **Terrain/Cliffs:** Excluded — terrain is too large and obscures the map at 2D projection scale; `3dmap_cliffs.glb` in particular overwhelms the Dogtown/Badlands border area
+- **Roads:** Fill faces at low opacity: shows grey road areas between buildings
+- **Metro:** Boundary edges only (edges belonging to exactly 1 face): clean track lines without interior mesh tessellation
+- **Landmarks:** Fill faces + boundary edge outline, both using the district colour resolved from the landmark's world CET position via `classify_district()`. Alpha 200/255 for fill, 240/255 for outline, matching building visual style. Each landmark's colour is looked up at render time so it blends with the surrounding district rather than being visually distinct
+- **Water:** Excluded: world-scale flat plane floods the entire canvas
+- **Terrain/Cliffs:** Excluded: terrain is too large and obscures the map at 2D projection scale; `3dmap_cliffs.glb` in particular overwhelms the Dogtown/Badlands border area
 
 ### 5a. Landmark Mesh Transforms
 
@@ -215,13 +215,13 @@ World extent constants were derived by inverting the existing `cetToLeaflet` for
 | File | Description | Size |
 |------|-------------|------|
 | `scripts/output/combined_8k.png` | Z-sorted composite: roads + metro + buildings + landmarks + borders | ~large |
-| `scripts/output/combined.svg` | Z-sorted combined SVG — all categories, cross-category depth correct | ~17 MB |
+| `scripts/output/combined.svg` | Z-sorted combined SVG: all categories, cross-category depth correct | ~17 MB |
 | `scripts/output/buildings.svg` | Building footprints by district; Z-sorted within each `<g>` | ~large |
 | `scripts/output/roads.svg` | Road surface fills; Z-sorted within file | ~3.6 MB |
 | `scripts/output/metro.svg` | Metro track boundary edges; Z-sorted within file | ~0.9 MB |
 | `scripts/output/landmarks.svg` | Landmark fills and outlines as `<g id="label">` / `<g id="label_outline">`; Z-sorted within each group | ~5.5 MB |
 | `scripts/output/district_borders.svg` | District boundary outlines from trigger polygons | ~6 KB |
-| `data/buildings.json` | Building polygons by district; each polygon: `{"z": float, "pts": [[lat,lng],...]}` — **gitignored, no longer used by the Three.js 3D view** | ~13 MB |
+| `data/buildings.json` | Building polygons by district; each polygon: `{"z": float, "pts": [[lat,lng],...]}`: **gitignored, no longer used by the Three.js 3D view** | ~13 MB |
 | `data/roads.json` | Road face polygons; each entry: `{"z": float, "pts": [[lat,lng],...]}` | ~3.7 MB |
 | `data/metro.json` | Metro edge segments; each entry: `{"z": float, "pts": [[lat,lng],[lat,lng]]}` | ~0.7 MB |
 | `data/landmarks.json` | `{label: {"faces": [{"z":,"pts":},...], "edges": [{"z":,"pts":},...}]}}` | ~5.0 MB |
@@ -229,7 +229,7 @@ World extent constants were derived by inverting the existing `cetToLeaflet` for
 
 ### Output Statistics (as of 2026-04-01)
 
-- **255,220** total building instances decoded across 8 district textures (no area filter — all instances extracted)
+- **255,220** total building instances decoded across 8 district textures (no area filter: all instances extracted)
 - **236,010** classified into districts, **19,210** classified as badlands
 - All buildings include `hz` (height half-extent) for shadow/extrusion rendering
 - **8** landmark meshes with names and district classification
@@ -245,7 +245,7 @@ Terrain and satellite base layers are delivered as WebP `L.imageOverlay` files (
 | `assets/img/terrain_8k.webp` | 290 KB | Schematic terrain, neutral dark grey |
 | `assets/img/satellite_8k.webp` | 9.6 MB | Satellite photograph, RGBA with transparency |
 
-Overlay data (roads, buildings, metro, landmarks) is rendered via a canvas-based `L.GridLayer` (`overlay.js`) with unified z-sorted drawing and grid-based spatial index. (Note: this section describes the legacy 2D overlay; the current schema view uses the live Three.js scene — see [`three-js-scene.md`](three-js-scene.md).)
+Overlay data (roads, buildings, metro, landmarks) is rendered via a canvas-based `L.GridLayer` (`overlay.js`) with unified z-sorted drawing and grid-based spatial index. (Note: this section describes the legacy 2D overlay; the current schema view uses the live Three.js scene, see [`three-js-scene.md`](three-js-scene.md).)
 
 ## District Colours (from game Ink styles)
 

--- a/docs/nczoning-auto-discovery.md
+++ b/docs/nczoning-auto-discovery.md
@@ -8,14 +8,14 @@ The map can automatically discover and display your mod without a GitHub submiss
 
 ## What the API Reads from Your Mod Page
 
-When your mod is discovered, the map reads these fields from the Nexus V2 GraphQL API — no authentication required, all public data:
+When your mod is discovered, the map reads these fields from the Nexus V2 GraphQL API (no authentication required, all public data):
 
 | Nexus field | Used as | Notes |
 | --- | --- | --- |
 | `modId` | Nexus mod ID / URL | Used to build `nexusmods.com/cyberpunk2077/mods/<id>` link |
 | `name` | Mod display name | Shown in popup title and sidebar |
 | `summary` | Popup description | Shown as the description text; truncated to 500 chars if longer |
-| `description` | Metadata source | Full BBCode body — only used to extract the `[NCZoning]` block, then discarded |
+| `description` | Metadata source | Full BBCode body; only used to extract the `[NCZoning]` block, then discarded |
 | `uploader.name` | First author | Always prepended to the author list; additional authors come from `authors=` in the block |
 | `thumbnailUrl` | Thumbnail image | Displayed in the popup and sidebar entry |
 | `updatedAt` | Recently Updated badge | If within the last `NCZ.RECENTLY_UPDATED_DAYS` days, an `UPDATED` badge is shown on the pin popup, sidebar entry, and cluster flyout |
@@ -26,21 +26,21 @@ When your mod is discovered, the map reads these fields from the Nexus V2 GraphQ
 
 ## How It Works
 
-When the map loads, it queries the Nexus Mods API for all Cyberpunk 2077 mods tagged with **NCZoning**. For each result it finds, it looks for a `[NCZoning]` metadata block inside the mod description. If a valid block is found, the mod is automatically added to the map as a live pin — no GitHub account or pull request required.
+When the map loads, it queries the Nexus Mods API for all Cyberpunk 2077 mods tagged with **NCZoning**. For each result it finds, it looks for a `[NCZoning]` metadata block inside the mod description. If a valid block is found, the mod is automatically added to the map as a live pin, with no GitHub account or pull request required.
 
 Auto-discovered pins are identical to manually submitted ones, with a small amber **[ N ]** badge in the popup title and sidebar entry (tooltip: "Sourced automatically from Nexus Mods"). They are also automatically tagged with **nczoning**, which appears as a tag badge on their popup and can be used in the tag filter to show only auto-discovered mods. If the mod was updated on Nexus within the last `NCZ.RECENTLY_UPDATED_DAYS` days, an additional **UPDATED** badge is shown alongside the title.
 
 ---
 
-## Step 1 — Tag Your Mod on Nexus
+## Step 1: Tag Your Mod on Nexus
 
 On your mod's Nexus page, go to **Tags** and add the tag: **NCZoning**
 
 ---
 
-## Step 2 — Add the Metadata Block
+## Step 2: Add the Metadata Block
 
-Paste the following block into your mod description. The easiest way to generate it is to use the **[+] Submit** button on the map itself — it builds the block from a form and copies it to your clipboard.
+Paste the following block into your mod description. The easiest way to generate it is to use the **[+] Submit** button on the map itself: it builds the block from a form and copies it to your clipboard.
 
 ### Block format
 
@@ -73,22 +73,22 @@ yaw=180.0
 
 | Field | Required | Format | Notes |
 |---|---|---|---|
-| `coords` | Yes | `X,Y,Z` | CET float values (X=east/west, Y=north/south, Z=height/elevation) — see [Getting Coordinates](#getting-coordinates) |
+| `coords` | Yes | `X,Y,Z` | CET float values (X=east/west, Y=north/south, Z=height/elevation); see [Getting Coordinates](#getting-coordinates) |
 | `category` | Yes | enum | `location-overhaul`, `new-location`, or `other` |
 | `yaw` | No | degrees | Player facing direction in degrees from CET output |
-| `tags` | No | comma-separated | Must match tags from the [Tag Registry](tags.md) — unknown tags are silently ignored |
-| `credits` | No | free text | Optional — team name or secondary acknowledgments |
+| `tags` | No | comma-separated | Must match tags from the [Tag Registry](tags.md); unknown tags are silently ignored |
+| `credits` | No | free text | Optional: team name or secondary acknowledgements |
 | `authors` | No | comma-separated names | Additional authors beyond the Nexus uploader |
 
 The Nexus uploader is always included as the first author automatically. Use `authors=` only for co-authors.
 
 ### Parsing rules
 
-- The parser finds the `NCZoning:` marker (it can sit inline — even glued to the end of a sentence) and reads the `key=value` lines that follow it; if `NCZoning:` also appears in your prose, the real block is still found as long as its `coords`/`category` are valid
-- `coords` and `category` are required — mods missing either are skipped entirely
-- `coords` accepts either 2 values (`X,Y` — legacy format) or 3 values (`X,Y,Z` — new format). For new submissions, Z is required
+- The parser finds the `NCZoning:` marker (it can sit inline, even glued to the end of a sentence) and reads the `key=value` lines that follow it; if `NCZoning:` also appears in your prose, the real block is still found as long as its `coords`/`category` are valid
+- `coords` and `category` are required; mods missing either are skipped entirely
+- `coords` accepts either 2 values (`X,Y`, legacy format) or 3 values (`X,Y,Z`, new format). For new submissions, Z is required
 - `tags` that don't exist in the tag registry are silently dropped (the mod still appears)
-- All BBCode formatting is stripped before parsing, so the block still works if it loses its `[code]` wrapper or picks up stray styling (`[spoiler]`, `[size]`, `[font]`, `[color]`) — e.g. from a copy-paste round-trip. The `[code]` wrapper is still recommended for readability; the generator emits it
+- All BBCode formatting is stripped before parsing, so the block still works if it loses its `[code]` wrapper or picks up stray styling (`[spoiler]`, `[size]`, `[font]`, `[color]`), e.g. from a copy-paste round-trip. The `[code]` wrapper is still recommended for readability; the generator emits it
 
 ### Transition Note
 
@@ -101,7 +101,7 @@ The old `coords=X,Y` format (2 values) remains valid for existing mod descriptio
 1. Stand at the location in-game
 2. Open the CET console (`~`)
 3. Run: `local p,r = GetPlayer():GetWorldPosition(), GetPlayer():GetWorldOrientation():ToEulerAngles(); print(string.format("x=%.4f  y=%.4f  z=%.4f  yaw=%.4f", p.x, p.y, p.z, r.yaw))`
-4. Use the **X**, **Y**, **Z**, and **Yaw** values from the output — do not swap X and Y
+4. Use the **X**, **Y**, **Z**, and **Yaw** values from the output; do not swap X and Y
 
 See [Coordinate System](coordinate-system.md) for more detail and alternative tools like Simple Location Manager.
 
@@ -109,7 +109,7 @@ See [Coordinate System](coordinate-system.md) for more detail and alternative to
 
 ## Editing Your Entry
 
-To update your mod's map data, edit the `[NCZoning]` block in your Nexus description and save. The map fetches live on every page load — your changes will be reflected within a few minutes.
+To update your mod's map data, edit the `[NCZoning]` block in your Nexus description and save. The map fetches live on every page load, so your changes will be reflected within a few minutes.
 
 There is no "Suggest Edit" button for auto-discovered mods. All edits go through the Nexus description directly.
 
@@ -124,7 +124,7 @@ To remove your mod from the map:
 1. Remove the `[NCZoning]` block from your Nexus description, **or**
 2. Remove the **NCZoning** tag from your mod on Nexus
 
-Either action will cause the mod to be skipped on the next page load. There is nothing to delete from the repository — auto-discovered entries are never committed.
+Either action will cause the mod to be skipped on the next page load. There is nothing to delete from the repository; auto-discovered entries are never committed.
 
 ---
 
@@ -140,22 +140,22 @@ This means maintainers can always override an auto-discovered pin with a correct
 
 ## Limitations
 
-- The **Suggest Edit** button is not shown for auto-discovered mods — to correct the data, update the `[NCZoning]` block in your Nexus description directly
-- Auto-discovered pins are not stored in the repository — they are fetched fresh on every page load
+- The **Suggest Edit** button is not shown for auto-discovered mods; to correct the data, update the `[NCZoning]` block in your Nexus description directly
+- Auto-discovered pins are not stored in the repository; they are fetched fresh on every page load
 - Description text shown in the popup comes from your Nexus mod **summary** field (max 500 characters), not the `[NCZoning]` block
-- The `nczoning` tag is applied automatically and is not part of `data/tags.json` — it cannot be added to manually submitted entries
+- The `nczoning` tag is applied automatically and is not part of `data/tags.json`; it cannot be added to manually submitted entries
 
 ---
 
 ## Misuse Policy
 
-The **NCZoning** tag is provided by the Nexus Mods team specifically for this system. Maintainers reserve the right to request removal of the tag from mods that misuse it — including mods using the tag with incorrect or misleading coordinates, mods unrelated to Cyberpunk 2077 location content, or any use intended to spam or pollute the map.
+The **NCZoning** tag is provided by the Nexus Mods team specifically for this system. Maintainers reserve the right to request removal of the tag from mods that misuse it, including mods using the tag with incorrect or misleading coordinates, mods unrelated to Cyberpunk 2077 location content, or any use intended to spam or pollute the map.
 
 ---
 
 ## Exclusion List (maintainers)
 
-Some mods carry the **NCZoning** tag but should not appear on the map — a mistaken tag, or a mod the maintainers judge too minor to register. These can't be handled by a manual entry (we don't *want* them on the map), and a tag we don't control can't simply be removed, so they are listed in `data/excluded_mods.json`:
+Some mods carry the **NCZoning** tag but should not appear on the map: a mistaken tag, or a mod the maintainers judge too minor to register. These can't be handled by a manual entry (we don't *want* them on the map), and a tag we don't control can't simply be removed, so they are listed in `data/excluded_mods.json`:
 
 ```json
 {
@@ -163,12 +163,12 @@ Some mods carry the **NCZoning** tag but should not appear on the map — a mist
 }
 ```
 
-The format is a flat `{ "nexusId": "reason" }` object (same shape as `data/tags.json`). The `reason` is a maintainer note only — it is never shown to users.
+The format is a flat `{ "nexusId": "reason" }` object (same shape as `data/tags.json`). The `reason` is a maintainer note only; it is never shown to users.
 
 An excluded id is honoured in two places:
 
-1. **The Data API merge (`worker/src/merge.js`)** — the mod is never rendered as a pin, *even if its block parses correctly*, and it's kept out of `/v1/meta.skipped`. This is what stops a mistakenly-tagged mod that happens to have valid coordinates from showing up. (The site's client-side fallback in `services.js` honours the same list.)
-2. **Health monitor (`scripts/monitor_auto_discovery.js`)** — reads `/v1/meta.skipped`, which the API has already filtered, so an excluded mod is never flagged. Without the exclusion an intentionally-excluded mod with no block would be reported every day.
+1. **The Data API merge (`worker/src/merge.js`)**: the mod is never rendered as a pin, *even if its block parses correctly*, and it's kept out of `/v1/meta.skipped`. This is what stops a mistakenly-tagged mod that happens to have valid coordinates from showing up. (The site's client-side fallback in `services.js` honours the same list.)
+2. **Health monitor (`scripts/monitor_auto_discovery.js`)**: reads `/v1/meta.skipped`, which the API has already filtered, so an excluded mod is never flagged. Without the exclusion an intentionally-excluded mod with no block would be reported every day.
 
 To exclude a mod, add its Nexus id and a short reason to `data/excluded_mods.json` and open a PR. To re-include it later, delete the entry.
 
@@ -178,9 +178,9 @@ To exclude a mod, add its Nexus id and a short reason to `data/excluded_mods.jso
 
 The map includes a built-in generator to make adding the block easier. Click **[+] Submit** in the map header (or the **Submit a New Mod Location** button in the sidebar) to open the generator. The modal walks you through four steps:
 
-1. **Acquire Coordinates** — get your CET X/Y values in-game
-2. **Configure Metadata** — fill out the form (category, tags, credits, authors) and click **Generate Block**
-3. **Tag Your Mod** — add the `NCZoning` tag on your Nexus mod page
-4. **Deploy Block** — copy the output and paste it into your Nexus mod description
+1. **Acquire Coordinates**: get your CET X/Y values in-game
+2. **Configure Metadata**: fill out the form (category, tags, credits, authors) and click **Generate Block**
+3. **Tag Your Mod**: add the `NCZoning` tag on your Nexus mod page
+4. **Deploy Block**: copy the output and paste it into your Nexus mod description
 
 The block can be placed anywhere in your description. A common spot is at the bottom. Use the **spoiler wrap** option to keep it hidden from casual readers.

--- a/docs/nexus-api-reference.md
+++ b/docs/nexus-api-reference.md
@@ -16,15 +16,15 @@ The V2 API is not officially supported by Nexus Mods. Per direct conversation wi
 
 **Rate Limits:** No rate limits are publicly documented for V2 GraphQL, and none have been encountered in practice. For scale: the REST API's documented limits are **20,000 requests/day + 500 requests/hour**. Our 5-minute cron makes ~8 Nexus requests/run → ~96/hour (~2,300/day), comfortably under either figure.
 
-### Nexus API v3 (REST) — reviewed 2026-07-05, NOT a replacement for our discovery
+### Nexus API v3 (REST): reviewed 2026-07-05, NOT a replacement for our discovery
 
-Nexus published an official REST **API v3** (`https://api.nexusmods.com/v3`; OpenAPI at `https://api.nexusmods.com/openapi.yaml`; docs at <https://api-docs.nexusmods.com/>). It requires authentication (API key or OAuth JWT) and has a real stability + deprecation policy (stable endpoints get a 90-day notice). **But it does not replace what we depend on.** v3 is a mod *publishing / management* API — uploads, mod-files, versions, collections. Its only read operations are `getMod` / `getModsBatch` (by id) and `getTrendingMods`; there is **no "mods by tag" or mod-search endpoint**, and the spec surfaces no mod image/description fields. Our auto-discovery ("find every mod tagged `NCZoning`") exists **only** in V2 GraphQL, so V2 stays required and there is no v3 migration path for it today.
+Nexus published an official REST **API v3** (`https://api.nexusmods.com/v3`; OpenAPI at `https://api.nexusmods.com/openapi.yaml`; docs at <https://api-docs.nexusmods.com/>). It requires authentication (API key or OAuth JWT) and has a real stability + deprecation policy (stable endpoints get a 90-day notice). **But it does not replace what we depend on.** v3 is a mod *publishing / management* API: uploads, mod-files, versions, collections. Its only read operations are `getMod` / `getModsBatch` (by id) and `getTrendingMods`; there is **no "mods by tag" or mod-search endpoint**, and the spec surfaces no mod image/description fields. Our auto-discovery ("find every mod tagged `NCZoning`") exists **only** in V2 GraphQL, so V2 stays required and there is no v3 migration path for it today.
 
-**Watch for:** (a) v3 gaining a mods-by-tag / search endpoint → a migration becomes possible; or (b) a V2 GraphQL retirement announcement → we'd need a new discovery mechanism (e.g. author self-registration), since v3 can't do tag discovery. Note: if we ever adopt v3, its API key must live **server-side** in the Worker cron (it can't go in the browser) — which the B7 server-side move already accommodates.
+**Watch for:** (a) v3 gaining a mods-by-tag / search endpoint → a migration becomes possible; or (b) a V2 GraphQL retirement announcement → we'd need a new discovery mechanism (e.g. author self-registration), since v3 can't do tag discovery. Note: if we ever adopt v3, its API key must live **server-side** in the Worker cron (it can't go in the browser), which the B7 server-side move already accommodates.
 
 ## Queries Used
 
-### 1. `modsByUid` — Thumbnail Fetch for Manual Mods
+### 1. `modsByUid`: Thumbnail Fetch for Manual Mods
 
 **Purpose:** Fetches featured images (`pictureUrl`, `thumbnailUrl`) for manually registered mods.
 
@@ -44,8 +44,8 @@ query modsByUid($uids: [ID!]!, $count: Int!) {
 ```
 
 **Input Variables:**
-- `uids` — Array of composite Nexus UIDs (see UID Construction below)
-- `count` — **Must equal the number of UIDs requested** ⚠️
+- `uids`: Array of composite Nexus UIDs (see UID Construction below)
+- `count`: **Must equal the number of UIDs requested** ⚠️
 
 **UID Construction:**
 
@@ -60,10 +60,10 @@ toNexusUid(modId) {
 Where `3333` is the game ID for Cyberpunk 2077.
 
 **Output Fields per Node:**
-- `modId` — The numeric Nexus mod ID
-- `pictureUrl` — URL to the featured image (full resolution)
-- `thumbnailUrl` — URL to a thumbnail version of the featured image
-- `updatedAt` — ISO 8601 timestamp of the mod's last update on Nexus; used to drive the recently-updated badge
+- `modId`: The numeric Nexus mod ID
+- `pictureUrl`: URL to the featured image (full resolution)
+- `thumbnailUrl`: URL to a thumbnail version of the featured image
+- `updatedAt`: ISO 8601 timestamp of the mod's last update on Nexus; used to drive the recently-updated badge
 
 **Pagination:** Chunked into batches of `NCZ.NEXUS_BATCH_SIZE` (50), dispatched in parallel via `Promise.all`. Single large requests are silently truncated by the API even when `count` is set correctly (see Silent Result Cap below).
 
@@ -72,20 +72,20 @@ Where `3333` is the game ID for Cyberpunk 2077.
 The Nexus API silently truncates `modsByUid` responses for large batches:
 
 - **Fixed 2026-03-13:** If the `count` variable is omitted, only the first 20 results are returned regardless of UID count. Mitigation: always pass `count: validIds.length`.
-- **Fixed 2026-05-04:** Even with `count` set correctly, batches of ~250 UIDs return only a partial subset of nodes — manifesting as missing pin thumbnails on first page load that "self-heal" on subsequent reloads (incremental cache fills the gaps as each retry sends a smaller batch). Mitigation: chunk into 50-UID batches before dispatch. Live testing showed *residual* per-UID flakiness even at chunk sizes well below 50, so each chunk also gets a single in-flight retry of just the dropped UIDs before the result is returned. Two warnings are logged for visibility:
-  - `Thumbnails: chunk dropped X/Y UIDs (...); retrying` — first attempt dropped some UIDs; will be retried automatically.
-  - `Thumbnails: N UIDs still missing after retry (...); likely deleted or hidden on Nexus` — both attempts failed for these UIDs. Persistent appearance of the same UIDs across reloads indicates a stale `nexus_id` in `data/locations/*.json` (mod hidden or deleted).
+- **Fixed 2026-05-04:** Even with `count` set correctly, batches of ~250 UIDs return only a partial subset of nodes, manifesting as missing pin thumbnails on first page load that "self-heal" on subsequent reloads (incremental cache fills the gaps as each retry sends a smaller batch). Mitigation: chunk into 50-UID batches before dispatch. Live testing showed *residual* per-UID flakiness even at chunk sizes well below 50, so each chunk also gets a single in-flight retry of just the dropped UIDs before the result is returned. Two warnings are logged for visibility:
+  - `Thumbnails: chunk dropped X/Y UIDs (...); retrying`: first attempt dropped some UIDs; will be retried automatically.
+  - `Thumbnails: N UIDs still missing after retry (...); likely deleted or hidden on Nexus`: both attempts failed for these UIDs. Persistent appearance of the same UIDs across reloads indicates a stale `nexus_id` in `data/locations/*.json` (mod hidden or deleted).
 
 **Caching:**
 - Cache key: `nc_nexus_thumbs`
 - TTL: 24 hours
-- Strategy: Incremental — checks which IDs are cached, fetches only missing ones, merges result with existing cache before re-saving
+- Strategy: Incremental. Checks which IDs are cached, fetches only missing ones, merges result with existing cache before re-saving
 
 **Implementation:** [`fetchNexusThumbnails()` in services.js](../assets/js/services.js)
 
 ---
 
-### 2. `NCZoningMods` (`mods`) — Auto-Discovery Query
+### 2. `NCZoningMods` (`mods`): Auto-Discovery Query
 
 **Purpose:** Finds all mods on Nexus Mods for Cyberpunk 2077 that have been tagged `NCZoning` by their authors. These mods' descriptions are parsed for an `[NCZoning]` metadata block.
 
@@ -112,21 +112,21 @@ query NCZoningMods($filter: ModsFilter!, $count: Int!, $offset: Int!) {
 ```
 
 **Input Variables:**
-- `filter.gameId` — `[{ value: "3333" }]` (Cyberpunk 2077)
-- `filter.tag` — `[{ value: "NCZoning" }]`
-- `count` — Results per page (see Pagination below)
-- `offset` — Current page offset
+- `filter.gameId`: `[{ value: "3333" }]` (Cyberpunk 2077)
+- `filter.tag`: `[{ value: "NCZoning" }]`
+- `count`: Results per page (see Pagination below)
+- `offset`: Current page offset
 
 **Output Fields per Node:**
-- `modId` — Numeric Nexus mod ID
-- `name` — Mod title
-- `summary` — Short description; used as the pin popup description (truncated to 500 chars)
-- `description` — Full mod description; parsed for `[NCZoning]` metadata block
-- `pictureUrl` — Featured image URL (full resolution)
-- `thumbnailUrl` — Featured image thumbnail URL
-- `updatedAt` — ISO 8601 timestamp of the mod's last update on Nexus; used to drive the recently-updated badge
-- `uploader.name` — Nexus username of the mod author (used as first author)
-- `totalCount` — Total number of mods matching the filter (used for pagination loop)
+- `modId`: Numeric Nexus mod ID
+- `name`: Mod title
+- `summary`: Short description; used as the pin popup description (truncated to 500 chars)
+- `description`: Full mod description; parsed for `[NCZoning]` metadata block
+- `pictureUrl`: Featured image URL (full resolution)
+- `thumbnailUrl`: Featured image thumbnail URL
+- `updatedAt`: ISO 8601 timestamp of the mod's last update on Nexus; used to drive the recently-updated badge
+- `uploader.name`: Nexus username of the mod author (used as first author)
+- `totalCount`: Total number of mods matching the filter (used for pagination loop)
 
 **Pagination: Offset-Based (Undocumented)**
 
@@ -152,7 +152,7 @@ The Nexus API does not document pagination for the `mods` query, but it supports
 4. Construct authors array: Nexus uploader name + any additional authors from the block
 5. Truncate `summary` to 500 characters for the popup description
 6. Prepend `"nczoning"` tag automatically (identifies auto-discovered mods in the UI)
-7. Store `updatedAt` as `_updatedAt` on the mod object — if within `NCZ.RECENTLY_UPDATED_DAYS` days, an `UPDATED` badge is shown in the popup, sidebar, and cluster flyout
+7. Store `updatedAt` as `_updatedAt` on the mod object; if within `NCZ.RECENTLY_UPDATED_DAYS` days, an `UPDATED` badge is shown in the popup, sidebar, and cluster flyout
 
 The function returns `{ mods, meta }` where `meta` contains image/timestamp data for manually registered mods that are also NCZoning-tagged. In `app.js`, `meta` is merged into `nexusThumbs` so those manual mods receive their thumbnails and `_updatedAt` without a separate `modsByUid` call. Mods covered by `meta` are excluded from the `modsByUid` batch.
 
@@ -162,15 +162,15 @@ The function returns `{ mods, meta }` where `meta` contains image/timestamp data
 
 ## Image Availability Limitation ⚠️
 
-**Only the featured/header image is available via the public API — for now.**
+**Only the featured/header image is available via the public API, for now.**
 
 Both `modsByUid()` and `mods()` queries return only:
-- `pictureUrl` — the mod's featured image (full resolution)
-- `thumbnailUrl` — a thumbnail-sized version of the same featured image
+- `pictureUrl`: the mod's featured image (full resolution)
+- `thumbnailUrl`: a thumbnail-sized version of the same featured image
 
 **Full mod image galleries are NOT currently accessible** without authenticated/private API access.
 
-This limitation has been **confirmed directly with Nexus Mods staff (Pickysaurus)**. Per Pickysaurus, featured image only is a "for now" limitation — full mod image galleries may be added to the public API in the future.
+This limitation has been **confirmed directly with Nexus Mods staff (Pickysaurus)**. Per Pickysaurus, featured image only is a "for now" limitation: full mod image galleries may be added to the public API in the future.
 
 **Current design implication:** The UI can only display the single featured image per mod from Nexus. Manual mod entries can link to external image galleries in their `description` field or credits if needed.
 
@@ -182,8 +182,8 @@ Both API calls use browser `localStorage` for caching via `cacheGet()`/`cacheSet
 
 | Cache Key | TTL | What's Stored | Merge Strategy |
 |---|---|---|---|
-| `nc_nexus_thumbs` | 24 hours | Map of `nexus_id → { pictureUrl, thumbnailUrl }` | Incremental — only missing IDs fetched |
-| `nc_nexus_autodiscovery` | 10 minutes | `{ mods: [...], meta: { nexusId → { pictureUrl, thumbnailUrl, updatedAt } } }` | Full replacement — re-filtered on read; backwards-compatible with old array format |
+| `nc_nexus_thumbs` | 24 hours | Map of `nexus_id → { pictureUrl, thumbnailUrl }` | Incremental, only missing IDs fetched |
+| `nc_nexus_autodiscovery` | 10 minutes | `{ mods: [...], meta: { nexusId → { pictureUrl, thumbnailUrl, updatedAt } } }` | Full replacement, re-filtered on read; backwards-compatible with old array format |
 
 ### Cache Envelope
 
@@ -214,7 +214,7 @@ On read, `Date.now() - ts > ttl` determines expiry.
 ## Known Risks & Future Considerations
 
 1. **API Retirement Risk:** V2 is unsupported. Monitor for Nexus announcements of REST migration.
-2. **Undocumented Pagination:** The `mods` query's offset-based pagination is not documented. Page size and behavior may change without notice.
+2. **Undocumented Pagination:** The `mods` query's offset-based pagination is not documented. Page size and behaviour may change without notice.
 3. **No Retry Logic:** Transient network failures don't trigger retries; silent partial results are returned.
 4. **Image URLs:** If Nexus changes URL formats or removes images, thumbnails will break without warning.
 5. **Image Galleries (Future):** Full mod image galleries may be added to the public API in the future (per Pickysaurus). When that happens, the thumbnail fetch and auto-discovery queries should be revisited to consider caching and displaying gallery images.

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -14,10 +14,10 @@ Reviewers are coordinated through the **[Locations Hub Discord](https://discord.
 
 ### Discord Notification Statuses
 
-The notification in Discord will update its color and status automatically:
+The notification in Discord will update its colour and status automatically:
 
 - ⏳ **Awaiting review** (Yellow): Initial submission, needs a human eye.
-- ✅ **Approved — pin is now live!** (Green): PR merged successfully.
+- ✅ **Approved: pin is now live!** (Green): PR merged successfully.
 - ❌ **Closed without merging** (Red): PR was closed or rejected.
 
 ---

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,7 @@ The NC Zoning Board is an interactive map and coordinate registry for Cyberpunk 
 ### What Works
 
 - ✅ 16k WebP tiled map with zoom levels 0–8 (native to 6, upscaled to 8)
-- ✅ Transparent map background — tiles regenerated from source
+- ✅ Transparent map background: tiles regenerated from source
 - ✅ CET coordinate transform (16-point calibrated, linear, accurate)
 - ✅ Mod pins with clickable popups (name, authors, description, Nexus link)
 - ✅ Cyberpunk-themed UI (Orbitron/Rajdhani fonts, dark theme)
@@ -15,52 +15,52 @@ The NC Zoning Board is an interactive map and coordinate registry for Cyberpunk 
 - ✅ Automated mod submission via GitHub Issue form → PR pipeline
 - ✅ Cloudflare Pages deployment
 - ✅ Tile generation script (`scripts/generate_tiles.js`)
-- ✅ **Data refactor** — split `mods.json` into individual JSON files for cleaner management
-- ✅ **Custom pin icons** — colour-coded by mod category
-- ✅ **Tagging system** — dynamic filters with hover tooltips and definitions
-- ✅ **Multi-author & credits** — support for authorship arrays and team credits
-- ✅ **URL optimisation** — store only the Nexus mod ID and generate links dynamically
-- ✅ **Image support** — dynamically fetching thumbnails and full-size images from the Nexus GraphQL API
-- ✅ **Pin clustering** — group nearby pins at low zoom, with 4-tier colour thresholds and inlined MarkerCluster CSS
-- ✅ **Cluster menu panel** — clicking a cluster opens a resizable side panel listing all mods with thumbnails, tags, and descriptions
-- ✅ **Marker tooltips** — hovering a pin shows a smart-positioned tooltip with the mod name
-- ✅ **Dynamic popup positioning** — popups stay within map bounds with directional arrows
-- ✅ **NCZoning auto-discovery** — automatic pin creation from Nexus-tagged mods via GraphQL API, with BBCode generator modal
-- ✅ **Mod update indicator** — API-driven badge for recently updated mods (within 7 days)
-- ✅ **Preferences menu** — in-app theme selection (Night Corp, Arasaka, Militech, Aldecaldos)
-- ✅ **Sort by last updated** — locations list sortable by most recently updated
-- ✅ **Discover a location button** — quick-jump UI to find a random or nearby pin
-- ✅ **Progressive cluster colours** — smooth colour gradients across cluster size tiers
-- ✅ **Less restrictive map panning** — map edge allows movement up to halfway across the screen
-- ✅ **Nexus API documentation** — full reference for queries, fields, caching, and known limitations
-- ✅ **Deep links to mod pins** — URL param (e.g. `?mod=13821`) jumps directly to a pin on the map; Copy Link button copies shareable URLs
+- ✅ **Data refactor**: split `mods.json` into individual JSON files for cleaner management
+- ✅ **Custom pin icons**: colour-coded by mod category
+- ✅ **Tagging system**: dynamic filters with hover tooltips and definitions
+- ✅ **Multi-author & credits**: support for authorship arrays and team credits
+- ✅ **URL optimisation**: store only the Nexus mod ID and generate links dynamically
+- ✅ **Image support**: dynamically fetching thumbnails and full-size images from the Nexus GraphQL API
+- ✅ **Pin clustering**: group nearby pins at low zoom, with 4-tier colour thresholds and inlined MarkerCluster CSS
+- ✅ **Cluster menu panel**: clicking a cluster opens a resizable side panel listing all mods with thumbnails, tags, and descriptions
+- ✅ **Marker tooltips**: hovering a pin shows a smart-positioned tooltip with the mod name
+- ✅ **Dynamic popup positioning**: popups stay within map bounds with directional arrows
+- ✅ **NCZoning auto-discovery**: automatic pin creation from Nexus-tagged mods via GraphQL API, with BBCode generator modal
+- ✅ **Mod update indicator**: API-driven badge for recently updated mods (within 7 days)
+- ✅ **Preferences menu**: in-app theme selection (Night Corp, Arasaka, Militech, Aldecaldos)
+- ✅ **Sort by last updated**: locations list sortable by most recently updated
+- ✅ **Discover a location button**: quick-jump UI to find a random or nearby pin
+- ✅ **Progressive cluster colours**: smooth colour gradients across cluster size tiers
+- ✅ **Less restrictive map panning**: map edge allows movement up to halfway across the screen
+- ✅ **Nexus API documentation**: full reference for queries, fields, caching, and known limitations
+- ✅ **Deep links to mod pins**: URL param (e.g. `?mod=13821`) jumps directly to a pin on the map; Copy Link button copies shareable URLs
 
 ### In Progress
 
-- 🔄 **Building / road / metro overlays** — extracting game geometry and aligning to CET coordinate space
-- 🔄 **District overlays** — district and subdistrict boundary outlines rendered as GeoJSON layers, zoom-switchable
+- 🔄 **Building / road / metro overlays**: extracting game geometry and aligning to CET coordinate space
+- 🔄 **District overlays**: district and subdistrict boundary outlines rendered as GeoJSON layers, zoom-switchable
 
 ## Planned Features
 
 ### Medium Priority
 
-- [ ] **Mobile layout / optimisations** — responsive sidebar and touch-friendly markers
-- [ ] **Sort controls** — ascending/descending toggles and additional sort methods for the locations list
+- [ ] **Mobile layout / optimisations**: responsive sidebar and touch-friendly markers
+- [ ] **Sort controls**: ascending/descending toggles and additional sort methods for the locations list
 
 ### Low Priority / Nice to Have
 
-- [ ] **SLM integration** — button on mod popup to generate a Simple Location Manager export string
-- [ ] **Search handles credits** — location search should match against the credits field as well as name/author
-- [ ] **Unofficial district overlays** — community-recognised areas not in the base game (North/East/South Badlands subdivisions, Rocky Ridge, Casino, Sonora Canyon)
+- [ ] **SLM integration**: button on mod popup to generate a Simple Location Manager export string
+- [ ] **Search handles credits**: location search should match against the credits field as well as name/author
+- [ ] **Unofficial district overlays**: community-recognised areas not in the base game (North/East/South Badlands subdivisions, Rocky Ridge, Casino, Sonora Canyon)
 - [ ] **New theme: Netrunner**
 - [ ] **New theme: Blade Runner**
 - [ ] **New theme: Deus Ex**
-- [ ] **Showcase editor** — GUI tool for creating custom flyover sequences (very low priority)
-- [ ] **Theme editor** — GUI tool for creating and customising themes (very low priority)
-- [ ] **Multiple coordinate sets** — support `coords`, `additional_coords`, `nav_coords` on a single mod entry
+- [ ] **Showcase editor**: GUI tool for creating custom flyover sequences (very low priority)
+- [ ] **Theme editor**: GUI tool for creating and customising themes (very low priority)
+- [ ] **Multiple coordinate sets**: support `coords`, `additional_coords`, `nav_coords` on a single mod entry
 
 ### Blocked
 
-- [ ] **16k tile support** — higher zoom fidelity; blocked pending performance impact assessment
-- [ ] **32k tile support** — dependent on 16k work
-- [ ] **Click-on-map coordinates** — implemented but removed at collaborator request; revisit if consensus changes
+- [ ] **16k tile support**: higher zoom fidelity; blocked pending performance impact assessment
+- [ ] **32k tile support**: dependent on 16k work
+- [ ] **Click-on-map coordinates**: implemented but removed at collaborator request; revisit if consensus changes

--- a/docs/showcase-flyover.md
+++ b/docs/showcase-flyover.md
@@ -1,6 +1,6 @@
 # Showcase Flyover
 
-A cinematic flyover of Night City synced to the in-game radio broadcast *Good Morning Night City*. Implemented as an opt-in module (`flyover.js`) — add or remove the `<script>` tag in `index.html` to include or exclude the feature.
+A cinematic flyover of Night City synced to the in-game radio broadcast *Good Morning Night City*. Implemented as an opt-in module (`flyover.js`): add or remove the `<script>` tag in `index.html` to include or exclude the feature.
 
 ## Activation
 
@@ -8,7 +8,7 @@ Click the **Showcase** button in the 3D scene controls. The browser enters nativ
 
 ## Audio
 
-`assets/audio/GMNC.mp3` — *Good Morning Night City*, a Cyberpunk 2077 radio broadcast (~800 KB, ~57 s). The audio clock (`audio.currentTime`) drives:
+`assets/audio/GMNC.mp3`: *Good Morning Night City*, a Cyberpunk 2077 radio broadcast (~800 KB, ~57 s). The audio clock (`audio.currentTime`) drives:
 
 - Beat-triggered theme transitions
 - Sun position (sunrise → sunset arc)
@@ -29,7 +29,7 @@ Click the **Showcase** button in the 3D scene controls. The browser enters nativ
 | 6 | 34.743 | Westbrook | Approach from east |
 | 7 | 43.377 | Pacifica | Top-down |
 | 8 | 48.077 | Dogtown | Low sweep |
-| 9 | 52.747 | Badlands | Rising, looking east — districts off |
+| 9 | 52.747 | Badlands | Rising, looking east, districts off |
 | 10 | 57.417 | Rocky Ridge | High, city silhouette on the horizon |
 
 Waypoint positions are in GLB space (`X = CET_X`, `Y = elevation`, `Z = -CET_Y`). Edit `FLYOVER_WAYPOINTS` in `flyover.js` to adjust.
@@ -42,7 +42,7 @@ The `FLYOVER_REVEAL_LAYERS` constant at the top of `flyover.js` controls the sta
 
 | Value | Behaviour |
 |-------|-----------|
-| `false` (default) | Roads, metro, and buildings are **on from frame 1** — building shadows visible immediately during the ocean/coastline approach |
+| `false` (default) | Roads, metro, and buildings are **on from frame 1**: building shadows visible immediately during the ocean/coastline approach |
 | `true` | All layers hidden at WP0, staggered back in over 6.9 s (original cinematic reveal) |
 
 Either way, WP0 always applies Night Corp theme. At WP9 (Badlands, city behind camera) districts are turned off. On exit, all overlay checkboxes and the sun slider are restored exactly.
@@ -54,7 +54,7 @@ Either way, WP0 always applies Night Corp theme. At WP9 (Badlands, city behind c
 | +1.5 s | Roads |
 | +3.0 s | Metro |
 | +4.5 s | Buildings |
-| ~~+6.0 s~~ | ~~Districts~~ (omitted — cleaner showcase without boundary lines) |
+| ~~+6.0 s~~ | ~~Districts~~ (omitted: cleaner showcase without boundary lines) |
 
 ## Beat-Driven Theme Visualiser
 
@@ -62,7 +62,7 @@ Either way, WP0 always applies Night Corp theme. At WP9 (Badlands, city behind c
 
 **Night Corp → Militech → Arasaka → Aldecaldos → Synthwave → repeat**
 
-Colors are read directly from CSS custom properties at first use via `readThemeColors(themeId)` — the function temporarily swaps the theme class on `<html>`, reads computed styles, then restores. This means the beat cycle **automatically stays in sync with `theme.css`** — no hardcoded color values, no separate update needed when themes change.
+Colours are read directly from CSS custom properties at first use via `readThemeColors(themeId)`: the function temporarily swaps the theme class on `<html>`, reads computed styles, then restores. This means the beat cycle **automatically stays in sync with `theme.css`**: no hardcoded colour values, no separate update needed when themes change.
 
 Buildings are included in beat transitions (terrain, water, cliffs, roads, metro, and buildings all transition together).
 
@@ -70,7 +70,7 @@ Beat timestamps are defined in `BEAT_TIMESTAMPS_MS` in `flyover.js`. To update t
 
 ## Sun Animation
 
-`updateFlyoverSun(audio.currentTime)` is called every frame. It maps `audio.currentTime / FLYOVER_DURATION_S` to the summer solstice (June 21) sunrise→sunset window at **Morro Bay, CA** (35.37°N, 120.85°W) — Night City's real-world location — via SunCalc.
+`updateFlyoverSun(audio.currentTime)` is called every frame. It maps `audio.currentTime / FLYOVER_DURATION_S` to the summer solstice (June 21) sunrise→sunset window at **Morro Bay, CA** (35.37°N, 120.85°W), Night City's real-world location, via SunCalc.
 
 - Directional light colour: warm orange at the horizon, neutral white overhead
 - Sun sphere: visible orb in the sky, tracks the exact sun direction
@@ -132,9 +132,9 @@ E:\Audio\Cyberpunk 2077\GMNC - District beats.txt
 | `setControlsEnabled(bool)` | Disable OrbitControls during flyover |
 | `renderFrame(camera)` | Render one frame with the perspective camera |
 | `getCanvasElement()` | Size the perspective camera on creation |
-| `captureColors()` | Snapshot material colors before a theme transition (includes buildings) |
+| `captureColors()` | Snapshot material colours before a theme transition (includes buildings) |
 | `transitionMaterials(from, ms)` | Lerp materials to new CSS theme values |
-| `transitionToColors(from, to, ms)` | Lerp materials to explicit colors — beat cycle (includes buildings) |
+| `transitionToColors(from, to, ms)` | Lerp materials to explicit colours: beat cycle (includes buildings) |
 | `setLayerVisibility(name, bool)` | Toggle terrain/water/cliffs/roads/metro/buildings/districts |
 | `getLayerVisibility(name)` | Read current layer visibility (used for state save/restore) |
 | `setSunPosition(az, alt)` | Move directional light + sun sphere |

--- a/docs/skills-and-roles.md
+++ b/docs/skills-and-roles.md
@@ -1,6 +1,6 @@
-# NC Zoning Board — How You Can Help
+# NC Zoning Board: How You Can Help
 
-This is a passion project built by and for the Cyberpunk 2077 modding community. No hierarchy, no job titles, no obligations — just modders helping modders. If you see something interesting and want to help, jump in! No experience required either — we're happy to learn together.
+This is a passion project built by and for the Cyberpunk 2077 modding community. No hierarchy, no job titles, no obligations: just modders helping modders. If you see something interesting and want to help, jump in! No experience required either: we're happy to learn together.
 
 Here are the main areas where help would be awesome:
 
@@ -34,7 +34,7 @@ Depending on what excites you, here are some natural areas where people tend to 
 
 ### 🖥️ Website & UI Work
 
-Like working on interactive web stuff? The frontend is where a lot of the magic happens. We're actively building **district overlays** and **building/road/metro overlays** — extracting game geometry and aligning it to our map coordinate system. You'd use Leaflet.js, vanilla JS/CSS, and maybe some coordinate transforms.
+Like working on interactive web stuff? The frontend is where a lot of the magic happens. We're actively building **district overlays** and **building/road/metro overlays**: extracting game geometry and aligning it to our map coordinate system. You'd use Leaflet.js, vanilla JS/CSS, and maybe some coordinate transforms.
 
 Current active work: **[Spuddeh](https://www.nexusmods.com/profile/Spuddeh/mods?gameId=3333)** is developing overlays and **[Akiway](https://www.nexusmods.com/profile/Akiway/mods?gameId=3333)** leads UI/UX. If you want to collaborate, reach out!
 
@@ -50,7 +50,7 @@ Areas that sometimes need tweaks: submission workflows, CI/CD validation, secret
 
 ### 🎨 Design & Icons
 
-Want to make things look cool? Visual polish, **dark theme refinements**, UI refinements — this is where aesthetics meet functionality.
+Want to make things look cool? Visual polish, **dark theme refinements**, UI refinements: this is where aesthetics meet functionality.
 
 ---
 

--- a/docs/streaming-sector-shapes.md
+++ b/docs/streaming-sector-shapes.md
@@ -6,7 +6,7 @@ How to extract boundary polygons from CP2077 streaming sector files for district
 
 The in-game 3D map entity (`3dmap_view.ent`) only contains trigger polygons for the 8 main city districts and their 16 subdistricts. The Badlands subdistricts (and any other zones not shown on the in-game map) store their boundary data in **streaming sector files** as `worldLocationAreaNode` entries.
 
-These were previously considered too complex to decode because the `AreaShapeOutline.points` field is a placeholder unit square `(-1,-1)` to `(1,1)`. The actual shape data is in a **binary buffer** field — which turns out to have a simple format.
+These were previously considered too complex to decode because the `AreaShapeOutline.points` field is a placeholder unit square `(-1,-1)` to `(1,1)`. The actual shape data is in a **binary buffer** field, which turns out to have a simple format.
 
 ## Finding the Right Sector Files
 
@@ -44,13 +44,13 @@ Each exported `.streamingsector.json` has this structure:
 
 ```
 Data.RootChunk
-├── nodes[]              — Array of world nodes (meshes, triggers, areas, etc.)
-│   └── [i].Data.$type   — Node type (e.g., "worldLocationAreaNode")
-│   └── [i].Data.outline  — Contains the AreaShapeOutline with buffer
-├── nodeData.Data[]      — Array of transform data (position, orientation, scale)
-│   └── [i].NodeIndex    — Maps to the node index in nodes[]
-│   └── [i].Position     — World-space position (Vector4: X, Y, Z, W)
-└── nodeRefs[]           — Node reference strings
+├── nodes[]              - Array of world nodes (meshes, triggers, areas, etc.)
+│   └── [i].Data.$type   - Node type (e.g., "worldLocationAreaNode")
+│   └── [i].Data.outline  - Contains the AreaShapeOutline with buffer
+├── nodeData.Data[]      - Array of transform data (position, orientation, scale)
+│   └── [i].NodeIndex    - Maps to the node index in nodes[]
+│   └── [i].Position     - World-space position (Vector4: X, Y, Z, W)
+└── nodeRefs[]           - Node reference strings
 ```
 
 ## Finding worldLocationAreaNode Entries
@@ -62,7 +62,7 @@ Filter `nodes[]` where `Data.$type == "worldLocationAreaNode"`. Each has:
 | `Data.debugName.$value` | Human-readable name (e.g., `"{laguna_bend}"`) |
 | `Data.notifiers[0].Data.districtID.$value` | TweakDB path (e.g., `"Districts.LagunaBend"`) |
 | `Data.outline.Data.buffer` | Base64-encoded binary polygon data |
-| `Data.outline.Data.points` | **Placeholder only** — always a unit square, ignore this |
+| `Data.outline.Data.points` | **Placeholder only**: always a unit square, ignore this |
 
 The node's world position comes from `nodeData.Data[]` where `NodeIndex` matches the node's index in the `nodes[]` array.
 
@@ -79,10 +79,10 @@ Offset  Size    Type        Description
 ```
 
 Each point is 4 little-endian float32 values:
-- **x** — local X coordinate
-- **y** — local Y coordinate
-- **z** — local Z coordinate (usually constant for a flat boundary; can be used for height)
-- **w** — always 1.0
+- **x**: local X coordinate
+- **y**: local Y coordinate
+- **z**: local Z coordinate (usually constant for a flat boundary; can be used for height)
+- **w**: always 1.0
 
 **To get CET world coordinates**, apply the node's `Orientation` quaternion (yaw rotation) then add the world `Position` from `nodeData`:
 
@@ -98,7 +98,7 @@ CET_Y = rotated_y + nodeData.Position.Y
 
 Most nodes have identity rotation (`r=1, k=0` → yaw=0°), but some like SoCal Border Crossing have significant rotation (-37.6°).
 
-The trailing 4 bytes after the point data are a float32 representing the **boundary volume height** — how tall the trigger area extends vertically. Areas with more elevation variation have larger values (Laguna Bend: 895, Jackson Plains: 463, SoCal: 43). Not needed for 2D map rendering.
+The trailing 4 bytes after the point data are a float32 representing the **boundary volume height**: how tall the trigger area extends vertically. Areas with more elevation variation have larger values (Laguna Bend: 895, Jackson Plains: 463, SoCal: 43). Not needed for 2D map rendering.
 
 ### Rotation Data
 
@@ -294,7 +294,7 @@ These were also found in the sectors but are nomad lifepath start areas, not geo
 
 ## Overlap Issues & Clipping
 
-The `worldLocationAreaNode` polygons are **3D trigger volumes** — they detect when the player enters a zone to update the HUD district name. They were never designed to be rendered as non-overlapping 2D map regions. As a result:
+The `worldLocationAreaNode` polygons are **3D trigger volumes**: they detect when the player enters a zone to update the HUD district name. They were never designed to be rendered as non-overlapping 2D map regions. As a result:
 
 1. **Badlands subdistricts overlap city districts.** Red Peaks, Rocky Ridge, Jackson Plains, Biotechnica Flats, and North Sunrise Oil Field all have edges that cross into city district territory (1-3% overlap each).
 
@@ -319,7 +319,7 @@ for sub in badlands_subdistricts:
     sub["polygon"] = extract_coords(clipped)
 ```
 
-**Pass 2: Resolve inter-subdistrict overlaps.** Process subdistricts in order of area, smallest first. Each subdistrict subtracts all previously processed shapes. This gives priority to smaller, more specific zones — SoCal Border Crossing (tiny) won't get consumed by the much larger Jackson Plains or Rattlesnake Creek.
+**Pass 2: Resolve inter-subdistrict overlaps.** Process subdistricts in order of area, smallest first. Each subdistrict subtracts all previously processed shapes. This gives priority to smaller, more specific zones: SoCal Border Crossing (tiny) won't get consumed by the much larger Jackson Plains or Rattlesnake Creek.
 
 ```python
 # Sort indices by area (smallest first = highest priority)
@@ -337,23 +337,23 @@ for idx in indexed:
 
 ### Pass 3: Gap filling between Badlands subdistricts
 
-After Passes 1 and 2, small geometric voids remain between adjacent Badlands subdistricts. These occur because the original trigger volumes were authored independently — their edges meet at single vertices, not shared lines, leaving slivers of unclaimed space that are visually obvious as dark voids in the rendered map.
+After Passes 1 and 2, small geometric voids remain between adjacent Badlands subdistricts. These occur because the original trigger volumes were authored independently: their edges meet at single vertices, not shared lines, leaving slivers of unclaimed space that are visually obvious as dark voids in the rendered map.
 
 **Detection method:** Buffer the union of all Badlands subdistricts by a small amount (50 CET units), subtract the original union and all city districts, keep only pieces smaller than 200,000 sq units. The large open wasteland area always appears as a single large piece and is excluded by this size filter.
 
-**Why `distance() == 0` is misleading:** Shapely's `distance()` returns 0 if two polygons share even a single vertex. Two polygons can share one point and still have a triangular gap between them — they are topologically touching but not edge-sharing.
+**Why `distance() == 0` is misleading:** Shapely's `distance()` returns 0 if two polygons share even a single vertex. Two polygons can share one point and still have a triangular gap between them: they are topologically touching but not edge-sharing.
 
-**Assignment rule:** Single-neighbor gaps are merged directly into that neighbor. Multi-neighbor gaps are split using a centroid-distance priority rule — each neighbor claims the portion of the gap closer to it than to any other neighbor.
+**Assignment rule:** Single-neighbour gaps are merged directly into that neighbour. Multi-neighbour gaps are split using a centroid-distance priority rule: each neighbour claims the portion of the gap closer to it than to any other neighbour.
 
 **Results of Pass 3:**
 
 | Gap | Area (sq) | Resolution |
 |-----|-----------|------------|
 | Biotechnica Flats general gaps | 31,164 + 502 | Merged into Biotechnica Flats |
-| Sierra Sonora / Rocky Ridge / Vasquez Pass / Laguna Bend triangle | 6,609 | Split between 4 neighbors |
+| Sierra Sonora / Rocky Ridge / Vasquez Pass / Laguna Bend triangle | 6,609 | Split between 4 neighbours |
 | Red Peaks south edge (borders Rancho Coronado) | 4,706 | Merged into Red Peaks |
-| Red Peaks / Rocky Ridge junction | 108 | Split between 2 neighbors |
-| Jackson Plains / Biotechnica / Rattlesnake Creek junction | 16 | Split between 3 neighbors |
+| Red Peaks / Rocky Ridge junction | 108 | Split between 2 neighbours |
+| Jackson Plains / Biotechnica / Rattlesnake Creek junction | 16 | Split between 3 neighbours |
 
 ### Known unfixable gaps
 
@@ -361,33 +361,33 @@ Two gaps cannot be resolved without modifying authoritative city district polygo
 
 **1. SoCal Border Crossing wedges**
 
-SoCal Border Crossing is a small rotated rectangle (4 points, -37.6° yaw). Its straight edges create wedge-shaped voids against the irregular polygon edges of Rattlesnake Creek and Jackson Plains. These voids connect directly to the large open-wasteland void, so the buffer detection method sees them as part of the wasteland and excludes them. The gap edges exist inside the coordinate space between SoCal and its neighbors but cannot be isolated cleanly.
+SoCal Border Crossing is a small rotated rectangle (4 points, -37.6° yaw). Its straight edges create wedge-shaped voids against the irregular polygon edges of Rattlesnake Creek and Jackson Plains. These voids connect directly to the large open-wasteland void, so the buffer detection method sees them as part of the wasteland and excludes them. The gap edges exist inside the coordinate space between SoCal and its neighbours but cannot be isolated cleanly.
 
-This is consistent with the nature of the SoCal zone — it marks the exact point where the nomad lifepath start connects to Night City. The geometry reflects that it was authored as a standalone trigger, not designed to tile with surrounding zones.
+This is consistent with the nature of the SoCal zone: it marks the exact point where the nomad lifepath start connects to Night City. The geometry reflects that it was authored as a standalone trigger, not designed to tile with surrounding zones.
 
 **2. Biotechnica Flats / Dogtown / West Wind Estate triangle**
 
 A triangular dark void is visible at the point where the Dogtown district (city, authoritative) and West Wind Estate subdistrict (Pacifica, authoritative) touch at a single vertex (-2437.95, -2593.64). Biotechnica Flats' nearest boundary is 381 CET units south of this meeting point.
 
 Investigation confirmed:
-- Dogtown and West Wind Estate touch at exactly one vertex — their boundary is a degenerate zero-length line
+- Dogtown and West Wind Estate touch at exactly one vertex: their boundary is a degenerate zero-length line
 - The triangle between that vertex and Biotechnica's north edge lies **inside Dogtown's polygon** (99.6% of the triangle area overlaps with Dogtown)
 - Biotechnica cannot be expanded to fill this area without crossing into Dogtown's city district boundary
-- The void is geometrically a property of how CDPR authored the Dogtown and West Wind Estate trigger volumes — they were designed for 3D trigger detection, not 2D tiling
+- The void is geometrically a property of how CDPR authored the Dogtown and West Wind Estate trigger volumes: they were designed for 3D trigger detection, not 2D tiling
 
-**Why both are unfixable:** The correct fix for both would require editing Dogtown, West Wind Estate, or the Pacifica subdistricts — all of which are authoritative CDPR-defined boundaries that must not be modified. In the actual frontend implementation, these zones use border-only rendering (no fill), so the dark voids are only visible in the preview SVG, not in the final map.
+**Why both are unfixable:** The correct fix for both would require editing Dogtown, West Wind Estate, or the Pacifica subdistricts, all of which are authoritative CDPR-defined boundaries that must not be modified. In the actual frontend implementation, these zones use border-only rendering (no fill), so the dark voids are only visible in the preview SVG, not in the final map.
 
 ### For modding: using raw polygons vs clipped polygons
 
-If you're creating a mod that adds Badlands subdistricts to the in-game map (e.g., via `gameStaticTriggerAreaComponent` in a custom entity), you probably want the **raw unclipped polygons** from this document. The game's trigger system handles overlaps naturally — the district manager uses a stack, and the most specific (innermost) zone takes precedence. The clipping is only needed for 2D flat map rendering where overlapping fills look wrong.
+If you're creating a mod that adds Badlands subdistricts to the in-game map (e.g., via `gameStaticTriggerAreaComponent` in a custom entity), you probably want the **raw unclipped polygons** from this document. The game's trigger system handles overlaps naturally: the district manager uses a stack, and the most specific (innermost) zone takes precedence. The clipping is only needed for 2D flat map rendering where overlapping fills look wrong.
 
 The raw polygon coordinates in this document are the **unclipped originals** as decoded from the streaming sectors. For the clipped versions used in the NC Zoning Board map, see `data/subdistricts.json` (regenerated by `scripts/regenerate_subdistricts.py`).
 
 ## Notes
 
-- The `AreaShapeOutline.points` field is always a placeholder unit square — ignore it
-- The `z` coordinate in buffer points is usually constant per polygon (the boundary height above sea level) — useful for 3D rendering but not needed for 2D map overlays
-- Some nodes have `isVisibleInGame: 1` — this controls whether the area name shows in the HUD when the player enters
-- The `sourcePrefabHash` field is shared across nodes in the same sector — it identifies the prefab template
+- The `AreaShapeOutline.points` field is always a placeholder unit square, ignore it
+- The `z` coordinate in buffer points is usually constant per polygon (the boundary height above sea level), useful for 3D rendering but not needed for 2D map overlays
+- Some nodes have `isVisibleInGame: 1`, which controls whether the area name shows in the HUD when the player enters
+- The `sourcePrefabHash` field is shared across nodes in the same sector: it identifies the prefab template
 - World coordinates are CET space: X increases east, Y increases north
 - For a mod adding these to the in-game map, you'd create `gameStaticTriggerAreaComponent` entries in a custom `.ent` file, similar to how `3dmap_view.ent` defines city district triggers. The polygon points go in the `outline.Data.points` array, and the `notifiers` array links to the TweakDB `District_Record` via `districtID`

--- a/docs/submission-pipeline.md
+++ b/docs/submission-pipeline.md
@@ -43,7 +43,7 @@ This workflow triggers whenever the `mod-submission` label is applied to an issu
 
 Within the same `auto-pr-submission.yml` workflow, the bot reaches out to a Discord channel (using the `DISCORD_WEBHOOK_URL` secret) with an embedded message noting that a PR is awaiting review.
 
-> `DISCORD_WEBHOOK_URL` is the **submissions** channel. Operational alerts (health/monitoring) go to a separate channel via `NCZ_ALERTS_DISCORD_WEBHOOK_URL` — see [architecture.md](architecture.md#discord-notifications).
+> `DISCORD_WEBHOOK_URL` is the **submissions** channel. Operational alerts (health/monitoring) go to a separate channel via `NCZ_ALERTS_DISCORD_WEBHOOK_URL`. See [architecture.md](architecture.md#discord-notifications).
 
 **The Clever Part:**
 To allow the bot to update this exact discord message later on, the webhook returns a unique `message_id`. The bot saves this ID as a hidden HTML comment at the bottom of the original GitHub Issue `<!-- discord_message_id: XXXXX -->`.
@@ -54,11 +54,11 @@ To allow the bot to update this exact discord message later on, the webhook retu
 
 When a PR is opened, GitHub Actions launches this workflow. It **always runs** on every PR (so the required status check is always reported), but skips the validation steps if no data files changed.
 
-1. **Change Detection**: Diffs the PR branch against its base — if no `data/locations/`, `data/tags.json`, or `mods.schema.json` files changed, the remaining steps are skipped and the check passes immediately.
+1. **Change Detection**: Diffs the PR branch against its base: if no `data/locations/`, `data/tags.json`, or `mods.schema.json` files changed, the remaining steps are skipped and the check passes immediately.
 2. **Schema Validation**: Uses `ajv-cli` to compare the compiled `mods.json` (after a test build) against `mods.schema.json`.
 3. **Tag Validation**: Runs `node scripts/validate_tags.js` to ensure all tags used in the PR exist in the `data/tags.json` registry.
 
-## 🎉 Stage 5: Finalization & Merge
+## 🎉 Stage 5: Finalisation & Merge
 
 When a maintainer reviews the PR and hits Merge, the newly added mod goes live on the `main` branch.
 
@@ -74,6 +74,6 @@ If a user wants to update their mod's coordinates, tags, or authors (or request 
 
 1. **Issue Form**: They click "Suggest Edit" on the map popup, which pre-fills the [**`modify_location.yml`**](../.github/ISSUE_TEMPLATE/modify_location.yml) GitHub Issue template with the mod's UUID.
 2. **Bot Processing**: The [**`modify-location-submission.yml`**](../.github/workflows/modify-location-submission.yml) workflow fires when the `mod-modification` label is applied. It parses the new values, merging them with the existing file (blank fields keep their current value).
-3. **Discord Notification**: Follows the same stored-ID pattern as submissions — the initial "Awaiting Review" message ID is saved as a hidden comment on the issue so it can be edited (not reposted) on merge/close.
+3. **Discord Notification**: Follows the same stored-ID pattern as submissions: the initial "Awaiting Review" message ID is saved as a hidden comment on the issue so it can be edited (not reposted) on merge/close.
 4. **PR Creation**: The bot modifies the existing `data/locations/<UUID>.json` file and creates a Pull Request reflecting the diff.
 5. **Validation & Merge**: Functions identically to the standard submission pipeline. Once merged, the map updates.

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -14,9 +14,9 @@ Tags are used to describe the aesthetic, function, or intended audience of a loc
 | `entropism` | The look of poverty that derives from humans grappling with and struggling against technology and its unforgiving advance. |
 | `house` | A standalone player dwelling or safehouse structure. |
 | `infrastructure` | Roads, bridges, parking structures, and public works. |
-| `kitsch` | Flashy, bold and usually cheap — the look of a long lost golden age. |
+| `kitsch` | Flashy, bold and usually cheap: the look of a long lost golden age. |
 | `neokitsch` | Synonymous with luxury and infinite wealth. |
-| `neomilitarism` | Cold, sharp, and modern — making everyone look ready for combat. |
+| `neomilitarism` | Cold, sharp, and modern: making everyone look ready for combat. |
 | `nomad` | Off-the-grid, scrapyard, desert, or vehicular-based habitats. |
 | `photos` | Scenic or atmospheric locations well-suited for virtual photography. |
 | `quest` | A location closely tied to custom gigs, missions, or storylines. |
@@ -34,22 +34,22 @@ Synthetic tags are applied automatically by the map system. They are **not** in 
 | Tag | Applied by | Description |
 | --- | --- | --- |
 | `nczoning` | Auto-discovery (`fetchNexusTaggedMods`) | Applied to every mod sourced automatically from Nexus Mods. Appears as a filter tag and as a badge on the popup and sidebar entry. |
-| `updated` | `app.js` filter setup | A virtual filter that surfaces any mod whose Nexus `updatedAt` timestamp falls within `NCZ.RECENTLY_UPDATED_DAYS` days. Not stored on the mod object — evaluated live by `isRecentlyUpdated()`. |
+| `updated` | `app.js` filter setup | A virtual filter that surfaces any mod whose Nexus `updatedAt` timestamp falls within `NCZ.RECENTLY_UPDATED_DAYS` days. Not stored on the mod object, evaluated live by `isRecentlyUpdated()`. |
 
 ---
 
 ## Adding a Tag
 
-1. **`data/tags.json`** — Add the new key and a concise definition sentence.
+1. **`data/tags.json`**: Add the new key and a concise definition sentence.
 
-2. **`.github/ISSUE_TEMPLATE/mod_submission.yml`** — Add a checkbox entry under the `tags` checkboxes field, in alphabetical order:
+2. **`.github/ISSUE_TEMPLATE/mod_submission.yml`**: Add a checkbox entry under the `tags` checkboxes field, in alphabetical order:
    ```yaml
    - label: "your-tag — Short description matching the one in tags.json"
    ```
 
-3. **`.github/ISSUE_TEMPLATE/modify_location.yml`** — Add the same checkbox entry in the same alphabetical position.
+3. **`.github/ISSUE_TEMPLATE/modify_location.yml`**: Add the same checkbox entry in the same alphabetical position.
 
-The sidebar filter UI in `app.js` is fully data-driven — the new tag will appear automatically once any mod uses it. No frontend changes are needed.
+The sidebar filter UI in `app.js` is fully data-driven: the new tag will appear automatically once any mod uses it. No frontend changes are needed.
 
 ---
 
@@ -57,9 +57,9 @@ The sidebar filter UI in `app.js` is fully data-driven — the new tag will appe
 
 If you only need to update the wording of an existing tag's description (not rename the key):
 
-1. **`data/tags.json`** — Update the definition string for the key.
-2. **`.github/ISSUE_TEMPLATE/mod_submission.yml`** — Update the matching checkbox label text.
-3. **`.github/ISSUE_TEMPLATE/modify_location.yml`** — Update the matching checkbox label text.
+1. **`data/tags.json`**: Update the definition string for the key.
+2. **`.github/ISSUE_TEMPLATE/mod_submission.yml`**: Update the matching checkbox label text.
+3. **`.github/ISSUE_TEMPLATE/modify_location.yml`**: Update the matching checkbox label text.
 
 > The label text shown in the issue form (after ` — `) is cosmetic only. The authoritative definition lives in `tags.json` and is used as tooltip text on the live map.
 
@@ -67,13 +67,13 @@ If you only need to update the wording of an existing tag's description (not ren
 
 ## Renaming a Tag Key
 
-Renaming a tag key (e.g. `photos` → `photography`) is a **breaking change** — it invalidates any existing location data that uses the old key.
+Renaming a tag key (e.g. `photos` → `photography`) is a **breaking change**: it invalidates any existing location data that uses the old key.
 
-1. **Audit existing data** — find all locations using the old key:
+1. **Audit existing data**: find all locations using the old key:
    ```bash
    grep -rl '"old-tag"' data/locations/
    ```
-2. **Update each affected location file** — replace the old key with the new key in the `tags` array.
+2. **Update each affected location file**: replace the old key with the new key in the `tags` array.
 3. Follow the [Adding a Tag](#adding-a-tag) steps for the new key.
 4. Follow the [Removing a Tag](#removing-a-tag) steps for the old key.
 
@@ -81,9 +81,9 @@ Renaming a tag key (e.g. `photos` → `photography`) is a **breaking change** �
 
 ## Removing a Tag
 
-1. **Audit existing data** — confirm no location files use the tag (see command above). If any do, update or remove the tag from those files first.
-2. **`data/tags.json`** — Delete the key.
-3. **`.github/ISSUE_TEMPLATE/mod_submission.yml`** — Remove the checkbox entry.
-4. **`.github/ISSUE_TEMPLATE/modify_location.yml`** — Remove the checkbox entry.
+1. **Audit existing data**: confirm no location files use the tag (see command above). If any do, update or remove the tag from those files first.
+2. **`data/tags.json`**: Delete the key.
+3. **`.github/ISSUE_TEMPLATE/mod_submission.yml`**: Remove the checkbox entry.
+4. **`.github/ISSUE_TEMPLATE/modify_location.yml`**: Remove the checkbox entry.
 
 The tag will disappear from the sidebar filter automatically on next deploy.

--- a/docs/three-js-scene.md
+++ b/docs/three-js-scene.md
@@ -1,4 +1,4 @@
-# Three.js 3D Scene — Reference Documentation
+# Three.js 3D Scene: Reference Documentation
 
 Full documentation for the Three.js schematic view. For pending phase-by-phase work see the [GitHub Project](https://github.com/users/spuddeh/projects/1) (WebGPU Migration stream). For the overall app architecture see [`architecture.md`](architecture.md).
 
@@ -13,7 +13,7 @@ The NC Zoning Board has two map views that share the same sidebar, filters, and 
 | Satellite | `#map` | Leaflet.js | Real satellite tile layer with location pins |
 | Schematic | `#map-3d` | Three.js | Live 3D scene: terrain, buildings, roads, pins |
 
-Only one container is visible at a time. Neither is destroyed on switch — Leaflet state persists and the Three.js scene stays in GPU memory. The Three.js render loop pauses when `#map-3d` is hidden.
+Only one container is visible at a time. Neither is destroyed on switch: Leaflet state persists and the Three.js scene stays in GPU memory. The Three.js render loop pauses when `#map-3d` is hidden.
 
 ---
 
@@ -21,12 +21,12 @@ Only one container is visible at a time. Neither is destroyed on switch — Leaf
 
 ```
 assets/js/
-  constants.js      — NCZ namespace + all shared constants (unchanged)
-  utils.js          — Pure utility functions including shared popup/filter logic
-  services.js       — Nexus API + data loading (unchanged)
-  three-scene.js    — Three.js scene: renderer, camera, GLB loading, materials, render loop
-  three-markers.js  — 3D pin/popup/tooltip/cluster layer (NCZ.ThreeMarkers). See three-markers.md.
-  app.js            — Main app: Leaflet init, DOM events, view switching
+  constants.js      - NCZ namespace + all shared constants (unchanged)
+  utils.js          - Pure utility functions including shared popup/filter logic
+  services.js       - Nexus API + data loading (unchanged)
+  three-scene.js    - Three.js scene: renderer, camera, GLB loading, materials, render loop
+  three-markers.js  - 3D pin/popup/tooltip/cluster layer (NCZ.ThreeMarkers). See three-markers.md.
+  app.js            - Main app: Leaflet init, DOM events, view switching
 ```
 
 ### Load order in `index.html`
@@ -44,7 +44,7 @@ app.js (regular script)
 
 ### Why two Three.js files
 
-`three-scene.js` owns the renderer — it has no knowledge of mod data. `three-markers.js` owns the pins — it reads mod data and calls into the scene to position things, but doesn't control the renderer. This mirrors the existing `services.js` / `app.js` split: data vs. DOM. You can iterate on hover/click behaviour in `three-markers.js` without touching the scene, and vice versa.
+`three-scene.js` owns the renderer: it has no knowledge of mod data. `three-markers.js` owns the pins: it reads mod data and calls into the scene to position things, but doesn't control the renderer. This mirrors the existing `services.js` / `app.js` split: data vs. DOM. You can iterate on hover/click behaviour in `three-markers.js` without touching the scene, and vice versa.
 
 ### Namespaces
 
@@ -124,7 +124,7 @@ Hillshade matching the in-game map appearance:
 
 ### Theme support
 
-Material colors are read from CSS custom properties at scene init and on theme change:
+Material colours are read from CSS custom properties at scene init and on theme change:
 
 ```javascript
 function readThemeColor(varName) {
@@ -134,7 +134,7 @@ function readThemeColor(varName) {
 }
 ```
 
-When the user switches theme, `NCZ.ThreeScene.updateMaterials()` is called to re-read all CSS vars and update material colors. This means the 3D scene is fully theme-aware — terrain, water, roads, and buildings all respond to theme switches.
+When the user switches theme, `NCZ.ThreeScene.updateMaterials()` is called to re-read all CSS vars and update material colours. This means the 3D scene is fully theme-aware: terrain, water, roads, and buildings all respond to theme switches.
 
 ---
 
@@ -144,7 +144,7 @@ For full details on the three coordinate systems (CET, GLB, building instance te
 
 ### Camera Up Vector
 
-The camera uses the standard Three.js up vector `up=(0,1,0)`. This ensures correct rendering at all camera angles — when tilted, the Y-axis orientation is preserved and buildings correctly extend upward from terrain.
+The camera uses the standard Three.js up vector `up=(0,1,0)`. This ensures correct rendering at all camera angles: when tilted, the Y-axis orientation is preserved and buildings correctly extend upward from terrain.
 
 ### CET → Three.js mapping
 
@@ -160,7 +160,7 @@ CET and GLB share the same XZ coordinate space at 1:1 scale. The terrain GLB ext
 
 ## GLB Assets
 
-The runtime loads from `assets/glb-meshopt/` (gltfpack-compressed). The repo only commits this folder. Source GLBs (uncompressed WolvenKit exports) live at `assets/glb-source/` which is **gitignored** — drop fresh exports there before running `npm run encode-meshopt`. The runtime path is the `NCZ.GLB_DIR` constant in [`assets/js/constants.js`](../assets/js/constants.js).
+The runtime loads from `assets/glb-meshopt/` (gltfpack-compressed). The repo only commits this folder. Source GLBs (uncompressed WolvenKit exports) live at `assets/glb-source/` which is **gitignored**. Drop fresh exports there before running `npm run encode-meshopt`. The runtime path is the `NCZ.GLB_DIR` constant in [`assets/js/constants.js`](../assets/js/constants.js).
 
 Loaded in tiers so the scene is interactive as quickly as possible.
 
@@ -169,42 +169,42 @@ Loaded in tiers so the scene is interactive as quickly as possible.
 | `3dmap_terrain.glb` | 6.4 MB | **423 KB** | 1 (required) | Terrain surface, 247k verts (sub-meshes merged by gltfpack) |
 | `3dmap_water.glb` | ~5 KB | ~2 KB | 1 (required) | Water plane with land cutouts; writes stencil=2 |
 | `3dmap_cliffs.glb` | 3.4 MB | 891 KB | 1 (with terrain) | Dogtown cliff faces |
-| `3dmap_roads.glb` | 1.4 MB | 223 KB | 2 (idle) | Road surfaces — loaded twice (see Roads section) |
-| `3dmap_roads_borders.glb` | 5.9 MB | **357 KB** | 2 (idle) | Road border outlines — loaded twice |
+| `3dmap_roads.glb` | 1.4 MB | 223 KB | 2 (idle) | Road surfaces, loaded twice (see Roads section) |
+| `3dmap_roads_borders.glb` | 5.9 MB | **357 KB** | 2 (idle) | Road border outlines, loaded twice |
 | `3dmap_metro.glb` | 530 KB | 69 KB | 2 (idle) | Metro tracks with vertex-color LOD |
-| `3dmap_obelisk.glb` | 175 KB | 32 KB | 3 (with buildings) | The Needle — Dogtown |
-| `monument_ave_pyramid.glb` | 4 KB | 2 KB | 3 (with buildings) | Heavy Hearts Club — Dogtown |
-| `3dmap_statue_splash_a.glb` | 542 KB | 121 KB | 3 (with buildings) | De-votion statue — Dogtown |
-| `3dmap_ext_monument_av_building_b.glb` | 364 KB | 55 KB | 3 (with buildings) | Brainporium — Dogtown |
-| `northoak_sign_a.glb` | 124 KB | 20 KB | 3 (with buildings) | North Oak arch gate — Westbrook |
-| `cz_cz_building_h_icosphere.glb` | 70 KB | 16 KB | 3 (with buildings) | Brave Atlas — Dogtown |
+| `3dmap_obelisk.glb` | 175 KB | 32 KB | 3 (with buildings) | The Needle, Dogtown |
+| `monument_ave_pyramid.glb` | 4 KB | 2 KB | 3 (with buildings) | Heavy Hearts Club, Dogtown |
+| `3dmap_statue_splash_a.glb` | 542 KB | 121 KB | 3 (with buildings) | De-votion statue, Dogtown |
+| `3dmap_ext_monument_av_building_b.glb` | 364 KB | 55 KB | 3 (with buildings) | Brainporium, Dogtown |
+| `northoak_sign_a.glb` | 124 KB | 20 KB | 3 (with buildings) | North Oak arch gate, Westbrook |
+| `cz_cz_building_h_icosphere.glb` | 70 KB | 16 KB | 3 (with buildings) | Brave Atlas, Dogtown |
 | `rcr_park_ferris_wheel.glb` | 86 KB | 22 KB | 3 (with buildings) | Used twice: upright (Pacifica) + collapsed (Santo Domingo border) |
 | **Total** | **18.5 MB** *(not in repo)* | **2.18 MB (-88%) committed** | | |
 
 Tier 1 loads in parallel on scene init. Tier 2 loads after Tier 1 resolves, during idle. Tier 3 loads after Tier 2.
 
-### Compression pipeline — gltfpack/meshopt
+### Compression pipeline: gltfpack/meshopt
 
-GLBs are compressed with [`gltfpack`](https://github.com/zeux/meshoptimizer/tree/master/gltf) (from the meshoptimizer project). The runtime loads them via the `MeshoptDecoder` bundled with three.js examples — no extra dependency, ~30 KB WASM decoder fetched once. Decoded geometry preserves vertex/index ordering, so vertex cache + fetch optimisations remain effective on the GPU.
+GLBs are compressed with [`gltfpack`](https://github.com/zeux/meshoptimizer/tree/master/gltf) (from the meshoptimizer project). The runtime loads them via the `MeshoptDecoder` bundled with three.js examples: no extra dependency, ~30 KB WASM decoder fetched once. Decoded geometry preserves vertex/index ordering, so vertex cache + fetch optimisations remain effective on the GPU.
 
 ```bash
 # Re-encode all GLBs from assets/glb/ → assets/glb-meshopt/
 npm run encode-meshopt
 ```
 
-The encoder script ([`scripts/encode_glbs_meshopt.js`](../scripts/encode_glbs_meshopt.js)) replaces both the older Draco-compression flow (considered, see decisions wiki) AND the legacy `strip_glb_attributes.js` step in one tool — gltfpack drops unused vertex attributes, merges sub-meshes per material, runs vertex cache + fetch optimisation, applies quantization, then encodes via `EXT_meshopt_compression`.
+The encoder script ([`scripts/encode_glbs_meshopt.js`](../scripts/encode_glbs_meshopt.js)) replaces both the older Draco-compression flow (considered, see decisions wiki) AND the legacy `strip_glb_attributes.js` step in one tool: gltfpack drops unused vertex attributes, merges sub-meshes per material, runs vertex cache + fetch optimisation, applies quantisation, then encodes via `EXT_meshopt_compression`.
 
 Key flags used:
 
-- `-cc` — aggressive `EXT_meshopt_compression`
-- `-vp 16` — 16-bit position quantization for world-coord meshes (CET 12 km extent → ~0.18 m precision)
-- `-vp 14` — for landmarks (local mesh space, smaller bounding box → sub-cm precision)
-- `-vn 10 -vt 12 -vc 8` — quantization bits for normals/UVs/colors
-- **No `-kn`** (deliberately) — preserving named nodes confuses Three.js's transform composition through the wrapper hierarchy and prevents gltfpack from merging sub-meshes
+- `-cc`: aggressive `EXT_meshopt_compression`
+- `-vp 16`: 16-bit position quantisation for world-coord meshes (CET 12 km extent → ~0.18 m precision)
+- `-vp 14`: for landmarks (local mesh space, smaller bounding box → sub-cm precision)
+- `-vn 10 -vt 12 -vc 8`: quantisation bits for normals/UVs/colours
+- **No `-kn`** (deliberately): preserving named nodes confuses Three.js's transform composition through the wrapper hierarchy and prevents gltfpack from merging sub-meshes
 
 ### Legacy: GLB attribute stripping (no longer needed)
 
-`scripts/strip_glb_attributes.js` is retained for inspection but **not required** in the live pipeline — `gltfpack` does the same attribute pruning automatically. If you do need to inspect a stripped-but-uncompressed GLB:
+`scripts/strip_glb_attributes.js` is retained for inspection but **not required** in the live pipeline: `gltfpack` does the same attribute pruning automatically. If you do need to inspect a stripped-but-uncompressed GLB:
 
 ```bash
 # POSITION only (default)
@@ -218,9 +218,9 @@ node scripts/strip_glb_attributes.js input.glb output.glb POSITION,COLOR_0
 | Material | Keep | Reason |
 | --- | --- | --- |
 | `MeshBasicMaterial` | `POSITION` only | No lighting, no UVs |
-| `MeshLambertMaterial` + `flatShading:true` — **terrain, water, cliffs, landmarks** | `POSITION,NORMAL` | NORMAL required for `shadow.normalBias` — stripping it causes shadow acne |
+| `MeshLambertMaterial` + `flatShading:true` (**terrain, water, cliffs, landmarks**) | `POSITION,NORMAL` | NORMAL required for `shadow.normalBias`: stripping it causes shadow acne |
 | Metro LOD shader | `POSITION,COLOR_0` | `COLOR_0` encodes LOD tier (B/G/R) |
-| Building DDS pipeline | N/A — no GLB | Geometry is `BoxGeometry(1,1,1)` generated in JS |
+| Building DDS pipeline | N/A, no GLB | Geometry is `BoxGeometry(1,1,1)` generated in JS |
 
 **Bug fixed:** The remap loop previously only remapped `POSITION`. With a multi-attribute keep-list, other attributes (e.g. `NORMAL`, `COLOR_0`) were left with their original large accessor indices, causing GLTFLoader to fail with `bufferView undefined`. Fixed in the current script.
 
@@ -255,7 +255,7 @@ mesh.rotation.y = Math.PI;
 
 ### Materials
 
-| Layer | Material type | Color source |
+| Layer | Material type | Colour source |
 |-------|--------------|--------------|
 | Terrain | `MeshLambertMaterial` (flatShading, DoubleSide) | `--scene-terrain` CSS var |
 | Water | `MeshLambertMaterial` (flatShading, DoubleSide, stencil=2) | `--scene-water` CSS var |
@@ -271,23 +271,23 @@ mesh.rotation.y = Math.PI;
 
 ## Landmarks
 
-7 GLBs, 8 instances (ferris wheel shared). Added to `layers.buildings` group — toggles with the buildings checkbox. Uses `--scene-buildings` colour, `MeshLambertMaterial` with `flatShading:true`.
+7 GLBs, 8 instances (ferris wheel shared). Added to `layers.buildings` group: toggles with the buildings checkbox. Uses `--scene-buildings` colour, `MeshLambertMaterial` with `flatShading:true`.
 
-### Coordinate system — critical difference from roads/terrain
+### Coordinate system: critical difference from roads/terrain
 
 Landmark GLBs are in **local model space** (vertices centred near origin), not world CET space like roads/terrain. This means:
 
-- **No** `rotation.y = Math.PI` (X-flip) needed — unlike roads/terrain
+- **No** `rotation.y = Math.PI` (X-flip) needed, unlike roads/terrain
 - World position comes from two sources in the ent file:
   - **XY**: resolved by `cp2077_extract_footprints.py --list-landmarks` (walks the full parent transform chain)
-  - **Z (height)**: from `localTransform.Position.z` field (`Bits / 131072.0`) — the 2D extraction script discards this
-- Three.js placement: `position.set(cetX, cetZ, -cetY)` — note cetZ as the Y (height) axis
+  - **Z (height)**: from `localTransform.Position.z` field (`Bits / 131072.0`); the 2D extraction script discards this
+- Three.js placement: `position.set(cetX, cetZ, -cetY)`; note cetZ as the Y (height) axis
 
 ### Quaternion conversion
 
 CET space is Z-up; Three.js is Y-up. Ent quaternion `[i, j, k, r]` → Three.js `Quaternion(x=i, y=k, z=-j, w=r)`.
 
-Note: `cp2077_extract_footprints.py` applies `CET_X = -GLB_X` when projecting to Leaflet 2D space. This negation is **not** needed in Three.js 3D rendering — the model-local vertices render correctly without the X-flip.
+Note: `cp2077_extract_footprints.py` applies `CET_X = -GLB_X` when projecting to Leaflet 2D space. This negation is **not** needed in Three.js 3D rendering: the model-local vertices render correctly without the X-flip.
 
 ### World positions (from ent + extraction script)
 
@@ -300,17 +300,17 @@ Note: `cp2077_extract_footprints.py` applies `CET_X = -GLB_X` when projecting to
 | North Oak sign | 196.9 | 873.7 | 152.76 | High elevation on cliffs |
 | Brave Atlas icosphere | -1974.8 | -2701.0 | 102.70 | Complex pitch+roll |
 | Ferris wheel (Pacifica) | -2442.4 | -2178.0 | 34.26 | Upright |
-| Ferris wheel (collapsed) | 445.2 | -1672.2 | 10.87 | Lying on side — full pitch+roll quaternion |
+| Ferris wheel (collapsed) | 445.2 | -1672.2 | 10.87 | Lying on side, full pitch+roll quaternion |
 
 ### GLB stripping gotcha
 
-The `strip_glb_attributes.js` script had a bug with the `byteOffset` field: use `bv.byteOffset || 0` not `bv.byteOffset` (the field is optional in GLTF and defaults to 0 — missing field caused incorrect slice).
+The `strip_glb_attributes.js` script had a bug with the `byteOffset` field: use `bv.byteOffset || 0` not `bv.byteOffset` (the field is optional in GLTF and defaults to 0; missing field caused incorrect slice).
 
 ---
 
 ## Roads, Borders & Metro Rendering
 
-Roads and borders are each rendered **twice** from the same geometry — matching the game's `entMeshComponent` dual-appearance setup (`default` + `SeeThrough1` in `3dmap_view.ent`).
+Roads and borders are each rendered **twice** from the same geometry, matching the game's `entMeshComponent` dual-appearance setup (`default` + `SeeThrough1` in `3dmap_view.ent`).
 
 ### Normal pass (depthTest:true)
 
@@ -318,7 +318,7 @@ Surface roads sit correctly in the scene, occluded by terrain when viewed at til
 
 ### SeeThrough pass (depthTest:false + water stencil)
 
-A second draw call using the same geometry with `depthTest:false`. This is NOT a full "show through everything" pass — it uses the **WebGL stencil buffer** to limit where it renders:
+A second draw call using the same geometry with `depthTest:false`. This is NOT a full "show through everything" pass. It uses the **WebGL stencil buffer** to limit where it renders:
 
 - **Water** (`3dmap_water.glb`) writes `stencil=2` during the opaque pass
 - **Buildings** write `stencil=1` during the opaque pass
@@ -336,7 +336,7 @@ This is a deliberate improvement over the game's `RenderOnTop=1` approach, which
 
 Metro uses `onBeforeCompile` to read vertex `COLOR_0` for LOD tier:
 
-Channels are **mutually exclusive** — only one tier is visible at any zoom level:
+Channels are **mutually exclusive**, only one tier is visible at any zoom level:
 
 | Channel | Tier | Visible when | Game distance parameter |
 | ------- | ---- | ------------ | ----------------------- |
@@ -344,7 +344,7 @@ Channels are **mutually exclusive** — only one tier is visible at any zoom lev
 | G=1 (26%) | Thin solid | `LOD_MED < zoom < LOD_NEAR` (medium) | VisibilityDistanceRegular=18000 |
 | R=1 (47%) | Dotted | `zoom > LOD_NEAR` (close) | VisibilityDistanceDashed=5000 |
 
-B must be discarded at both ends (two separate discard conditions in the shader). Metro uses `AdditiveAlphaBlend=1` in-game. The channel-to-tier mapping was determined by visual isolation testing — it is NOT documented in the exported material JSON (shader bytecode only).
+B must be discarded at both ends (two separate discard conditions in the shader). Metro uses `AdditiveAlphaBlend=1` in-game. The channel-to-tier mapping was determined by visual isolation testing: it is NOT documented in the exported material JSON (shader bytecode only).
 
 ---
 
@@ -356,14 +356,14 @@ B must be discarded at both ends (two separate discard conditions in the shader)
 ### Data pipeline
 
 ```
-assets/dds/*_data.dds  (DXGI_FORMAT_R16G16B16A16_UNORM — 16-bit RGBA, DX10 header)
-    ↓ loadDataDds()  — fetch → Uint16Array (skip 148-byte DX10 header)
+assets/dds/*_data.dds  (DXGI_FORMAT_R16G16B16A16_UNORM - 16-bit RGBA, DX10 header)
+    ↓ loadDataDds()  - fetch → Uint16Array (skip 148-byte DX10 header)
     ↓ CPU decode per valid pixel: position / quaternion / scale → setMatrixAt()
     ↓
 THREE.InstancedMesh with correct bounding sphere and frustum culling
 
-assets/dds/*_m.dds  (DXGI_FORMAT_R8_UNORM — 8-bit greyscale, DX10 header)
-    ↓ loadMDds()  — Uint8Array (mip 0) → DataTexture (RedFormat, generateMipmaps)
+assets/dds/*_m.dds  (DXGI_FORMAT_R8_UNORM - 8-bit greyscale, DX10 header)
+    ↓ loadMDds()  - Uint8Array (mip 0) → DataTexture (RedFormat, generateMipmaps)
     ↓
 MeshLambertMaterial.onBeforeCompile injects planar UV + _m modulation + edge highlight
 ```
@@ -380,7 +380,7 @@ Each `_data.dds` pixel encodes one building instance across three horizontal blo
 | Scale | 2×blockW..3×blockW | RGB=XYZ half-extents × cubeSize |
 
 Position precision: ~0.036 CET units (16-bit). Earlier 8-bit PNG exports gave ~9.4 CET
-units error — visible as jumbled circular ring structures.
+units error, visible as jumbled circular ring structures.
 
 ### CPU decode (loadDataDds)
 
@@ -404,10 +404,10 @@ mesh.count = validCount;
 
 `buildBuildingMaterial()` in `three-scene.js` creates one material per district:
 
-- **Lambert lighting** — driven by scene lights automatically; no manual uniform syncing
-- **Planar UV** — computed from `instanceMatrix * vertex` world position in `project_vertex`
-- **`_m.dds` modulation** — `diffuseColor.rgb *= 0.3 + mVal * 0.7` before lighting
-- **Edge highlight** — from `3d_map_cubes.mt` EdgeColor/EdgeThickness/EdgeSharpnessPower
+- **Lambert lighting**: driven by scene lights automatically; no manual uniform syncing
+- **Planar UV**: computed from `instanceMatrix * vertex` world position in `project_vertex`
+- **`_m.dds` modulation**: `diffuseColor.rgb *= 0.3 + mVal * 0.7` before lighting
+- **Edge highlight**: from `3d_map_cubes.mt` EdgeColor/EdgeThickness/EdgeSharpnessPower
 
 `mat.userData.shader` stores the `onBeforeCompile` shader reference for later uniform
 updates (edge colour on theme change).
@@ -435,7 +435,7 @@ const pin = new CSS2DObject(div);
 pin.position.set(cetX, cetZ || 0, -cetY);
 ```
 
-Popup HTML is generated by `NCZ.buildPopupHtml()` (in `utils.js`) — the same function used by the Leaflet view, so both views produce identical popups.
+Popup HTML is generated by `NCZ.buildPopupHtml()` (in `utils.js`), the same function used by the Leaflet view, so both views produce identical popups.
 
 ### Clustering
 
@@ -451,7 +451,7 @@ Screen-space proximity clustering, recalculated on camera change. Pins within 40
 
 ## Shared Utility Functions
 
-All in `utils.js`. Both views call these — nothing view-specific lives here.
+All in `utils.js`. Both views call these: nothing view-specific lives here.
 
 | Function | Description |
 |----------|-------------|
@@ -468,7 +468,7 @@ All in `utils.js`. Both views call these — nothing view-specific lives here.
 Handled in `overlay.js` via `NCZ.switchBaseLayer(layerName)`. On switch:
 
 1. The outgoing container is hidden (`display: none`), its render loop paused
-2. The incoming container is shown, its init called (lazy — only runs once)
+2. The incoming container is shown, its init called (lazy, only runs once)
 
 Camera state is synced on switch via coordinate transform: Leaflet center → inverse `cetToLeaflet()` → CET coords → `cetToThree()` → Three.js camera target, and vice versa. Zoom is mapped proportionally between Leaflet zoom levels and Three.js frustum size.
 
@@ -511,7 +511,7 @@ copy(JSON.stringify(NCZ.ThreeScene.getCameraState()))
 NCZ.ThreeScene.setCameraState(JSON.parse('PASTE_JSON_HERE'))
 ```
 
-Useful for taking consistent before/after screenshots. If the showcase flyover is running, pause it before restoring — the flyover overrides sun state on each tick.
+Useful for taking consistent before/after screenshots. If the showcase flyover is running, pause it before restoring: the flyover overrides sun state on each tick.
 
 ### Sun position
 

--- a/docs/three-markers.md
+++ b/docs/three-markers.md
@@ -1,4 +1,4 @@
-# `NCZ.ThreeMarkers` — 3D pin/popup/cluster layer
+# `NCZ.ThreeMarkers`: 3D pin/popup/cluster layer
 
 The Three.js view's interactive layer: pins, tooltips, popups, cluster bubbles,
 camera fly-to, and the cluster panel integration. Mirrors the Leaflet 2D
@@ -22,7 +22,7 @@ attach(scene, camera, container, controls)         // lifecycle: called by Three
 setMods(mods, nexusThumbs, tagsDict)               // data: full mod list + thumb URLs + tag dict
 applyFilters(visibleIdSet)                          // filter: Set<modId> of currently-visible mods
 getVisibleModIds()                                  // Discover button helper
-focusMod(modId)                                     // sidebar/Discover click — fly + open popup
+focusMod(modId)                                     // sidebar/Discover click - fly + open popup
 setPulse(modId, on)                                 // sidebar hover → pin pulse
 setClusterClickHandler(fn)                          // app.js registers cluster-click bridge
 setClustersChangedHandler(fn)                       // app.js registers map-aware panel hook
@@ -54,12 +54,12 @@ applyFilters() in app.js    ─► NCZ.ThreeMarkers.applyFilters(visibleIds)
                                   │  is now filtered out, runs recomputeClusters() synchronously.
 
 OrbitControls 'change'      ─► scheduleRecomputeClusters()
-                                  │  rAF-debounced — at most one recompute per frame regardless
+                                  │  rAF-debounced - at most one recompute per frame regardless
                                   │  of how often controls fires.
 
 render() each frame         ─► updateFlyTween() (if active)
                                 ─► cssRenderer.render(scene, camera)
-                                ─► updatePopupPlacement() (if popup open) — toggles auto-flip
+                                ─► updatePopupPlacement() (if popup open) - toggles auto-flip
 ```
 
 **Two data-arrival orders are supported** (whichever runs first triggers a
@@ -83,7 +83,7 @@ let _modsState = { mods, nexusThumbs, tagsDict };
 let popup = null;                 // CSS2DObject or null
 let popupModId = null;
 
-// Tooltip — single reusable CSS2DObject
+// Tooltip - single reusable CSS2DObject
 let tooltipObj = null;
 let tooltipText = null;
 
@@ -103,17 +103,17 @@ let _activeClusterMods = null;    // Set<modId> the cluster panel is showing
 
 ## Pins
 
-One `CSS2DObject` per mod. The element is `<div class="three-marker category-marker"><div class="marker-pin {category}"></div></div>` — same `marker-pin` class as Leaflet's 2D markers, so the diamond shape and category colours come from a single CSS source ([style.css:790-835](../assets/css/style.css#L790)).
+One `CSS2DObject` per mod. The element is `<div class="three-marker category-marker"><div class="marker-pin {category}"></div></div>`, the same `marker-pin` class as Leaflet's 2D markers, so the diamond shape and category colours come from a single CSS source ([style.css:790-835](../assets/css/style.css#L790)).
 
-Pin Y position uses `mod.coordinates[2]` (CET Z) directly + `PIN_3D_GROUND_OFFSET` (cosmetic lift). CET Z and terrain GLB Y are in the same coordinate space — see [coordinate-system-3d.md](coordinate-system-3d.md) for the validation experiment.
+Pin Y position uses `mod.coordinates[2]` (CET Z) directly + `PIN_3D_GROUND_OFFSET` (cosmetic lift). CET Z and terrain GLB Y are in the same coordinate space. See [coordinate-system-3d.md](coordinate-system-3d.md) for the validation experiment.
 
 ## Popups
 
 Click pin → `openPopup(mod)`. Single popup at a time; clicking the same pin again deselects (Leaflet-style toggle). Outside-click closes (with drag detection so a camera drag doesn't close the popup).
 
-Popup chrome is **shared CSS** with Leaflet — `.ncz-dynamic-popup` background gradient, arrow geometry, category colours. The 3D popup uses `.three-popup-anchor` (zero-size CSS2DObject element) wrapping `.three-popup` (the styled card) inside it. Direction classes `.ncz-popup-top` / `.ncz-popup-bottom` toggled by `updatePopupPlacement()` for auto-flip when the pin is near the viewport top.
+Popup chrome is **shared CSS** with Leaflet: `.ncz-dynamic-popup` background gradient, arrow geometry, category colours. The 3D popup uses `.three-popup-anchor` (zero-size CSS2DObject element) wrapping `.three-popup` (the styled card) inside it. Direction classes `.ncz-popup-top` / `.ncz-popup-bottom` toggled by `updatePopupPlacement()` for auto-flip when the pin is near the viewport top.
 
-Popup HTML comes from `NCZ.buildPopupHtml(mod, catStyle, nexusThumbs, tagsDict)` — also shared between views.
+Popup HTML comes from `NCZ.buildPopupHtml(mod, catStyle, nexusThumbs, tagsDict)`, also shared between views.
 
 Cross-view popup state syncs via `?mod=` URL param. `switchView()` re-opens the same popup in the destination view via `onViewSwitched`.
 
@@ -136,7 +136,7 @@ Single persistent `CSS2DObject` created at attach time. On pin `mouseenter`, pos
 
 ## Clustering
 
-**world-space XZ proximity grouping** (not screen-space — switched 2026-05 after Aki's UX feedback). Cluster radius is `PIN_3D_CLUSTER_RADIUS_PX` (40) converted to world units at current zoom, so clusters dissolve as the user zooms in (matching Leaflet's behaviour) but stay invariant to camera tilt and rotation (unlike the original screen-space approach which mis-clustered visually-close-but-far-apart pins at high tilt). Greedy O(N²) on filter-visible pins, recomputed on **zoom change** or filter change only — pan and tilt leave clusters intact. Cluster bubbles use `.marker-cluster` class + Leaflet's existing colour ramp. Pool of CSS2DObjects reused across recomputes.
+**world-space XZ proximity grouping** (not screen-space, switched 2026-05 after Aki's UX feedback). Cluster radius is `PIN_3D_CLUSTER_RADIUS_PX` (40) converted to world units at current zoom, so clusters dissolve as the user zooms in (matching Leaflet's behaviour) but stay invariant to camera tilt and rotation (unlike the original screen-space approach which mis-clustered visually-close-but-far-apart pins at high tilt). Greedy O(N²) on filter-visible pins, recomputed on **zoom change** or filter change only; pan and tilt leave clusters intact. Cluster bubbles use `.marker-cluster` class + Leaflet's existing colour ramp. Pool of CSS2DObjects reused across recomputes.
 
 ## Cluster panel integration
 
@@ -150,36 +150,36 @@ Both views' panel handlers are registered *inside* the data-load try block in
 app.js so they have access to `mods` and `nexusThumbs`.
 
 The active cluster bubble (the one whose contents are showing in the panel)
-gets `.marker-cluster.marker-cluster-active` — cyan ring + glow. Mark
+gets `.marker-cluster.marker-cluster-active`: cyan ring + glow. Mark
 auto-syncs across recomputes via `setActiveClusterMods(modSet)` and
 `refreshActiveClusterMark()`.
 
-## Constants — all in [`constants.js`](../assets/js/constants.js)
+## Constants: all in [`constants.js`](../assets/js/constants.js)
 
 | Name | Default | What it does |
 |---|---|---|
-| `PIN_3D_GROUND_OFFSET` | 5 | CET metres above CET Z — cosmetic lift only, never read elsewhere |
+| `PIN_3D_GROUND_OFFSET` | 5 | CET metres above CET Z: cosmetic lift only, never read elsewhere |
 | `PIN_3D_DRAG_THRESHOLD_PX` | 4 | Pixels of pointerdown→pointerup movement before treating as a drag (popup doesn't close on drag end) |
 | `PIN_3D_POPUP_FLIP_PADDING_PX` | 24 | Pixels of clearance above viewport top before popup flips below pin |
 | `PIN_3D_FLY_DURATION_MS` | 700 | Total tween time for sidebar click → camera fly-to-pin |
 | `PIN_3D_FLY_ZOOM` | 15 | Target `camera.zoom` at end of fly |
-| `PIN_3D_CLUSTER_RADIUS_PX` | 40 | Equivalent pixel radius for cluster grouping. Converted to world units at recompute time — `PIN_3D_CLUSTER_RADIUS_PX × ((camera.right − camera.left) / (camera.zoom × canvasWidth))` — so clusters dissolve at the same rate as Leaflet's pixel-radius does. Stays in `_PX` for naming because the dev-intuition target is a Leaflet-equivalent pixel size. |
+| `PIN_3D_CLUSTER_RADIUS_PX` | 40 | Equivalent pixel radius for cluster grouping. Converted to world units at recompute time via `PIN_3D_CLUSTER_RADIUS_PX × ((camera.right − camera.left) / (camera.zoom × canvasWidth))`, so clusters dissolve at the same rate as Leaflet's pixel-radius does. Stays in `_PX` for naming because the dev-intuition target is a Leaflet-equivalent pixel size. |
 
 All five are JS-side runtime tunables. Visual constants (popup margin, arrow
-size, tooltip padding) live in CSS — see [style.css](../assets/css/style.css)
+size, tooltip padding) live in CSS. See [style.css](../assets/css/style.css)
 sections at `.three-popup`, `.three-tooltip-anchor`, etc.
 
 ## Shared substrate with Leaflet
 
 Both views share, by design:
 
-- **Mod data** — `mods.json` parsed once, fed into both layers.
-- **Filter logic** — `NCZ.computeVisibleMods(mods, filterState)` returns a `Set<modId>` consumed by both views' `applyFilters`.
-- **Popup HTML** — `NCZ.buildPopupHtml(mod, catStyle, nexusThumbs, tagsDict)`.
-- **Cluster panel DOM** — `#cluster-panel` in `index.html`, populated by `populateClusterPanel(modsList, opts)`.
-- **CSS classes** — `.marker-pin`, `.pin-tooltip*`, `.marker-cluster*`, `.ncz-dynamic-popup*`, `.pulsing`.
-- **`?mod=` URL state** — both views write/read on popup open/close.
-- **Sidebar event handlers** — sidebar item click and hover dispatch to whichever view is active.
+- **Mod data**: `mods.json` parsed once, fed into both layers.
+- **Filter logic**: `NCZ.computeVisibleMods(mods, filterState)` returns a `Set<modId>` consumed by both views' `applyFilters`.
+- **Popup HTML**: `NCZ.buildPopupHtml(mod, catStyle, nexusThumbs, tagsDict)`.
+- **Cluster panel DOM**: `#cluster-panel` in `index.html`, populated by `populateClusterPanel(modsList, opts)`.
+- **CSS classes**: `.marker-pin`, `.pin-tooltip*`, `.marker-cluster*`, `.ncz-dynamic-popup*`, `.pulsing`.
+- **`?mod=` URL state**: both views write/read on popup open/close.
+- **Sidebar event handlers**: sidebar item click and hover dispatch to whichever view is active.
 
 The split:
 
@@ -193,24 +193,24 @@ between the two containers in `switchView`).
 
 Short version: AtlasForge runs Three.js inside a MapLibre `CustomLayerInterface`
 (single GL context). That works when 2D and 3D fuse into one view. Our product
-treats SAT and SCHEMA as **distinct visual experiences** — the schematic 3D
+treats SAT and SCHEMA as **distinct visual experiences**: the schematic 3D
 scene has its own theme palette, lighting, flyover, and pin-Z-anchored popups
 that wouldn't translate to a flat-pins overlay. Dual canvas is the correct
 trade-off; cross-view consistency comes from the shared substrate above, not
 from sharing the renderer.
 
-## Adding a new pin behaviour — quick guide
+## Adding a new pin behaviour: quick guide
 
 1. Decide whether the behaviour is view-agnostic or 3D-only.
    - **View-agnostic** (e.g. a new badge, sidebar tweak, popup field): add to the relevant shared helper (`NCZ.buildPopupHtml`, `populateClusterPanel`, etc.) and let both views inherit.
    - **3D-only** (e.g. building-shadow on pin hover, animated pin entry): add to ThreeMarkers, exposed via a new method on the public API.
 2. If you need new tunables: add to `constants.js` under the `// 3D pin layer` section, named `PIN_3D_*` to make scope explicit.
 3. If you need new CSS: see if Leaflet already has equivalent styling (`grep "\.pin-tooltip\|\.marker-pin\|\.marker-cluster" assets/css/style.css`). If yes, share via combined selectors (e.g. `.leaflet-popup.ncz-dynamic-popup, .three-popup.ncz-dynamic-popup`). If no, add a new rule.
-4. Cross-reference the parity plan — if you're adding something Leaflet does too, it probably has an entry in the plan that should be ticked off or expanded.
+4. Cross-reference the parity plan: if you're adding something Leaflet does too, it probably has an entry in the plan that should be ticked off or expanded.
 
 ## Related documents
 
-- [three-js-scene.md](three-js-scene.md) — 3D scene infrastructure (renderer, GLBs, camera, lighting, shadows). ThreeMarkers attaches to it.
-- [GitHub Project](https://github.com/users/spuddeh/projects/1) — current pending parity work, tracked under the Three.js Parity stream.
-- [coordinate-system-3d.md](coordinate-system-3d.md) — CET ↔ Three.js coordinate spaces, including the validated CET-Z = terrain-GLB-Y finding that lets `pinYFor()` work without a raycast.
-- [architecture.md](architecture.md) — repo-wide file structure and module loading order.
+- [three-js-scene.md](three-js-scene.md): 3D scene infrastructure (renderer, GLBs, camera, lighting, shadows). ThreeMarkers attaches to it.
+- [GitHub Project](https://github.com/users/spuddeh/projects/1): current pending parity work, tracked under the Three.js Parity stream.
+- [coordinate-system-3d.md](coordinate-system-3d.md): CET ↔ Three.js coordinate spaces, including the validated CET-Z = terrain-GLB-Y finding that lets `pinYFor()` work without a raycast.
+- [architecture.md](architecture.md): repo-wide file structure and module loading order.

--- a/docs/tile-generation.md
+++ b/docs/tile-generation.md
@@ -6,7 +6,7 @@ The map image is too large to load as a single file. Instead, we slice it into 2
 
 ## Source Image
 
-Tiles are generated from the **16k PNG** source (lossless) and encoded directly to WebP. This avoids double lossy compression — Sharp decodes the PNG into raw pixels, then encodes each tile to WebP in one step.
+Tiles are generated from the **16k PNG** source (lossless) and encoded directly to WebP. This avoids double lossy compression: Sharp decodes the PNG into raw pixels, then encodes each tile to WebP in one step.
 
 Source images are stored in `raw maps/` (not committed due to size):
 
@@ -66,14 +66,14 @@ The script (`scripts/generate_tiles.js`) uses [Sharp](https://sharp.pixelplumbin
 ### WebP Encoding
 
 - **Quality 90**: Visually indistinguishable from lossless at 256×256 tile size, ~5× smaller than PNG
-- **Effort 6**: Maximum compression effort — slower encode, smaller files. One-time generation cost.
+- **Effort 6**: Maximum compression effort (slower encode, smaller files). One-time generation cost.
 - **Source format matters**: Tiles are generated from PNG (lossless) to avoid generation loss from double lossy compression
 
 ### Tile Coordinates
 
-- `{z}` — zoom level (0 = zoomed out, 6 = native resolution)
-- `{x}` — column index (0 = left)
-- `{y}` — row index (0 = top)
+- `{z}`: zoom level (0 = zoomed out, 6 = native resolution)
+- `{x}`: column index (0 = left)
+- `{y}`: row index (0 = top)
 
 At zoom 6: 64 columns × 64 rows = 4,096 tiles.
 
@@ -97,9 +97,9 @@ L.tileLayer('assets/tiles/{z}/{x}/{y}.webp', {
 }).addTo(map);
 ```
 
-- `maxNativeZoom: 6` — Leaflet knows zoom 6 is the best available
-- `maxZoom: 8` — Users can zoom 2 levels deeper (tiles are upscaled 4×)
-- `bounds` — Calculated via `map.unproject()` to align pixel coords with `CRS.Simple`
+- `maxNativeZoom: 6` tells Leaflet zoom 6 is the best available
+- `maxZoom: 8` lets users zoom 2 levels deeper (tiles are upscaled 4×)
+- `bounds` is calculated via `map.unproject()` to align pixel coords with `CRS.Simple`
 
 ### Coordinate Projection
 
@@ -107,4 +107,4 @@ L.tileLayer('assets/tiles/{z}/{x}/{y}.webp', {
 
 ## Why Not 32k?
 
-The 32k source would give zoom 7 (128×128 = 16,384 tiles at native, ~21,845 total). That alone exceeds Cloudflare Pages' 20,000-files-per-deployment limit (before counting the ~5,461 existing tiles and all other assets), and adds significant repo size (~100+ MB) for diminishing returns — users already get sharp detail at zoom 6 with only 4× upscaling at max zoom. The 32k source is available if we move tiles to external object storage (e.g. Cloudflare R2) in the future.
+The 32k source would give zoom 7 (128×128 = 16,384 tiles at native, ~21,845 total). That alone exceeds Cloudflare Pages' 20,000-files-per-deployment limit (before counting the ~5,461 existing tiles and all other assets), and adds significant repo size (~100+ MB) for diminishing returns: users already get sharp detail at zoom 6 with only 4× upscaling at max zoom. The 32k source is available if we move tiles to external object storage (e.g. Cloudflare R2) in the future.

--- a/docs/url-parameters.md
+++ b/docs/url-parameters.md
@@ -7,14 +7,14 @@ Query-string flags the app reads at load time. Append to the site URL, e.g.
 | --- | --- | --- | --- |
 | `?mod=<nexus_id>` | value | Deep-link: opens the given mod's pin/popup and flies to it on load. Used by the in-app "copy link" button. See `docs/` deep-link notes. | `app.js`, `three-scene.js` |
 | `?debug` | flag | Shows the on-screen stats panel (FPS, draw calls, triangles) and a **Copy debug info** button; enables extra console diagnostics. | `three-scene.js` |
-| `?webgpuprobe` | flag | Runs a WebGPU adapter/device negotiation probe and logs the result — diagnostic for "scene fell back to WebGL / won't start". | `three-scene.js` |
+| `?webgpuprobe` | flag | Runs a WebGPU adapter/device negotiation probe and logs the result: diagnostic for "scene fell back to WebGL / won't start". | `three-scene.js` |
 | `?forcewebgl` | flag | Forces the Three.js renderer to the WebGL2 backend instead of WebGPU (for comparison/debugging; the scene's compute buildings need WebGPU, so expect a degraded/2D fallback). | `three-scene.js` |
 | `?gamelight` | flag | Lighting **calibration reference** mode: pins the decoded in-game sun, freezes the time-of-day slider, and strips Districts/Pins overlays so surfaces can be matched against the in-game capture. | `app.js`, `three-scene.js` |
-| `?only=<district>` | value | Renders **only** the named `DISTRICT_META` building cloud (e.g. `?only=my_district`, `?only=ugly_building`, `?only=watson`) — isolates one cloud for diagnosing placement/content. | `three-scene.js` |
+| `?only=<district>` | value | Renders **only** the named `DISTRICT_META` building cloud (e.g. `?only=my_district`, `?only=ugly_building`, `?only=watson`): isolates one cloud for diagnosing placement/content. | `three-scene.js` |
 
 Notes:
 
-- Flags are presence-based (`?debug` — no value needed); value params take `=<value>`.
+- Flags are presence-based (`?debug`, no value needed); value params take `=<value>`.
 - Combine with `&` (e.g. `?debug&only=my_district`).
 - These are developer/diagnostic aids except `?mod`, which is a user-facing share link.
 
@@ -31,7 +31,7 @@ The value must match a `DISTRICT_META` entry name in `assets/js/three-scene.js`:
 | `santo_domingo` | both | |
 | `watson` | both | |
 | `ep1_dogtown` | both | Phantom Liberty |
-| `ep1_spaceport` | both | no fixed variant — base-game in either set |
+| `ep1_spaceport` | both | no fixed variant: base-game in either set |
 | `my_district` | Fixed only | malgalad's combined corrections overlay |
 | `ugly_building` | Fixed only | malgalad's "ugly building" add-on (Watson) |
 
@@ -40,9 +40,9 @@ active (Settings → Map data). See [`3dmap-fixed-assets.md`](3dmap-fixed-assets
 
 ## Other debug aids (not URL flags)
 
-Not query params, but the same family of developer/diagnostic tools — catalogued
+Not query params, but the same family of developer/diagnostic tools, catalogued
 here so they're easy to find.
 
 | Aid | How | What it does | Read in |
 | --- | --- | --- | --- |
-| Showcase pause | `Space` during the showcase | Freezes the flyover on the current frame (camera + audio stop) while keeping pins clickable — open a pin's popup to identify which mod it is on a suspect frame. `Space` again resumes from the same point. No on-screen UI advertises it; intended for the maintainer or "screenshot this frame for me" requests. | `flyover.js` |
+| Showcase pause | `Space` during the showcase | Freezes the flyover on the current frame (camera + audio stop) while keeping pins clickable: open a pin's popup to identify which mod it is on a suspect frame. `Space` again resumes from the same point. No on-screen UI advertises it; intended for the maintainer or "screenshot this frame for me" requests. | `flyover.js` |


### PR DESCRIPTION
## What

Applies the house style across all 30 `docs/` files. Docs only, no runtime surface.

- **Em-dashes removed from prose (565).** Each replaced with the punctuation the clause actually wants (colon, comma, parentheses, or a sentence split), not a blanket `--` swap.
- **Incidental code-fence em-dashes converted to hyphens** (annotated file trees, illustrative code comments). **Kept** the three that document the literal ` - ` label separator (`tags.md`, `nczoning-auto-discovery.md`): those are content, not formatting.
- **Australian English** in prose (colour, behaviour, centre, organise, acknowledgements, ...). Code identifiers, CSS variables, API field names and JSON keys left untouched.
- **Light voice polish** for readability where phrasing read stiff. Facts, numbers, structure and headings preserved.
- **Arrows kept** as meaningful notation.

## Verification

- Prose is 100% em-dash-free; only the 3 semantic separators remain (in code fences, documenting a literal character).
- No code identifiers AU-mangled (`MainColors`, `localizedName`, `city_center`, `DISTRICT_COLORS` all intact).
- All internal and cross-file `#anchor` links resolve; a pre-existing broken heading anchor in `creating-a-new-district.md` was fixed as a side effect.
- Line endings kept CRLF to match the repo.

## Method

Fanned out to parallel copy-editors over disjoint file groups, then reviewed the aggregate diff for consistency, identifier integrity, and anchor safety. Worth a read for the voice polish specifically (six files got more than punctuation: `tile-generation`, `3d-map-lighting`, `architecture`, `3dmap-fixed-assets`, `three-markers`, `map-data-extraction`) since only you can judge whether the reworded phrasing reads better.

## Not in this PR

The 5 docs that diverge on `feat/3dmap-night-lighting` (`3d-map-lighting`, `3dmap-lighting-shadows`, `building-classification`, `showcase-flyover`, `url-parameters`) carry night-branch-only content that needs its own pass. Also separate: the shipped **code-comment** em-dashes (house style covers those too), which would be their own diff across the JS.

## CI

No workflow fires on a PR to `dev` (validate-mods and deploy-api are `main`/`worker/**` scoped).