### PR TITLE
chore(comments): house-style pass on shipped code comments

### DIFF
--- a/.github/workflows/modify-location-submission.yml
+++ b/.github/workflows/modify-location-submission.yml
@@ -84,7 +84,7 @@ jobs:
 
               const existingData = JSON.parse(fs.readFileSync(filePath, 'utf8'));
 
-              // Prepare new data — keep existing coordinates if all are blank
+              // Prepare new data: keep existing coordinates if all are blank
               let coordX, coordY, coordZ;
               const hasNewCoords = coordXRaw || coordYRaw || coordZRaw;
               if (!hasNewCoords) {

--- a/.github/workflows/monitor-api-health.yml
+++ b/.github/workflows/monitor-api-health.yml
@@ -1,7 +1,7 @@
 name: Monitor Data API Health
 
-# The site consumes /v1 with a client-side fallback (B7), and in-game mods —
-# the API's primary consumer — have NO fallback. So a silent website fallback
+# The site consumes /v1 with a client-side fallback (B7), and in-game mods
+# (the API's primary consumer) have NO fallback. So a silent website fallback
 # would mask an API outage. This is the independent alarm: it hits the live API
 # on a schedule and pings Discord (+ fails the run) when it isn't serving.
 

--- a/.github/workflows/monitor-auto-discovery.yml
+++ b/.github/workflows/monitor-auto-discovery.yml
@@ -2,7 +2,7 @@ name: Monitor Auto-Discovery Health
 
 # Authors add NCZoning metadata blocks to their Nexus descriptions at any time,
 # and a parse failure is silent. Since B7 the parsing runs server-side (the Data
-# API cron) and the result is exposed at /v1/meta.skipped — mods tagged NCZoning
+# API cron) and the result is exposed at /v1/meta.skipped: mods tagged NCZoning
 # that aren't excluded/manual and didn't parse. This reads that list and pings
 # Discord when it's non-empty, so a broken block is caught within a day instead
 # of when an author complains. (One source of truth: no client/server drift.)

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@
 !/sitemap.xml
 !/_headers
 
-# Large generated data files — regenerate with scripts, do not commit
+# Large generated data files: regenerate with scripts, do not commit
 data/buildings.json
 data/roads.json
 data/metro.json
@@ -43,11 +43,11 @@ node_modules/
 .DS_Store
 Thumbs.db
 
-# Uncompressed source GLBs — drop WolvenKit exports here for `npm run encode-meshopt`.
+# Uncompressed source GLBs: drop WolvenKit exports here for `npm run encode-meshopt`.
 # Repo only commits the encoded output at assets/glb-meshopt/.
 assets/glb-source/
 
-# Source .cube for the colour-grading LUT — drop the WolvenKit .cube export
+# Source .cube for the colour-grading LUT: drop the WolvenKit .cube export
 # here for `npm run build-lut`. Repo only commits the runtime asset at
 # assets/data/.
 assets/lut-source/

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -30,7 +30,7 @@
 /* Force the WebGLRenderer canvas to fill its container.
    Three.js is initialised with `setSize(w, h, false)` (updateStyle:false), so
    it never writes inline width/height onto <canvas>. Without this rule, the
-   canvas — a replaced element — falls back to its intrinsic dimensions (the
+   canvas (a replaced element) falls back to its intrinsic dimensions (the
    drawingBuffer pixel size, = clientSize × devicePixelRatio), which overflows
    the container on any DPR > 1.0 and shifts the WebGL scene off the CSS2D pin
    overlay. See three-scene.js:225 for the renderer setup. */
@@ -39,8 +39,8 @@
     height: 100%;
 }
 
-/* Overlay toggles — floats over the map, above the view toggle */
-/* District hover info panel — top-right under the header, right-aligned with the
+/* Overlay toggles: floats over the map, above the view toggle */
+/* District hover info panel: top-right under the header, right-aligned with the
    icon on the right (parity with the in-game bottom-right readout; bottom-right
    here is taken by the overlay controls). --di-color is set per-district by
    NCZ.DistrictInfo. pointer-events:none so it never blocks the map. */
@@ -56,7 +56,7 @@
     pointer-events: none;
     /* Text-only (no plate). A solid four-direction dark casing (like the map
        labels) keeps it legible over bright satellite imagery as well as the dark
-       schematic — a soft blur alone washed out over the rooftops. */
+       schematic; a soft blur alone washed out over the rooftops. */
     text-shadow:
         -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000,
         0 0 4px rgba(0, 0, 0, 0.9),
@@ -191,7 +191,7 @@
     }
 }
 
-/* View toggle (SAT | SCHEMA) — floats over the map in the bottom-right */
+/* View toggle (SAT | SCHEMA): floats over the map in the bottom-right */
 #map-view-toggle {
     position: absolute;
     bottom: 80px; /* above Leaflet zoom controls */
@@ -225,7 +225,7 @@
     }
 }
 
-/* Controls reference + reset — bottom-left of #map-3d */
+/* Controls reference + reset: bottom-right of #map-3d */
 #scene-controls {
     position: absolute;
     bottom: var(--space-sm);
@@ -389,7 +389,7 @@
 }
 
 
-/* Showcase fullscreen — applied directly to #map-3d, no ancestor cascade needed */
+/* Showcase fullscreen: applied directly to #map-3d, no ancestor cascade needed */
 #map-3d.showcase-fullscreen {
     position: fixed;
     inset: 0;
@@ -399,7 +399,7 @@
 }
 
 
-/* Flyover start-screen — opening title card */
+/* Flyover start-screen: opening title card */
 #flyover-start-screen {
     position: absolute;
     inset: 0;
@@ -1073,7 +1073,7 @@ body.cluster-panel-resizing * {
         line-height: var(--lh-zoom-control) !important;
     }
 
-    /* Leaflet Scale Control — placement only. Visual styling lives below
+    /* Leaflet Scale Control: placement only. Visual styling lives below
        so the 3D view's #scene-scale can wear the same skin. */
     .leaflet-control-scale {
         margin-bottom: var(--space-md);
@@ -1081,7 +1081,7 @@ body.cluster-panel-resizing * {
     }
 }
 
-/* Distance scale bar — shared by Leaflet (.leaflet-control-scale at
+/* Distance scale bar: shared by Leaflet (.leaflet-control-scale at
    bottom-right of the SAT view) and ThreeMarkers (#scene-scale at bottom-
    right of the SCHEMA view). Both wear the same .leaflet-control-scale-line
    skin so 2D and 3D distance bars render identically. */
@@ -1102,7 +1102,7 @@ body.cluster-panel-resizing * {
     }
 }
 
-/* 3D-specific placement — floats above the bottom controls strip, below the
+/* 3D-specific placement: floats above the bottom controls strip, below the
    #map-view-toggle. Kept out of #scene-controls so the strip's flex row
    doesn't shift width every time the bar relabels at a new zoom level.
    Bottom value sits in the gap between scene-controls top (~44px) and
@@ -1161,7 +1161,7 @@ body.cluster-panel-resizing * {
     background-color: var(--secondary) !important;
 }
 
-/* ── Popup chrome — shared by Leaflet (2D) and ThreeMarkers (3D) ──────────
+/* ── Popup chrome: shared by Leaflet (2D) and ThreeMarkers (3D) ──────────
    Leaflet renders the popup inside `.leaflet-popup.ncz-dynamic-popup >
    .leaflet-popup-content-wrapper`. ThreeMarkers renders it as
    `.three-popup.ncz-dynamic-popup` directly (no auto-generated wrapper).
@@ -1177,7 +1177,7 @@ body.cluster-panel-resizing * {
     &.popup-cat-other             { --popup-border-color: var(--category-other); }
 }
 
-/* Leaflet-only structural reset — strip Leaflet's default close button, tip,
+/* Leaflet-only structural reset: strip Leaflet's default close button, tip,
    and outer wrapper margins so our chrome can render cleanly. */
 .leaflet-popup.ncz-dynamic-popup {
     margin: 0 !important;
@@ -1187,7 +1187,7 @@ body.cluster-panel-resizing * {
     .leaflet-popup-tip-container { display: none !important; }
 }
 
-/* The styled card — Leaflet's content-wrapper or 3D's .three-popup. */
+/* The styled card: Leaflet's content-wrapper or 3D's .three-popup. */
 .leaflet-popup.ncz-dynamic-popup .leaflet-popup-content-wrapper,
 .three-popup.ncz-dynamic-popup {
     position: relative;
@@ -1211,7 +1211,7 @@ body.cluster-panel-resizing * {
     }
 }
 
-/* Direction classes — ncz-popup-top = popup is above pin (arrow at popup
+/* Direction classes: ncz-popup-top = popup is above pin (arrow at popup
    bottom pointing down). ncz-popup-bottom = popup below pin (arrow at top
    pointing up). top/bottom work for both views; left/right are Leaflet-only. */
 .leaflet-popup.ncz-dynamic-popup.ncz-popup-top .leaflet-popup-content-wrapper::after,
@@ -1793,7 +1793,7 @@ header {
 }
 
 h1 {
-    /* Tier 0 wordmark — the one place the Night Corp Display face earns its keep.
+    /* Tier 0 wordmark: the one place the Night Corp Display face earns its keep.
        The display face is wider than Orbitron, so pin it to one line. */
     font-family: var(--font-nightcorp);
     font-size: 1.75rem;
@@ -1964,7 +1964,7 @@ body::before {
     }
 }
 
-/* Tier 0 boot splash — display face, biggest branded moment in the welcome flow */
+/* Tier 0 boot splash: display face, biggest branded moment in the welcome flow */
 .welcome-hero {
     font-family: var(--font-nightcorp);
     font-size: var(--text-2xl);
@@ -2012,7 +2012,7 @@ body::before {
     gap: var(--space-sm);
 }
 
-/* Attribution block — "Asset & data credits" heading, CDPR Fan Content
+/* Attribution block: "Asset & data credits" heading, CDPR Fan Content
    disclaimer, then the per-asset credit list. Body reads at the modal text
    size; heading reuses the .parameters-section-title idiom (Orbitron, accent,
    uppercase) so it matches the Settings section headings. */
@@ -2148,7 +2148,7 @@ body::before {
 }
 
 /* Always-visible hint under a Settings checkbox (the toggles' hover-title made
-   visible, per request) — a bit smaller than the setting label. */
+   visible); a bit smaller than the setting label. */
 .parameters-hint {
     margin: 0 0 var(--space-xs) calc(var(--space-md) + var(--space-2xs));
     font-family: var(--font-body);
@@ -2514,7 +2514,7 @@ body::before {
         color: var(--color-white);
     }
 
-    /* Active cluster — the one whose contents are currently in the cluster
+    /* Active cluster: the one whose contents are currently in the cluster
        panel. Shared between Leaflet (SAT) and ThreeMarkers (SCHEMA) views. */
     &.marker-cluster-active {
         box-shadow:
@@ -2578,7 +2578,7 @@ body::before {
 }
 
 /* Outline-hover emphasis: the hovered district/subdistrict's label pops to full
-   opacity, scales up slightly, and gains a colour glow — paired with the
+   opacity, scales up slightly, and gains a colour glow, paired with the
    outline brighten in setHoveredDistrict (3D) / onMapMouseMove (2D). */
 .district-label.district-label-hover {
     opacity: 1;
@@ -2607,14 +2607,14 @@ body::before {
 }
 
 /* The satellite imagery is bright and busy, so the 3D schematic's soft halo
-   isn't enough — give the SAT labels a solid dark text-casing (1px outline in
+   isn't enough: give the SAT labels a solid dark text-casing (1px outline in
    all four diagonals + glow) and a heavier weight / more present baseline so the
    names stay legible over any tile. Scoped to the Leaflet tooltip so the 3D
    labels keep their faint look. Higher specificity than the shared hover rule,
    so the hover override below must match it (4 classes) to still win. */
 .leaflet-tooltip.district-label-tooltip .district-label {
     /* Faded baseline (so the fade + hover-emphasis still read) but kept legible
-       by the solid dark casing below — the outline carries contrast even at low
+       by the solid dark casing below; the outline carries contrast even at low
        fill opacity, where the old soft halo couldn't. */
     opacity: 0.6;
     font-weight: 700;
@@ -2631,7 +2631,7 @@ body::before {
         0 0 6px var(--label-color, #fff), 0 0 12px #000;
 }
 
-/* 3D tooltip anchor — wraps the shared `.pin-tooltip` skin (defined above).
+/* 3D tooltip anchor: wraps the shared `.pin-tooltip` skin (defined above).
    CSS2DRenderer projects the anchor to the pin's world position; the inner
    .pin-tooltip is then offset upward in screen space so the arrow points
    down at the pin. Single instance reused on every hover. */
@@ -2656,7 +2656,7 @@ body::before {
 }
 
 .three-popup-anchor {
-    /* CSS2DRenderer applies translate(-50%, -50%) — a zero-size box centres
+    /* CSS2DRenderer applies translate(-50%, -50%): a zero-size box centres
        its inner content's reference point exactly on the world position. */
     position: relative;
     width: 0;
@@ -2664,8 +2664,8 @@ body::before {
     pointer-events: none;
     /* CSS2DRenderer sets style.zIndex inline per frame based on camera
        distance, which can place a closer pin in front of a popup attached
-       to a further pin. !important is the only way to beat inline styles
-       — combined with renderOrder=1000 on the CSS2DObject (see three-markers.js)
+       to a further pin. !important is the only way to beat inline styles;
+       combined with renderOrder=1000 on the CSS2DObject (see three-markers.js)
        this guarantees the popup always paints above every pin.
        Value 500 is deliberately chosen between:
          - CSS2DRenderer's auto-assigned zIndex range (0–~300 for our pin count)
@@ -2674,7 +2674,7 @@ body::before {
     z-index: 500 !important;
 }
 
-/* 3D-specific positioning — sizes the popup and floats it above (default)
+/* 3D-specific positioning: sizes the popup and floats it above (default)
    or below (when `.ncz-popup-bottom` is added) the anchor's world point.
    Visual chrome (background, arrow, category colour) comes from the shared
    `.ncz-dynamic-popup` rules above; this rule only deals with layout. */

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,4 +1,4 @@
-/* Tier 0 — Display / Brand face (derived from the Night Corp logo).
+/* Tier 0: Display / Brand face (derived from the Night Corp logo).
    Caps-only subset: A-Z, 0-9, punctuation. Reserve for the shortest, biggest,
    most branded moments only (wordmarks, splash hero text). Never body copy. */
 @font-face {
@@ -23,7 +23,7 @@
     --space-md: 10px;
     --space-lg: 12px;
 
-    /* Semantic color aliases */
+    /* Semantic colour aliases */
     --color-black: #000;
     --color-white: #fff;
     --text-muted: #666;
@@ -65,7 +65,7 @@
     --lh-zoom-control: 1.625rem;
     --lh-cluster-count: 30px;
 
-    /* Decorative scanline colors */
+    /* Decorative scanline colours */
     --scanline-dark: rgba(18, 16, 16, 0);
     --scanline-red: rgba(255, 0, 0, 0.03);
     --scanline-green: rgba(0, 255, 0, 0.01);
@@ -79,11 +79,11 @@
     --font-heading: 'Orbitron', sans-serif;
     --font-body: 'Rajdhani', sans-serif;
 
-    /* Relative color tints derived from active theme base colors */
+    /* Relative colour tints derived from active theme base colours */
 
     --primary-60: rgb(from var(--primary) r g b / 0.6);
 
-    /* Building edge glow — defined per-theme; read by Three.js shader via readThemeColor() */
+    /* Building edge glow: defined per-theme; read by Three.js shader via readThemeColor() */
 
     --secondary-05: rgb(from var(--secondary) r g b / 0.05);
     --secondary-10: rgb(from var(--secondary) r g b / 0.1);
@@ -98,7 +98,7 @@
 
     --gray-40: rgb(from var(--gray) r g b / 0.4);
 
-    /* Cluster colors (10 steps, 0..100 count range) */
+    /* Cluster colours (10 steps, 0..100 count range) */
     --cluster-bg-saturation: 84%;
     --cluster-bg-lightness: 64%;
     --cluster-bg-alpha: 0.6;
@@ -127,7 +127,7 @@ html.theme-night-corp {
     --white-78: rgba(230, 241, 255, 0.78);
     --white-86: rgba(230, 241, 255, 0.86);
 
-    /* Theme category colors */
+    /* Theme category colours */
     --category-location-overhaul: var(--secondary);
     --category-location-overhaul-glow: var(--secondary-40);
     --category-new-location: var(--tertiary);
@@ -135,7 +135,7 @@ html.theme-night-corp {
     --category-other: var(--gray);
     --category-other-glow: var(--gray-40);
 
-    /* 3D scene mesh colors */
+    /* 3D scene mesh colours */
     --scene-terrain:         #2e4a62;
     --scene-water:           #1e3048;
     --scene-cliffs:          #2e4a62;
@@ -144,10 +144,10 @@ html.theme-night-corp {
     --scene-buildings-edge:  #00f0ff;
     --scene-grid:            #5b86a8;
 
-    /* Overlay colors (roads/metro for SCHEMA, districts for both) */
+    /* Overlay colours (roads/metro for SCHEMA, districts for both) */
     --overlay-road-color:        #485c70;
     --overlay-road-border-color: #608898;
-    --overlay-metro-color:       #bfe0ec;  /* light — additive @0.235 opacity */
+    --overlay-metro-color:       #bfe0ec;  /* light; additive @0.235 opacity */
 
 }
 
@@ -171,7 +171,7 @@ html.theme-arasaka {
     --white-78: rgba(230, 241, 255, 0.78);
     --white-86: rgba(230, 241, 255, 0.86);
 
-    /* Theme category colors */
+    /* Theme category colours */
     --category-location-overhaul: var(--secondary);
     --category-location-overhaul-glow: var(--secondary-40);
     --category-new-location: var(--tertiary);
@@ -179,7 +179,7 @@ html.theme-arasaka {
     --category-other: var(--gray);
     --category-other-glow: var(--gray-40);
 
-    /* 3D scene mesh colors */
+    /* 3D scene mesh colours */
     --scene-terrain:         #3a2e2e;
     --scene-water:           #241818;
     --scene-cliffs:          #3a2e2e;
@@ -188,10 +188,10 @@ html.theme-arasaka {
     --scene-buildings-edge:  #ff5050;
     --scene-grid:            #8a5a5a;
 
-    /* Overlay colors */
+    /* Overlay colours */
     --overlay-road-color:        #4a3838;
     --overlay-road-border-color: #603030;
-    --overlay-metro-color:       #f0d2d2;  /* light — additive @0.235 opacity */
+    --overlay-metro-color:       #f0d2d2;  /* light; additive @0.235 opacity */
 
 }
 
@@ -215,7 +215,7 @@ html.theme-militech {
     --white-78: rgba(230, 241, 255, 0.78);
     --white-86: rgba(230, 241, 255, 0.86);
 
-    /* Theme category colors */
+    /* Theme category colours */
     --category-location-overhaul: var(--secondary);
     --category-location-overhaul-glow: var(--secondary-40);
     --category-new-location: var(--tertiary);
@@ -223,7 +223,7 @@ html.theme-militech {
     --category-other: var(--gray);
     --category-other-glow: var(--gray-40);
 
-    /* 3D scene mesh colors */
+    /* 3D scene mesh colours */
     --scene-terrain:         #384030;
     --scene-water:           #202c20;
     --scene-cliffs:          #384030;
@@ -232,10 +232,10 @@ html.theme-militech {
     --scene-buildings-edge:  #ffd040;
     --scene-grid:            #6f7c55;
 
-    /* Overlay colors */
+    /* Overlay colours */
     --overlay-road-color:        #485248;
     --overlay-road-border-color: #606040;
-    --overlay-metro-color:       #ebe6c4;  /* light — additive @0.235 opacity */
+    --overlay-metro-color:       #ebe6c4;  /* light; additive @0.235 opacity */
 
 }
 
@@ -259,7 +259,7 @@ html.theme-aldecaldos {
     --white-78: rgba(230, 241, 255, 0.78);
     --white-86: rgba(230, 241, 255, 0.86);
 
-    /* Theme category colors */
+    /* Theme category colours */
     --category-location-overhaul: var(--secondary);
     --category-location-overhaul-glow: var(--secondary-40);
     --category-new-location: var(--tertiary);
@@ -267,7 +267,7 @@ html.theme-aldecaldos {
     --category-other: var(--gray);
     --category-other-glow: var(--gray-40);
 
-    /* 3D scene mesh colors */
+    /* 3D scene mesh colours */
     --scene-terrain:         #3a3428;
     --scene-water:           #242018;
     --scene-cliffs:          #3a3428;
@@ -276,10 +276,10 @@ html.theme-aldecaldos {
     --scene-buildings-edge:  #ff8050;
     --scene-grid:            #847349;
 
-    /* Overlay colors */
+    /* Overlay colours */
     --overlay-road-color:        #4a4238;
     --overlay-road-border-color: #605840;
-    --overlay-metro-color:       #ecdcc0;  /* light — additive @0.235 opacity */
+    --overlay-metro-color:       #ecdcc0;  /* light; additive @0.235 opacity */
 
 }
 
@@ -303,7 +303,7 @@ html.theme-synthwave {
     --white-78: rgba(255, 228, 245, 0.78);
     --white-86: rgba(255, 228, 245, 0.86);
 
-    /* Theme category colors */
+    /* Theme category colours */
     --category-location-overhaul: var(--tertiary);
     --category-location-overhaul-glow: var(--tertiary-40);
     --category-new-location: var(--secondary);
@@ -311,25 +311,25 @@ html.theme-synthwave {
     --category-other: var(--gray);
     --category-other-glow: var(--gray-40);
 
-    /* 3D scene mesh colors */
+    /* 3D scene mesh colours */
     --scene-terrain:         #241047;  /* deep indigo land */
-    --scene-water:           #3a1d5e;  /* lighter violet — bay reads brighter than land */
+    --scene-water:           #3a1d5e;  /* lighter violet; bay reads brighter than land */
     --scene-cliffs:          #241047;  /* match terrain */
     --scene-buildings:       #9d4edd;
     --scene-landmarks:       #9d4edd;  /* = buildings (Preem is the only theme that splits them) */
     --scene-buildings-edge:  #00e5ff;
-    --scene-grid:            #6e2750;  /* muted magenta — subtle, not dominant */
+    --scene-grid:            #6e2750;  /* muted magenta; subtle, not dominant */
     --scene-edge-glow:       1;    /* default-on for the edge-glow toggle (binary; intensity = NCZ.EDGE_GLOW_INTENSITY) */
 
-    /* Overlay colors — road borders are cyan for neon grid feel */
+    /* Overlay colours: road borders are cyan for neon grid feel */
     --overlay-road-color:        #18102a;
     --overlay-road-border-color: #006890;
-    --overlay-metro-color:       #d9b6f5;  /* light — additive @0.235 opacity */
+    --overlay-metro-color:       #d9b6f5;  /* light; additive @0.235 opacity */
 }
 
 html.theme-game {
     /* Cyberpunk 2077 in-game world-map palette. Every value is extracted
-       verbatim from WolvenKit material/inkstyle exports — this is the one
+       verbatim from WolvenKit material/inkstyle exports; this is the one
        theme that keeps the raw game colours instead of restyling them. */
     --primary: #0e0e17;       /* MainColors.Fullscreen_PrimaryBackgroundDarkest */
     --secondary: #ff6159;     /* MainColors.Red (HDR clamped) */
@@ -350,7 +350,7 @@ html.theme-game {
     --white-78: rgba(237, 231, 230, 0.78);
     --white-86: rgba(237, 231, 230, 0.86);
 
-    /* Theme category colors */
+    /* Theme category colours */
     --category-location-overhaul: var(--tertiary);
     --category-location-overhaul-glow: var(--tertiary-40);
     --category-new-location: var(--secondary);
@@ -358,7 +358,7 @@ html.theme-game {
     --category-other: var(--gray);
     --category-other-glow: var(--gray-40);
 
-    /* 3D scene mesh colors — the raw game material albedo, verbatim. The scene
+    /* 3D scene mesh colours: the raw game material albedo, verbatim. The scene
        now reproduces the game's lighting pipeline (ACES tonemap + the decoded
        3dmap.envparam sun/ambient), so exact game colours in → in-game look out;
        no inverse-transfer fudge. Sources: 3d_map_cubes.mt BaseColorScale,
@@ -367,42 +367,42 @@ html.theme-game {
     --scene-water:           #566c88;  /* shares the terrain albedo; 0.7 Brightness applied on the water material (3dmap_water.mi) */
     --scene-cliffs:          #566c88;  /* shares the terrain material */
     --scene-buildings:       #c97e87;  /* 3d_map_cubes.mt BaseColorScale */
-    --scene-landmarks:       #c97e87;  /* monuments render the same red as the buildings in-game (verified vs the SDR landmark capture) — = --scene-buildings */
+    --scene-landmarks:       #c97e87;  /* monuments render the same red as the buildings in-game (verified vs the SDR landmark capture); = --scene-buildings */
     --scene-buildings-edge:  #ff99a5;  /* 3d_map_cubes.mt EdgeColor */
     --scene-grid:            #6d8ab0;  /* 3d_map_terrain.mt LinesColor */
 
     /* Enable the in-game colour grade + braindance LUT (decoded from
-       3dmap.envparam ColorGradingAreaSettings — see aces-tonemap.js). The five
+       3dmap.envparam ColorGradingAreaSettings; see aces-tonemap.js). The five
        stylised themes leave this unset (0) and get only the ACES tonemap. */
     --scene-grade:           1;
 
-    /* Overlay colors. Metro is the verbatim game value (additive @0.235 is
+    /* Overlay colours. Metro is the verbatim game value (additive @0.235 is
        gentle). Roads/borders are the game colours #1cb3bf / #1ec3c8 darkened
-       for full-strength additive (raw values blow out) — same raw-value-vs-
+       for full-strength additive (raw values blow out); same raw-value-vs-
        blend-input gap as the --scene-* colours. Borders stay brighter than the
        road fill: the game emphasises the road edge. */
     --overlay-road-color:        #0e5a60;  /* 3dmap_roads #1cb3bf x~0.5 (additive) */
-    --overlay-road-border-color: #178e92;  /* 3dmap_roads_borders #1ec3c8 x~0.72 — kept bright */
+    --overlay-road-border-color: #178e92;  /* 3dmap_roads_borders #1ec3c8 x~0.72; kept bright */
     --overlay-metro-color:       #ffeded;  /* 3dmap_metro.Material.json (verbatim) */
 }
 
 html.theme-preem {
-    /* Preem Map theme — based on the Preem Map mod by CyanideX (permission
+    /* Preem Map theme: based on the Preem Map mod by CyanideX (permission
        granted 2026-05-01; attribution required at ship time). 3D-scene colours
        are renderer-calibrated: the eyedropped in-game Preem look inverted
        through the measured renderer transfer. UI chrome derived from the
        Preem 3D palette. */
-    /* UI chrome — canonical Preem material colours where one exists.
+    /* UI chrome: canonical Preem material colours where one exists.
        Preem Map ships no UI inkstyle, so there is no canonical page-background
        or text colour; --primary/--dark-accent reuse Preem's dark teal map
        colours, --white has no canonical source (light teal-tint, design pick). */
-    --primary: #082d38;        /* 3dmap_water LinesColor — darkest Preem value */
+    --primary: #082d38;        /* 3dmap_water LinesColor; darkest Preem value */
     --secondary: #18ffec;      /* 3d_map_cubes EdgeColor */
     --tertiary: #ca654a;       /* 3dmap_roads_borders Color */
 
     --gray: #787879;           /* 3d_map_cubes BaseColorScale */
 
-    --white: #d4e8e6;          /* no canonical Preem source — design pick */
+    --white: #d4e8e6;          /* no canonical Preem source; design pick */
     --dark-accent: #1e2e36;    /* 3dmap_terrain LinesColor */
 
     /* Themed surfaces */
@@ -415,7 +415,7 @@ html.theme-preem {
     --white-78: rgba(212, 232, 230, 0.78);
     --white-86: rgba(212, 232, 230, 0.86);
 
-    /* Theme category colors */
+    /* Theme category colours */
     --category-location-overhaul: var(--secondary);
     --category-location-overhaul-glow: var(--secondary-40);
     --category-new-location: var(--tertiary);
@@ -423,23 +423,23 @@ html.theme-preem {
     --category-other: var(--gray);
     --category-other-glow: var(--gray-40);
 
-    /* 3D scene mesh colors — renderer-calibrated to the eyedropped in-game
+    /* 3D scene mesh colours: renderer-calibrated to the eyedropped in-game
        Preem targets (dark building body #0a3d3c, terrain #042c30,
        water #021114). Buildings read dark with a bright teal edge. */
     --scene-terrain:         #1f737f;
     --scene-water:           #15404c;
     --scene-cliffs:          #1f737f;
     --scene-buildings:       #2f9aa0;
-    --scene-landmarks:       #ff9fa7;  /* Game-theme building colour — Preem leaves monuments vanilla */
+    --scene-landmarks:       #ff9fa7;  /* Game-theme building colour; Preem leaves monuments vanilla */
     --scene-buildings-edge:  #18ffec;  /* 3d_map_cubes.mt EdgeColor (used directly) */
     --scene-grid:            #1e2e36;  /* 3dmap_terrain.Material LinesColor (used directly) */
-    --scene-grade:           1;        /* map-replica theme — in-game colour grade + LUT on (like Game) */
+    --scene-grade:           1;        /* map-replica theme: in-game colour grade + LUT on (like Game) */
 
-    /* Overlay colors — additive. Roads/borders darkened from the raw Preem
-       material (#c92917 / #ca654a) — full-strength additive blows them out;
+    /* Overlay colours: additive. Roads/borders darkened from the raw Preem
+       material (#c92917 / #ca654a): full-strength additive blows them out;
        metro keeps the raw value (additive @0.235 is gentle). */
-    --overlay-road-color:        #7a3812;  /* orange — Preem roads read orange, not pure red */
-    --overlay-road-border-color: #984c38;  /* 3dmap_roads_borders #ca654a x~0.75 — kept bright */
+    --overlay-road-color:        #7a3812;  /* orange; Preem roads read orange, not pure red */
+    --overlay-road-border-color: #984c38;  /* 3dmap_roads_borders #ca654a x~0.75; kept bright */
     --overlay-metro-color:       #999689;  /* 3dmap_metro.Material (verbatim) */
 }
 

--- a/assets/js/aces-tonemap.js
+++ b/assets/js/aces-tonemap.js
@@ -1,5 +1,5 @@
 /**
- * NC Zoning Board — CP2077 3D-map colour pipeline (ACES tonemap + grade + LUT)
+ * NC Zoning Board: CP2077 3D-map colour pipeline (ACES tonemap + grade + LUT)
  *
  * Reproduces the in-game 3D world map's full colour pipeline, decoded from
  * `base/weather/24h_basic/3dmap.envparam`. The map renders:
@@ -10,16 +10,16 @@
  * `THREE.NeutralToneMapping`). The grade + LUT are gated by `_gradeEnabled`:
  * on for the Game / Preem "replicate a real map" themes, off for the five
  * stylised themes, which keep their own colour identity. The ACES tonemap is
- * always on — it is the theme-agnostic HDR→display curve.
+ * always on; it is the theme-agnostic HDR→display curve.
  *
  * ── 1. ACES tonemap ─────────────────────────────────────────────────────────
- * The ACES **SSTS** (Single-Stage Tone Scale) — the parametric ACES Output
- * Transform tone curve — ported verbatim from the ACES 1.3 reference
+ * The ACES **SSTS** (Single-Stage Tone Scale), the parametric ACES Output
+ * Transform tone curve, ported verbatim from the ACES 1.3 reference
  * `ACESlib.SSTS.ctl` (ampas/aces-dev), driven by the decoded
  * `STonemappingACESParams`: minStops -7, maxStops 9, midGrayScale 1,
  * dimSurround 1, surroundGamma 1, desaturate 0, toneCurveSaturation 1,
  * tonemapLuminance 0. `tonemapLuminance: 0` ⇒ per-channel; `desaturate: 0` ⇒
- * no ACES desaturation — so it is the SSTS tone scale per RGB channel, no RRT
+ * no ACES desaturation, so it is the SSTS tone scale per RGB channel, no RRT
  * sweeteners. The SSTS `TsParams` depend only on the params, so they are built
  * once here in JS and baked into the TSL graph; the GPU evaluates a 4-knot
  * log-space quadratic B-spline per channel.
@@ -36,7 +36,7 @@
  * (the tonemap output is encoded to sRGB first). brightness/lift/offsets/hue
  * are all identity in the decoded data and omitted. The combination order
  * (contrast → gain → gamma → saturation) is the standard primary-correction
- * order — the *params* are exact, the formula is the conventional one.
+ * order: the *params* are exact, the formula is the conventional one.
  *
  * ── 3. Braindance LUT ───────────────────────────────────────────────────────
  * The envparam `ldrLut` → `cube_cp_braindance_v001.xbm`, a 32³ RGBA-float 3D
@@ -103,7 +103,7 @@ const log2js = (x) => Math.log2(x);
 
 // ── The braindance LUT (Data3DTexture) ──────────────────────────────────────
 // Created empty; loadBraindanceLUT() fills it from assets/data/braindance-lut.bin.
-// Referenced by the tone-mapping graph as a texture binding — the binding is to
+// Referenced by the tone-mapping graph as a texture binding; the binding is to
 // this stable object, so a later data fill + needsUpdate uploads transparently.
 const _lutTexture = new Data3DTexture(
   new Float32Array(LUT_SIZE * LUT_SIZE * LUT_SIZE * 4), LUT_SIZE, LUT_SIZE, LUT_SIZE);
@@ -114,11 +114,11 @@ _lutTexture.magFilter  = LinearFilter;
 _lutTexture.wrapS      = ClampToEdgeWrapping;
 _lutTexture.wrapT      = ClampToEdgeWrapping;
 _lutTexture.wrapR      = ClampToEdgeWrapping;
-_lutTexture.colorSpace = NoColorSpace; // LUT data is sampled raw — no decode
+_lutTexture.colorSpace = NoColorSpace; // LUT data is sampled raw, no decode
 _lutTexture.name       = 'braindance-lut';
 _lutTexture.needsUpdate = true;
 
-// Grade + LUT gate — 0 for the stylised themes (ACES tonemap only), 1 for the
+// Grade + LUT gate: 0 for the stylised themes (ACES tonemap only), 1 for the
 // Game / Preem themes. A uniform, so theme switches need no pipeline rebuild.
 const _gradeEnabled = uniform(0);
 
@@ -145,14 +145,14 @@ export function setSceneGradeEnabled(enabled) {
 
 // ── CPU: build the SSTS TsParams from the decoded params ────────────────────
 
-/** ACES `interpolate1D` — clamped linear interpolation on a sorted 2-point table. */
+/** ACES `interpolate1D`: clamped linear interpolation on a sorted 2-point table. */
 function interp1D([[x0, y0], [x1, y1]], x) {
   if (x <= x0) return y0;
   if (x >= x1) return y1;
   return y0 + (y1 - y0) * ((x - x0) / (x1 - x0));
 }
 
-/** Port of `init_coefsLow` — the 6 low-segment spline coefficients (log10 space). */
+/** Port of `init_coefsLow`: the 6 low-segment spline coefficients (log10 space). */
 function initCoefsLow(low, mid) {
   const knotInc = (log10(mid.x) - log10(low.x)) / 3;
   const c = [];
@@ -165,7 +165,7 @@ function initCoefsLow(low, mid) {
   return [c[0], c[1], c[2], c[3], c[4], c[4]]; // last duplicated, per init_TsParams
 }
 
-/** Port of `init_coefsHigh` — the 6 high-segment spline coefficients (log10 space). */
+/** Port of `init_coefsHigh`: the 6 high-segment spline coefficients (log10 space). */
 function initCoefsHigh(mid, max) {
   const knotInc = (log10(max.x) - log10(mid.x)) / 3;
   const c = [];
@@ -207,7 +207,7 @@ function makeToneMappingFn() {
   const logMinX = log10(P.min.x), logMidX = log10(P.mid.x), logMaxX = log10(P.max.x);
   const logMinY = log10(P.min.y), logMaxY = log10(P.max.y);
 
-  // Per-segment quadratic coefficients (knot j ∈ {0,1,2}) — compile-time
+  // Per-segment quadratic coefficients (knot j ∈ {0,1,2}): compile-time
   // constants; only `t` and the j-select run on the GPU.
   const lo = [
     quadraticABC([P.coefsLow[0],  P.coefsLow[1],  P.coefsLow[2]]),
@@ -226,7 +226,7 @@ function makeToneMappingFn() {
   const pick3 = (j, v0, v1, v2) =>
     select(j.lessThan(0.5), float(v0), select(j.lessThan(1.5), float(v1), float(v2)));
 
-  /** Evaluate one 4-knot SSTS segment — a log-space quadratic B-spline. */
+  /** Evaluate one 4-knot SSTS segment: a log-space quadratic B-spline. */
   const segment = (logx, logA, logB, seg) => {
     const knot = logx.sub(logA).div(logB - logA).mul(3); // N_KNOTS-1 = 3
     const j = clamp(floor(knot), float(0), float(2));
@@ -237,7 +237,7 @@ function makeToneMappingFn() {
     return a.mul(t).mul(t).add(b.mul(t)).add(c); // logy
   };
 
-  /** ACES `ssts()` on one channel — scene-linear x → display luminance. */
+  /** ACES `ssts()` on one channel: scene-linear x → display luminance. */
   const sstsChannel = (x) => {
     const logx = log2(max(x, float(1e-10))).mul(INV_LOG2_10);
     const logyLow  = segment(logx, logMinX, logMidX, lo);
@@ -262,14 +262,14 @@ function makeToneMappingFn() {
   const applyGrade = (c) => {
     // Contrast about the pivot.
     let g = c.sub(GRADE_CONTRAST_PIVOT).mul(GRADE_CONTRAST).add(GRADE_CONTRAST_PIVOT);
-    // Per-channel gain — the map's cool cast (G/B +30%).
+    // Per-channel gain: the map's cool cast (G/B +30%).
     g = g.mul(vec3(GRADE_GAIN[0], GRADE_GAIN[1], GRADE_GAIN[2]));
-    // Luminance gamma — applied to luma so chroma is preserved.
+    // Luminance gamma, applied to luma so chroma is preserved.
     const luma  = g.r.mul(REC709[0]).add(g.g.mul(REC709[1])).add(g.b.mul(REC709[2]));
     const lumaC = max(luma, float(1e-5));
     const scale = pow(lumaC, float(1 / GRADE_GAMMA_LUM)).div(lumaC);
     const gamma = max(g.mul(scale), float(0));
-    // Saturation about luma — `desat + (colour − desat)·saturation`, written
+    // Saturation about luma: `desat + (colour − desat)·saturation`, written
     // out (not the TSL `.mix()` method, which mis-orders operands).
     const sLuma = vec3(gamma.r.mul(REC709[0]).add(gamma.g.mul(REC709[1])).add(gamma.b.mul(REC709[2])));
     return max(sLuma.add(gamma.sub(sLuma).mul(float(GRADE_SATURATION))), float(0));
@@ -295,7 +295,7 @@ function makeToneMappingFn() {
       Y.sub(float(MIN_LUM_SDR)).div(float(MAX_LUM_SDR - MIN_LUM_SDR)),
       float(0), float(1));
 
-    // Dim-surround compensation (envparam dimSurround: 1) — ACES ODT viewing-
+    // Dim-surround compensation (envparam dimSurround: 1): ACES ODT viewing-
     // environment gamma on luminance, chroma preserved.
     if (DIM_SURROUND) {
       const g = DIM_SURROUND_GAMMA * SURROUND_GAMMA;
@@ -313,7 +313,7 @@ function makeToneMappingFn() {
     // Gate: stylised themes get the ACES result; Game/Preem get grade + LUT.
     const out = select(_gradeEnabled.greaterThan(0.5), lutOut, cv);
 
-    // Return linear display values — the renderer applies the sRGB OETF after.
+    // Return linear display values; the renderer applies the sRGB OETF after.
     return clamp(out, float(0), float(1));
   });
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,11 +1,11 @@
 /**
- * NC Zoning Board — Main Application Logic
- * DOM manipulation, map initialization, event handlers, sidebar, modals, image gallery.
+ * NC Zoning Board: Main Application Logic
+ * DOM manipulation, map initialisation, event handlers, sidebar, modals, image gallery.
  * Depends on: constants.js, utils.js, services.js (via NCZ namespace).
  */
 
 document.addEventListener("DOMContentLoaded", () => {
-  // Terminal header close buttons — delegates to each modal's existing close button
+  // Terminal header close buttons: delegates to each modal's existing close button
   document.querySelectorAll(".terminal-close-btn[data-close-modal]").forEach((btn) => {
     btn.addEventListener("click", () => {
       const modal = document.getElementById(btn.dataset.closeModal);
@@ -17,7 +17,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   });
 
-  // Welcome Modal Logic — runs immediately, independent of map loading
+  // Welcome Modal Logic: runs immediately, independent of map loading
   const welcomeModal = document.getElementById("welcome-modal");
   const closeModalBtn = document.getElementById("close-modal");
 
@@ -47,7 +47,7 @@ document.addEventListener("DOMContentLoaded", () => {
     aboutModal.classList.add("hidden");
   });
 
-  // WebGPU-unsupported notice — footer button. The header X is handled by the
+  // WebGPU-unsupported notice: footer button. The header X is handled by the
   // delegated .terminal-close-btn[data-close-modal] listener above.
   const closeWebgpuModalBtn = document.getElementById("close-webgpu-unsupported-modal");
   if (closeWebgpuModalBtn) {
@@ -132,7 +132,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Reflect a theme's render-toggle defaults (--scene-grade / --scene-edge-glow)
   // into the Settings checkboxes. Reads the CSS var directly so it's independent
-  // of the scene's async build timing (buildings — and thus glow — finish after
+  // of the scene's async build timing (buildings, and thus glow, finish after
   // init resolves). Called at initial load and on every theme switch, both of
   // which reset the toggles to the active theme's default.
   function syncRenderToggles() {
@@ -169,12 +169,12 @@ document.addEventListener("DOMContentLoaded", () => {
     // so both renderers pick up the new CSS custom properties immediately.
     NCZ.ThreeScene?.updateMaterials();
     // A theme switch resets the LUT grade + edge glow to the new theme's
-    // defaults — reflect that in the Settings toggles.
+    // defaults; reflect that in the Settings toggles.
     syncRenderToggles();
     NCZ._clearOverlayCache?.();
   }
 
-  // Expose for flyover.js — persist:false so showcase changes don't overwrite
+  // Expose for flyover.js; persist:false so showcase changes don't overwrite
   // the user's saved preference in localStorage.
   NCZ.applyTheme = (id) => applyThemeById(id, { persist: false });
 
@@ -548,7 +548,7 @@ async function initMap() {
   const southWest = map.unproject([0, 16384], maxNativeZoom);
   const northEast = map.unproject([16384, 0], maxNativeZoom);
   const mapBounds = new L.LatLngBounds(southWest, northEast);
-  const panEdgeFraction = 0.5; // Let each map edge travel about halfway toward screen center.
+  const panEdgeFraction = 0.5; // Let each map edge travel about halfway toward screen centre.
 
   function updatePannableBounds() {
     const size = map.getSize();
@@ -597,15 +597,15 @@ async function initMap() {
   // switchView calls it after toggling so the open popup persists across views.
   let onViewSwitched = null;
   // Set false once WebGPU is known unavailable (forceSatFallback). Blocks any
-  // re-entry into the broken 3D view — deep link, keyboard, stray call.
+  // re-entry into the broken 3D view: deep link, keyboard, stray call.
   let threeDAvailable = true;
   let webgpuFallbackDone = false;
-  // ?gamelight — calibration reference mode. Pins the 3D scene to the decoded
+  // ?gamelight: calibration reference mode. Pins the 3D scene to the decoded
   // in-game 3D-map lighting state: sun fixed at the 3dmap.envparam
   // GlobalLightOverride (azimuth 107.12°, elevation 7°), time-of-day slider
   // frozen, and the Districts/Pins overlays stripped so the terrain/buildings
   // can be colour-matched against the in-game SDR capture without obstruction.
-  // A reproducible reference frame — same URL always yields the identical
+  // A reproducible reference frame: same URL always yields the identical
   // lighting state. Debug/calibration only; not linked from the UI.
   const GAMELIGHT = new URLSearchParams(window.location.search).has('gamelight');
   function switchView(viewName) {
@@ -620,7 +620,7 @@ async function initMap() {
     });
 
     if (viewName === "schema") {
-      // Capture the Leaflet viewport BEFORE hiding #map — getCenter()/getSize()
+      // Capture the Leaflet viewport BEFORE hiding #map: getCenter()/getSize()
       // only read true while the container is laid out. On the *first* SCHEMA
       // entry the scene isn't built yet, so the E5 intro owns the framing; on
       // later toggles we carry the 2D viewport across.
@@ -636,12 +636,12 @@ async function initMap() {
       Promise.resolve(NCZ.ThreeScene.init("map-3d"))
         .then(() => {
           // init() aborts early (no render loop wired) when the renderer fell
-          // back to WebGL2 — buildings can't run there. Don't show a broken
+          // back to WebGL2 (buildings can't run there). Don't show a broken
           // 3D scene: drop the user onto the 2D Leaflet map instead.
           if (NCZ.ThreeScene.isWebGPUActive()) {
             NCZ.ThreeScene.startRenderLoop();
             if (GAMELIGHT) applyGameLightRef();
-            // Sync the 2D viewport into the 3D camera — but only once the scene
+            // Sync the 2D viewport into the 3D camera, but only once the scene
             // already exists, so the first-entry intro fly-in isn't stomped.
             if (wasInit) NCZ.ThreeScene.frameLeafletView({ ...leafletView, leafletPxW });
           } else {
@@ -652,7 +652,7 @@ async function initMap() {
       // Carry the 3D camera's viewport back to the Leaflet map. Capture from the
       // canvas (Leaflet-independent) before showing #map; round zoom to an
       // integer for tile crispness, clamp to the map's range. Use the *visible*
-      // 3D container's width for the px basis — map.getSize() reads 0 while #map
+      // 3D container's width for the px basis: map.getSize() reads 0 while #map
       // is still display:none, which would collapse the derived zoom.
       const view = NCZ.ThreeScene.getLeafletView?.({ leafletPxW: map3dEl.clientWidth });
       map3dEl.style.display = "none";
@@ -669,7 +669,7 @@ async function initMap() {
 
   // Frame the 2D map at the view equivalent to the *default* 3D framing (the E5
   // intro rest pose). Used by the WebGPU fallback, where the 3D camera never
-  // gets built — without this the map sits at its init fitBounds(mapBounds)
+  // gets built; without this the map sits at its init fitBounds(mapBounds)
   // (the whole 16k image, framing nothing). Runs the intro rest constants
   // through the same horizontal-extent transform a real SCHEMA→SAT switch uses,
   // so the fallback lands exactly where switching to 2D from the default 3D view
@@ -698,7 +698,7 @@ async function initMap() {
     threeDAvailable = false;
     switchView("sat");
     // switchView's SAT branch can't carry a view across (no 3D camera exists on
-    // the fallback), so it leaves the init fitBounds in place — override it with
+    // the fallback), so it leaves the init fitBounds in place; override it with
     // the default 3D-equivalent framing now that #map is laid out.
     applyDefaultSatView();
     const schemaBtn = document.querySelector('.map-view-btn[data-view="schema"]');
@@ -719,26 +719,26 @@ async function initMap() {
     NCZ.ThreeScene.resetCamera();
   });
 
-  // ── Sun slider — time of day at Morro Bay, CA (Night City's real-world location)
+  // ── Sun slider: time of day at Morro Bay, CA (Night City's real-world location)
   // Slider values are always in Morro Bay PDT (UTC-7, the summer offset).
   // All conversions use UTC internally so the browser's local timezone never
   // affects the sun position calculation.
   const SUN_LAT  = 35.370781, SUN_LNG = -120.851173;
   const PDT_OFFSET = -7; // Morro Bay summer (PDT) = UTC-7
-  // June 21 at UTC midnight — year doesn't matter for sun geometry
+  // June 21 at UTC midnight; year doesn't matter for sun geometry
   const SOLSTICE = new Date(Date.UTC(new Date().getFullYear(), 5, 21));
 
   const sunSlider      = document.getElementById("scene-sun-slider");
   const sunTimeDisplay = document.getElementById("scene-sun-time");
 
-  // The decoded 3dmap.envparam GlobalLightOverride sun — fixed, no time of day.
+  // The decoded 3dmap.envparam GlobalLightOverride sun: fixed, no time of day.
   const GAMELIGHT_SUN_AZIMUTH   = 107.121956 * Math.PI / 180;
   const GAMELIGHT_SUN_ELEVATION = 7 * Math.PI / 180;
 
   function applySunTime(morroMinutes) {
-    // ?gamelight — pin to the decoded reference sun, ignore the slider value.
+    // ?gamelight: pin to the decoded reference sun, ignore the slider value.
     // Gating here (not just at the call sites) means every path that drives the
-    // sun — slider setup, terrain-loaded apply, the UI-sync poll — keeps it
+    // sun (slider setup, terrain-loaded apply, the UI-sync poll) keeps it
     // pinned, so the reference frame can't drift.
     if (GAMELIGHT) {
       NCZ.ThreeScene?.setSunPosition?.(GAMELIGHT_SUN_AZIMUTH, GAMELIGHT_SUN_ELEVATION);
@@ -752,7 +752,7 @@ async function initMap() {
     date.setUTCHours((Math.floor(morroMinutes / 60) - PDT_OFFSET) % 24, morroMinutes % 60, 0, 0);
     const pos = SunCalc.getPosition(date, SUN_LAT, SUN_LNG);
     NCZ.ThreeScene.setSunPosition(pos.azimuth, pos.altitude);
-    // Time-of-day exposure — floor the dark ends without flattening the natural
+    // Time-of-day exposure: floor the dark ends without flattening the natural
     // day/night variation. Keyed on elevation so the flyover shares it. See
     // NCZ.SCENE_EXPOSURE_CURVE + NCZ.exposureForSunElevation.
     NCZ.ThreeScene?.setSceneExposure?.(NCZ.exposureForSunElevation(pos.altitude));
@@ -775,7 +775,7 @@ async function initMap() {
       sunSlider.max = 1216;
     }
 
-    // Default: 8:00 AM PDT — sun ~24° elevation from the east. The high-noon
+    // Default: 8:00 AM PDT (sun ~24° elevation from the east). The high-noon
     // default (10am, el 48°) over-lights building tops under the new photometric
     // lighting; a moderate morning sun reads as 3D-massed city without blasting.
     const DEFAULT_SUN_MINUTES = 480;
@@ -798,7 +798,7 @@ async function initMap() {
     });
   }
 
-  // Settings → "Edge glow" toggle — binary self-lit building edges. Same
+  // Settings → "Edge glow" toggle: binary self-lit building edges. Same
   // override-the-theme-default pattern as the LUT toggle above.
   const glowToggle = document.getElementById("edge-glow-toggle");
   if (glowToggle) {
@@ -807,7 +807,7 @@ async function initMap() {
     });
   }
 
-  // Settings → "Fixed building assets" toggle — selects the 3D-map building
+  // Settings → "Fixed building assets" toggle: selects the 3D-map building
   // asset set: checked = malgalad's alignment-fixed textures, unchecked =
   // base-game. Unlike the render toggles above, this is a PERSISTED user
   // preference (localStorage, not theme-scoped). The building data is CPU-
@@ -823,7 +823,7 @@ async function initMap() {
     });
   }
 
-  // ?gamelight — apply the calibration reference state once the 3D scene is
+  // ?gamelight: apply the calibration reference state once the 3D scene is
   // live (called from switchView's schema branch). The sun is already pinned
   // by applySunTime()'s GAMELIGHT gate; here we freeze the slider and strip the
   // Districts/Pins overlays so they don't obscure the surfaces being matched
@@ -846,7 +846,7 @@ async function initMap() {
 
   const flyoverBtn = document.getElementById("scene-flyover-btn");
   // Elements to hide during showcase. We save each one's inline display value
-  // so we can restore it exactly — this handles elements that JS may have
+  // so we can restore it exactly; this handles elements that JS may have
   // already toggled (e.g. sidebar-open uses a .visible class, not display).
   const _showcaseEls = [];
 
@@ -940,9 +940,9 @@ async function initMap() {
     NCZ.Flyover.startFlyover(opts); // creates and manages the fade overlay internally
     flyoverBtn.classList.add("active");
     flyoverBtn.textContent = "Exit showcase";
-    // Request native browser fullscreen — must be called from a user gesture (button click)
+    // Request native browser fullscreen; must be called from a user gesture (button click)
     document.documentElement.requestFullscreen().catch(() => {});
-    // Reconcile the renderer + CSS2DRenderer to the new container size — the
+    // Reconcile the renderer + CSS2DRenderer to the new container size: the
     // fullscreen class grows #map-3d without firing a window resize, and the
     // CSS2DRenderer must adopt the new client size or every pin/cluster/
     // district label drifts off its world anchor (#769). (Mid-showcase
@@ -1016,7 +1016,7 @@ async function initMap() {
     if (!document.fullscreenElement && flyoverBtn.classList.contains("active")) exitShowcase();
   });
 
-  // Overlay toggles — delegate to the right renderer based on active view
+  // Overlay toggles: delegate to the right renderer based on active view
   document.querySelectorAll("[data-overlay]").forEach(checkbox => {
     checkbox.addEventListener("change", () => {
       const overlay = checkbox.dataset.overlay;
@@ -1030,7 +1030,7 @@ async function initMap() {
     });
   });
 
-  // UI sync — keep overlay checkboxes and sun slider in sync with actual scene state.
+  // UI sync: keep overlay checkboxes and sun slider in sync with actual scene state.
   // Runs at 200ms so console commands (setLayerVisibility, setCameraState etc.)
   // are reflected immediately in the UI. Cost: negligible (boolean reads + DOM writes
   // that short-circuit when unchanged).
@@ -1038,7 +1038,7 @@ async function initMap() {
   setInterval(() => {
     if (!NCZ.ThreeScene?.getLayerVisibility) return;
 
-    // ?gamelight — hold the calibration reference state. Districts and the
+    // ?gamelight: hold the calibration reference state. Districts and the
     // shadow pass initialise asynchronously (after terrain load), so the
     // one-shot applyGameLightRef() can't catch them; re-assert here. The
     // checkbox sync below then unticks them to match. Guarded so it's a no-op
@@ -1058,7 +1058,7 @@ async function initMap() {
       if (vis !== null && cb.checked !== vis) cb.checked = vis;
     });
 
-    // Sun slider — reverse-map scene elevation back to morroMinutes via SunCalc scan
+    // Sun slider: reverse-map scene elevation back to morroMinutes via SunCalc scan
     if (sunSlider && typeof SunCalc !== 'undefined') {
       const el = NCZ.ThreeScene.getSunElevation?.();
       if (el !== undefined && el !== _lastPolledSunEl) {
@@ -1092,7 +1092,7 @@ async function initMap() {
     maxClusterRadius: 40,
     iconCreateFunction: function (cluster) {
       const count = cluster.getChildCount();
-      // Color ramp uses 10 steps across a bounded 0..100 count range.
+      // Colour ramp uses 10 steps across a bounded 0..100 count range.
       const boundedCount = Math.max(0, Math.min(count, 100));
       const colorStep = Math.round(boundedCount / 11);
 
@@ -1119,17 +1119,17 @@ async function initMap() {
   let focusedRestoreFrame = null;
   // The single non-panel marker currently pulled out of the cluster group
   // for focus (Discover / sidebar / deep-link). The 2D analogue of 3D's
-  // "popupModId is excluded from the clusterer" rule — replaces spiderfy as
+  // "popupModId is excluded from the clusterer" rule; replaces spiderfy as
   // the way a clustered-but-focused pin stays visible. Panel-set markers are
   // owned by applyPanelPinFocus instead; this is only for the lone-pin paths.
   let soloFocusMarker = null;
 
   // ?mod= deep-link sync. Mirrors NCZ.ThreeMarkers.syncUrlForMod so the two
   // views stay coherent. Called EAGERLY when focus is initiated (not only
-  // from popupopen) — the popup now opens deferred (on flyTo's moveend), so
+  // from popupopen): the popup now opens deferred (on flyTo's moveend), so
   // waiting for popupopen left a window where switching views lost the
-  // pin (the "shared camera/popup broken on clustered pins" bug: clustered
-  // pins go through the deferred path, unclustered ones opened synchronously).
+  // pin (clustered pins go through the deferred path; unclustered ones
+  // opened synchronously and were unaffected).
   function setModUrlParam(mod) {
     if (!mod) return;
     const isNum = /^\d+$/.test(String(mod.nexus_id));
@@ -1160,7 +1160,7 @@ async function initMap() {
 
   // Safety net only: re-open the focused popup if it closed while the marker
   // is an un-clustered singleton. Spiderfy was removed entirely (per product
-  // decision) — focused/selected markers are now kept visible by pulling
+  // decision); focused/selected markers are now kept visible by pulling
   // them OUT of the cluster group (soloFocusMarker / applyPanelPinFocus), so
   // a focused marker is never hidden inside a bubble and never needs
   // spiderfying. For force-individual markers this whole function early-
@@ -1424,7 +1424,7 @@ async function initMap() {
 
   // True only while pin emphasis is actually applied (a panel item was
   // clicked). Lets clearPanelPinFocus() short-circuit when there's nothing
-  // to undo — important because populateClusterPanel() calls it on EVERY
+  // to undo; important because populateClusterPanel() calls it on EVERY
   // (re)populate, including the high-frequency successor-tracking path
   // during camera moves. Without this, each successor recompute would do a
   // full marker sweep + a synchronous 3D recomputeClusters for no reason.
@@ -1463,7 +1463,7 @@ async function initMap() {
   // True iff `set` contains exactly the IDs in `list`. Used by both cluster
   // bubble click handlers (2D + 3D) to detect "user clicked the cluster
   // whose contents are already in the panel" → toggle-close instead of
-  // re-populate. Cheap O(n) — cluster sizes are bounded by markercluster's
+  // re-populate. Cheap O(n): cluster sizes are bounded by markercluster's
   // disable-clustering-at-zoom threshold.
   function isSameModSet(set, list) {
     if (!set || set.size !== list.length) return false;
@@ -1479,7 +1479,7 @@ async function initMap() {
   // above its now-faded neighbours; 3D delegates to ThreeMarkers, which sets
   // the inner .marker-pin opacity (the only mechanism that survives
   // CSS2DRenderer's per-frame inline restyling). Two mechanisms, one
-  // behaviour — the divergence is forced by the two views' DOM lifecycles,
+  // behaviour: the divergence is forced by the two views' DOM lifecycles,
   // not parallel styling.
   function applyPanelPinFocus() {
     if (!panelClusterModIds) return;
@@ -1487,7 +1487,7 @@ async function initMap() {
       const marker = allMarkers.find((m) => m.modData.id === id);
       if (!marker) continue;
       // 2D force-individual: Leaflet.markercluster has no per-marker
-      // "don't cluster" flag — the idiomatic way to keep specific markers
+      // "don't cluster" flag; the idiomatic way to keep specific markers
       // always visible is to pull them out of the cluster group and add
       // them straight to the map. Idempotent: only move if still grouped.
       if (markerClusterGroup.hasLayer(marker)) {
@@ -1508,7 +1508,7 @@ async function initMap() {
 
   // Restore every panel pin to full opacity / default stacking. Must run
   // before panelClusterModIds is cleared (it drives the 2D iteration).
-  // No-ops unless emphasis was actually applied — keeps the per-populate
+  // No-ops unless emphasis was actually applied; keeps the per-populate
   // call cheap and breaks the populateClusterPanel→clear→setForced→recompute
   // re-entry in the common (no pin picked) case.
   function clearPanelPinFocus() {
@@ -1521,7 +1521,7 @@ async function initMap() {
         marker.setZIndexOffset(0);
         // Return the marker to the cluster group so it re-clusters normally.
         // Only if we actually pulled it out (standalone on the map and not
-        // in the group) — guards the cluster-mode-then-close path where no
+        // in the group); guards the cluster-mode-then-close path where no
         // marker was ever moved.
         if (map.hasLayer(marker) && !markerClusterGroup.hasLayer(marker)) {
           map.removeLayer(marker);
@@ -1556,13 +1556,12 @@ async function initMap() {
   //    visible during the fly = no vibration.
   // 2. Sync ?mod= EAGERLY (not from popupopen). The popup is opened deferred
   //    on moveend, so a view switch during the fly would otherwise see no
-  //    ?mod= and fail to restore — that's the "shared camera/popup broken
-  //    on clustered pins" report (clustered pins route through this deferred
+  //    ?mod= and fail to restore (clustered pins route through this deferred
   //    path; unclustered ones open synchronously and were unaffected).
   // 3. Open the popup only once the flyTo settles. `opened` + the
   //    `focusedMarker === marker` guard handle rapid re-clicks (flyTo B
   //    interrupts flyTo A → A's moveend still fires, but focus moved on).
-  // targetZoom never zooms OUT — keep the user's zoom if already close.
+  // targetZoom never zooms OUT; keep the user's zoom if already close.
   // (6/8 is a building-detail zoom; tune here if it feels too near/far.)
   function flyToMarkerAndOpen(marker) {
     map.closePopup();
@@ -1581,7 +1580,7 @@ async function initMap() {
 
   // Pull `marker` out of the cluster group so a clustered-but-focused pin is
   // visible without spiderfy. Returns the previously soloed marker to the
-  // group first — unless it belongs to an active panel set, which
+  // group first, unless it belongs to an active panel set, which
   // applyPanelPinFocus / clearPanelPinFocus own. This is the lone-pin path
   // (Discover / sidebar / deep-link); the panel path force-individuals the
   // whole set separately.
@@ -1590,9 +1589,9 @@ async function initMap() {
   // prev's popup → the popupclose handler's solo-release branch fires
   // re-entrantly; if `soloFocusMarker` still pointed at `prev` there, that
   // branch would call setSoloFocusMarker(null) mid-call and the line below
-  // would `markerClusterGroup.addLayer(null)` — prev removed from the map
-  // and never re-added = the "Discover removes the pin when clicked again"
-  // bug. Reassigning first makes `popupSource === soloFocusMarker` false in
+  // would `markerClusterGroup.addLayer(null)`: prev removed from the map
+  // and never re-added, so a second click on a Discover pin deleted it.
+  // Reassigning first makes `popupSource === soloFocusMarker` false in
   // the re-entrant check, so it no-ops; using the `prev` local makes the
   // re-add robust regardless.
   function setSoloFocusMarker(marker) {
@@ -1624,7 +1623,7 @@ async function initMap() {
 
   // Panel-item focus. The marker is already individual (applyPanelPinFocus
   // pulled the whole panel set out of the cluster group before this runs),
-  // so just fly + open — no solo bookkeeping needed.
+  // so just fly + open; no solo bookkeeping needed.
   function flyToPanelMarker(marker) {
     flyToMarkerAndOpen(marker);
   }
@@ -1666,10 +1665,10 @@ async function initMap() {
     discoverLocationBtn.addEventListener("click", focusRandomVisibleMarker);
   }
 
-  // Populates the cluster panel with a sorted list of mods. View-agnostic —
+  // Populates the cluster panel with a sorted list of mods. View-agnostic:
   // both the Leaflet clusterclick handler and ThreeMarkers cluster clicks
   // call this. onItemClick receives the mod object; the active view flies to
-  // it (focusMarker for SAT, NCZ.ThreeMarkers.focusMod for SCHEMA) — the fly
+  // it (focusMarker for SAT, NCZ.ThreeMarkers.focusMod for SCHEMA); the fly
   // dissolves the cluster but the panel stays open as a comparison list, so
   // the user can click each member in turn. The clicked pin is kept at full
   // opacity and the rest dim (applyPanelPinFocus).
@@ -1745,7 +1744,7 @@ async function initMap() {
           // applyPanelPinFocus must run BEFORE the fly so the whole panel
           // set is already pulled out of the cluster group (2D) / excluded
           // from the clusterer (3D); otherwise the bubble persists through
-          // the fly (the original recording bug). The panel stays open on
+          // the fly. The panel stays open on
           // desktop; mobile still closes it (full-screen panel + fly +
           // popup at once is too much there).
           panelSelectedModId = mod.id;
@@ -1799,9 +1798,11 @@ async function initMap() {
   map.on("click", hideClusterPanel);
   map.on("zoomstart", () => {
     isZoomTransitioning = true;
-    // Note: cluster panel intentionally stays open on zoom (matches SCHEMA).
-    // Closing only happens via outside-click (map.on("click") above), the
-    // close button, view switch, or 3D successor-cluster going stale.
+    // Note: the cluster panel intentionally stays open during the zoom
+    // animation (matches SCHEMA). recomputeSatClusterPanel runs on zoomend
+    // and closes it only if its cluster dissolved or went singleton; the
+    // other close paths (outside-click, close button, toggle re-click,
+    // view switch) are unaffected by zoom.
   });
   map.on("zoomend", () => {
     isZoomTransitioning = false;
@@ -1814,7 +1815,7 @@ async function initMap() {
     // B7: primary data path is the server-built Data API (/v1). It already does
     // the manual + Nexus auto-discovery merge, district enrichment and thumbnail
     // resolution server-side, so the browser makes no Nexus calls here. tags.json
-    // stays a local static fetch (same-origin — not the Nexus fragility this
+    // stays a local static fetch (same-origin, not the Nexus fragility this
     // replaces). If the API is unavailable we fall back to the legacy
     // client-side merge, so the map never regresses during the transition.
     let mods, nexusThumbs, tagsDict;
@@ -1837,7 +1838,7 @@ async function initMap() {
       mods = fb.mods;
       nexusThumbs = fb.nexusThumbs;
       tagsDict = fb.tagsDict;
-      // No API envelope on the fallback path — compute recency with the constant.
+      // No API envelope on the fallback path; compute recency with the constant.
       NCZ.recentlyUpdatedDays = NCZ.RECENTLY_UPDATED_DAYS;
       console.log(`Data source: client-side fallback — ${mods.length} mods`);
     }
@@ -1845,14 +1846,14 @@ async function initMap() {
     modCountEl.textContent = `(${mods.length})`;
 
     const sortedMods = mods.sort(NCZ.sortModsByUpdated);
-    // Hand the same data set to the 3D pin layer — pins won't appear until ThreeScene
+    // Hand the same data set to the 3D pin layer; pins won't appear until ThreeScene
     // is initialised (first switch to SCHEMA), but the call is safe before that and the
     // data is held internally so the layer can build pins on attach.
     NCZ.ThreeMarkers?.setMods?.(sortedMods, nexusThumbs, tagsDict);
-    // District info panel stats — attribute each mod to its district/subdistrict.
+    // District info panel stats: attribute each mod to its district/subdistrict.
     NCZ.DistrictInfo?.setMods?.(sortedMods);
 
-    // Cluster panel wiring — both views call the same populateClusterPanel
+    // Cluster panel wiring: both views call the same populateClusterPanel
     // helper. Registered here (inside the try block) so each handler's
     // closure can pass `nexusThumbs` and reference the loaded `mods` array.
 
@@ -1865,7 +1866,7 @@ async function initMap() {
         .sort((left, right) => NCZ.sortModsByUpdated(left.modData, right.modData));
       const childMods = childMarkers.map((m) => m.modData);
       // Toggle-close: re-clicking the cluster whose contents the panel shows
-      // closes it — but only before a pin was picked. Once a pin is selected
+      // closes it, but only before a pin was picked. Once a pin is selected
       // the cluster has dissolved (flown into), so this path can't be hit
       // for that cluster anyway; the guard makes the intent explicit.
       if (
@@ -1887,7 +1888,7 @@ async function initMap() {
     // 3D (ThreeMarkers) cluster click → cluster panel
     NCZ.ThreeMarkers?.setClusterClickHandler?.((modIds) => {
       // Toggle-close on the active cluster, before a pin is picked (parity
-      // with 2D — see that handler for the rationale).
+      // with 2D; see that handler for the rationale).
       if (panelSelectedModId === null && isSameModSet(panelClusterModIds, modIds)) {
         hideClusterPanel();
         return;
@@ -1909,17 +1910,17 @@ async function initMap() {
 
     // 3D map-aware panel: when 3D clusters recompute (camera moved/zoomed/
     // tilted), follow the cluster the panel was opened for. Find the
-    // "successor" — the current cluster with the most overlap with the
-    // panel's mod set — and update the panel's contents to match. Close
+    // "successor" (the current cluster with the most overlap with the
+    // panel's mod set) and update the panel's contents to match. Close
     // only when no current cluster has any of the original mods, OR the
     // best successor has fewer than 2 mods (no longer a real cluster).
     NCZ.ThreeMarkers?.setClustersChangedHandler?.((clusterSets) => {
       if (!panelClusterModIds || panelClusterModIds.size === 0) return;
-      // Once a pin is picked the panel is a static comparison list — the
+      // Once a pin is picked the panel is a static comparison list; the
       // flyTo already dissolved the cluster it tracked, so don't let the
       // recompute close or rewrite the panel out from under the user.
       if (panelSelectedModId !== null) return;
-      // Skip while SAT is active — SAT panel state is independent.
+      // Skip while SAT is active; SAT panel state is independent.
       if (mapEl.style.display !== "none") return;
 
       let bestSet = null;
@@ -1970,7 +1971,7 @@ async function initMap() {
       // Pin picked → static comparison list; the panel set is force-
       // individual now, so don't auto-close or rewrite the panel.
       if (panelSelectedModId !== null) return;
-      // Skip while SCHEMA is active — SCHEMA panel state is independent.
+      // Skip while SCHEMA is active; SCHEMA panel state is independent.
       if (mapEl.style.display === "none") return;
 
       // Group panel mods by their current visible parent (cluster or singleton).
@@ -2011,7 +2012,7 @@ async function initMap() {
       }
 
       // Skip rebuild if membership identical (avoid flicker during continuous interaction).
-      // Still re-apply the active mark — Leaflet recreates cluster DOM elements
+      // Still re-apply the active mark: Leaflet recreates cluster DOM elements
       // on zoom, so the previously-marked element may no longer exist.
       if (childMarkers.length === panelClusterModIds.size) {
         let identical = true;
@@ -2037,7 +2038,7 @@ async function initMap() {
     // Re-evaluate SAT panel after Leaflet finishes its zoom transition (clusters
     // recomputed at the new zoom level).
     map.on("zoomend", recomputeSatClusterPanel);
-    // markercluster fires animationend after cluster animations settle —
+    // markercluster fires animationend after cluster animations settle;
     // covers zoom-driven cluster regrouping (spiderfy is no longer used).
     markerClusterGroup.on("animationend", recomputeSatClusterPanel);
 
@@ -2117,7 +2118,7 @@ async function initMap() {
         });
 
         // Pulse marker (or parent cluster) on sidebar hover. Both views share
-        // the `.pulsing` class + @keyframes markerPulse — calling both layers
+        // the `.pulsing` class + @keyframes markerPulse; calling both layers
         // is idempotent and keeps SAT/SCHEMA in sync without checking which
         // is active.
         li.addEventListener("mouseenter", () => {
@@ -2156,7 +2157,7 @@ async function initMap() {
     // its visible framing comes from view-sync on a SCHEMA→SAT switch, or from
     // applyDefaultSatView() on the WebGPU fallback. A fit-to-all-pins default
     // squashed the city into a corner (badlands outliers stretch the bounds) and
-    // only ever showed on the fallback — superseded by the 3D-equivalent default.
+    // only ever showed on the fallback; superseded by the 3D-equivalent default.
 
     // Deep-link: open pin if ?mod= is in the URL
     const deepLinkParam = new URLSearchParams(window.location.search).get(NCZ.URL_PARAM_MOD);
@@ -2169,7 +2170,7 @@ async function initMap() {
 
     // Re-open the popup in the freshly-activated view. Both ThreeMarkers and
     // the Leaflet popupopen handler keep ?mod= in sync, so this restore picks
-    // up whatever was open before the switch — popups stay coherent across modes.
+    // up whatever was open before the switch; popups stay coherent across modes.
     onViewSwitched = (viewName) => {
       // Cluster panel state is view-specific: SAT and SCHEMA cluster differently
       // (Leaflet's stable IDs vs Three's screen-space recompute), so the panel's
@@ -2340,7 +2341,7 @@ async function initMap() {
     }
     updateSearchClearButtonVisibility();
 
-    // Centralized Filter Logic
+    // Centralised Filter Logic
     function applyFilters() {
       const query = searchInput.value.toLowerCase();
       const activeCats = Array.from(
@@ -2381,7 +2382,7 @@ async function initMap() {
       // Apply same filter set to 3D pin layer
       NCZ.ThreeMarkers?.applyFilters?.(visibleIds);
 
-      // SAT cluster panel may need to update or close after filter change —
+      // SAT cluster panel may need to update or close after filter change:
       // some of its mods might no longer be in the visible cluster set.
       recomputeSatClusterPanel();
 

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -1,5 +1,5 @@
 /**
- * NC Zoning Board — Shared Constants
+ * NC Zoning Board: Shared Constants
  * Creates the NCZ global namespace and defines all configuration values.
  */
 window.NCZ = window.NCZ || {};
@@ -81,7 +81,7 @@ NCZ.NEXUS_GAME_ID = 3333; // Cyberpunk 2077
 NCZ.NEXUS_GQL_ENDPOINT = "https://api.nexusmods.com/v2/graphql";
 NCZ.NEXUS_BATCH_SIZE = 50;
 
-// Data API (B7) — the site consumes the server-built /v1 dataset instead of
+// Data API (B7): the site consumes the server-built /v1 dataset instead of
 // running the Nexus auto-discovery merge client-side. Base URL is chosen by
 // hostname so environments line up with the API's: prod → prod API; everything
 // else (dev.nczoning.net, *.pages.dev previews, localhost) → staging API.
@@ -103,7 +103,7 @@ NCZ.DATA_EXCLUDED_PATH = "data/excluded_mods.json";
 
 // 3D scene GLB source folder. The committed runtime path is "assets/glb-meshopt"
 // (gltfpack-compressed via EXT_meshopt_compression, decoded by MeshoptDecoder).
-// WolvenKit-exported source GLBs live at the gitignored "assets/glb-source/" —
+// WolvenKit-exported source GLBs live at the gitignored "assets/glb-source/";
 // drop fresh exports there and run `npm run encode-meshopt` to regenerate.
 // Flip this constant to "assets/glb-source" to test against uncompressed locally
 // (only works when the source folder is populated).
@@ -119,7 +119,7 @@ NCZ.SITE_URL      = "https://nczoning.net";
 NCZ.URL_PARAM_MOD = "mod";
 
 // Map world extent (CET world-space)
-// Source: Realistic Map 8k mod terrain quad UV mapping — the authoritative projection
+// Source: Realistic Map 8k mod terrain quad UV mapping, the authoritative projection
 // for the satellite tile layer (16k WebP tiles) and terrain tiles.
 // See docs/coordinate-system.md for derivation and why TweakDB bounds differ.
 NCZ.WORLD_MIN_X = -6298;
@@ -138,14 +138,14 @@ NCZ.CET_TO_LEAFLET_X_SCALE = 256 / (NCZ.WORLD_MAX_X - NCZ.WORLD_MIN_X);  // 0.02
 NCZ.CET_TO_LEAFLET_Y_SCALE = 256 / (NCZ.WORLD_MAX_Y - NCZ.WORLD_MIN_Y);  // 0.02113385
 NCZ.CET_TO_LEAFLET_X_OFFSET = -NCZ.WORLD_MIN_X * NCZ.CET_TO_LEAFLET_X_SCALE;
 NCZ.CET_TO_LEAFLET_Y_OFFSET = -NCZ.WORLD_MAX_Y * NCZ.CET_TO_LEAFLET_Y_SCALE;
-// Set this if you want to calibrate CET units to physical meters.
-// Default assumes 1 CET unit ~= 1 meter.
+// Set this if you want to calibrate CET units to physical metres.
+// Default assumes 1 CET unit ~= 1 metre.
 NCZ.CET_UNITS_PER_METER = 1;
 
 // LocalStorage cache keys & TTLs
 NCZ.THEME_PREFERENCE_KEY = "nc_theme_id";
 NCZ.SHOWCASE_OPTIONS_KEY = "nc_showcase_options";
-// Fallback recency window (days). The API owns this rule — it computes each
+// Fallback recency window (days). The API owns this rule: it computes each
 // mod's `recently_updated` bool and publishes the window as
 // `recently_updated_days` on the response envelope, which the app adopts into
 // NCZ.recentlyUpdatedDays. This constant is only used when the API is
@@ -157,7 +157,7 @@ NCZ.THUMB_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
 NCZ.AUTODISCOVERY_CACHE_KEY = "nc_nexus_autodiscovery";
 NCZ.AUTODISCOVERY_CACHE_TTL = 10 * 60 * 1000; // 10 minutes
 
-// Three.js Object3D.layers — bitmask channels that cameras opt into via Camera.layers.
+// Three.js Object3D.layers: bitmask channels that cameras opt into via Camera.layers.
 // Layer 0 (default) carries the static scene (terrain, water, buildings, roads, metro,
 // districts, landmarks). The pins/clusters/popup/tooltip overlay lives on its own layer
 // so it can be toggled independently per camera: the schema camera has both layers
@@ -187,7 +187,7 @@ NCZ.CLUSTER_PANEL_DEFAULT_WIDTH = 400;
 NCZ.CLUSTER_PANEL_MIN_WIDTH = 260;
 NCZ.CLUSTER_PANEL_MAX_WIDTH = 720;
 
-// District border colors — matched to game's main_colors.inkstyle
+// District border colours, matched to game's main_colors.inkstyle
 NCZ.DISTRICT_COLORS = {
   city_center:    "#ffd741",  // MainColors.Yellow
   watson:         "#ff3e34",  // MainColors.CombatRed
@@ -200,7 +200,7 @@ NCZ.DISTRICT_COLORS = {
   badlands:       "#c882ff",  // Bright violet
 };
 
-// District icon atlas (district_icons.png, 1192×256) — UV rects (Left/Top/
+// District icon atlas (district_icons.png, 1192×256): UV rects (Left/Top/
 // Right/Bottom) for the `_large` icon of each district, extracted from
 // district_icons.inkatlas. The icons are pre-coloured per district (Watson red,
 // etc.), so they render as-is. Used by the hover info panel (NCZ.DistrictInfo).
@@ -222,7 +222,7 @@ NCZ.DISTRICT_ICON_ATLAS = {
 };
 // (The atlas also has north/south badlands icons, but in TweakDB all of our
 //  badlands subdistricts belong to the central Districts.Badlands, so we only
-//  use the central badlands icon — see the district-info panel.)
+//  use the central badlands icon; see the district-info panel.)
 
 // Badlands has no district polygon, so its name label has no centroid to sit at.
 // Hand-placed CET [x, y] in an open patch of the badlands (maintainer-chosen);
@@ -232,12 +232,11 @@ NCZ.BADLANDS_LABEL_CET = [2957.33, -691.04];
 // Overlay zoom thresholds (Leaflet zoom levels)
 NCZ.DISTRICT_ZOOM_THRESHOLD = 3;  // below = districts only, above = subdistricts
 
-// District border appearance — shared between SAT (Leaflet) and SCHEMA (Three.js)
-NCZ.DISTRICT_LINE_WIDTH     = 4;  // px — main district borders
-NCZ.SUBDISTRICT_LINE_WIDTH  = 3;  // px — subdistrict borders
+// District border appearance, shared between SAT (Leaflet) and SCHEMA (Three.js)
+NCZ.DISTRICT_LINE_WIDTH     = 4;  // px: main district borders
+NCZ.SUBDISTRICT_LINE_WIDTH  = 3;  // px: subdistrict borders
 // Faint baseline matches the in-game inkLinePatternWidget.opacity (5%); the
-// hover-brighten state fades to ~full over 250 ms. See
-// wiki/sources/district-outline-widget.md.
+// hover-brighten state fades to ~full over 250 ms.
 NCZ.DISTRICT_LINE_OPACITY        = 0.05;
 NCZ.DISTRICT_LINE_OPACITY_HOVER  = 1.0;
 NCZ.DISTRICT_HOVER_FADE_MS       = 250;
@@ -247,22 +246,22 @@ NCZ.DISTRICT_HOVER_FADE_MS       = 250;
 // WebGLRenderer pixel-ratio cap. GPU fragment cost scales as DPR², so on
 // high-DPI displays (Retina 2.0, 4K@200% 2.0, 1440p@200% 2.0, etc.) the
 // uncapped path costs 78%+ more shader work than 1.5 for a soft-edge difference
-// the user is unlikely to notice — pin/popup/tooltip text is unaffected because
+// the user is unlikely to notice; pin/popup/tooltip text is unaffected because
 // CSS2DRenderer rasterises HTML at the real device DPR regardless. The cap is a
 // no-op for everyone at DPR ≤ 1.5, so most desktops see zero change.
 NCZ.MAX_DEVICE_PIXEL_RATIO = 1.5;
 
-// Camera — perspective projection, positioned above world centre looking straight down.
-// Source: TweakDB WorldMap.TopDownCameraSettingsDefault — see docs/data/worldmap_tweakdb_tree.json.
+// Camera: perspective projection, positioned above world centre looking straight down.
+// Source: TweakDB WorldMap.TopDownCameraSettingsDefault; see docs/data/worldmap_tweakdb_tree.json.
 // The schema camera matches the game's TopDown view (FOV 25°, distance in CET / world units).
-NCZ.SCHEMA_CAMERA_FOV              = 25;     // degrees — game canonical (TopDownCameraSettingsDefault.fovMin/Max)
-NCZ.SCHEMA_CAMERA_NEAR             = 10;     // CET units — perspective near clip; must be > 0
-NCZ.SCHEMA_CAMERA_FAR              = 50000;  // CET units — far clip; covers shadow camera + sun sphere
-NCZ.SCHEMA_CAMERA_MIN_DISTANCE     = 800;    // CET units — zoom-in limit  (TweakDB zoomMin)
-NCZ.SCHEMA_CAMERA_MAX_DISTANCE     = 15000;  // CET units — zoom-out limit (TweakDB zoomMax)
-NCZ.SCHEMA_FLY_TO_DISTANCE         = 1250;   // CET units — fly-to-pin target distance (TweakDB zoomToZoomValue)
+NCZ.SCHEMA_CAMERA_FOV              = 25;     // degrees: game canonical (TopDownCameraSettingsDefault.fovMin/Max)
+NCZ.SCHEMA_CAMERA_NEAR             = 10;     // CET units: perspective near clip; must be > 0
+NCZ.SCHEMA_CAMERA_FAR              = 50000;  // CET units: far clip; covers shadow camera + sun sphere
+NCZ.SCHEMA_CAMERA_MIN_DISTANCE     = 800;    // CET units: zoom-in limit  (TweakDB zoomMin)
+NCZ.SCHEMA_CAMERA_MAX_DISTANCE     = 15000;  // CET units: zoom-out limit (TweakDB zoomMax)
+NCZ.SCHEMA_FLY_TO_DISTANCE         = 1250;   // CET units: fly-to-pin target distance (TweakDB zoomToZoomValue)
 
-// 3D-map intro fly-in (E5) — on first load the camera drops in from a far,
+// 3D-map intro fly-in (E5): on first load the camera drops in from a far,
 // near-straight-down pose, descending and leaning back to a resting framing
 // of the city. Skipped when a ?mod= deep-link is present (the deep-link
 // fly-to takes over). The near-vertical start "feels" like a top-down reveal;
@@ -270,127 +269,130 @@ NCZ.SCHEMA_FLY_TO_DISTANCE         = 1250;   // CET units — fly-to-pin target 
 //
 // START_TILT is 2°, not 0°: at *exactly* straight-down the camera-to-target
 // offset is (0, +y, 0) and OrbitControls derives the azimuth as
-// atan2(0, 0) — degenerate, so float noise picks the angle and makeSafe()
+// atan2(0, 0): degenerate, so float noise picks the angle and makeSafe()
 // perpetuates it as a camera roll (the map renders rotated/upside-down).
 // 2° gives the offset a solid z-component → stable azimuth 0. Visually
 // indistinguishable from dead top-down.
-NCZ.SCHEMA_INTRO_START_DISTANCE = 15000;       // CET units — far pose (= SCHEMA_CAMERA_MAX_DISTANCE)
-NCZ.SCHEMA_INTRO_REST_DISTANCE  = 12200;       // CET units — resting framing distance (whole city in frame)
-NCZ.SCHEMA_INTRO_START_TILT     = 2;           // degrees off vertical at the far pose — near top-down (see note above)
-NCZ.SCHEMA_INTRO_REST_TILT      = 11;          // degrees off vertical at the rest pose — game world-map lean-back
-NCZ.SCHEMA_INTRO_AZIMUTH        = 0;           // radians — compass heading of the lean; constant start→rest (no sweep)
-NCZ.SCHEMA_INTRO_DURATION_MS    = 1200;        // fly-in length — ~"first second after load" per E5
-NCZ.SCHEMA_INTRO_REST_CENTER    = [-800, -500]; // [cetX, cetY] framed by the rest pose — the city's visual centre
+NCZ.SCHEMA_INTRO_START_DISTANCE = 15000;       // CET units: far pose (= SCHEMA_CAMERA_MAX_DISTANCE)
+NCZ.SCHEMA_INTRO_REST_DISTANCE  = 12200;       // CET units: resting framing distance (whole city in frame)
+NCZ.SCHEMA_INTRO_START_TILT     = 2;           // degrees off vertical at the far pose: near top-down (see note above)
+NCZ.SCHEMA_INTRO_REST_TILT      = 11;          // degrees off vertical at the rest pose: game world-map lean-back
+NCZ.SCHEMA_INTRO_AZIMUTH        = 0;           // radians: compass heading of the lean; constant start→rest (no sweep)
+NCZ.SCHEMA_INTRO_DURATION_MS    = 1200;        // fly-in length: ~"first second after load" per E5
+NCZ.SCHEMA_INTRO_REST_CENTER    = [-800, -500]; // [cetX, cetY] framed by the rest pose: the city's visual centre
                                                 // (not the world centre, which is biased south into the badlands)
 
-// Pan envelope — clamps controls.target so the camera can't roam off the map.
+// Pan envelope: clamps controls.target so the camera can't roam off the map.
 // Source: TweakDB WorldMap.DefaultSettings.cursorBoundary{Min,Max}.
 // CET → Three.js: X stays as-is; CET Y maps to Three Z with a sign flip
 // (GLB_Z = -CET_Y), so CET Y range (-7300..5000) becomes Three Z (-5000..7300).
-NCZ.PAN_BOUND_MIN_X =  -5500;  // CET / Three X — TweakDB cursorBoundaryMin.X
-NCZ.PAN_BOUND_MAX_X =   6050;  // CET / Three X — TweakDB cursorBoundaryMax.X
-NCZ.PAN_BOUND_MIN_Z =  -5000;  // Three Z — derived from -cursorBoundaryMax.Y
-NCZ.PAN_BOUND_MAX_Z =   7300;  // Three Z — derived from -cursorBoundaryMin.Y
+NCZ.PAN_BOUND_MIN_X =  -5500;  // CET / Three X: TweakDB cursorBoundaryMin.X
+NCZ.PAN_BOUND_MAX_X =   6050;  // CET / Three X: TweakDB cursorBoundaryMax.X
+NCZ.PAN_BOUND_MIN_Z =  -5000;  // Three Z: derived from -cursorBoundaryMax.Y
+NCZ.PAN_BOUND_MAX_Z =   7300;  // Three Z: derived from -cursorBoundaryMin.Y
 
 // Camera controls (OrbitControls)
-NCZ.CAMERA_MIN_TILT     = 0;              // min polar angle (Three.js default: 0)           — 0 = perfectly top-down
-NCZ.CAMERA_MAX_TILT     = Math.PI * 0.39; // max polar angle (Three.js default: Math.PI)     — ~70° tilt from top-down
-NCZ.CAMERA_DAMPING      = 0.05;           // dampingFactor   (Three.js default: 0.05)        — higher = more inertia/lag
-NCZ.CAMERA_ZOOM_SPEED   = 2.0;            // zoomSpeed       (Three.js default: 1.0)         — scroll wheel rate; increase if too slow
-NCZ.CAMERA_PAN_SPEED    = 1.0;            // panSpeed        (Three.js default: 1.0)         — left-drag pan rate
-NCZ.CAMERA_ROTATE_SPEED = 0.6;            // rotateSpeed     (Three.js default: 1.0)         — right-drag tilt rate; lower = more precise
+NCZ.CAMERA_MIN_TILT     = 0;              // min polar angle (Three.js default: 0);          0 = perfectly top-down
+NCZ.CAMERA_MAX_TILT     = Math.PI * 0.39; // max polar angle (Three.js default: Math.PI);    ~70° tilt from top-down
+NCZ.CAMERA_DAMPING      = 0.05;           // dampingFactor   (Three.js default: 0.05);       higher = more inertia/lag
+NCZ.CAMERA_ZOOM_SPEED   = 2.0;            // zoomSpeed       (Three.js default: 1.0);        scroll wheel rate; increase if too slow
+NCZ.CAMERA_PAN_SPEED    = 1.0;            // panSpeed        (Three.js default: 1.0);        left-drag pan rate
+NCZ.CAMERA_ROTATE_SPEED = 0.6;            // rotateSpeed     (Three.js default: 1.0);        right-drag tilt rate; lower = more precise
 
-// Shadow map — one OrthographicCamera fitted each frame to exactly the visible-
+// Shadow map: one OrthographicCamera fitted each frame to exactly the visible-
 // ground footprint (updateShadowCamera in three-scene.js), rendered into a
 // single depth32float texture (the WebGPU `shadowMapping` pattern). Single map
-// for now; a CSM revisit is queued — the original "no cascades because schema
+// for now; a CSM revisit is queued: the original "no cascades because schema
 // is ortho" rationale no longer holds since the schema camera moved to perspective
 // (FOV 25°, TweakDB-aligned).
-NCZ.SHADOW_MAP_SIZE      = 8192;  // px² — ~1.5 u/texel at a whole-city zoom, razor-sharp zoomed in. Always-on (interactive + showcase): the fine texels keep the showcase's fast sun from shimmering. One fixed size, not resized per-mode (maintainer call).
-NCZ.SHADOW_MAX_DISTANCE  =  8600; // CET units — cap on the footprint half-side. Matches the world half-diagonal (sqrt((WORLD_MAX_X-WORLD_MIN_X)² + (WORLD_MAX_Y-WORLD_MIN_Y)²) / 2 ≈ 8565 wu) with tiny headroom: nothing renders past the world bounds, so a larger cap just stretches texels over empty void. Trace data on PR #656 showed `half` pinned at the cap (12600 = 12000 cap + 600 margin) every showcase frame; reducing the cap shrinks the box uniformly → ~1.4× sharper texels for free at no performance cost.
-NCZ.SHADOW_GROUND_MARGIN =   600; // CET units the footprint extends past the visible ground — covers building heights / terrain relief + a sliver of just-off-screen casters. Wider off-screen-caster coverage waits on the union-frustum cull (a follow-up).
+NCZ.SHADOW_MAP_SIZE      = 8192;  // px²: ~1.5 u/texel at a whole-city zoom, razor-sharp zoomed in. Always-on (interactive + showcase): the fine texels keep the showcase's fast sun from shimmering. One fixed size, not resized per-mode (maintainer call).
+NCZ.SHADOW_MAX_DISTANCE  =  8600; // CET units: cap on the footprint half-side. Matches the world half-diagonal (sqrt((WORLD_MAX_X-WORLD_MIN_X)² + (WORLD_MAX_Y-WORLD_MIN_Y)²) / 2 ≈ 8565 wu) with tiny headroom: nothing renders past the world bounds, so a larger cap just stretches texels over empty void. Trace data on PR #656 showed `half` pinned at the then-current cap (12600 = the old 12000 cap + 600 margin) every showcase frame; reducing the cap to 8600 shrinks the box uniformly → ~1.4× sharper texels for free at no performance cost.
+NCZ.SHADOW_GROUND_MARGIN =   600; // CET units the footprint extends past the visible ground; covers building heights / terrain relief + a sliver of just-off-screen casters. Wider off-screen-caster coverage waits on the union-frustum cull (a follow-up).
 NCZ.SHADOW_SIZE_QUANTUM  =  1.10; // multiplicative ladder the ortho box half-side snaps UP to, so texel size is piecewise-constant. The texel snap (updateShadowCamera) only cancels swim while texelSize holds frame-to-frame; pan/azimuth already keep `half` constant (sphere fit), but tilt + zoom change it continuously. Quantising holds the box on one rung across a slow tilt, trading continuous edge shimmer for an occasional ~10% resolution step. Smaller (→1.0) = sharper/adaptive but reintroduces swim; larger = more stable but coarser/poppier.
-NCZ.SHADOW_RADIUS          = 1;   // PCFSoftShadowMap blur kernel (texels) for the interactive schema cam — 1 keeps shadows crisp. NOTE: a fixed-width blur, NOT physical penumbra (a DirectionalLight has zero angular size → no real penumbra/antumbra; distance-dependent softening would need PCSS).
+NCZ.SHADOW_RADIUS          = 1;   // PCFSoftShadowMap blur kernel (texels) for the interactive schema cam: 1 keeps shadows crisp. NOTE: a fixed-width blur, NOT physical penumbra (a DirectionalLight has zero angular size → no real penumbra/antumbra; distance-dependent softening would need PCSS).
 NCZ.SHADOW_RADIUS_SHOWCASE = 4;   // wider blur during the showcase only. The fly cam can't use the texel snap (flyover arcs the sun every frame → no frame-coherent texel lattice), so its moving-sun edge-crawl is hidden by softening the edge instead. Higher = softer/less shimmer but mushier contact.
 NCZ.SHADOW_CAM_NEAR      =     1; // shadow camera near clip
-NCZ.SHADOW_CAM_FAR       = 40000; // shadow camera far clip — the camera sits SUN_DIST up the sun ray, so this must still reach the far edge of the footprint even at a low sun (orthographic ⇒ a wide range costs no precision)
-NCZ.SHADOW_BIAS          =     0; // NDC depth bias — 0; native depth32float + reverse-Z have ample depth precision (the old -0.0005 was for the WebGL RGBA8-packed path). The geometric self-shadow ("texel patch covers a depth range") is handled by the normal bias instead:
-NCZ.SHADOW_NORMAL_BIAS_TEXELS = 2.5; // receiver-sample offset along the surface normal, in shadow-texel widths — converted to world units per-frame by updateShadowCamera (scaling with the footprint keeps it the same texel offset at every zoom). Raise to kill residual grazing-sun acne ("the wave" on flat terrain/water); lower if shadows visibly detach from their casters at high zoom.
+NCZ.SHADOW_CAM_FAR       = 40000; // shadow camera far clip: the camera sits SUN_DIST up the sun ray, so this must still reach the far edge of the footprint even at a low sun (orthographic ⇒ a wide range costs no precision)
+NCZ.SHADOW_BIAS          =     0; // NDC depth bias: 0; native depth32float + reverse-Z have ample depth precision (the old -0.0005 was for the WebGL RGBA8-packed path). The geometric self-shadow ("texel patch covers a depth range") is handled by the normal bias instead:
+NCZ.SHADOW_NORMAL_BIAS_TEXELS = 2.5; // receiver-sample offset along the surface normal, in shadow-texel widths; converted to world units per-frame by updateShadowCamera (scaling with the footprint keeps it the same texel offset at every zoom). Raise to kill residual grazing-sun acne ("the wave" on flat terrain/water); lower if shadows visibly detach from their casters at high zoom.
 
-// Lighting — recalibrated to the decoded in-game 3D world map environment
+// Lighting: recalibrated to the decoded in-game 3D world map environment
 // (base/weather/24h_basic/3dmap.env + 3dmap.envparam).
 //
 // The flat-looking buildings were a lighting problem, not a colour one: the
 // old sun:ambient ratio (1.1 : 0.42 ≈ 2.6 : 1) had ambient washing every face
 // to nearly the same tone. The in-game map's within-building contrast is
 // ~10× (bright sun-faces vs shadow faces); decoding the envparam and fitting
-// against the in-game SDR capture gives a sun:ambient ratio of ~50 : 1.
+// against the in-game SDR capture pointed at a ratio near 50 : 1, and the
+// shipped envelope fit (SUN_INTENSITY / AMBIENT_INTENSITY below) settled at
+// ≈7.4 : 1, still far above the old wash.
 //
-// Decode note — the in-game map exposes through a *physical camera*
+// Decode note: the in-game map exposes through a *physical camera*
 // (`CameraAreaSettings`: f/3.0, ISO 35, 1/300 s ⇒ EV100 12.9, exposure
 // 1/(1.2·2^EV) = 0.000108; cross-confirmed in PIX event-306 cb12 [50].x =
 // 0.000108025). That exposure can't be used literally here: the roads, metro
 // and district lines are *unlit* materials with plain [0,1] colours, and a
 // 0.000108 global `toneMappingExposure` would crush them to black. So the
-// renderer works in a normalised gauge — exposure stays at the value the
-// unlit overlays need (0.85), and the lights are scaled by the same factor
-// (0.000108/0.85). The building result is identical; the overlays survive.
+// renderer works in a normalised gauge: exposure stays at an overlay-friendly
+// magnitude (SCENE_EXPOSURE below, plus the time-of-day curve) and the
+// lights are scaled up by the inverse factor, so the physical-camera product
+// is preserved. The building result is identical; the overlays survive.
 //
 // SUN/AMBIENT are still a capture-fit ratio (the exact engine lux awaits the
-// PIX light-accumulation pass — TODO(pix)). Sun + ambient COLOURS are exact
+// PIX light-accumulation pass; TODO(pix)). Sun + ambient COLOURS are exact
 // decoded envparam values (linear RGB).
-NCZ.SCENE_EXPOSURE     = 0.720;                     // renderer.toneMappingExposure — init fallback + ?gamelight reference exposure (fixed for colour calibration)
+NCZ.SCENE_EXPOSURE     = 0.720;                     // renderer.toneMappingExposure: init fallback + ?gamelight reference exposure (fixed for colour calibration)
 
 // Time-of-day exposure curve, keyed on SUN ELEVATION (degrees above horizon).
 // Our sun is real SunCalc data, so without help the scene crushes to black at
-// dawn/dusk. But the goal is NOT constant brightness — the map should still
+// dawn/dusk. But the goal is NOT constant brightness: the map should still
 // read like real-world light: bright midday, dim/atmospheric at sunrise &
 // sunset. So this is a gentle "floor the darkness" curve, not a normalise:
 // exposure stays at the calibrated midday value for most of the day (letting
 // the sun's own N·L falloff carry the natural variation), and only opens up
-// modestly near the horizon — CAPPED — so low sun stays dim without going
+// modestly near the horizon (CAPPED) so low sun stays dim without going
 // unusably black. (An earlier version held a fixed target brightness all day;
 // that flattened the day/night feel and over-exposed sunrise/sunset.)
 //
 // Keyed on elevation (not time) so BOTH the time-of-day slider (applySunTime)
 // and the showcase flyover (updateFlyoverSun) drive it from the same function
-// (NCZ.exposureForSunElevation in utils.js) — the flyover animates the sun via
+// (NCZ.exposureForSunElevation in utils.js); the flyover animates the sun via
 // setSunPosition directly, so it must apply exposure itself.
 //
 // [elevationDeg, exposure], ascending; interpolated piecewise-linear, clamped
 // to the endpoints. Tune the two ends: row 0 = horizon cap (dawn/dusk),
 // last row = midday base.
 NCZ.SCENE_EXPOSURE_CURVE = [
-  [0,  0.95],  // horizon (sunrise/sunset) — capped lift so it stays atmospheric, not daylight
+  [0,  0.95],  // horizon (sunrise/sunset): capped lift so it stays atmospheric, not daylight
   [5,  0.80],
   [15, 0.58],
   [30, 0.49],
-  [50, 0.45],  // calibrated midday base — natural variation comes from the sun, not exposure
+  [50, 0.45],  // calibrated midday base; natural variation comes from the sun, not exposure
   [90, 0.45],
 ];
 
-// Building edge "glow" — self-lit emissive on the decoded edge highlight, a
+// Building edge "glow": self-lit emissive on the decoded edge highlight, a
 // per-theme opt-in (see --scene-edge-glow). It's a binary on/off (no slider):
 // when on, the edge emissive uses this fixed intensity. The per-theme CSS var
 // is just the default on/off state; the Settings checkbox overrides it for the
 // session. Synthwave defaults on; every other theme off.
 NCZ.EDGE_GLOW_INTENSITY = 0.3;
 
-NCZ.SUN_COLOR_RGB      = [0.975, 0.869, 0.774];     // envparam LightAreaSettings.sunColor — warm white (linear)
+NCZ.SUN_COLOR_RGB      = [0.975, 0.869, 0.774];     // envparam LightAreaSettings.sunColor: warm white (linear)
 NCZ.SUN_INTENSITY      = 3.00;                      // envelope-fit (sun:ambient ratio + level tuned across V1/V2/V3/V4)
-NCZ.AMBIENT_SKY_RGB    = [0.796, 0.895, 1.0];       // envparam AmbientOverride — the 5 bright cube faces, cool white (linear)
-NCZ.AMBIENT_GROUND_RGB = [0.566, 0.766, 1.0];       // envparam AmbientOverride — the dim ground face, blue (linear)
-NCZ.AMBIENT_INTENSITY  = 0.405;                     // envelope-fit — sun:ambient ≈ 7.4:1
-NCZ.SHADOW_INTENSITY   = 0.60;                      // cast-shadow strength when "Shadows" overlay is on — tuned with the new lighting
-NCZ.SUN_DIST           = 22000;  // CET units the sun light (and its shadow camera) sits up the sun ray from the visible-ground centre — only the direction matters for shading; large enough that the whole footprint stays in front of the shadow camera even at a low sun
+NCZ.AMBIENT_SKY_RGB    = [0.796, 0.895, 1.0];       // envparam AmbientOverride: the 5 bright cube faces, cool white (linear)
+NCZ.AMBIENT_GROUND_RGB = [0.566, 0.766, 1.0];       // envparam AmbientOverride: the dim ground face, blue (linear)
+NCZ.AMBIENT_INTENSITY  = 0.405;                     // envelope-fit: sun:ambient ≈ 7.4:1
+NCZ.SHADOW_INTENSITY   = 0.60;                      // cast-shadow strength when "Shadows" overlay is on; tuned with the new lighting
+NCZ.SUN_DIST           = 22000;  // CET units the sun light (and its shadow camera) sits up the sun ray from the visible-ground centre: only the direction matters for shading; large enough that the whole footprint stays in front of the shadow camera even at a low sun
 NCZ.SUN_SPHERE_DIST    = 20000;  // visible sun disc distance from world centre
-NCZ.SUN_SPHERE_RADIUS  =   600;  // CET units — ≈1.7° apparent diameter at SUN_SPHERE_DIST (≈3× real sun)
+NCZ.SUN_SPHERE_RADIUS  =   600;  // CET units: ≈1.7° apparent diameter at SUN_SPHERE_DIST (≈3× real sun)
 
-// Building instance decode — DDS _data.dds (DXGI_FORMAT_R16G16B16A16_UNORM, DX10 header)
+// Building instance decode: DDS _data.dds (DXGI_FORMAT_R16G16B16A16_UNORM, DX10 header)
 // Each pixel encodes one building instance across three horizontal blocks: position | rotation | scale.
 NCZ.DDS_PIXEL_OFFSET  = 148;      // byte offset to pixel data: 128-byte standard DDS header + 20-byte DX10 extension
-NCZ.UINT16_MAX        = 65535.0;  // normalisation denominator — pixel channels are 0–65535
-// 0.01 × UINT16_MAX — the "empty slot" cutoff. Used two ways in loadBuildings:
+NCZ.UINT16_MAX        = 65535.0;  // normalisation denominator: pixel channels are 0–65535
+// 0.01 × UINT16_MAX: the "empty slot" cutoff. Used two ways in loadBuildings:
 // base-game textures mark empties with near-zero position ALPHA below this;
 // malgalad's "3D World Map Fixed" textures keep alpha full and mark empties by
 // zeroing the SCALE block instead (see docs/3dmap-fixed-assets.md).
@@ -399,12 +401,12 @@ NCZ.DDS_ALPHA_THRESH  = 655;
 
 // 3D-map building asset set: 'fixed' = malgalad's "3D World Map Fixed" textures
 // (DISTRICT_META.dataDdsFixed); 'cdpr' = base-game textures (DISTRICT_META.dataDds).
-// Persisted as a user preference (NOT theme-scoped) — selected in the Settings
+// Persisted as a user preference (NOT theme-scoped); selected in the Settings
 // modal; loadBuildings reads it at load time. Fixed is the default.
 NCZ.ASSET_SET_KEY     = 'ncz-asset-set';
 NCZ.ASSET_SET_DEFAULT = 'fixed';
 
-// Building edge highlight — decoded from the game's 3d_map_cubes.mt gbuffer
+// Building edge highlight, decoded from the game's 3d_map_cubes.mt gbuffer
 // pixel shader (PIX capture).
 // Per-district EdgeThickness / EdgeSharpnessPower live in DISTRICT_META
 // (three-scene.js) alongside the other per-district game constants.
@@ -414,12 +416,12 @@ NCZ.BUILDING_EDGE_CAMDIST_K =  0.002; // game's camera-distance widening coeffic
 //   surface = 0.5·(0.05 + 0.75·ao + m)   →   ao = 1 (the vertical-AO term is
 // gated by DebugScaleOffset, which ships at a default that disables it)
 //   →   surface = 0.5·(0.8 + m) = 0.4 + 0.5·m
-NCZ.BUILDING_TEX_FLOOR      =   0.4;  // _m.dds brightness floor — game 0.5·0.8
-NCZ.BUILDING_TEX_RANGE      =   0.5;  // brightness range above the floor — game 0.5·m
+NCZ.BUILDING_TEX_FLOOR      =   0.4;  // _m.dds brightness floor: game 0.5·0.8
+NCZ.BUILDING_TEX_RANGE      =   0.5;  // brightness range above the floor: game 0.5·m
 // Sloped-face guard for the _m planar sample (see buildBuildingMaterial):
 // world-normal Y thresholds for the smoothstep blend between the per-fragment
-// planar UV (flat roofs — exact decoded behaviour) and the instance-centre UV
-// (steep/oblique faces — the building's own roof texel, which can't paint a
+// planar UV (flat roofs: exact decoded behaviour) and the instance-centre UV
+// (steep/oblique faces: the building's own roof texel, which can't paint a
 // 2-D image of the district map onto a slanted surface).
 // Thresholds are tight because a partially-blended UV still draws a (squashed)
 // image: a ~30°-pitched face at a mid blend re-rendered the artifact as smeared
@@ -428,16 +430,16 @@ NCZ.BUILDING_TEX_RANGE      =   0.5;  // brightness range above the floor — ga
 NCZ.BUILDING_TEX_SLOPE_FADE_START = 0.95;  // normal.y ≤ this (pitch ≥ ~18°) → fully centre-sampled
 NCZ.BUILDING_TEX_SLOPE_FADE_END   = 0.995; // normal.y ≥ this (pitch ≤ ~6°)  → fully planar
 
-// Terrain "graph-paper" grid — decoded from the game's 3d_map_terrain pixel
+// Terrain "graph-paper" grid, decoded from the game's 3d_map_terrain pixel
 // shader (PIX DXIL capture). Three
 // nested anti-aliased line grids on world XZ, combined into one line factor.
-// Every value below is the game's exact decoded value — the "game:" note in
+// Every value below is the game's exact decoded value; the "game:" note in
 // each comment keeps the original recoverable if a value is later tuned.
-NCZ.TERRAIN_GRID_CELLS       = [80, 8, 400]; // world-unit cell sizes, main/fine/major — game: [80, 8, 400]
-NCZ.TERRAIN_GRID_LINE_N      = [20, 2, 75];  // line-width factors, line ≈ cell/N wide — game: [20, 2, 75]
-NCZ.TERRAIN_GRID_FINE_OFFSET = 1423.6;       // phase offset on the fine grid — game: 1423.6
-NCZ.TERRAIN_GRID_MAIN_WEIGHT = 0.65;         // main-grid contribution, before the fine grid is subtracted — game: 0.65
-NCZ.TERRAIN_GRID_MAJOR_BOOST = 50;           // major-line emphasis: (1 + BOOST·major) multiplies the result — game: 50
+NCZ.TERRAIN_GRID_CELLS       = [80, 8, 400]; // world-unit cell sizes, main/fine/major (game: [80, 8, 400])
+NCZ.TERRAIN_GRID_LINE_N      = [20, 2, 75];  // line-width factors, line ≈ cell/N wide (game: [20, 2, 75])
+NCZ.TERRAIN_GRID_FINE_OFFSET = 1423.6;       // phase offset on the fine grid (game: 1423.6)
+NCZ.TERRAIN_GRID_MAIN_WEIGHT = 0.65;         // main-grid contribution, before the fine grid is subtracted (game: 0.65)
+NCZ.TERRAIN_GRID_MAJOR_BOOST = 50;           // major-line emphasis: (1 + BOOST·major) multiplies the result (game: 50)
 
 // District / subdistrict outline visibility thresholds in CET camera-to-target
 // distance. Three-state, matching the game's WorldMap.ZoomLevel* TweakDB records:
@@ -447,11 +449,11 @@ NCZ.TERRAIN_GRID_MAJOR_BOOST = 50;           // major-line emphasis: (1 + BOOST�
 // Sources: WorldMap.ZoomLevelDistricts.zoom = 11000 (showDistricts = 1),
 // WorldMap.ZoomLevelSubDistricts.zoom = 7000 (showSubDistricts = 1). All
 // closer zoom-level records (Important / Vendors / AllMappins / ExtraMappins)
-// have both flags false — i.e. neither outline tier is shown below 7000.
+// have both flags false, i.e. neither outline tier is shown below 7000.
 NCZ.DISTRICT_DISTANCE_3D    = 11000;
 NCZ.SUBDISTRICT_DISTANCE_3D =  7000;
 
-// Metro LOD — decoded from the game's 3d_map_metro.mt pixel shader (PIX
+// Metro LOD, decoded from the game's 3d_map_metro.mt pixel shader (PIX
 // capture). The metro mesh carries
 // three LOD tiers in COLOR_0, one channel per vertex:
 //   R = dotted (closest)   G = thin solid (medium)   B = wide solid (far)
@@ -461,7 +463,7 @@ NCZ.SUBDISTRICT_DISTANCE_3D =  7000;
 // The game drives this off `D = 2 × cameraZ`, comparing against
 // VisibilityDistance{Dashed,Regular,Bold} = 5000 / 18000 / 30000. Our
 // camera-to-target distance is that same metric halved, so the thresholds
-// below are the game values ÷ 2 — FAR (15000) lands exactly on
+// below are the game values ÷ 2; FAR (15000) lands exactly on
 // SCHEMA_CAMERA_MAX_DISTANCE, which is why the raw game values looked too
 // large until the `2×` was decoded out of the camera cbuffer.
 NCZ.METRO_LOD_DISTANCE_NEAR = 2500;   // R→G boundary  (game VisibilityDistanceDashed  5000 ÷ 2)
@@ -469,22 +471,22 @@ NCZ.METRO_LOD_DISTANCE_MED  = 9000;   // G→B boundary  (game VisibilityDistanc
 NCZ.METRO_LOD_DISTANCE_FAR  = 15000;  // B→hidden      (game VisibilityDistanceBold    30000 ÷ 2)
 NCZ.METRO_LOD_TRANSITION    = 150;    // crossfade band width (game TransitionLength 300 ÷ 2)
 
-// SeeThrough roads — the Pacifica tunnel: a road visible *through* the open bay water.
-// Water (rendered in the transparent pass — see three-scene.js loadTerrain) writes
+// SeeThrough roads, the Pacifica tunnel: a road visible *through* the open bay water.
+// Water (rendered in the transparent pass; see three-scene.js loadTerrain) writes
 // stencil=STENCIL_WATER where it's the visible surface; terrain/cliffs/buildings over-stamp
 // stencil=STENCIL_OCCLUDER where THEY are; the SeeThrough road pass renders where
 // stencil==STENCIL_WATER (with depthTest off, so it draws on top of the water).
 NCZ.STENCIL_WATER    = 2;     // stencil ref written by the water mesh / tested by the SeeThrough roads
 NCZ.STENCIL_OCCLUDER = 1;     // stencil ref written by terrain / cliffs / buildings (visible-surface over-stamp)
-NCZ.WATER_OPACITY    = 1.0;   // water material opacity — water is in the transparent pass (so its stencil write is depth-limited to the visible bay) but renders visually opaque at 1.0; lower to make the ocean see-through
+NCZ.WATER_OPACITY    = 1.0;   // water material opacity: water is in the transparent pass (so its stencil write is depth-limited to the visible bay) but renders visually opaque at 1.0; lower to make the ocean see-through
 
-// 3D pin layer (NCZ.ThreeMarkers) — visual + UX tunables for CSS2DObject markers
+// 3D pin layer (NCZ.ThreeMarkers): visual + UX tunables for CSS2DObject markers
 // Used ONLY by pin/popup rendering. Mod data Z is read raw everywhere else.
-NCZ.PIN_3D_GROUND_OFFSET            =  5;  // CET metres above player CET Z — purely cosmetic lift so the diamond reads above the surface, not embedded
+NCZ.PIN_3D_GROUND_OFFSET            =  5;  // CET metres above player CET Z: purely cosmetic lift so the diamond reads above the surface, not embedded
 NCZ.PIN_3D_DRAG_THRESHOLD_PX        =  4;  // pixels of pointerdown→pointerup movement before a click is treated as a drag (and thus does not close the popup)
 NCZ.PIN_3D_POPUP_FLIP_PADDING_PX    = 24;  // pixels of clearance above the viewport top before the popup flips from above-pin to below-pin placement
 NCZ.PIN_3D_FLY_DURATION_MS          = 700; // total tween time for sidebar click → camera fly-to-pin
 // Fly-to-pin target distance lives in SCHEMA_FLY_TO_DISTANCE (TweakDB zoomToZoomValue = 1250)
-NCZ.PIN_3D_CLUSTER_RADIUS_PX        = 40;  // screen-pixel radius for grouping pins into a cluster — matches Leaflet's maxClusterRadius
-NCZ.PIN_3D_PAN_EDGE_FRACTION        = 0.5; // viewport-relative pan padding — at the bound, the world edge sits at screen-center (matches Leaflet's `panEdgeFraction`). Smaller = tighter bound.
-NCZ.PIN_3D_SCALE_TARGET_PX          = 100; // ideal scale-bar width in pixels — the actual bar rounds to a "nice" length (1, 2, 5 × 10ⁿ metres) closest to this width
+NCZ.PIN_3D_CLUSTER_RADIUS_PX        = 40;  // screen-pixel radius for grouping pins into a cluster; matches Leaflet's maxClusterRadius
+NCZ.PIN_3D_PAN_EDGE_FRACTION        = 0.5; // viewport-relative pan padding: at the bound, the world edge sits at screen-centre (matches Leaflet's `panEdgeFraction`). Smaller = tighter bound.
+NCZ.PIN_3D_SCALE_TARGET_PX          = 100; // ideal scale-bar width in pixels; the actual bar rounds to a "nice" length (1, 2, 5 × 10ⁿ metres) closest to this width

--- a/assets/js/district-info.js
+++ b/assets/js/district-info.js
@@ -1,8 +1,8 @@
 /**
- * NC Zoning Board — District Info Panel
+ * NC Zoning Board: District Info Panel
  * Namespace: NCZ.DistrictInfo
  *
- * The hover info panel (top-right, under the header) — a parity nod to the
+ * The hover info panel (top-right, under the header), a parity nod to the
  * in-game world map's bottom-right district readout. Shows the district icon +
  * name, the subdistrict (when one is hovered), and location stats for that
  * area: count, category breakdown, share of the whole map, and how many were
@@ -12,10 +12,10 @@
  * and the 2D (SAT) hover (onMapMouseMove in overlay) drive it via show()/hide().
  *
  * Public API:
- *   NCZ.DistrictInfo.init()                 — cache DOM + load district polygons
- *   NCZ.DistrictInfo.setMods(mods)          — (re)compute per-area stats
- *   NCZ.DistrictInfo.show(districtId, subId) — populate + reveal for a hover
- *   NCZ.DistrictInfo.hide()                 — hide on hover-exit
+ *   NCZ.DistrictInfo.init()                 - cache DOM + load district polygons
+ *   NCZ.DistrictInfo.setMods(mods)          - (re)compute per-area stats
+ *   NCZ.DistrictInfo.show(districtId, subId) - populate + reveal for a hover
+ *   NCZ.DistrictInfo.hide()                 - hide on hover-exit
  *
  * Depends on: constants.js (DISTRICT_COLORS, CATEGORY_STYLES), utils.js
  *   (pointInPolygon, isRecentlyUpdated, escapeHtml).
@@ -35,13 +35,13 @@ NCZ.DistrictInfo = (() => {
   let _defaultDistrict = null;    // the game's catch-all district (Badlands)
 
   // The game's default district: anywhere outside every district polygon is
-  // Badlands (it has no polygon of its own — the parent is the catch-all).
+  // Badlands (it has no polygon of its own; the parent is the catch-all).
   // Mirrors DEFAULT_DISTRICT_ID in worker/src/districts.js assignDistrict().
   // Used only when resolving from coordinates on the API-down fallback path;
   // on the normal API path the served label is already "Badlands".
   const DEFAULT_DISTRICT_ID = "badlands";
 
-  // Shoelace area (absolute) — smallest matching polygon wins, so a mod inside
+  // Shoelace area (absolute): smallest matching polygon wins, so a mod inside
   // both a subdistrict and its parent district is attributed to the subdistrict.
   function polyArea(ring) {
     let a = 0;
@@ -59,7 +59,7 @@ NCZ.DistrictInfo = (() => {
   // subdistrict containing it (and that sub's parent district), else the
   // smallest containing district polygon. Returns { dist, sub } or null. Used
   // both to attribute mods (setMods) and to drive the panel from the cursor
-  // (showAt) — independent of which outline tier is currently drawn.
+  // (showAt), independent of which outline tier is currently drawn.
   function resolveArea(pt) {
     let sub = null, subArea = Infinity, dist = null;
     for (const d of _districts) {
@@ -115,7 +115,7 @@ NCZ.DistrictInfo = (() => {
 
   // Aggregate count / category / recently-updated per area. Normal (API) path:
   // group by the district/subdistrict the API already assigned (served as names,
-  // mapped to panel ids) — counting the API's own labels is what keeps the panel
+  // mapped to panel ids); counting the API's own labels is what keeps the panel
   // from ever disagreeing with the API (the root of #823; the ex-ocean mods are
   // already labelled Badlands server-side). API-down fallback path: mods carry
   // no served label, so resolve from coordinates (with the Badlands default),
@@ -129,7 +129,7 @@ NCZ.DistrictInfo = (() => {
       let distId = m.district ? _distIdByName[m.district] : undefined;
       let subId = m.subdistrict ? (_subIdByName[m.subdistrict] ?? null) : null;
       if (!distId) {
-        // No served label (fallback path) — resolve from coordinates.
+        // No served label (fallback path): resolve from coordinates.
         const c = m.coordinates;
         if (!c || c.length < 2) continue;
         const area = resolveArea([c[0], c[1]]) || (_defaultDistrict && { dist: _defaultDistrict, sub: null });
@@ -206,7 +206,7 @@ NCZ.DistrictInfo = (() => {
   // Crop the district's icon out of the atlas (district_icons.png) and scale it
   // to fit the icon box, centred. (All our badlands subdistricts are children of
   // the central Districts.Badlands in TweakDB, so badlands always uses the
-  // central icon — the North/South atlas icons belong to subdistricts we don't map.)
+  // central icon; the North/South atlas icons belong to subdistricts we don't map.)
   function setDistrictIcon(districtId) {
     const el = _els.icon;
     const atlas = NCZ.DISTRICT_ICON_ATLAS;
@@ -216,7 +216,7 @@ NCZ.DistrictInfo = (() => {
     if (!rect) { el.style.backgroundImage = "none"; return; }
 
     // Box = the icon's EXACT scaled rect (no margin) so adjacent atlas icons
-    // can't bleed into it — a fixed square box + centred crop would show e.g.
+    // can't bleed into it; a fixed square box + centred crop would show e.g.
     // Watson's edge above City Center. Normalise by HEIGHT so every district
     // icon renders at the same height (their native slices vary in aspect);
     // width follows the icon's aspect.
@@ -233,7 +233,7 @@ NCZ.DistrictInfo = (() => {
     el.style.backgroundPosition = `${-rect.l * atlas.w * scale}px ${-rect.t * atlas.h * scale}px`;
   }
 
-  // Resolve + show from a CET cursor point — the panel always reports the most
+  // Resolve + show from a CET cursor point: the panel always reports the most
   // specific subdistrict under the cursor, even at the district zoom tier where
   // only district outlines are drawn (matches the in-game readout).
   function showAt(cetX, cetY, statsLevel) {

--- a/assets/js/district-line-material.js
+++ b/assets/js/district-line-material.js
@@ -1,21 +1,20 @@
 /**
- * DistrictLineMaterial — custom TSL wide-line material for the district
+ * DistrictLineMaterial: custom TSL wide-line material for the district
  * outlines (issue #775), replacing three's Line2NodeMaterial.
  *
  * Why not Line2NodeMaterial: the r185 rewrite doesn't support real
- * transparency ("not supported, yet" — it forces NoBlending and fakes
+ * transparency ("not supported, yet"; it forces NoBlending and fakes
  * semi-transparent lines by blending against viewportOpaqueMipTexture(), a
  * canvas-size copy of the opaque-only framebuffer, in-shader). For our
  * outlines that fake was the root of three bugs at once: the #771 resize
  * wedge (stale binding to the destroyed framebuffer copy), the unhovered
  * colour regression (lines composited against the opaque backdrop, ignoring
  * the roads/metro/water actually beneath them), and the alphaToCoverage
- * quantisation of faint lines. See wiki
- * learnings/line2-fake-transparency-root-of-r185-issues.
+ * quantisation of faint lines.
  *
  * What this ports from upstream (r185 Line2NodeMaterial, screen-space path):
  *   - the instanced quad expansion from LineGeometry's instanceStart /
- *     instanceEnd attributes (geometry pipeline unchanged — only the
+ *     instanceEnd attributes (geometry pipeline unchanged; only the
  *     material is swapped)
  *   - the reversed-depth-aware near-plane segment trim (upstream #33572,
  *     the fix this repo tracked as mrdoob#33570)
@@ -26,7 +25,7 @@
  *     the hover fade tween and the faint resting opacity composite against
  *     whatever is actually behind the line (r184-equivalent look)
  *   - endcap edges are fwidth-AA'd unconditionally (no alphaToCoverage, no
- *     MSAA sample-count gate — the sub-pixel-detail lesson from the terrain
+ *     MSAA sample-count gate; the sub-pixel-detail lesson from the terrain
  *     grid / building edges applies here too)
  *   - degenerate segments (zero NDC length after projection) are guarded
  *     in-shader: belt-and-braces alongside dedupRing()'s data hygiene, so
@@ -36,10 +35,10 @@
  * colors, raycast support.
  *
  * Joint dedup (the `stencilRef` parameter): every segment is an independent
- * quad with cap extensions, so a ring self-overlaps at each corner — under
+ * quad with cap extensions, so a ring self-overlaps at each corner; under
  * real alpha blending that double-blend reads as a brighter dot at partial
  * opacity. (r184 never showed it: its backdrop-premix fake made overlapping
- * writes idempotent.) Fix: per-ring stencil ref with NotEqual + Replace —
+ * writes idempotent.) Fix: per-ring stencil ref with NotEqual + Replace;
  * within a frame each ring's first fragment at a pixel stamps the ref and
  * later fragments of the SAME ring fail the test, so a ring touches each
  * pixel once. Coincident neighbour borders carry different refs and still
@@ -58,7 +57,7 @@ import {
 
 // Near-plane estimate from the projection matrix, branching on the depth
 // convention: te[10] is positive under a reversed depth buffer, so its sign
-// selects the formula (verbatim port of r185's trimSegmentAlpha — the r184
+// selects the formula (verbatim port of r185's trimSegmentAlpha; the r184
 // version assumed the WebGL layout and returned ~-far/2 under reversed-Z,
 // the rays-across-viewport bug).
 const trimSegmentAlpha = Fn(({ start, end }) => {
@@ -81,7 +80,7 @@ const districtLineClipPosition = /*@__PURE__*/ Fn(() => {
 
   const aspect = viewport.z.div(viewport.w);
 
-  // Trim segments that cross the camera plane under perspective projection —
+  // Trim segments that cross the camera plane under perspective projection:
   // NDC math below is meaningless for endpoints behind the camera.
   const perspective = cameraProjectionMatrix.element(2).element(3).equal(-1.0);
   If(perspective, () => {
@@ -100,7 +99,7 @@ const districtLineClipPosition = /*@__PURE__*/ Fn(() => {
   const ndcStart  = clipStart.xyz.div(clipStart.w);
   const ndcEnd    = clipEnd.xyz.div(clipEnd.w);
 
-  // segment direction in aspect-corrected NDC — guarded against degenerate
+  // segment direction in aspect-corrected NDC, guarded against degenerate
   // (zero-length after projection) segments instead of normalize(0,0) = NaN
   const dir = ndcEnd.xy.sub(ndcStart.xy).toVar('dir');
   dir.x.assign(dir.x.mul(aspect));
@@ -133,7 +132,7 @@ const districtLineClipPosition = /*@__PURE__*/ Fn(() => {
 })();
 
 // Fragment coverage: 1 in the quad body; round endcaps beyond uv.y ∈ [-1, 1]
-// with an fwidth-AA'd circular edge (always on — no sample-count gate).
+// with an fwidth-AA'd circular edge (always on: no sample-count gate).
 const districtLineCoverage = /*@__PURE__*/ Fn(() => {
   const vUv = uv();
   const alpha = float(1).toVar('alpha');
@@ -157,7 +156,7 @@ export class DistrictLineMaterial extends THREE.NodeMaterial {
     this.isDistrictLineMaterial = true;
 
     // Properties the TSL accessors read (materialColor / materialOpacity /
-    // materialLineWidth) — must exist before setValues copies parameters in.
+    // materialLineWidth); must exist before setValues copies parameters in.
     this.color = new THREE.Color(0xffffff);
     this.linewidth = 1;
 
@@ -179,7 +178,7 @@ export class DistrictLineMaterial extends THREE.NodeMaterial {
       this.stencilWriteMask = 0xff;
     }
 
-    // Wired once here, NOT in setup() — assigning node properties during
+    // Wired once here, NOT in setup(): assigning node properties during
     // setup() dirties the material every build and forces a full pipeline
     // recompile per frame (~1 s/frame when first tried). The nodes are
     // module-level singletons shared by all instances.

--- a/assets/js/flyover.js
+++ b/assets/js/flyover.js
@@ -1,5 +1,5 @@
 /**
- * NC Zoning Board — Flyover Showcase
+ * NC Zoning Board: Flyover Showcase
  * Namespace: NCZ.Flyover
  *
  * Cinematic flyover tour synced to "Good Morning Night City" (57.417s per loop).
@@ -15,13 +15,13 @@ import * as THREE from 'three';
 window.NCZ = window.NCZ || {};
 
 // ── Flyover constants ──────────────────────────────────────────────────────────
-// Kept here (not in constants.js) — flyover.js is opt-in and removable.
+// Kept here (not in constants.js): flyover.js is opt-in and removable.
 const FLYOVER_DURATION_S    = 57.417;   // audio track length in seconds
 const FLYOVER_FOV           = 55;       // perspective camera field of view (degrees)
 const FLYOVER_CAM_NEAR      = 1;        // perspective camera near clip (CET units)
 const FLYOVER_CAM_FAR       = 120000;   // perspective camera far clip
 const FLYOVER_FADE_MS       = 2000;     // fade in / fade to black duration (ms)
-const FLYOVER_BEAT_DISSOLVE = 938;      // theme cross-dissolve duration per beat (ms) — 70% of ~1340ms beat period
+const FLYOVER_BEAT_DISSOLVE = 938;      // theme cross-dissolve duration per beat (ms): 70% of ~1340ms beat period
 const FLYOVER_REVEAL_ROADS  = 1500;     // ms after WP0 to stagger roads in (only used when run opts revealLayers = true)
 const FLYOVER_REVEAL_METRO  = 3000;     // ms after WP0 to stagger metro in
 const FLYOVER_REVEAL_BLDGS  = 4500;     // ms after WP0 to stagger buildings in
@@ -48,48 +48,48 @@ const Flyover = (() => {
   //    6   34.743   Westbrook    ★    top-down
   //    7   43.377   Pacifica     ★    top-down
   //    8   48.077   Dogtown           low sweep
-  //    9   52.747   Badlands          rising, looking east — districts off here
+  //    9   52.747   Badlands          rising, looking east; districts off here
   //   10   57.417   Rocky Ridge       high, looking back west at the city
 
   const FLYOVER_WAYPOINTS = [
     //  #   cam position (GLB)        look-at target (GLB)         dur(ms)
-    //  0 — Open ocean, sea-level, city glowing on the horizon
+    //  0: Open ocean, sea-level, city glowing on the horizon
     [  -5800,   250,     400,        -2500,    200,      400,          0],
-    //  1 — Skim the coastline as "Good Morning Night City" hits  @6.948s
+    //  1: Skim the coastline as "Good Morning Night City" hits  @6.948s
     [  -3200,   150,     500,          800,    300,      800,       6948],
-    //  2 — Watson: near-ground sweep south, city core on the horizon ahead  @10.948s
-    //      Low and nearly horizontal — unnamed flythrough, no top-down
+    //  2 (Watson): near-ground sweep south, city core on the horizon ahead  @10.948s
+    //      Low and nearly horizontal: unnamed flythrough, no top-down
     [  -1000,   120,   -3000,          600,    120,     -900,       4000],
-    //  3 — HEYWOOD top-down  @14.842s  ★ district beat
+    //  3: HEYWOOD top-down  @14.842s  ★ district beat
     //      CET ≈ (200, -1500) → GLB target (200, 0, 1500); camera offset north
     [    200,  2800,    1100,          200,      0,     1500,       3894],
-    //  4 — City Center: banking sweep west across the skyline  @20.842s
-    //      Medium height — enough to clear terrain, shallow horizontal gaze
+    //  4 (City Center): banking sweep west across the skyline  @20.842s
+    //      Medium height: enough to clear terrain, shallow horizontal gaze
     [    700,   600,    -500,         -400,    300,    -1400,       6000],
-    //  5 — Santo Domingo: near-ground south, looking north — city skyline ahead  @26.977s
+    //  5 (Santo Domingo): near-ground south, looking north; city skyline ahead  @26.977s
     //      Flat terrain reads as industrial outskirts; city visible in the distance
     [    600,   250,    4000,          300,    300,     1200,       6135],
-    //  6 — Westbrook: sweeping in from the east, city grid visible to the west  @34.743s
+    //  6 (Westbrook): sweeping in from the east, city grid visible to the west  @34.743s
     [   3000,   600,   -2000,          500,    200,    -1000,       7766],
-    //  7 — PACIFICA top-down  @43.377s
+    //  7: PACIFICA top-down  @43.377s
     //      CET ≈ (-3200, -2000) → GLB target (-3200, 0, 2000)
     [  -3200,  2800,    1600,        -3200,      0,     2000,       8634],
-    //  8 — Dogtown: low sweep through the stadium district  @48.077s
+    //  8 (Dogtown): low sweep through the stadium district  @48.077s
     [  -3000,   250,    2500,        -1500,    200,     1500,       4700],
-    //  9 — Badlands: rising, camera looking east (city behind) — districts off  @52.747s
+    //  9 (Badlands): rising, camera looking east (city behind); districts off  @52.747s
     [   2500,   500,    2000,         4500,    200,     3500,       4670],
-    // 10 — Rocky Ridge: high, full city silhouette on the western horizon  @57.417s
+    // 10 (Rocky Ridge): high, full city silhouette on the western horizon  @57.417s
     [   4500,  1500,    4000,            0,    100,        0,       4670],
   ];
 
   // ── Layer events ──────────────────────────────────────────────────────────
   // Fired the instant a waypoint is reached.
   // Opening reveal: staggered via scheduleLayerReveal() during the ocean approach.
-  // Closing:        districts only — turned off at WP9 while city is behind camera.
+  // Closing:        districts only, turned off at WP9 while city is behind camera.
 
   // ── Theme cross-dissolve ──────────────────────────────────────────────────
-  // Captures scene colors before the theme changes, then lerps all materials
-  // from the old values to the new ones over ~1 second — no black flash,
+  // Captures scene colours before the theme changes, then lerps all materials
+  // from the old values to the new ones over ~1 second: no black flash,
   // just a smooth meld from one palette to the next.
 
   function applyThemeSmooth(themeId, durationMs = 1000) {
@@ -97,13 +97,13 @@ const Flyover = (() => {
       NCZ.applyTheme?.(themeId);
       return;
     }
-    const from = NCZ.ThreeScene.captureColors();  // snapshot current colors
+    const from = NCZ.ThreeScene.captureColors();  // snapshot current colours
     NCZ.applyTheme(themeId);                      // CSS class + materials snap
     NCZ.ThreeScene.transitionMaterials(from, durationMs); // lerp back from old
   }
 
   const FLYOVER_EVENTS = {
-    // WP 0 — Ocean: snap to opening theme; showcase always controls its own layer state.
+    // WP 0 (Ocean): snap to opening theme; showcase always controls its own layer state.
     // _runOpts.revealLayers=true  → hide everything, stagger layers back in over 6.9s
     // _runOpts.revealLayers=false → all layers on from frame 1 (immediate shadows)
     // Districts honour the split _runOpts.districtNames/districtOutlines in
@@ -126,7 +126,7 @@ const Flyover = (() => {
       const lockedTheme = _runOpts?.theme && _runOpts.theme !== 'cycle' ? _runOpts.theme : 'night-corp';
       NCZ.applyTheme?.(lockedTheme);
     },
-    // WP 9 — Badlands sweep: drop districts so the city behind camera reads cleaner.
+    // WP 9 (Badlands sweep): drop districts so the city behind camera reads cleaner.
     // Skipped when the user opted to keep districts visible.
     9: () => {
       if (!(_runOpts?.districtNames || _runOpts?.districtOutlines)) {
@@ -137,7 +137,7 @@ const Flyover = (() => {
 
   // ── Beat-cycle visualiser ─────────────────────────────────────────────────
   // Exact beat timestamps from the Audacity beat finder (cluster-start beats,
-  // ~1.34s apart — the track's bass pulse). Checked each animation frame
+  // ~1.34s apart, the track's bass pulse). Checked each animation frame
   // against audio.currentTime so theme changes lock to the actual audio.
 
   const BEAT_TIMESTAMPS_MS = [
@@ -147,9 +147,9 @@ const Flyover = (() => {
     44421, 45738, 47088, 48386, 49722, 52403,
   ];
 
-  // Read all scene colors for a theme directly from CSS custom properties.
+  // Read all scene colours for a theme directly from CSS custom properties.
   // Temporarily swaps the theme class on <html>, reads computed styles, then restores.
-  // No visual flash — requestAnimationFrame doesn't fire during synchronous execution.
+  // No visual flash: requestAnimationFrame doesn't fire during synchronous execution.
   function readThemeColors(themeId) {
     const html     = document.documentElement;
     const prevCls  = Array.from(html.classList).filter(c => c.startsWith('theme-'));
@@ -157,7 +157,7 @@ const Flyover = (() => {
     html.classList.add(`theme-${themeId}`);
     const s = getComputedStyle(html);
     const c = v => new THREE.Color(s.getPropertyValue(v).trim());
-    // Auto-derive from ThreeScene registry — no manual updates needed when materials change
+    // Auto-derive from ThreeScene registry: no manual updates needed when materials change
     const colors = {};
     for (const { key, cssVar, fallback } of (NCZ.ThreeScene?.getSceneColorVars() ?? [])) {
       const raw = s.getPropertyValue(cssVar).trim();
@@ -168,7 +168,7 @@ const Flyover = (() => {
     return colors;
   }
 
-  // Derived from CSS at first use — stays in sync with theme.css automatically.
+  // Derived from CSS at first use; stays in sync with theme.css automatically.
   // Order matches NCZ.THEMES rotation sequence.
   let _beatColors = null;
   function getBeatColors() {
@@ -178,7 +178,7 @@ const Flyover = (() => {
 
   // Per-theme render-toggle defaults (--scene-grade / --scene-edge-glow), read
   // from CSS the same way as the colours. Lets the beat cycle apply each
-  // theme's LUT-grade + edge-glow defaults as it sweeps palettes — otherwise
+  // theme's LUT-grade + edge-glow defaults as it sweeps palettes; otherwise
   // those gates (which live in updateMaterials, bypassed by the colour-tween
   // path) would freeze at the opening theme's state for the whole showcase.
   let _beatToggles = null;
@@ -206,7 +206,7 @@ const Flyover = (() => {
   let _runOpts        = null; // per-run options captured at startFlyover (null when idle)
 
   // ── Flyover sun animation ─────────────────────────────────────────────────
-  // Maps audio.currentTime to real sunrise→sunset at Morro Bay, CA —
+  // Maps audio.currentTime to real sunrise→sunset at Morro Bay, CA,
   // the real-world location of Night City. Computed once per flyover start.
 
   // MORRO_BAY defined as module-level constant above the IIFE
@@ -215,7 +215,7 @@ const Flyover = (() => {
 
   function initFlyoverSun() {
     if (typeof SunCalc === 'undefined') return;
-    // Use summer solstice — longest day, widest sun arc, most dramatic hillshading.
+    // Use summer solstice: longest day, widest sun arc, most dramatic hillshading.
     // Year doesn't affect the solar geometry meaningfully at this precision.
     const solstice = new Date(new Date().getFullYear(), 5, 21); // June 21
     const times = SunCalc.getTimes(solstice, MORRO_BAY.lat, MORRO_BAY.lng);
@@ -229,7 +229,7 @@ const Flyover = (() => {
     const epochMs = _sunriseMs + (_sunsetMs - _sunriseMs) * t;
     const pos = SunCalc.getPosition(new Date(epochMs), MORRO_BAY.lat, MORRO_BAY.lng);
     NCZ.ThreeScene.setSunPosition(pos.azimuth, pos.altitude);
-    // Drive exposure off the same elevation curve as the slider — the flyover
+    // Drive exposure off the same elevation curve as the slider: the flyover
     // animates the sun directly (bypassing applySunTime), so without this the
     // exposure froze at its pre-showcase value and the whole flyover rendered
     // at one brightness. See NCZ.exposureForSunElevation.
@@ -245,7 +245,7 @@ const Flyover = (() => {
     _beatColorIndex++;
     NCZ.ThreeScene.transitionToColors(from, to, FLYOVER_BEAT_DISSOLVE);
     // Apply this theme's grade + edge-glow defaults so the cycle honours each
-    // palette's render toggles (binary — they snap on the beat; the colours
+    // palette's render toggles (binary: they snap on the beat; the colours
     // cross-dissolve). The user's pre-showcase toggle choices are restored on stop.
     const tog = getBeatToggles()[idx];
     NCZ.ThreeScene.setGradeEnabled?.(tog.grade);
@@ -263,8 +263,9 @@ const Flyover = (() => {
   }
 
   // ── Layer reveal ──────────────────────────────────────────────────────────
-  // Stagger Roads → Metro → Buildings → Districts across the 6.948s ocean
-  // approach so all four are visible before "Good Morning" is announced.
+  // Stagger Roads → Metro → Buildings across the 6.948s ocean approach so
+  // the overlays are visible before "Good Morning" is announced. Districts
+  // are deliberately not revealed (cleaner showcase without boundary lines).
 
   let _layerRevealTimers = [];
 
@@ -274,7 +275,7 @@ const Flyover = (() => {
       setTimeout(() => NCZ.ThreeScene.setLayerVisibility('roads',     true), FLYOVER_REVEAL_ROADS),
       setTimeout(() => NCZ.ThreeScene.setLayerVisibility('metro',     true), FLYOVER_REVEAL_METRO),
       setTimeout(() => NCZ.ThreeScene.setLayerVisibility('buildings', true), FLYOVER_REVEAL_BLDGS),
-      // Districts omitted — cleaner showcase without boundary lines
+      // Districts omitted: cleaner showcase without boundary lines
     ];
     // Pins reveal happens after buildings so they don't pop up against an empty
     // grey scene. Only scheduled when the user opted into both revealLayers and
@@ -310,7 +311,7 @@ const Flyover = (() => {
 
   function fadeIn() {
     if (!_fadeEl) return;
-    // Element starts at opacity:1 — transition to transparent
+    // Element starts at opacity:1; transition to transparent
     void _fadeEl.offsetWidth; // force reflow so transition fires from 1 not 0
     _fadeEl.style.transition = `opacity ${FLYOVER_FADE_MS}ms ease`;
     _fadeEl.style.opacity    = '0';
@@ -328,7 +329,7 @@ const Flyover = (() => {
   }
 
   // ── Start screen ──────────────────────────────────────────────────────────
-  // Opening title card — shown during the fade-in at the start of the showcase.
+  // Opening title card, shown during the fade-in at the start of the showcase.
 
   let _startScreenEl    = null;
   let _startScreenTimer = null;
@@ -362,7 +363,7 @@ const Flyover = (() => {
   let flyActive       = false;
   let flySeg          = 0;
   let flySegStart     = 0;
-  let _paused         = false; // spacebar pause — freezes camera + audio, keeps pins clickable
+  let _paused         = false; // spacebar pause: freezes camera + audio, keeps pins clickable
   let _pausedSegElapsed = 0;   // ms into the current segment when paused (restored on resume)
   let _savedTheme     = null; // theme ID active when showcase started
   let _savedState     = null; // overlay checkbox + sun slider state to restore on exit
@@ -371,14 +372,14 @@ const Flyover = (() => {
   const _flyPos = new THREE.Vector3();
   const _flyTar = new THREE.Vector3();
   let _lastShadowTraceMs = 0; // throttle anchor for the `__shadowTrace` debug logger (10 Hz cap)
-  let _shadowTraceMarkerN = 0; // sequential marker id; user-pressed Space during shadow trace push a marker into the buffer
+  let _shadowTraceMarkerN = 0; // sequential marker id; pressing Space during a shadow trace pushes a marker into the buffer
 
   // Space-bar marker for the shadow trace. When `NCZ.__shadowTrace` is true
   // and the showcase is running, pressing Space pushes a fully-decorated
   // trace entry into `window.__shadowTraceBuffer` with a `marker: N` field,
   // capturing the EXACT moment the user sees a visual issue. Lets us
-  // correlate "shadows turned off here" complaints with the per-frame state
-  // — much sharper than guessing from audio timestamps.
+  // correlate "shadows turned off here" complaints with the per-frame state,
+  // much sharper than guessing from audio timestamps.
   window.addEventListener('keydown', (e) => {
     if (!flyActive || !NCZ.__shadowTrace) return;
     if (e.code !== 'Space' && e.key !== ' ') return;
@@ -404,8 +405,8 @@ const Flyover = (() => {
   // Spacebar freezes the flyover on the current frame: camera + audio stop, but
   // the render loop keeps re-drawing the held pose so pins stay on-screen and
   // clickable (open a popup to read which mod a pin is). Press Space again to
-  // resume from exactly where it left off. A debugging aid as much as a feature
-  // — lets you stop on a suspect frame and identify pins directly.
+  // resume from exactly where it left off. A debugging aid as much as a feature:
+  // lets you stop on a suspect frame and identify pins directly.
 
   let _pauseHintEl = null;
 
@@ -453,7 +454,7 @@ const Flyover = (() => {
   }
 
   // Spacebar toggles pause. The shadow-trace marker logger (above) also binds
-  // Space, but only fires when NCZ.__shadowTrace is on — guard here so the two
+  // Space, but only fires when NCZ.__shadowTrace is on; guard here so the two
   // never both act on one keypress.
   window.addEventListener('keydown', (e) => {
     if (!flyActive || NCZ.__shadowTrace) return;
@@ -516,7 +517,7 @@ const Flyover = (() => {
       flyCamera.layers.disable(NCZ.LAYER_PINS);
     }
     NCZ.ThreeMarkers?.setActiveCamera?.(flyCamera);
-    // During the showcase we want individual mod pins, not cluster bubbles —
+    // During the showcase we want individual mod pins, not cluster bubbles:
     // big number badges sweeping past in a cinematic read as visual noise.
     // setUnclusteredMode(true) hides the cluster layer and unhides every
     // filter-passing pin; setUnclusteredMode(false) on stop triggers a
@@ -536,7 +537,7 @@ const Flyover = (() => {
       glow:      NCZ.ThreeScene?.getEdgeGlowEnabled?.() ?? null,
     };
 
-    // Start audio — beats and sun position are driven by audio.currentTime each frame.
+    // Start audio: beats and sun position are driven by audio.currentTime each frame.
     // When _runOpts.audio === false, mute the element rather than skip play(): the
     // currentTime clock and 'ended' event still fire on muted media in Chromium and
     // Firefox, so beats / sun / end-of-showcase fade stay locked to the same timeline.
@@ -550,7 +551,7 @@ const Flyover = (() => {
       _audio.addEventListener('ended', _onAudioEnded = () => {
         if (!flyActive) return;
         if (_runOpts?.loop) {
-          // Restart the run. _beatColorIndex deliberately NOT reset — the colour
+          // Restart the run. _beatColorIndex deliberately NOT reset: the colour
           // cycle is meant to continue across loops (per CHANGELOG).
           _audio.currentTime = 0;
           _lastBeatIndex = 0;
@@ -586,15 +587,15 @@ const Flyover = (() => {
     flySeg      = 0;
     flySegStart = performance.now();
     _paused     = false;
-    // Drive fly frames through the scene's shared animation loop (issue #768)
-    // — the loop invokes flyoverFrame every tick while the callback is set.
+    // Drive fly frames through the scene's shared animation loop (issue #768):
+    // the loop invokes flyoverFrame every tick while the callback is set.
     NCZ.ThreeScene.setFlyoverFrame(flyoverFrame);
   }
 
   // Short fade-out/in across the camera swap. The showcase camera renders at
   // FOV 55° and the schema camera at 25°; cutting from one to the other is a
   // jarring perspective snap. Dipping the 3D container's opacity for a moment
-  // bridges them — feels like an intentional transition, not a glitch.
+  // bridges them: feels like an intentional transition, not a glitch.
   const EXIT_FADE_MS = 150;
 
   function stopFlyover() {
@@ -616,7 +617,7 @@ const Flyover = (() => {
       // is active).
       NCZ.ThreeMarkers?.setActiveCamera?.(null);
       // Hand the district-outline band back to the schema camera's zoom logic
-      // (pinned to the main-district tier for the flight — see startFlyover).
+      // (pinned to the main-district tier for the flight; see startFlyover).
       NCZ.ThreeScene.forceDistrictBand?.(null);
       clearLayerReveal();
       _paused = false;
@@ -638,7 +639,7 @@ const Flyover = (() => {
       _runOpts = null;
 
       // Restore all overlay checkboxes + sun slider to exactly what they were.
-      // Dispatching the native events ensures the app.js handlers run —
+      // Dispatching the native events ensures the app.js handlers run:
       // layer visibility, shadow state, and UI all stay in sync.
       if (_savedState) {
         _savedState.overlays.forEach(({ cb, checked }) => {
@@ -651,7 +652,7 @@ const Flyover = (() => {
           slider.dispatchEvent(new Event('input'));
         }
         // Restore the render-toggle overrides over the theme default that
-        // applyThemeSmooth() just re-applied — set the checkbox + dispatch
+        // applyThemeSmooth() just re-applied: set the checkbox + dispatch
         // change so the app.js handler re-applies to the scene (matches the
         // overlay restore pattern). Keeps the user's pre-showcase choices.
         const restoreToggle = (id, val) => {
@@ -686,14 +687,14 @@ const Flyover = (() => {
     }, EXIT_FADE_MS);
   }
 
-  // Per-tick showcase frame — invoked by three-scene's shared animation loop
+  // Per-tick showcase frame, invoked by three-scene's shared animation loop
   // while registered via setFlyoverFrame (no private rAF; issue #768).
   function flyoverFrame() {
     if (!flyActive) return;
 
     // Paused: hold the current pose. Re-render every frame so pins stay drawn
     // and clickable (popup placement tracks the frozen camera), but advance
-    // nothing — no waypoint progression, no sun/beat updates.
+    // nothing: no waypoint progression, no sun/beat updates.
     if (_paused) {
       flyCamera.position.copy(_flyPos);
       flyCamera.up.set(0, 1, 0);
@@ -707,7 +708,7 @@ const Flyover = (() => {
     const nextSeg = flySeg + 1;
 
     if (nextSeg >= FLYOVER_WAYPOINTS.length) {
-      // Last waypoint reached — hold this frame and wait for audio.ended to trigger the fade.
+      // Last waypoint reached: hold this frame and wait for audio.ended to trigger the fade.
       // If audio isn't available, fall back to fading immediately.
       if (!_audio) {
         NCZ.ThreeScene.setFlyoverFrame(null);
@@ -739,12 +740,12 @@ const Flyover = (() => {
     // layer-test handles visibility based on the flyCamera's mask.
     NCZ.ThreeMarkers?.render?.();
 
-    // Shadow trace logger — gated on `NCZ.__shadowTrace` (set via devtools:
+    // Shadow trace logger, gated on `NCZ.__shadowTrace` (set via devtools:
     // `NCZ.__shadowTrace = true` before clicking Showcase). Throttled to ~10 Hz
     // and tagged `[shadow-trace]` so Needle's `console_read` filter can pull
     // just these entries. Logged per-frame data: audio time, waypoint segment
     // + t, cam/look positions, plus the full shadow snapshot from
-    // getShadowSnapshot() — light pose, shadow camera bounds, fit state
+    // getShadowSnapshot(): light pose, shadow camera bounds, fit state
     // (incl. degeneration fallback flag), renderer flags, hemisphere fill.
     if (NCZ.__shadowTrace && now - _lastShadowTraceMs > 100) {
       _lastShadowTraceMs = now;
@@ -756,10 +757,9 @@ const Flyover = (() => {
         tar:   _flyTar.toArray().map(v => Math.round(v)),
         ...NCZ.ThreeScene.getShadowSnapshot?.(),
       };
-      // Push to a global buffer too — Needle MCP's console capture is flaky;
-      // this lets the user copy the entire trace via devtools with one call:
+      // Push to a global buffer too: console capture tooling is flaky;
+      // this lets a tester copy the entire trace via devtools in one call:
       //   copy(JSON.stringify(window.__shadowTraceBuffer))
-      // and paste back here for offline analysis.
       (window.__shadowTraceBuffer ||= []).push(entry);
       console.log('[shadow-trace]', JSON.stringify(entry));
     }
@@ -771,7 +771,7 @@ const Flyover = (() => {
     }
   }
 
-  // Resize handler — keeps flyCamera aspect correct if window is resized during showcase
+  // Resize handler: keeps flyCamera aspect correct if window is resized during showcase
   window.addEventListener('resize', () => {
     if (!flyCamera || !flyActive) return;
     const canvas = NCZ.ThreeScene.getCanvasElement();

--- a/assets/js/overlay.js
+++ b/assets/js/overlay.js
@@ -1,5 +1,5 @@
 /**
- * NC Zoning Board — Overlay Module
+ * NC Zoning Board: Overlay Module
  * Namespace: NCZ.Overlay
  *
  * Manages overlay layers for the Leaflet satellite view:
@@ -16,20 +16,20 @@
  *                   + canonical:false subs (casino)
  *
  * Public API (called by app.js):
- *   NCZ.Overlay.init(map)             — load subdistricts.json, add layers
- *   NCZ.Overlay.setDistricts(visible) — show/hide district borders
+ *   NCZ.Overlay.init(map):             load subdistricts.json, add layers
+ *   NCZ.Overlay.setDistricts(visible): show/hide district borders
  *
  * Depends on: constants.js (NCZ.DISTRICT_COLORS, NCZ.DISTRICT_ZOOM_THRESHOLD), utils.js
  */
 
 NCZ.Overlay = (() => {
   let _map = null;
-  let alwaysLayer    = null; // no-sub districts + canonical:false — always visible
-  let outerLayer     = null; // districts with subs — zoom-out only
-  let subLayer       = null; // canonical subdistricts — zoom-in only
+  let alwaysLayer    = null; // no-sub districts + canonical:false, always visible
+  let outerLayer     = null; // districts with subs, zoom-out only
+  let subLayer       = null; // canonical subdistricts, zoom-in only
   let districtsVisible = true;
 
-  // Hover-brighten registry — mirrors the SCHEMA (Three.js) behaviour: outlines
+  // Hover-brighten registry. Mirrors the SCHEMA (Three.js) behaviour: outlines
   // sit at the faint baseline and brighten when the cursor is inside the
   // district's area (point-in-polygon, not a thin-line hit). Each entry knows
   // its tier so we only test outlines currently on the map. The 250 ms fade is
@@ -54,7 +54,7 @@ NCZ.Overlay = (() => {
     pane:    "districtPane",
   });
 
-  // Shoelace area (lat/lng space) — smallest matching ring wins so a small
+  // Shoelace area (lat/lng space): smallest matching ring wins so a small
   // nested outline (casino inside Westbrook) takes the hover over its parent.
   function ringArea(ring) {
     let a = 0;
@@ -101,7 +101,7 @@ NCZ.Overlay = (() => {
     map.getPane("districtPane").classList.add("district-outline-pane");
 
     // Name labels live just above the outlines but BELOW the markerPane (600),
-    // so pins always render on top of labels — matching the 3D view. Leaflet's
+    // so pins always render on top of labels, matching the 3D view. Leaflet's
     // default tooltipPane (650) would put them above the pins. pointer-events:
     // none so the pane never intercepts map/pin interaction.
     map.createPane("districtLabelPane");
@@ -141,7 +141,7 @@ NCZ.Overlay = (() => {
               properties: { color, name: sub.name, level: "subdistrict", ring: coords, districtId: dist.id, subId: sub.id },
               geometry: { type: "Polygon", coordinates: [coords.map(c => [c[1], c[0]])] },
             };
-            // canonical:false (casino etc) — always visible
+            // canonical:false (casino etc): always visible
             (sub.canonical === false ? alwaysFeatures : subFeatures).push(feature);
           }
         }
@@ -206,7 +206,7 @@ NCZ.Overlay = (() => {
       .catch(err => console.error("[NCZ] Failed to load subdistricts.json:", err));
   }
 
-  // Drop the brightened state — a feature hidden mid-hover (zoom tier swap or
+  // Drop the brightened state: a feature hidden mid-hover (zoom tier swap or
   // districts toggled off) would otherwise stay bright when it re-appears.
   function clearHover() {
     if (_hoveredFeature) {

--- a/assets/js/services.js
+++ b/assets/js/services.js
@@ -1,5 +1,5 @@
 /**
- * NC Zoning Board — API & Data Services
+ * NC Zoning Board: API & Data Services
  * All fetch/network functions. Depends on NCZ constants + utils.
  */
 
@@ -18,7 +18,7 @@ NCZ.fetchNexusThumbnails = async function (nexusIds) {
   // Return cached thumbnails if still fresh
   const cached = NCZ.cacheGet(NCZ.THUMB_CACHE_KEY, NCZ.THUMB_CACHE_TTL);
   if (cached) {
-    // Check if all requested IDs are in the cache — if so, skip the API call
+    // Check if all requested IDs are in the cache; if so, skip the API call
     const missing = validIds.filter((id) => !cached[id]);
     if (missing.length === 0) {
       console.log(`Thumbnails: serving ${validIds.length} from cache`);
@@ -40,7 +40,7 @@ NCZ.fetchNexusThumbnails = async function (nexusIds) {
 NCZ.fetchNexusThumbnailsFromApi = async function (validIds) {
   if (validIds.length === 0) return {};
 
-  // Chunk the request — large modsByUid calls silently return a partial subset
+  // Chunk the request: large modsByUid calls silently return a partial subset
   // of nodes, leaving some pins without thumbnails on first load. Mirrors the
   // pagination already used in fetchNexusTaggedMods.
   const CHUNK = NCZ.NEXUS_BATCH_SIZE;
@@ -85,7 +85,7 @@ NCZ.fetchNexusThumbnailsFromApi = async function (validIds) {
     }
   };
 
-  // Single in-flight retry for UIDs the API silently dropped — covers the
+  // Single in-flight retry for UIDs the API silently dropped; covers the
   // residual per-UID flakiness that batching alone doesn't fix. UIDs still
   // missing after the retry are likely deleted/hidden mods on Nexus.
   const fetchChunk = async (chunkIds) => {
@@ -116,7 +116,7 @@ NCZ.fetchNexusThumbnailsFromApi = async function (validIds) {
 // Fields use [BaseFilterValue] = array of { value: ... } objects.
 // "uploader" on the Mod type is a plain string (username), not a nested object.
 NCZ.fetchNexusTaggedMods = async function (existingNexusIds, validTagNames, excludedNexusIds) {
-  // Mods tagged NCZoning by mistake (or too minor to map) — never rendered,
+  // Mods tagged NCZoning by mistake (or too minor to map): never rendered,
   // even if their block parses. Optional arg so existing callers/tests don't break.
   const excluded = excludedNexusIds || new Set();
   // Return cached auto-discovery results if still fresh
@@ -196,7 +196,7 @@ NCZ.fetchNexusTaggedMods = async function (existingNexusIds, validTagNames, excl
       for (const node of nodes) {
         const nexusId = String(node.modId);
         if (excluded.has(nexusId)) {
-          // Intentionally off the map — skip without creating a meta entry.
+          // Intentionally off the map: skip without creating a meta entry.
           console.log(`NCZoning: excluding mod ${nexusId} (${node.name}) — on the exclusion list`);
           continue;
         }
@@ -279,13 +279,13 @@ NCZ.fetchModData = async function () {
 
 // Primary data path: fetch the whole registry from the server-built Data API
 // (/v1/locations?full=1). This replaces the client-side manual + Nexus
-// auto-discovery merge — the server already does that merge (plus district
+// auto-discovery merge; the server already does that merge (plus district
 // enrichment and, since B7, manual-mod thumbnails), so the browser makes ZERO
 // Nexus calls here. Uses If-None-Match/304 against a localStorage-cached body.
 //
 // Returns { mods, nexusThumbs } in the same shapes the rest of app.js expects.
 // THROWS on any failure (network, non-2xx, malformed) so the caller can fall
-// back to the legacy client-side path — never a silent empty map.
+// back to the legacy client-side path: never a silent empty map.
 NCZ.fetchLocationsFromApi = async function () {
   const url = `${NCZ.API_BASE}/v1/locations?full=1`;
 
@@ -324,11 +324,11 @@ NCZ.fetchLocationsFromApi = async function () {
     throw new Error(`Data API: HTTP ${res.status}`);
   }
 
-  // Guard against a slim payload (an API that doesn't honour ?full=1 — e.g. an
+  // Guard against a slim payload (an API that doesn't honour ?full=1, e.g. an
   // older deploy still on the endpoint). Full entries always carry a
   // `description` key; if it's missing the popups/cluster list would render
   // empty, so treat it as unusable and let the caller fall back rather than
-  // ship a degraded map. (Zero locations is a valid dataset — don't trip on it.)
+  // ship a degraded map. (Zero locations is a valid dataset; don't trip on it.)
   // Runs before caching so a rejected slim body is never stored.
   if (rawLocations.length > 0 && !("description" in rawLocations[0])) {
     throw new Error("Data API: slim payload (full=1 not honoured) — falling back");
@@ -338,7 +338,7 @@ NCZ.fetchLocationsFromApi = async function () {
     try {
       localStorage.setItem(NCZ.API_LOCATIONS_CACHE_KEY, JSON.stringify({ etag: freshEtag, data: rawLocations, recentlyUpdatedDays }));
     } catch {
-      /* localStorage quota — fine, we just won't get a 304 next load */
+      /* localStorage quota: fine, we just won't get a 304 next load */
     }
   }
 
@@ -371,7 +371,7 @@ NCZ.fetchLocationsFromApi = async function () {
 // excluded_mods.json, merge Nexus auto-discovery, fetch thumbnails via
 // modsByUid, backfill _updatedAt. Retained as the graceful FALLBACK for when
 // the Data API is unavailable; a follow-up deletes it once B7 parity has baked.
-// Returns { mods, nexusThumbs, tagsDict } — the same trio the API path yields
+// Returns { mods, nexusThumbs, tagsDict }, the same trio the API path yields
 // (plus tagsDict, which the API path fetches locally alongside).
 NCZ.fetchModDataClientSide = async function () {
   const { mods, tagsDict, excludedIds } = await NCZ.fetchModData();

--- a/assets/js/three-markers.js
+++ b/assets/js/three-markers.js
@@ -1,5 +1,5 @@
 /**
- * NC Zoning Board — Three.js Pin/Marker Layer
+ * NC Zoning Board: Three.js Pin/Marker Layer
  * Namespace: NCZ.ThreeMarkers
  *
  * Mirrors the Leaflet marker behaviour for the 3D view: pins read from the same
@@ -7,14 +7,14 @@
  * NCZ.computeVisibleMods, popups reuse NCZ.buildPopupHtml.
  *
  * The shared "interface" both views satisfy:
- *   setMods(mods, nexusThumbs, tagsDict) — build pins from data
- *   applyFilters(visibleIdSet)           — toggle which pins render
- *   focusMod(modId)                       — fly to mod, then open popup
- *   setPanelPinFocus(modIds, selectedId)  — dim a cluster's pins, keep the
+ *   setMods(mods, nexusThumbs, tagsDict) - build pins from data
+ *   applyFilters(visibleIdSet)           - toggle which pins render
+ *   focusMod(modId)                       - fly to mod, then open popup
+ *   setPanelPinFocus(modIds, selectedId)  - dim a cluster's pins, keep the
  *                                           selected one at full opacity
- *   closePopup()                          — programmatic close
+ *   closePopup()                          - programmatic close
  *
- * Rendering uses CSS2DRenderer so each pin is a real DOM node — DOM events,
+ * Rendering uses CSS2DRenderer so each pin is a real DOM node: DOM events,
  * theme CSS, and the existing popup HTML all work without re-implementation.
  */
 
@@ -43,27 +43,27 @@ const ThreeMarkers = (() => {
   const pins = new Map(); // modId → CSS2DObject (the pin)
 
   // Camera fly-to tween state. Active when non-null. Holds start/end targets,
-  // start/end camera positions (XZ-plane only — height stays put), start/end
+  // start/end camera positions (XZ-plane only; height stays put), start/end
   // zoom, elapsed/total time, and an onComplete callback.
   let _flyTween = null;
   let _flyLastTime = 0;
 
-  // Clustering — pool CSS2DObjects (cluster bubbles), recompute on filter
+  // Clustering: pool CSS2DObjects (cluster bubbles), recompute on filter
   // change or camera move. Filter-visible set is tracked separately from
   // pin.visible because clustering OVERRIDES pin.visible to hide grouped pins.
   let _clusterLayer = null;
-  const _clusterPool = [];          // CSS2DObject[] — reused across recomputes
+  const _clusterPool = [];          // CSS2DObject[], reused across recomputes
   let _filterVisibleIds = new Set();
   let _unclusteredMode = false;     // showcase: every filter-visible pin shown
                                     // individually, cluster bubbles suppressed
   let _recomputeFrame = null;
   let _onClusterClick = null;       // cluster-click callback (set by app.js)
   let _onClustersChanged = null;    // recompute-fired callback (set by app.js)
-  let _onEmptyClick = null;         // empty-canvas click (set by app.js) —
+  let _onEmptyClick = null;         // empty-canvas click (set by app.js);
                                     // parity with Leaflet map.on('click')
-  let _activeClusterMods = null;    // Set<modId> | null — mods of the cluster
+  let _activeClusterMods = null;    // Set<modId> | null: mods of the cluster
                                     // whose contents the cluster panel is showing
-  let _forcedIndividualIds = null;  // Set<modId> | null — pins that must never
+  let _forcedIndividualIds = null;  // Set<modId> | null: pins that must never
                                     // be absorbed into a bubble (panel
                                     // comparison mode expands the whole set)
   const _projectVec = new THREE.Vector3();
@@ -81,7 +81,7 @@ const ThreeMarkers = (() => {
   // camera must call this so the CSS2DRenderer pass picks the change up.
   function _redraw() { NCZ.ThreeScene?.requestRender?.(); }
 
-  // Tooltip — single reusable CSS2DObject created at attach time. Hidden by
+  // Tooltip: single reusable CSS2DObject created at attach time. Hidden by
   // default; show()/hide() toggle .visible and update text/position.
   let tooltipObj = null;
   let tooltipText = null;
@@ -95,13 +95,13 @@ const ThreeMarkers = (() => {
     scene = _scene;
     _schemaCamera = _camera;
     // Schema camera sees the static scene (layer 0) AND the marker overlay
-    // (layer 1) by default — the "Pins" entry in the overlay-controls panel
+    // (layer 1) by default; the "Pins" entry in the overlay-controls panel
     // toggles this membership.
     _schemaCamera.layers.enable(NCZ.LAYER_PINS);
     container = _container;
     controls = _controls || null;
 
-    // Cancel any active fly-tween if the user starts a manual drag/zoom —
+    // Cancel any active fly-tween if the user starts a manual drag/zoom:
     // last-write-wins, user input always overrides an in-flight tween.
     if (controls) controls.addEventListener('start', () => { _flyTween = null; });
 
@@ -137,17 +137,17 @@ const ThreeMarkers = (() => {
     pinsLayer.name = 'three-markers';
     scene.add(pinsLayer);
 
-    // Cluster bubble layer — sibling of pinsLayer at scene root so buildPins
+    // Cluster bubble layer: sibling of pinsLayer at scene root so buildPins
     // doesn't disturb it. Pool grows on demand and is reused across recomputes.
     _clusterLayer = new THREE.Group();
     _clusterLayer.name = 'three-clusters';
     scene.add(_clusterLayer);
 
-    // Re-cluster on any camera move (rAF-debounced — at most one recompute
+    // Re-cluster on any camera move (rAF-debounced: at most one recompute
     // per frame, regardless of how often controls fires 'change').
     if (controls) controls.addEventListener('change', scheduleRecomputeClusters);
 
-    // Tooltip — one persistent CSS2DObject, hidden by default. Shown on pin
+    // Tooltip: one persistent CSS2DObject, hidden by default. Shown on pin
     // hover with the mod's name. renderOrder=999 places it above pins
     // (default renderOrder=0) but below the popup (renderOrder=1000).
     //
@@ -155,7 +155,7 @@ const ThreeMarkers = (() => {
     // direction class) so 2D and 3D hover tooltips render identically.
     // Always has the `.visible` class because CSS2DRenderer toggles real
     // display/hide via inline `style.display`, falling through to .pin-tooltip
-    // CSS only when visible — without `.visible` the CSS would force display:none.
+    // CSS only when visible; without `.visible` the CSS would force display:none.
     //
     // Added to `scene` (not `pinsLayer`) on purpose: buildPins() rebuilds
     // pinsLayer's contents on every setMods call, which would otherwise
@@ -178,11 +178,11 @@ const ThreeMarkers = (() => {
     tooltipObj.renderOrder = 999;
     scene.add(tooltipObj);
 
-    // Drag-vs-click discrimination — Leaflet pattern.
+    // Drag-vs-click discrimination: Leaflet pattern.
     //
     // OrbitControls is attached to the container (see three-scene.js), and
     // its setPointerCapture is monkey-patched to a no-op there so the
-    // natural click flow survives — mousedown on a pin → mouseup on a pin
+    // natural click flow survives: mousedown on a pin → mouseup on a pin
     // → click event fires on the pin. But a click ALSO fires if the user
     // pans the camera then releases over a pin (mousedown=pin, mouseup=pin
     // even with movement in between). Leaflet handles this by tracking
@@ -209,14 +209,14 @@ const ThreeMarkers = (() => {
         return;
       }
       // True click on empty space (canvas). Pin and cluster clicks are
-      // handled by their own element listeners — guard so this doesn't
+      // handled by their own element listeners; guard so this doesn't
       // double-act on them.
       if (e.target.closest('.three-popup')) return;
       if (e.target.closest('.three-marker')) return;
       if (e.target.closest('.marker-cluster')) return;
       // Close any open popup AND dismiss the cluster panel. The panel close
       // is routed through app.js (it owns the panel) so this matches
-      // Leaflet's `map.on('click', hideClusterPanel)` — empty-space click
+      // Leaflet's `map.on('click', hideClusterPanel)`: empty-space click
       // closes the panel in both views.
       if (popup) closePopup();
       _onEmptyClick?.();
@@ -226,10 +226,10 @@ const ThreeMarkers = (() => {
     if (_modsState.mods.length) buildPins();
   }
 
-  // CET Z is the gameplay surface — already in the right space (player position
+  // CET Z is the gameplay surface: already in the right space (player position
   // including platforms, plazas, building tops). A small lift keeps the pin's
   // diamond visible above the player rather than overlapping it. The lift is
-  // purely cosmetic — only used for pin rendering, never for any other Z read.
+  // purely cosmetic: only used for pin rendering, never for any other Z read.
   function pinYFor(mod) {
     return (mod.coordinates[2] || 0) + NCZ.PIN_3D_GROUND_OFFSET;
   }
@@ -269,12 +269,12 @@ const ThreeMarkers = (() => {
         // Leaflet pattern: a drag that ended on the pin still fires a click
         // event. _dragSuppressClick is set by the container-level pointerup
         // when the gesture moved beyond PIN_3D_DRAG_THRESHOLD_PX, so we
-        // ignore those — only true clicks open the popup.
+        // ignore those; only true clicks open the popup.
         if (_dragSuppressClick) return;
         e.stopPropagation();
         // Toggle behaviour to match Leaflet: clicking the already-selected
         // pin deselects it. Sidebar item clicks (focusMod) deliberately
-        // do NOT toggle — they always open, matching Leaflet's focusMarker.
+        // do NOT toggle; they always open, matching Leaflet's focusMarker.
         if (popupModId === mod.id) {
           closePopup();
         } else {
@@ -310,7 +310,7 @@ const ThreeMarkers = (() => {
 
   function showTooltip(mod) {
     if (!tooltipObj || !tooltipText) return;
-    // Suppress when the popup is already open for this pin — popup contains
+    // Suppress when the popup is already open for this pin: popup contains
     // the same name plus the rest, tooltip would be redundant.
     if (popupModId === mod.id) return;
     const pin = pins.get(mod.id);
@@ -339,7 +339,7 @@ const ThreeMarkers = (() => {
   }
 
   // Returns mod IDs of pins that pass the active filter (regardless of cluster
-  // grouping). Discover uses this to pick a random target — clustered pins
+  // grouping). Discover uses this to pick a random target; clustered pins
   // are valid choices because the fly-to tween zooms in past the cluster
   // radius, dissolving the cluster around the target by the time the fly ends.
   function getVisibleModIds() {
@@ -348,23 +348,23 @@ const ThreeMarkers = (() => {
 
   // ── Clustering ────────────────────────────────────────────────────────
   // World-space proximity grouping. Cluster radius is computed in world units
-  // from the equivalent pixel radius at current zoom — so clusters dissolve
+  // from the equivalent pixel radius at current zoom, so clusters dissolve
   // as the user zooms in (matching Leaflet's behaviour) but stay invariant
   // to camera tilt and rotation (unlike the original screen-space approach,
   // which produced tilt-distorted "close on screen but far in world" pairs).
   //
   // Trigger: zoom changes or filter changes only. Pan and tilt don't shift
   // world distances, so they don't recompute. This makes clusters stable
-  // while the user explores — no reshuffle on rotation. (Aki's UX call,
+  // while the user explores: no reshuffle on rotation. (Aki's UX call,
   // applied 2026-05-02. Earlier screen-space approach in git history if
   // you ever want to revisit.)
   let _lastDistanceForCluster = null;
 
   function scheduleRecomputeClusters() {
-    // Skip if camera-to-target distance hasn't changed (pan/tilt only) —
+    // Skip if camera-to-target distance hasn't changed (pan/tilt only);
     // world clusters don't move. Filter changes call recomputeClusters()
     // synchronously and bypass this guard.
-    // During the showcase the active camera is the perspective fly camera —
+    // During the showcase the active camera is the perspective fly camera;
     // bail out and let clusters keep their last-recomputed positions for the
     // duration of the cinematic.
     if (_activeCamera) return;
@@ -382,7 +382,7 @@ const ThreeMarkers = (() => {
   // `notify` (default true): fire _onClustersChanged so app.js can follow
   // the cluster the panel tracks. Programmatic recomputes triggered FROM
   // within panel code (setForcedIndividualIds / openPopup / closePopup) pass
-  // notify:false — otherwise the notification re-enters populateClusterPanel
+  // notify:false; otherwise the notification re-enters populateClusterPanel
   // → clearPanelPinFocus → setForcedIndividualIds → recomputeClusters →
   // _onClustersChanged → … (infinite recursion / stack overflow). Only
   // genuine camera/filter-driven recomputes should rebuild the panel.
@@ -392,8 +392,8 @@ const ThreeMarkers = (() => {
     if (!w) return;
 
     // Showcase (unclustered) mode: keep every filter-visible pin individual and
-    // bubbles hidden. Synchronous recompute callers — notably openPopup /
-    // closePopup on a pin click — must NOT rebuild clusters here, or clicking a
+    // bubbles hidden. Synchronous recompute callers (notably openPopup /
+    // closePopup on a pin click) must NOT rebuild clusters here, or clicking a
     // pin mid-cinematic snaps the scene back into number badges.
     if (_unclusteredMode) {
       pins.forEach((pin, id) => { pin.visible = _filterVisibleIds.has(id); });
@@ -416,7 +416,7 @@ const ThreeMarkers = (() => {
     const radiusSq = radiusWorld * radiusWorld;
 
     // Build the filter-visible pin list with world XZ coords (Y intentionally
-    // ignored — rooftop pins should still cluster with same-XZ ground pins).
+    // ignored; rooftop pins should still cluster with same-XZ ground pins).
     const points = [];
     for (const [id, pin] of pins) {
       if (!_filterVisibleIds.has(id)) continue;
@@ -435,7 +435,7 @@ const ThreeMarkers = (() => {
     }
 
     // Greedy proximity grouping. For each unassigned pin, sweep all unassigned
-    // pins and pull in any within radius. O(N²) — fine at our N (~207 max).
+    // pins and pull in any within radius. O(N²), fine at our N (~207 max).
     const groups = [];
     for (const p of points) {
       if (p.used) continue;
@@ -462,7 +462,7 @@ const ThreeMarkers = (() => {
       }
       for (const m of group) m.pin.visible = false;
       const cluster = getOrCreateClusterObj(poolIdx++);
-      // Centroid in world space — CSS2DRenderer projects this each frame
+      // Centroid in world space; CSS2DRenderer projects this each frame
       let cx = 0, cy = 0, cz = 0;
       for (const m of group) {
         cx += m.pin.position.x;
@@ -541,7 +541,7 @@ const ThreeMarkers = (() => {
   // expand/collapse is immediate, not deferred to the next camera move.
   function setForcedIndividualIds(idSet) {
     _forcedIndividualIds = idSet && idSet.size ? idSet : null;
-    // notify:false — this is called from app.js panel code; re-notifying
+    // notify:false; this is called from app.js panel code; re-notifying
     // would recurse back into populateClusterPanel.
     recomputeClusters({ notify: false });
   }
@@ -593,7 +593,7 @@ const ThreeMarkers = (() => {
     );
 
     // Anchor wrapper sits at the pin position (zero-size); inner card rises
-    // above with an arrow pointing down — mirrors Leaflet's popup chrome.
+    // above with an arrow pointing down (mirrors Leaflet's popup chrome).
     const anchor = document.createElement('div');
     anchor.className = 'three-popup-anchor';
 
@@ -608,16 +608,16 @@ const ThreeMarkers = (() => {
     // The popup card has pointer-events:auto so its buttons/links are
     // interactive. Because OrbitControls is now wired to the container
     // (see three-scene.js), every pointerdown that bubbles up to it
-    // arms a potential drag — a tiny mouse jiggle inside the popup would
+    // arms a potential drag: a tiny mouse jiggle inside the popup would
     // pan the camera. Stop pointer events at the card boundary so the
     // popup behaves like a self-contained widget, exactly as the 2D
     // Leaflet popup shields the map drag handler from its own clicks.
-    // Wheel left intentionally bubbling — we don't have scrollable
+    // Wheel left intentionally bubbling: we don't have scrollable
     // popup content today, and forwarding wheel-to-zoom while a popup
     // is open matches Leaflet behaviour.
     card.addEventListener('pointerdown', (e) => e.stopPropagation());
 
-    // Clipboard copy handler — same behaviour as Leaflet popup
+    // Clipboard copy handler: same behaviour as Leaflet popup
     const copyBtn = card.querySelector('.ui-popup-action-link-copy-link');
     if (copyBtn) {
       let copyRevertTimer = null;
@@ -649,7 +649,7 @@ const ThreeMarkers = (() => {
     // hidden in. flyTo's last recompute fires mid-tween (before openPopup,
     // the onComplete callback, sets popupModId), so without this the pin
     // stays clustered after Discover / deep-link / a tight panel pick.
-    // notify:false — popup open must not re-trigger the panel-rebuild path.
+    // notify:false; popup open must not re-trigger the panel-rebuild path.
     recomputeClusters({ notify: false });
     syncUrlForMod(mod);
     _redraw();
@@ -663,14 +663,14 @@ const ThreeMarkers = (() => {
     popupModId = null;
     if (!silent) clearUrlMod();
     // Re-cluster so the pin can rejoin a bubble now that it's no longer
-    // focused. Skip when silent — that path is buildPins (which recomputes
+    // focused. Skip when silent: that path is buildPins (which recomputes
     // itself) or openPopup's internal close (it recomputes after reopening).
-    // notify:false — popup close must not re-trigger the panel-rebuild path.
+    // notify:false; popup close must not re-trigger the panel-rebuild path.
     if (!silent) recomputeClusters({ notify: false });
     _redraw();
   }
 
-  // URL deep-link sync — matches the Leaflet popupopen/popupclose handlers
+  // URL deep-link sync: matches the Leaflet popupopen/popupclose handlers
   // so refreshing or switching views re-opens the same pin.
   function syncUrlForMod(mod) {
     const isNum = /^\d+$/.test(String(mod.nexus_id));
@@ -690,10 +690,9 @@ const ThreeMarkers = (() => {
     if (!pin) return;
     // Sync ?mod= EAGERLY. openPopup (which also syncs) runs deferred as the
     // flyTo onComplete (~0.7s); a view switch during the fly would otherwise
-    // see no ?mod= and fail to restore the pin in the other view — the
-    // "shared camera/popup broken on clustered pins" report (clustered pins
-    // reach the popup via this deferred focusMod path; unclustered pins call
-    // openPopup synchronously and were unaffected).
+    // see no ?mod= and fail to restore the pin in the other view (clustered
+    // pins reach the popup via this deferred focusMod path; unclustered pins
+    // call openPopup synchronously and were unaffected).
     syncUrlForMod(pin.userData.modData);
     // If we don't have controls (called before attach somehow), just open.
     if (!controls) {
@@ -706,7 +705,7 @@ const ThreeMarkers = (() => {
   // Cluster-panel emphasis: once the user picks a pin from the panel the
   // cluster has dissolved (flyTo zoomed in past the cluster radius), so all
   // its pins are individually visible. Dim every pin in `modIds` except
-  // `selectedId`, which stays at full opacity — the "top pin, rest fade"
+  // `selectedId`, which stays at full opacity: the "top pin, rest fade"
   // effect. Opacity is set on the inner `.marker-pin` so the existing
   // `transition: all` (style.css) animates the fade. Passing
   // (null, null) restores every pin (panel closed / view switched).
@@ -737,7 +736,7 @@ const ThreeMarkers = (() => {
 
   // Tween OrbitControls' target + camera.position toward the pin. For a
   // perspective camera the "zoom level" at the end of the fly is a fixed
-  // *distance* (SCHEMA_FLY_TO_DISTANCE — the game's TweakDB zoomToZoomValue):
+  // *distance* (SCHEMA_FLY_TO_DISTANCE, the game's TweakDB zoomToZoomValue):
   // end position = endTarget + currentDirection × that distance, so the camera
   // approach angle is preserved but always lands at the same close zoom.
   // Runs in the render loop via updateFlyTween().
@@ -761,7 +760,7 @@ const ThreeMarkers = (() => {
       onComplete,
     };
     _flyLastTime = performance.now();
-    _redraw(); // Kickstart the loop — direct camera mutation in updateFlyTween
+    _redraw(); // Kickstart the loop: direct camera mutation in updateFlyTween
                // doesn't fire OrbitControls 'change', so we need an explicit nudge.
   }
 
@@ -790,7 +789,7 @@ const ThreeMarkers = (() => {
 
   // Cheap per-frame check: if the popup's anchor is too close to the viewport
   // top to fit the card above, flip it below the pin. Re-evaluates every render
-  // so it stays correct as the user pans/tilts/zooms — costs one Vector3.project()
+  // so it stays correct as the user pans/tilts/zooms; costs one Vector3.project()
   // and a className toggle, which is negligible.
   const _projectV = new THREE.Vector3();
   function updatePopupPlacement() {
@@ -810,7 +809,7 @@ const ThreeMarkers = (() => {
   }
 
   // CSS2DRenderer culls a marker when its projected point falls outside the
-  // NDC depth range (`z >= -1 && z <= 1`) — a test that assumes a STANDARD
+  // NDC depth range (`z >= -1 && z <= 1`), a test that assumes a STANDARD
   // forward projection. Our WebGPU renderer runs with `reversedDepthBuffer:true`,
   // so the renderer rebuilds `camera.projectionMatrix` with reversed Z; under
   // it, behind-camera points land at z≈[-1,0) and slip through the test, getting
@@ -881,8 +880,8 @@ const ThreeMarkers = (() => {
   // Cinematic mode: hide every cluster bubble and unhide every filter-passing
   // pin so the showcase shows individual mods instead of number-badges.
   //
-  // CSS2DRenderer checks `object.visible` per-CSS2DObject (not on parent groups
-  // — the renderer walks all children regardless of group.visible), so we have
+  // CSS2DRenderer checks `object.visible` per-CSS2DObject (not on parent groups;
+  // the renderer walks all children regardless of group.visible), so we have
   // to flip `visible` on each cluster bubble individually rather than on the
   // parent _clusterLayer Group.
   //

--- a/assets/js/three-scene.js
+++ b/assets/js/three-scene.js
@@ -1,5 +1,5 @@
 /**
- * NC Zoning Board — Three.js Scene
+ * NC Zoning Board: Three.js Scene
  * Namespace: NCZ.ThreeScene
  *
  * Manages the WebGPU renderer, perspective schema camera (FOV 25°, TweakDB-
@@ -31,7 +31,7 @@ import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 // WebGL-only registry) which the three.webgpu build does not expose, so
 // loading them at module-init time throws a SyntaxError before our code ever
 // runs. The webgpu wrapper extends LineSegments2 and pairs with the bundled
-// Line2NodeMaterial — same Line2 API, TSL-based shader, viewport size pulled
+// Line2NodeMaterial: same Line2 API, TSL-based shader, viewport size pulled
 // from the renderer automatically (no `resolution` field to keep in sync).
 import { Line2 } from 'three/addons/lines/webgpu/Line2.js';
 import { LineGeometry } from 'three/addons/lines/LineGeometry.js';
@@ -39,9 +39,9 @@ import { MeshoptDecoder } from 'three/addons/libs/meshopt_decoder.module.js';
 import { CSS2DObject } from 'three/addons/renderers/CSS2DRenderer.js';
 import Stats from 'three/addons/libs/stats.module.js';
 // The exact in-game 3D-map colour pipeline (decoded from 3dmap.envparam):
-// ACES tonemap + colour grade + braindance LUT — see assets/js/aces-tonemap.js.
+// ACES tonemap + colour grade + braindance LUT; see assets/js/aces-tonemap.js.
 import { registerCP2077ToneMapping, loadBraindanceLUT, setSceneGradeEnabled } from './aces-tonemap.js';
-// Custom TSL wide-line material for district outlines (#775) — replaces
+// Custom TSL wide-line material for district outlines (#775); replaces
 // THREE.Line2NodeMaterial; see the header of district-line-material.js.
 import { DistrictLineMaterial } from './district-line-material.js';
 
@@ -56,7 +56,7 @@ const ThreeScene = (() => {
   let initialized = false;
   // True only when the renderer ended up on a real WebGPU backend. The webgpu
   // build reports renderer.isWebGPURenderer === true even on its WebGL2
-  // fallback, so that flag can't be trusted — renderer.backend.isWebGPUBackend
+  // fallback, so that flag can't be trusted; renderer.backend.isWebGPUBackend
   // (set by r184's WebGPUBackend, absent on WebGLBackend) is the real signal.
   let _webgpuActive = false;
   let loadingEl      = null;
@@ -74,9 +74,9 @@ const ThreeScene = (() => {
   const _snapX = new THREE.Vector3();
   const _snapY = new THREE.Vector3();
   const _snapZ = new THREE.Vector3();
-  // Last computed shadow fit (half + center) captured by updateShadowCamera —
+  // Last computed shadow fit (half + center) captured by updateShadowCamera,
   // exposed via getShadowSnapshot() for the `__shadowTrace` debug logger.
-  // `fallback` true means rect was degenerate and we used the world-centered
+  // `fallback` true means rect was degenerate and we used the world-centred
   // safety net; `lastUpdateMs` lets us detect frames where updateShadowCamera
   // didn't run.
   let _lastShadowFit = { half: 0, cx: 0, cz: 0, fallback: false, lastUpdateMs: 0 };
@@ -88,7 +88,7 @@ const ThreeScene = (() => {
 
   // Cast rays from the camera through the four NDC corners and intersect with
   // the ground plane (Y=0). The XZ AABB of those four hits is the bounding rect
-  // of what the camera sees on the ground — used by pan bounds, scale bar, and
+  // of what the camera sees on the ground; used by pan bounds, scale bar, and
   // the shadow camera footprint. Works for any camera type (orthographic via
   // unproject's projection-matrix inversion, perspective likewise).
   // Mutates and returns _groundRectMin / _groundRectMax.
@@ -113,8 +113,8 @@ const ThreeScene = (() => {
   }
 
   // Bounding sphere (centroid + enclosing radius) of the visible-ground footprint.
-  // Same four corner ray-casts as _computeVisibleGroundRect, but the sphere — unlike
-  // the AABB — is invariant under camera azimuth: rotating the view yields a congruent
+  // Same four corner ray-casts as _computeVisibleGroundRect, but the sphere (unlike
+  // the AABB) is invariant under camera azimuth: rotating the view yields a congruent
   // ground footprint, so its corners' pairwise distances (hence the radius) don't
   // change and the centroid only translates. updateShadowCamera fits the sun's ortho
   // box to this so the shadow texel size stays constant as you pan/rotate, which is the
@@ -153,18 +153,18 @@ const ThreeScene = (() => {
     _groundSphereRadius = Math.sqrt(r2);
   }
   let _shadowsOn     = true;  // shadows on by default; checkbox reflects this via poll
-  // Stored shadow strength — independent of the on/off toggle. Initialised from
+  // Stored shadow strength, independent of the on/off toggle. Initialised from
   // the constant; the Shadows overlay multiplies by this when enabled, by 0 when
   // off (so the tuned strength survives a Shadows toggle).
   let _shadowIntensity = NCZ.SHADOW_INTENSITY;
-  let _sunSphere     = null; // visible sun disc — shown during showcase only
-  let _sunAz = Math.PI * 0.25, _sunEl = Math.PI * 0.35; // last *requested* setSunPosition args — placeholders only until the first call (the slider init in app.js), which may land before the lights exist
+  let _sunSphere     = null; // visible sun disc; shown during showcase only
+  let _sunAz = Math.PI * 0.25, _sunEl = Math.PI * 0.35; // last *requested* setSunPosition args; placeholders only until the first call (the slider init in app.js), which may land before the lights exist
   let _terrainBox = null;     // THREE.Box3 of the terrain GLB; gates pan-bound clamp
                               // because the bound shouldn't activate before terrain loads
   let _introTween   = null;   // E5 intro fly-in tween, or null when idle
   let _introLastTime = 0;     // performance.now() of the previous intro frame
 
-  // Material refs — stored so updateMaterials() can re-apply theme colors live
+  // Material refs, stored so updateMaterials() can re-apply theme colours live
   let terrainMat = null;
   let waterMat   = null;
   let cliffsMat  = null;
@@ -173,18 +173,18 @@ const ThreeScene = (() => {
   let normalRoadsMat  = null;  // Normal depth-tested pass
   let normalBordersMat= null;  // Normal depth-tested pass
   let metroMat        = null;
-  let metroDistanceUniform = null; // TSL uniform() — schema camera-to-target distance; drives metro LOD tier discard (mutex)
+  let metroDistanceUniform = null; // TSL uniform(): schema camera-to-target distance; drives metro LOD tier discard (mutex)
   // Captured at WebGPURenderer construction so dumpDebugInfo can introspect
-  // the antialias flag — WebGPURenderer has no getContextAttributes() to read it
+  // the antialias flag; WebGPURenderer has no getContextAttributes() to read it
   // back from, unlike WebGLRenderer.
   let _rendererInitParams = null;
 
   // ── Phase 2B compute culling state ─────────────────────────────────────
   // TWO 6-plane frustum sets shared by every district's cull compute:
-  //   • _frustumPlaneUniforms       — the camera frustum (what the user sees)
-  //   • _shadowFrustumPlaneUniforms — the sun's shadow camera frustum (what
+  //   • _frustumPlaneUniforms:       the camera frustum (what the user sees)
+  //   • _shadowFrustumPlaneUniforms: the sun's shadow camera frustum (what
   //                                   the shadow map covers)
-  // An instance is visible to the cull if it passes EITHER frustum — so an
+  // An instance is visible to the cull if it passes EITHER frustum, so an
   // off-screen building still in the shadow ortho box gets into the indirect
   // buffer and casts its shadow into the visible area. (Phase 2B originally
   // tested only the camera frustum, which made shadows pop in at screen
@@ -197,7 +197,7 @@ const ThreeScene = (() => {
   //   `dot(plane.xyz, center) + plane.w >= -radius`.
   // We recompute both sets on every `controls.change` (CPU-side, via Three's
   // existing `THREE.Frustum.setFromProjectionMatrix`) and push to the same
-  // uniform nodes — much cheaper than passing matrices and re-deriving
+  // uniform nodes; much cheaper than passing matrices and re-deriving
   // planes per-thread on the GPU.
   const _frustumPlaneUniforms = [
     uniform(new THREE.Vector4()), uniform(new THREE.Vector4()),
@@ -222,7 +222,7 @@ const ThreeScene = (() => {
     // `renderCam` defaults to the schema ortho camera; pass the perspective
     // `flyCamera` during showcase so the cull tests against what's actually
     // being rendered. `Frustum.setFromProjectionMatrix` handles both
-    // ortho + perspective projections — the algebra is the same.
+    // ortho + perspective projections; the algebra is the same.
     _frustumScratchMat.multiplyMatrices(renderCam.projectionMatrix, renderCam.matrixWorldInverse);
     // Critical: pass WebGPUCoordinateSystem so the near/far plane extraction
     // uses the WebGPU clip-space convention (depth range [0, 1]). The default
@@ -239,8 +239,8 @@ const ThreeScene = (() => {
 
   // Refresh the 6 sun-shadow-camera frustum planes from the current light
   // pose. Mirrors what `DirectionalLightShadow.updateMatrices()` does
-  // internally before the shadow pass — position the shadow camera at the
-  // light, aim it at the light target, refresh its world+inverse matrices —
+  // internally before the shadow pass (position the shadow camera at the
+  // light, aim it at the light target, refresh its world+inverse matrices)
   // so the planes we extract match the box the shadow renderer will use.
   // Called from `updateShadowCamera()` after the ortho box + light pose
   // have been re-fitted, so all existing `updateShadowCamera()` call sites
@@ -260,7 +260,7 @@ const ThreeScene = (() => {
     const shadowCam = _dirLight.shadow.camera;
     shadowCam.position.copy(_dirLight.position);
     shadowCam.lookAt(_dirLight.target.position);
-    // Camera.updateMatrixWorld() also refreshes matrixWorldInverse — needed
+    // Camera.updateMatrixWorld() also refreshes matrixWorldInverse, needed
     // for the projection × view multiply below.
     shadowCam.updateMatrixWorld(true);
     _shadowFrustumScratchMat.multiplyMatrices(shadowCam.projectionMatrix, shadowCam.matrixWorldInverse);
@@ -271,25 +271,25 @@ const ThreeScene = (() => {
     }
   }
   let buildingMeshes     = [];    // one InstancedMesh per district
-  let buildingMaterials  = [];    // parallel ShaderMaterial array for theme updates
+  let buildingMaterials  = [];    // parallel material array (Lambert node materials) for theme updates
   let landmarkMat        = null;  // shared MeshLambertMaterial for all landmark GLBs
 
-  // District metadata — sourced directly from 3dmap_triangle_soup.Material.json.
+  // District metadata, sourced directly from 3dmap_triangle_soup.Material.json.
   // Cache note: the *.dds paths below are served `no-cache` (see _headers), so
-  // updating a texture needs no cache-busting — just redeploy. Only tile regen
+  // updating a texture needs no cache-busting; just redeploy. Only tile regen
   // needs manual action. See docs/caching-strategy.md.
-  // dataDds: _data.dds (DXGI_FORMAT_R16G16B16A16_UNORM — raw 16-bit RGBA instance data)
+  // dataDds: _data.dds (DXGI_FORMAT_R16G16B16A16_UNORM: raw 16-bit RGBA instance data)
   // dataDdsFixed: optional alignment-fixed _data from malgalad's "3D World Map
   //   Fixed" mod (Nexus #26500). Same dimensions/transforms as the vanilla
   //   dataDds (texel placement corrected), so it's a straight texture swap when
   //   the Fixed asset set is selected. ep1_spaceport has no fixed version → it
   //   stays on dataDds in both sets. See docs/3dmap-fixed-assets.md.
-  // mDds:    _m.dds   (DXGI_FORMAT_R8_UNORM — 8-bit greyscale surface detail, 10 mips)
+  // mDds:    _m.dds   (DXGI_FORMAT_R8_UNORM: 8-bit greyscale surface detail, 10 mips)
   // transMin/transMax: district-local CET XYZ bounds (before district offset)
   // offset: world XY offset applied to decoded positions (no Z offset)
   // cubeSize: half-extent multiplier (from CubeSize shader parameter)
   // edgeThickness / edgeSharpness: EdgeThickness / EdgeSharpnessPower from
-  //   3d_map_cubes.mt — drive the building edge highlight. edgeSharpness sets
+  //   3d_map_cubes.mt; these drive the building edge highlight. edgeSharpness sets
   //   the visible band width; edgeThickness only feeds the sub-pixel
   //   camera-distance term.
   const DISTRICT_META = [
@@ -301,12 +301,12 @@ const ThreeScene = (() => {
     { name: 'watson',        dataDds: 'assets/dds/watson_data.dds',       dataDdsFixed: 'assets/dds/fixed/watson_data.dds',       mDds: 'assets/dds/watson_m.dds',       cubeSize: 237.175003,   transMin: [-1254.46997, -1258.68469, -24.7028503],  transMax: [1988.5448,    2032.52405,  475.268005],  offset: [-1979.372,   1873.951], edgeThickness: 0.0005, edgeSharpness: 50 },
     { name: 'ep1_dogtown',   dataDds: 'assets/dds/dogtown_data.dds',      dataDdsFixed: 'assets/dds/fixed/dogtown_data.dds',      mDds: 'assets/dds/dogtown_m.dds',      cubeSize: 198.020691,   transMin: [-2650.0,     -3126.6084,   -0.750015974], transMax: [-1025.51855, -1803.58118,  493.576111],  offset: [    0.0,        0.0  ], edgeThickness: 0.0005, edgeSharpness: 50 },
     { name: 'ep1_spaceport', dataDds: 'assets/dds/spaceport_data.dds',    mDds: 'assets/dds/spaceport_m.dds',    cubeSize: 115.298218,   transMin: [-1168.5874,   -765.104614, -41.4592323],  transMax: [1219.45483,   1018.70129,  296.498138],  offset: [-4200.000,    200.000], edgeThickness: 0.0005, edgeSharpness: 50 },
-    // Fixed-only "corrections overlay" — malgalad's combined my_district cloud
+    // Fixed-only "corrections overlay": malgalad's combined my_district cloud
     // (world-space, offset 0). The per-district fixed textures remove the game's
     // broken blocks but don't replace them; my_district fills those gaps (e.g.
     // the Corpo Plaza building cluster). Only loaded with the Fixed asset set;
     // reuses the game's Pacifica surface (pacifica_m) that malgalad's material
-    // points at — c_pacifica_m is byte-identical. See
+    // points at (c_pacifica_m is byte-identical). See
     // docs/3dmap-fixed-assets.md.
     { name: 'my_district',   dataDds: 'assets/dds/fixed/my_district_data.dds', mDds: 'assets/dds/pacifica_m.dds', cubeSize: 200, transMin: [-2766, -5399, -50], transMax: [2960, 4254, 650], offset: [-828, -531], edgeThickness: 0.0005, edgeSharpness: 50, fixedOnly: true },
     // Fixed-only "ugly building" add-on (malgalad's optional download that returns
@@ -320,7 +320,7 @@ const ThreeScene = (() => {
   function readThemeColor(varName, fallback) {
     const raw = getComputedStyle(document.documentElement)
       .getPropertyValue(varName).trim();
-    // CSS custom properties return their literal stored value — CSS functions like
+    // CSS custom properties return their literal stored value; CSS functions like
     // color-mix() are NOT resolved by getPropertyValue. Fall back if unparseable.
     try { return new THREE.Color(raw || fallback); }
     catch { return new THREE.Color(fallback); }
@@ -381,15 +381,15 @@ const ThreeScene = (() => {
 
   // Continuous anti-aliased grid-line coverage. The game's original formula
   // (round() + min(frac()·N,1), integrated over the pixel footprint) has hard
-  // step discontinuities — coverage JUMPS as the camera moves, and the game
+  // step discontinuities: coverage JUMPS as the camera moves, and the game
   // hides the resulting shimmer with TAA, which our scene does not have. This
   // replacement is continuous so it antialiases itself, no TAA needed:
-  //   • triangle-wave distance to the nearest line centre — no jumps,
+  //   • triangle-wave distance to the nearest line centre: no jumps,
   //   • smoothstep ramp across the pixel footprint,
-  //   • minification compensation — once a line is thinner than a pixel it is
+  //   • minification compensation: once a line is thinner than a pixel it is
   //     drawn at footprint width and dimmed proportionally, so it fades out
   //     smoothly instead of aliasing.
-  // N is the line-width factor — a line spans ≈ cell/N. The +0.5 places the
+  // N is the line-width factor; a line spans ≈ cell/N. The +0.5 places the
   // lines where the game's formula put them (same grid, no flicker).
   const gridCoverage = Fn(([c, N]) => {
     const w         = dFdx(c).abs().max(dFdy(c).abs());                  // pixel footprint per axis
@@ -420,18 +420,18 @@ const ThreeScene = (() => {
   // The game computes
   //   X    = max(|1-2u|, |1-2v|) + camDist·0.002·EdgeThickness / faceSize
   //   edge = saturate(pow(X, EdgeSharpnessPower))
-  // `pow(X, power)` is NOT a step — it is a GRADIENT: ~0 across the inner face,
+  // `pow(X, power)` is NOT a step; it is a GRADIENT: ~0 across the inner face,
   // curving up to the bright rim. `edge` then lerps albedo → EdgeColor, so each
   // face shades dark-centre → light-edge (the in-game look). An earlier port
   // mistook the steep curve for a near-step and rendered a flat smoothstep
-  // band, which dropped the gradient — this restores it.
+  // band, which dropped the gradient; this restores it.
   // No TAA here, so the steep rim is box-filtered over X's pixel footprint:
   // the analytic mean of X^p over [lo,hi] is
   //   (hi^(p+1) − lo^(p+1)) / ((hi − lo)(p+1))
   // → X^p as the footprint → 0, and self-flattens (toward 1/(p+1)) when the
   // whole gradient goes sub-pixel under minification, instead of shimmering.
   const buildingEdgeCoverage = Fn(([faceUv, sharpness, camTerm]) => {
-    // X = max(|1−2u|, |1−2v|) + camTerm — 0 at the face centre, 1 at the edge.
+    // X = max(|1−2u|, |1−2v|) + camTerm: 0 at the face centre, 1 at the edge.
     const X = faceUv.x.mul(2).sub(1).abs()
           .max( faceUv.y.mul(2).sub(1).abs() )
           .add(camTerm);
@@ -448,10 +448,10 @@ const ThreeScene = (() => {
   // theme base colour → theme grid colour by the procedural grid factor, so
   // each surface keeps its existing per-theme colour and the grid rides on
   // top. Where there's no grid line the factor is 0 and the colorNode is
-  // exactly `materialColor` — the fill is identical to the plain material.
+  // exactly `materialColor`; the fill is identical to the plain material.
   //
   // Use the `mix()` FUNCTION, never the `.mix()` node method here: the
-  // method does not evaluate as `mix(receiver, b, t)` — `materialColor.mix(
+  // method does not evaluate as `mix(receiver, b, t)`: `materialColor.mix(
   // uGrid, 0)` rendered the grid colour, not the base colour, washing the
   // whole surface even at factor 0. The `mix(a, b, t)` function is correct
   // (verified: `mix(materialColor, uGrid, 0) === materialColor`).
@@ -461,7 +461,7 @@ const ThreeScene = (() => {
   function makeHillshadeMaterial(colorVar, fallback, extra = {}, brightness = 1) {
     const mat = new THREE.MeshLambertNodeMaterial({
       color: readThemeColor(colorVar, fallback),
-      // INTENTIONAL faceted look — do NOT "fix" this. `flatShading` discards
+      // INTENTIONAL faceted look; do NOT "fix" this. `flatShading` discards
       // the GLBs' (present) smooth vertex normals for per-face ones, so the
       // directional sun (#694) renders the terrain/cliffs as crisp triangle
       // facets. PR #741 removed this for "correct" smooth hillshading; a 12–3
@@ -475,7 +475,7 @@ const ThreeScene = (() => {
     const uGrid = uniform(readThemeColor('--scene-grid', '#6d8ab0'));
     mat.userData.tslUniforms = { uGrid };
     // Base colour + procedural grid. `brightness` is the material's decoded
-    // Brightness param — water is 0.7 (3dmap_water.mi overrides it on the
+    // Brightness param: water is 0.7 (3dmap_water.mi overrides it on the
     // shared terrain material); terrain and cliffs are 1.
     const shaded = mix(materialColor, uGrid, terrainGridFactor());
     mat.colorNode = brightness === 1 ? shaded : shaded.mul(brightness);
@@ -491,7 +491,7 @@ const ThreeScene = (() => {
 
   // Give every descendant of `root` a prefixed, type-tagged name so the Needle
   // Inspector hierarchy reads as English instead of "mesh_0". WolvenKit/Blender
-  // bakes generic names like "mesh_0", "Object_3", "Cube.001" — those are
+  // bakes generic names like "mesh_0", "Object_3", "Cube.001"; those are
   // overwritten. Any descriptive name (e.g. "Crystal_Palace_Tower") is kept.
   const NAME_GENERIC = /^(mesh|object|node|cube|sphere|group|geometry|line|primitive)[\s._\d]*$/i;
   function nameSubtree(root, prefix) {
@@ -514,7 +514,7 @@ const ThreeScene = (() => {
   // Hoisted singleton: MeshoptDecoder is attached so GLBs encoded with
   // EXT_meshopt_compression decode transparently. The decoder is a no-op for
   // uncompressed GLBs (the extension is only triggered when present). The
-  // decoder ships with three.js examples — no extra dependency.
+  // decoder ships with three.js examples; no extra dependency.
   const gltfLoader = new GLTFLoader().setMeshoptDecoder(MeshoptDecoder);
 
   function loadGLB(file) {
@@ -527,8 +527,8 @@ const ThreeScene = (() => {
   // ── DDS loaders ─────────────────────────────────────────────────────────
   // DDS files exported by WolvenKit use DX10 extended headers (FourCC='DX10').
   // Standard header = 128 bytes, DX10 extension = 20 bytes → pixel data at offset 148.
-  // _data.dds: DXGI_FORMAT_R16G16B16A16_UNORM — raw 16-bit RGBA, 1 mip, no compression.
-  // _m.dds:    DXGI_FORMAT_R8_UNORM            — 8-bit greyscale, 10 mips, no compression.
+  // _data.dds: DXGI_FORMAT_R16G16B16A16_UNORM: raw 16-bit RGBA, 1 mip, no compression.
+  // _m.dds:    DXGI_FORMAT_R8_UNORM:            8-bit greyscale, 10 mips, no compression.
 
   // Load _data.dds → Uint16Array of raw 16-bit RGBA pixel values.
   // Width and height are read from the DDS header (offsets 16 and 12).
@@ -554,14 +554,14 @@ const ThreeScene = (() => {
     tex.generateMipmaps = true;
     tex.minFilter = THREE.LinearMipmapLinearFilter;
     tex.magFilter = THREE.LinearFilter;
-    // Anisotropic filtering — fixes shimmer on surfaces viewed at oblique angles
+    // Anisotropic filtering: fixes shimmer on surfaces viewed at oblique angles
     // (terrain/buildings tilted toward the camera). Mips alone aren't enough because
-    // mip selection picks based on the smaller of the screen-space derivatives —
+    // mip selection picks based on the smaller of the screen-space derivatives;
     // an elongated texture footprint still aliases along the long axis. AF samples
     // multiple texels along that axis. Free-ish on modern GPUs (fixed-function path).
     // WebGPU exposes the limit via `renderer.backend.device.limits.maxSamplerAnisotropy`
     // (post-init); WebGL2 fallback uses the legacy `renderer.capabilities.getMaxAnisotropy()`.
-    // Cap at 16 — the hardware ceiling on every consumer GPU since ~2009.
+    // Cap at 16, the hardware ceiling on every consumer GPU since ~2009.
     const maxAniso = renderer.backend?.device?.limits?.maxSamplerAnisotropy
                   ?? renderer.capabilities?.getMaxAnisotropy?.()
                   ?? 16;
@@ -607,7 +607,7 @@ const ThreeScene = (() => {
     loadingEl     = container.querySelector('.scene-loading');
     loadingFillEl = container.querySelector('.scene-loading__fill');
 
-    // Renderer — WebGPU build with WebGL2 auto-fallback. The canvas is kept at
+    // Renderer: WebGPU build with WebGL2 auto-fallback. The canvas is kept at
     // width/height:100% via the `#map-3d > canvas` rule in style.css so it
     // always fills #map-3d without pushing surrounding layout elements (and
     // without falling back to its intrinsic drawingBuffer size, which would
@@ -617,13 +617,13 @@ const ThreeScene = (() => {
     // and uses depthCompare:'greater' instead of 'less'. Combined with WebGPU's
     // native float depth, this redistributes precision so far-frustum surfaces
     // keep enough resolution to avoid Z-fighting at our 3-15km zoom range.
-    // Strictly better than the old `logarithmicDepthBuffer` workaround — log-depth
+    // Strictly better than the old `logarithmicDepthBuffer` workaround: log-depth
     // writes frag_depth from the fragment shader, killing the GPU's early-Z
-    // optimization. Reverse-Z achieves precision purely through projection-matrix
+    // optimisation. Reverse-Z achieves precision purely through projection-matrix
     // tricks; early-Z stays on. Available on `WebGPURenderer` since Three.js r183
     // (PR #32967, Feb 2026). Camera.reversedDepth is auto-corrected per PR #31410.
     //
-    // (No `powerPreference` here — Chrome confirmed it's currently ignored on
+    // (No `powerPreference` here; Chrome confirmed it's currently ignored on
     // Windows for navigator.gpu.requestAdapter() per https://crbug.com/369219127.
     // Hybrid-graphics laptops fall back to OS adapter selection. Watch list
     // item: revisit if dGPU isn't getting selected.)
@@ -638,7 +638,7 @@ const ThreeScene = (() => {
     // name at all, and WebGPU rejects the ENTIRE device request if
     // `requiredLimits` names a limit the adapter doesn't expose
     // ("OperationError: Limit 'maxStorageBuffersInVertexStage' not
-    // recognized") — which is exactly why the 3D scene silently fell back to
+    // recognized"), which is exactly why the 3D scene silently fell back to
     // WebGL2 on Firefox. So probe the adapter first and only ask for the limit
     // on adapters that actually have it; Firefox's core mode allows the
     // vertex-stage read under its `maxStorageBuffersPerShaderStage` budget
@@ -650,7 +650,7 @@ const ThreeScene = (() => {
         requiredLimits.maxStorageBuffersInVertexStage = 1;
       }
     } catch (_) {
-      // No navigator.gpu / adapter — WebGPURenderer falls back to WebGL2 on
+      // No navigator.gpu / adapter; WebGPURenderer falls back to WebGL2 on
       // its own; nothing to require here.
     }
     _rendererInitParams = {
@@ -659,7 +659,7 @@ const ThreeScene = (() => {
       reversedDepthBuffer: true,
       requiredLimits,
     };
-    // TEMP — verification only, remove before dev→main. ?forcewebgl forces
+    // TEMP: verification only, remove before dev→main. ?forcewebgl forces
     // the WebGL2 backend so the WebGPU-unavailable → 2D-Leaflet fallback can
     // be exercised on any browser (no about:config / exotic browser needed).
     if (new URLSearchParams(window.location.search).has('forcewebgl')) {
@@ -670,14 +670,14 @@ const ThreeScene = (() => {
     try {
       await renderer.init();   // WebGPURenderer requires async init before any use
     } catch (err) {
-      // Neither WebGPU nor the WebGL2 fallback could initialise — bail to 2D.
+      // Neither WebGPU nor the WebGL2 fallback could initialise; bail to 2D.
       console.warn('[NCZ] Renderer init failed — falling back to the 2D map.', err);
       _webgpuActive = false;
       hideLoading();
       return;
     }
     // The 3D scene's buildings hard-depend on WebGPU compute (storage buffers,
-    // indirect draw, atomics — no WebGL2 equivalent). On the WebGL2 fallback
+    // indirect draw, atomics: no WebGL2 equivalent). On the WebGL2 fallback
     // they throw and the scene is broken-looking, so we don't render a
     // degraded 3D view at all: abort init here and let app.js fall the user
     // back to the fully-functional 2D Leaflet map (see forceSatFallback).
@@ -691,15 +691,15 @@ const ThreeScene = (() => {
     // r185's #33700 "fixed" render-list sorting under reversedDepthBuffer with
     // a wholesale list.reverse() AFTER the painter sort. The sort key is
     // groupOrder → renderOrder → z → id, so the reverse fixes the z direction
-    // but also INVERTS renderOrder semantics — our transparent chain
+    // but also INVERTS renderOrder semantics: our transparent chain
     // (water 0 → SeeThrough roads 1 → metro 2) drew backwards: metro first
     // (then hidden under water's depthWrite) and SeeThrough roads before water
     // had written stencil=STENCIL_WATER (tunnel roads gone). Compensate by
     // handing the sorter comparators that are the exact NEGATION of the order
-    // we want — the engine's trailing .reverse() then lands the desired order:
+    // we want; the engine's trailing .reverse() then lands the desired order:
     // renderOrder ascending (the documented contract), z direction correct for
     // reversed-depth projected z (larger z = nearer). The id tiebreaker makes
-    // the order total, so reverse(sort(-D)) == sort(D) exactly — no stability
+    // the order total, so reverse(sort(-D)) == sort(D) exactly; no stability
     // caveats. Remove when upstream replaces the wholesale reverse with a
     // z-only fix: https://github.com/mrdoob/three.js/pull/33700
     if (renderer.reversedDepthBuffer === true) {
@@ -718,17 +718,17 @@ const ThreeScene = (() => {
     }
     // Make the sRGB-correct colour pipeline explicit. These match Three.js r170
     // defaults (since r152 / r155 respectively) but stating them here protects
-    // the scene's appearance against future Three.js default changes — both flags
+    // the scene's appearance against future Three.js default changes; both flags
     // have shifted in past major versions.
     THREE.ColorManagement.enabled = true;
     renderer.outputColorSpace     = THREE.SRGBColorSpace;
-    // Tonemap — the exact in-game 3D-map ACES Output Transform. The map renders
+    // Tonemap: the exact in-game 3D-map ACES Output Transform. The map renders
     // through `TonemappingModeACES` (decoded from 3dmap.envparam); aces-tonemap.js
     // ports the ACES SSTS tone scale parametrised by the decoded
     // STonemappingACESParams and registers it as a custom WebGPU tone-mapping
     // function. This supersedes the interim NeutralToneMapping; Three's built-in
-    // ACESFilmicToneMapping (the Narkowicz approximation — desaturates) is not used.
-    // Exposure (NCZ.SCENE_EXPOSURE) — a normalised gauge. The in-game map's
+    // ACESFilmicToneMapping (the Narkowicz approximation, which desaturates) is not used.
+    // Exposure (NCZ.SCENE_EXPOSURE): a normalised gauge. The in-game map's
     // physical camera decodes to exposure 0.000108, but that value can't be
     // used literally: it's a global multiplier and would crush the unlit
     // [0,1]-colour overlays (roads/metro/district lines) to black. So exposure
@@ -736,7 +736,7 @@ const ThreeScene = (() => {
     // See the lighting block in constants.js.
     renderer.toneMapping         = registerCP2077ToneMapping(renderer);
     renderer.toneMappingExposure = NCZ.SCENE_EXPOSURE;
-    // Load the braindance grading LUT — fire-and-forget; the texture binding is
+    // Load the braindance grading LUT (fire-and-forget); the texture binding is
     // stable so the data fill uploads transparently once the fetch lands. The
     // grade + LUT are gated per theme via the --scene-grade CSS var (Game/Preem
     // set it to 1; the five stylised themes leave it 0). Seed it from the
@@ -744,7 +744,7 @@ const ThreeScene = (() => {
     loadBraindanceLUT('assets/data/braindance-lut.bin')
       .catch(err => console.warn('[NCZ] braindance LUT load failed:', err));
     applyGrade(themeGradeEnabled());
-    // Cap effective DPR — see NCZ.MAX_DEVICE_PIXEL_RATIO. The debug-dump
+    // Cap effective DPR; see NCZ.MAX_DEVICE_PIXEL_RATIO. The debug-dump
     // "Renderer DPR" line shows the capped value; "Display ... DPR" still shows
     // the raw window.devicePixelRatio, so the two diverge for capped users.
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, NCZ.MAX_DEVICE_PIXEL_RATIO));
@@ -758,11 +758,11 @@ const ThreeScene = (() => {
     // renderer.shadowMap object only carries { enabled, transmitted, type }).
     // We hold _dirLight.shadow.autoUpdate = false (set just after the light is
     // created) and flag re-renders via flagShadowUpdate(), so the 4096² depth
-    // pass only re-renders when a caster or the sun/shadow-camera actually moves —
+    // pass only re-renders when a caster or the sun/shadow-camera actually moves;
     // theme tweens, pin hovers and other non-geometric frames skip it.
     // Take the canvas out of document flow so its pixel-buffer dimensions
     // can never push or displace surrounding layout elements.
-    // inset:0 stretches it to fill #map-3d on all four sides — no explicit
+    // inset:0 stretches it to fill #map-3d on all four sides; no explicit
     // width/height needed (and adding them alongside inset:0 can cause squishing).
     renderer.domElement.style.position = 'absolute';
     renderer.domElement.style.inset    = '0';
@@ -770,12 +770,12 @@ const ThreeScene = (() => {
 
     initStats(container);
 
-    // Scene background matches theme primary color
+    // Scene background matches theme primary colour
     scene = new THREE.Scene();
     scene.name = 'main-scene';
     scene.background = readThemeColor('--primary', '#0a192f');
 
-    // Perspective camera matching the game's TopDown view — FOV 25°, distance in
+    // Perspective camera matching the game's TopDown view: FOV 25°, distance in
     // CET / world units (see SCHEMA_CAMERA_* in constants.js; values mirror
     // WorldMap.TopDownCameraSettingsDefault in TweakDB). Z = -WORLD_CY because
     // GLB_Z = -CET_Y.
@@ -797,7 +797,7 @@ const ThreeScene = (() => {
     // cube, through an ACES tonemap (decoded from base/weather/24h_basic/
     // 3dmap.envparam). We reproduce that: a DirectionalLight with the decoded
     // warm sun colour + a HemisphereLight with the decoded sky/ground colours,
-    // both at fixed (calibrated) intensity — the game's map has no time-of-day
+    // both at fixed (calibrated) intensity; the game's map has no time-of-day
     // variation. The sun slider still moves the sun's *direction* (shadows sweep,
     // faces relight); colour + intensity stay put. Cast shadows are layered on
     // top as an intentional artistic choice (the in-game map has them disabled).
@@ -814,7 +814,7 @@ const ThreeScene = (() => {
     _dirLight.shadow.camera.near = NCZ.SHADOW_CAM_NEAR;
     _dirLight.shadow.camera.far  = NCZ.SHADOW_CAM_FAR; // orthographic ⇒ a wide range costs no precision
     _dirLight.shadow.camera.name = 'sun-shadow-cam';
-    _dirLight.shadow.bias        = NCZ.SHADOW_BIAS;        // 0 — native depth32float + reverse-Z need no depth cushion
+    _dirLight.shadow.bias        = NCZ.SHADOW_BIAS;        // 0: native depth32float + reverse-Z need no depth cushion
     // The real WebGPU shadow-pass gate: hold autoUpdate off and re-render only when
     // flagShadowUpdate() raises needsUpdate (caster/sun/shadow-cam moved). While the
     // Shadows overlay is off, flagShadowUpdate() no-ops → the depth pass never runs.
@@ -830,7 +830,7 @@ const ThreeScene = (() => {
     scene.add(_dirLight);
     scene.add(_dirLight.target);
 
-    // Hemisphere ambient — the decoded envparam ambient cube collapses to a
+    // Hemisphere ambient: the decoded envparam ambient cube collapses to a
     // hemisphere: 5 bright cool-white faces (sky + sides) over 1 dim blue face
     // (ground). Fixed colour + intensity, matching the game's fixed environment.
     _hemiLight = new THREE.HemisphereLight(0xffffff, 0xffffff, NCZ.AMBIENT_INTENSITY);
@@ -840,7 +840,7 @@ const ThreeScene = (() => {
     scene.add(_hemiLight);
     // Sun position is applied by app.js via the slider once terrain has loaded.
 
-    // Visible sun sphere — hidden by default, shown during showcase only.
+    // Visible sun sphere: hidden by default, shown during showcase only.
     // Radius NCZ.SUN_SPHERE_RADIUS units at NCZ.SUN_SPHERE_DIST distance ≈ 1.7° apparent diameter (≈3× real sun).
     _sunSphere = new THREE.Mesh(
       new THREE.SphereGeometry(NCZ.SUN_SPHERE_RADIUS, 16, 16),
@@ -850,11 +850,11 @@ const ThreeScene = (() => {
     _sunSphere.visible = false;
     scene.add(_sunSphere);
 
-    // OrbitControls — left=pan, right=tilt, middle=zoom.
+    // OrbitControls: left=pan, right=tilt, middle=zoom.
     //
     // Attached to `container` (#map-3d), not `renderer.domElement` (the
     // canvas), so pointer events bubbling up from the CSS2D pin/cluster
-    // overlay reach the controls — mirroring Leaflet's pattern where the
+    // overlay reach the controls, mirroring Leaflet's pattern where the
     // map's drag handler lives on the container element above the marker
     // layer. Combined with the pointer-capture defeat below, this lets
     // OrbitControls see drag/zoom gestures that start on a pin while the
@@ -863,25 +863,25 @@ const ThreeScene = (() => {
     // pointerup off the pin.)
     const _orbitDom = renderer.domElement.parentElement;
     controls = new OrbitControls(camera, _orbitDom);
-    // Defeat OrbitControls' setPointerCapture — Leaflet doesn't use pointer
+    // Defeat OrbitControls' setPointerCapture: Leaflet doesn't use pointer
     // capture for its map drag, and that's exactly the property that
     // preserves click event dispatch on child markers. Without this
     // override, `pointerup` would retarget to the container and the
     // browser would fire `click` on the lowest common ancestor (the
     // container) instead of on the pin. No-op'ing both methods is a
     // single-line patch; the only behavioural trade-off is that a drag
-    // pointer leaving the container during a gesture goes silent — the
+    // pointer leaving the container during a gesture goes silent; the
     // container fills the viewport so this is a near-impossible case.
     _orbitDom.setPointerCapture     = () => {};
     _orbitDom.releasePointerCapture = () => {};
-    // Scene-control UI (#scene-controls — Reset/Showcase buttons, sun slider,
+    // Scene-control UI (#scene-controls: Reset/Showcase buttons, sun slider,
     // tilt readout) lives *inside* #map-3d, so its gestures bubble up to the
     // OrbitControls listeners on _orbitDom and pan/zoom/tilt the camera while
     // you're operating a control (dragging the sun slider moved the map).
     // This is the inverse of the pin/cluster case above: pins *want* the
     // gesture to reach the camera (drag-to-pan, click still fires); controls
     // do NOT. Mirror Leaflet's L.DomEvent.disableClickPropagation /
-    // disableScrollPropagation — stop the gesture-initiating events at the
+    // disableScrollPropagation: stop the gesture-initiating events at the
     // control container so OrbitControls (the ancestor listener) never sees
     // them. stopPropagation only (no preventDefault / stopImmediatePropagation)
     // leaves the controls' own behaviour and click handlers fully intact.
@@ -893,7 +893,7 @@ const ThreeScene = (() => {
     }
     // District hover-brighten: cursor over a district's area fades its outline
     // up. Listener on the container so moves over the CSS2D pin overlay still
-    // reach it (events bubble; pointer capture is no-op'd above). passive — we
+    // reach it (events bubble; pointer capture is no-op'd above). passive: we
     // never preventDefault, so the camera drag path is untouched.
     _orbitDom.addEventListener('mousemove', onSceneMouseMove, { passive: true });
     _orbitDom.addEventListener('mouseleave', () => { setHoveredDistrict(null); NCZ.DistrictInfo?.hide?.(); }, { passive: true });
@@ -913,7 +913,7 @@ const ThreeScene = (() => {
     controls.enableDamping  = true;
     // Ground-plane panning, not screen-space. Under perspective, screen-space
     // panning (the OrbitControls default) has a world-Y component whenever
-    // the camera is tilted — left-drag at high tilt lifts controls.target off
+    // the camera is tilted: left-drag at high tilt lifts controls.target off
     // the ground, the orbit pivot moves up, and subsequent rotates/zooms
     // behave around a lifted point so the camera itself appears to climb as
     // you pan. With screenSpacePanning=false, panning is constrained to the
@@ -921,9 +921,9 @@ const ThreeScene = (() => {
     // at Y=0 implicitly and vertical drag at high tilt moves the target
     // forward/back along the camera look direction at the same rate as
     // horizontal drag moves it left/right. Ortho hid the drift; perspective
-    // surfaces it. See controls 'change' handler — no y-clamp needed.
+    // surfaces it. See controls 'change' handler; no y-clamp needed.
     controls.screenSpacePanning = false;
-    // Target the same point the camera is posed over (the E5 intro start —
+    // Target the same point the camera is posed over (the E5 intro start;
     // see camera.position above). A mismatch here would make controls.update()
     // derive a bogus azimuth from the off-axis offset, rotating the pre-intro
     // loading view ~180° (it looked upside-down before this).
@@ -946,7 +946,7 @@ const ThreeScene = (() => {
       if (_introTween) { _introTween = null; setContinuousRender(false); }
     });
 
-    // Pan bounds — clamp controls.target so the camera can't drift
+    // Pan bounds: clamp controls.target so the camera can't drift
     // arbitrarily far from the visible terrain. OrbitControls has no built-in
     // min/maxPan, so we listen for 'change' and snap target back if it leaves
     // bounds, also moving camera.position by the same delta so the spherical
@@ -954,17 +954,17 @@ const ThreeScene = (() => {
     //
     // Bounds use the *terrain GLB extent* (the visible square ~[-8000, 8000]
     // in both Three X and Three Z) rather than the playable CET world extent
-    // (which is asymmetric — playable area sits in the northern half of the
+    // (which is asymmetric: playable area sits in the northern half of the
     // Y range). This gives the same "perfect square" feel Leaflet has on the
     // SAT view, where the user can pan equally far past every edge.
     //
     // panEdgeFraction = 0.5 collapses to zero offset → target clamps at the
-    // terrain edge → at max pan, terrain edge sits at viewport center, half
+    // terrain edge → at max pan, terrain edge sits at viewport centre, half
     // terrain visible / half empty (matches Leaflet exactly at zero tilt).
     //
     // Tilt note: at high tilts the visible ground extent grows by 1/cos(polar)
     // in the tilt direction, so the "half-screen-past-terrain" feel stretches
-    // out — you can technically pan more terrain off-screen at high tilt
+    // out; you can technically pan more terrain off-screen at high tilt
     // before hitting the bound. An earlier tilt-correction attempt produced
     // catastrophic camera jumps when bounds inverted at extreme zoom-out +
     // tilt; that was reverted in favour of this stable simpler bound. A
@@ -973,7 +973,7 @@ const ThreeScene = (() => {
       const t = controls.target;
       const f = NCZ.PIN_3D_PAN_EDGE_FRACTION;
       // Pan envelope = TweakDB WorldMap.DefaultSettings.cursorBoundary (the
-      // game's own pan limits — tighter than the terrain GLB extent because
+      // game's own pan limits, tighter than the terrain GLB extent because
       // the playable area sits in the northern half of the world). Allow the
       // target to drift toward an edge by (f - 0.5) × visible-rect-size so
       // edge content can still be centred.
@@ -1007,7 +1007,7 @@ const ThreeScene = (() => {
     // layer can drive camera fly-to-pin tweens on focusMod().
     NCZ.ThreeMarkers?.attach?.(scene, camera, container, controls);
 
-    // Initial scale bar — controls 'change' won't fire until the user
+    // Initial scale bar: controls 'change' won't fire until the user
     // interacts, so paint the bar once at startup using the initial camera state.
     updateScaleBar();
 
@@ -1016,13 +1016,14 @@ const ThreeScene = (() => {
 
   // NOTE (issue #771 history): a `setResizeSuppressed` guard used to hold the
   // drawing buffer at its pre-showcase size because any r185 setSize wedged
-  // the canvas (stale Line2 binding to the destroyed viewport-mip texture —
-  // see the dispose() below). With that mitigation in place the guard was
-  // retested (showcase + mid-flight window resizes, zero errors) and removed;
-  // the showcase now renders at native fullscreen resolution instead of a
-  // CSS-stretched windowed buffer.
+  // the canvas (stale Line2 binding to the destroyed viewport-mip texture).
+  // A dispose-on-resize mitigation made resizes safe; the guard was retested
+  // with it (showcase + mid-flight window resizes, zero errors) and removed,
+  // and the mitigation itself went away with the move to DistrictLineMaterial
+  // (see onResize below). The showcase now renders at native fullscreen
+  // resolution instead of a CSS-stretched windowed buffer.
   //
-  // ThreeMarkers.onResize must ALWAYS run here — the CSS2DRenderer maps NDC
+  // ThreeMarkers.onResize must ALWAYS run here: the CSS2DRenderer maps NDC
   // to its own stored size; leaving it stale while the client size changes
   // offsets every pin, cluster and district label from its world anchor
   // (issue #769, the "floating pins" bug).
@@ -1036,7 +1037,7 @@ const ThreeScene = (() => {
     const h = container.clientHeight;
     const bufferResized = w !== _lastBufferW || h !== _lastBufferH;
     if (bufferResized) {
-      renderer.setSize(w, h, false); // updateStyle:false — CSS width/height stay at 100%
+      renderer.setSize(w, h, false); // updateStyle:false; CSS width/height stay at 100%
       _lastBufferW = w; _lastBufferH = h;
     }
     camera.aspect = w / h;
@@ -1045,7 +1046,7 @@ const ThreeScene = (() => {
     // flyCamera resize is handled in flyover.js
     // District lines need no resize handling: DistrictLineMaterial (#775)
     // reads the viewport from a TSL screen node at shader-execution time and
-    // binds no framebuffer-copy textures — the dispose-on-resize mitigation
+    // binds no framebuffer-copy textures; the dispose-on-resize mitigation
     // that Line2NodeMaterial's viewportOpaqueMipTexture binding required
     // (#771) was removed with it.
     NCZ.ThreeMarkers?.onResize?.(w, h);
@@ -1054,7 +1055,7 @@ const ThreeScene = (() => {
   }
 
   // ── Layer registry ─────────────────────────────────────────────────────
-  // Named scene groups — toggled by setLayerVisibility()
+  // Named scene groups, toggled by setLayerVisibility()
 
   const layers = {
     terrain:   null,
@@ -1062,29 +1063,29 @@ const ThreeScene = (() => {
     cliffs:    null,
     roads:     null,
     metro:     null,
-    districts: null,  // parent group — toggled as a unit
+    districts: null,  // parent group, toggled as a unit
     buildings: null,
   };
 
   // Sub-groups inside layers.districts (parent group controls overall visibility):
-  let _districtOuter  = null; // districts with subs — visible at the districts zoom band (d ≥ 11000)
-  let _districtSub    = null; // canonical subdistricts — visible at the subs band (7000 ≤ d < 11000)
-  let _districtAlways = null; // no-sub districts (Dogtown / Morro Rock) + non-canonical subs (Casino) — visible whenever EITHER outline tier is
+  let _districtOuter  = null; // districts with subs; visible at the districts zoom band (d ≥ 11000)
+  let _districtSub    = null; // canonical subdistricts; visible at the subs band (7000 ≤ d < 11000)
+  let _districtAlways = null; // no-sub districts (Dogtown / Morro Rock) + non-canonical subs (Casino); visible whenever EITHER outline tier is
 
-  // Name labels: { css: CSS2DObject, group } — `group` is the outline tier the
+  // Name labels: { css: CSS2DObject, group }; `group` is the outline tier the
   // label belongs to, so the label is shown exactly when that tier is.
   const _districtLabels = [];
 
   // Gate each label per-leaf (CSS2D `visible` doesn't cascade from a parent
   // group). A label shows when the Districts overlay is on AND its outline
-  // tier's group is currently visible — so district names appear at the
+  // tier's group is currently visible, so district names appear at the
   // district zoom band, subdistrict names at the subdistrict band.
   function updateDistrictLabelVisibility() {
     if (!_districtLabels.length) return;
     const districtsOn = layers.districts ? layers.districts.visible : true;
     // Showcase mode: names are a user option independent of the outline tier
-    // (the tier groups stay visible to carry the pinned outlines — see
-    // forceDistrictBand — so the label gate needs its own switch).
+    // (the tier groups stay visible to carry the pinned outlines (see
+    // forceDistrictBand), so the label gate needs its own switch).
     const namesOn = _showcaseDistricts ? _showcaseDistricts.names : true;
     for (const { css, group } of _districtLabels) css.visible = districtsOn && group.visible && namesOn;
   }
@@ -1098,7 +1099,7 @@ const ThreeScene = (() => {
       return;
     }
     if (name === 'shadows') { setShadowsEnabled(visible); return; }
-    // The marker overlay isn't a scene layer — it's a separate CSS2DRenderer
+    // The marker overlay isn't a scene layer; it's a separate CSS2DRenderer
     // pass owned by ThreeMarkers, gated by the schema camera's Three.js
     // Object3D.layers mask. Routing it through here keeps the overlay-controls
     // panel's [data-overlay] handler uniform across every toggle.
@@ -1110,7 +1111,7 @@ const ThreeScene = (() => {
 
   // Pins the district-outline tier independent of the schema camera's zoom
   // band. The showcase flyover renders through its own camera while the
-  // schema camera (which drives updateDistrictZoom) is frozen — starting a
+  // schema camera (which drives updateDistrictZoom) is frozen; starting a
   // showcase zoomed in below SUBDISTRICT_DISTANCE_3D froze ALL outline tiers
   // hidden for the whole flight, so "Show district outlines" silently did
   // nothing. 'district' pins the main-district tier (the cinematic look the
@@ -1120,7 +1121,7 @@ const ThreeScene = (() => {
   // the CSS2D labels (see updateDistrictLabelVisibility), outlines gate the
   // Line2 rings per-line (the tier groups stay visible either way so labels
   // can show without outlines). Outlines render at the HOVERED opacity for
-  // the whole flight — the 5% base is illegible from cinematic distances.
+  // the whole flight; the 5% base is illegible from cinematic distances.
   let _districtBandForced = null; // 'district' | null
   let _showcaseDistricts  = null; // { names, outlines } | null
   function forceDistrictBand(band, opts = null) {
@@ -1150,13 +1151,13 @@ const ThreeScene = (() => {
   }
 
   function updateDistrictZoom() {
-    if (_districtBandForced) return; // showcase owns the band — see forceDistrictBand
+    if (_districtBandForced) return; // showcase owns the band; see forceDistrictBand
     if (!_districtOuter || !_districtSub || !controls) return;
     // Three-state visibility, matching WorldMap.ZoomLevel* records:
     //   d ≥ 11000: main district outlines (ZoomLevelDistricts.showDistricts = 1)
     //   7000 ≤ d < 11000: subdistrict outlines (ZoomLevelSubDistricts.showSubDistricts = 1)
     //   d < 7000: neither (every closer zoom-level record has both flags false)
-    // The game hides outlines entirely at close zoom — only mappins remain.
+    // The game hides outlines entirely at close zoom; only mappins remain.
     // alwaysGroup (no-sub districts + non-canonical subs) follows the same
     // outline-tier-visible rule: shown whenever EITHER district or subdistrict
     // tier would render, hidden together with them below 7000.
@@ -1171,7 +1172,7 @@ const ThreeScene = (() => {
   // ── District hover-brighten ─────────────────────────────────────────────
   // In-game parity: outlines sit at NCZ.DISTRICT_LINE_OPACITY (5%) and brighten
   // to ~full over 250 ms when the cursor enters the district's area. No pick
-  // geometry — the rings are flat on Y=0, so we intersect the cursor ray with
+  // geometry: the rings are flat on Y=0, so we intersect the cursor ray with
   // the ground plane and run a CPU point-in-polygon over the in-memory rings.
   // One registry entry per outline; `group` is its visibility tier so we only
   // test (and brighten) outlines that are actually drawn at the current zoom.
@@ -1180,10 +1181,10 @@ const ThreeScene = (() => {
   // Draw the hovered outline last so it paints on top of any coincident faint
   // neighbour. Outlines have depthTest:false (depth ignored), so the only thing
   // that decides which of two coplanar coincident lines wins a pixel is paint
-  // order — and the transparent back-to-front sort is unstable for equal-
+  // order, and the transparent back-to-front sort is unstable for equal-
   // distance lines. District outlines sit at tier 7 of the explicit transparent
   // chain (water 0 → roads depth/colour 1/2 → borders depth/colour 3/4 →
-  // SeeThrough 5 → metro 6 → districts 7) so they always draw after water — a
+  // SeeThrough 5 → metro 6 → districts 7) so they always draw after water; a
   // shared tier would fall back to camera-angle-dependent centroid-z ties.
   // A higher renderOrder forces the hovered line last so it reads above its
   // siblings. Reset to the base tier on exit.
@@ -1196,7 +1197,7 @@ const ThreeScene = (() => {
   const _hoverNdc    = new THREE.Vector2();
   const _hoverWorld  = new THREE.Vector3();
 
-  // Shoelace area (absolute) — used to prefer the smallest matching ring when a
+  // Shoelace area (absolute), used to prefer the smallest matching ring when a
   // point sits inside nested outlines (e.g. the casino sub inside Westbrook).
   function polygonArea(ring) {
     let a = 0;
@@ -1232,15 +1233,15 @@ const ThreeScene = (() => {
       -(((clientY - rect.top) / rect.height) * 2 - 1)
     );
     _hoverRay.setFromCamera(_hoverNdc, camera);
-    // Near-horizontal rays barely graze Y=0 — bail rather than pick a point
-    // kilometres off (cf. ray-to-ground-thit-explodes-near-horizontal). Outlines
-    // only show when zoomed out/steep, so this never costs a real hover.
+    // Near-horizontal rays barely graze Y=0, so the plane hit lands kilometres
+    // off; bail instead. Outlines only show when zoomed out/steep, so this
+    // never costs a real hover.
     if (Math.abs(_hoverRay.ray.direction.y) < 1e-3) return null;
     if (!_hoverRay.ray.intersectPlane(_hoverPlane, _hoverWorld)) return null;
     return [_hoverWorld.x, -_hoverWorld.z]; // world (x,z) → ring (cetX, cetY)
   }
 
-  // The visible outline under a CET ground point (or null) — only outlines whose
+  // The visible outline under a CET ground point (or null); only outlines whose
   // tier group is currently drawn, smallest-area first. Drives the brighten;
   // the info panel resolves the subdistrict separately (all tiers).
   function pickDistrictAt(gp) {
@@ -1272,7 +1273,7 @@ const ThreeScene = (() => {
   }
 
   function onSceneMouseMove(e) {
-    // Showcase mode pins every outline at the hovered opacity — the pointer
+    // Showcase mode pins every outline at the hovered opacity; the pointer
     // must not re-target materials mid-flight (and the pick raycast uses the
     // schema camera, which is wrong under the fly camera anyway).
     if (_showcaseDistricts) return;
@@ -1298,7 +1299,7 @@ const ThreeScene = (() => {
     const maxStep = range * (dt / NCZ.DISTRICT_HOVER_FADE_MS);
     let active = false;
     for (const e of _districtHover) {
-      if (!e.material) continue; // label-only entry (Badlands) — no outline to tween
+      if (!e.material) continue; // label-only entry (Badlands); no outline to tween
       const diff = e.target - e.material.opacity;
       if (Math.abs(diff) <= maxStep || maxStep === 0) {
         if (e.material.opacity !== e.target) e.material.opacity = e.target;
@@ -1360,20 +1361,20 @@ const ThreeScene = (() => {
         loadGLB('3dmap_cliffs.glb'),
       ]);
 
-      // SeeThrough-roads stencil chain (Pacifica tunnel — a road visible *through* the open bay).
+      // SeeThrough-roads stencil chain (Pacifica tunnel: a road visible *through* the open bay).
       //   • Water writes stencil=STENCIL_WATER where it's the visible surface. The water GLB is a
       //     flat sea-level sheet (world Y ≈ -1) the whole terrain (Y -99..+879) pokes through, so
       //     for stencilZPass to land only on "pixels where you see water" (the open bay = where the
       //     terrain dips below sea level), water must be depth-tested against the FULLY-rendered
-      //     opaque scene. `transparent: true` (opacity = WATER_OPACITY, 1.0 by default — still
+      //     opaque scene. `transparent: true` (opacity = WATER_OPACITY, 1.0 by default, still
       //     visually opaque) moves water out of the opaque list into the transparent pass, which is
-      //     unconditionally drawn after every opaque object — so its depth test sees terrain/cliffs/
+      //     unconditionally drawn after every opaque object, so its depth test sees terrain/cliffs/
       //     buildings already in the depth buffer and fails over all of them, confining
       //     stencil=STENCIL_WATER to the bay. (Plain renderOrder doesn't push water past the terrain
-      //     in the opaque sort under WebGPURenderer — cause unclear; the transparent pass sidesteps
+      //     in the opaque sort under WebGPURenderer, cause unclear; the transparent pass sidesteps
       //     the sort entirely.) renderOrder stays 0, so water still draws before the SeeThrough roads.
       //   • Terrain, cliffs and buildings over-stamp stencil=STENCIL_OCCLUDER where THEY are the
-      //     visible surface (depth-tested, ZPass:Replace) — so SeeThrough roads don't draw through
+      //     visible surface (depth-tested, ZPass:Replace), so SeeThrough roads don't draw through
       //     them. Safe vs the tunnel because water (transparent pass) re-writes stencil=STENCIL_WATER
       //     over the bay AFTER the terrain seabed wrote stencil=STENCIL_OCCLUDER there in the opaque pass.
       const stencilOverstamp = { stencilWrite: true, stencilRef: NCZ.STENCIL_OCCLUDER, stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp };
@@ -1388,14 +1389,14 @@ const ThreeScene = (() => {
       applyMaterial(waterScene,   waterMat);
       applyMaterial(cliffsScene,  cliffsMat);
 
-      // Shadow flags — terrain RECEIVES only (no longer casts). Road/metro
+      // Shadow flags: terrain RECEIVES only (no longer casts). Road/metro
       // decals sit near-coplanar with terrain and use shadow() to receive
       // building shadows; if terrain also casts, the decal's shadow sample
       // reads as occluded by the terrain right under it → black-stripe acne
       // along the road. Cliffs still cast (they're elevated and the user
       // wants long cliff-base shadows). Water receives only (flat ocean).
       // Side-benefit: terrain self-shadow "the wave" (grazing-sun acne) goes
-      // away as a consequence — Phase 3's footprint-scaled normalBias was
+      // away as a consequence; Phase 3's footprint-scaled normalBias was
       // there to mask exactly that.
       terrainScene.traverse(c => { if (c.isMesh) { c.receiveShadow = true; c.frustumCulled = false; } });
       waterScene.traverse(c =>   { if (c.isMesh) { c.receiveShadow = true; c.frustumCulled = false; } });
@@ -1437,14 +1438,14 @@ const ThreeScene = (() => {
 
       // Trigger the sun slider so app.js applies the correct initial sun position.
       // Done here (post-terrain) because ThreeScene.setSunPosition now exists and
-      // the directional light is in the scene — the slider fires too early otherwise.
+      // the directional light is in the scene; the slider fires too early otherwise.
       document.getElementById('scene-sun-slider')?.dispatchEvent(new Event('input'));
 
       // Tier 2+3: start all concurrent tasks, hide loading only when all complete.
       // Add future loaders (loadLandmarks etc.) to this array.
       Promise.all([loadRoadsMetro(), loadDistricts(), loadBuildings(), loadLandmarks()])
         .then(() => {
-          // Buildings now exist — apply the active theme's edge-glow default to
+          // Buildings now exist; apply the active theme's edge-glow default to
           // their uniforms (updateMaterials' early applyEdgeGlow ran before the
           // materials were built; the grade has no such dependency).
           applyEdgeGlow(themeEdgeGlowDefault());
@@ -1467,7 +1468,7 @@ const ThreeScene = (() => {
         loadGLB('3dmap_roads_borders.glb'),
       ]);
 
-      // All road GLBs have inverted X axis — rotate 180° around Y to correct
+      // All road GLBs have inverted X axis; rotate 180° around Y to correct
       roadsScene.rotation.y   = Math.PI;
       metroScene.rotation.y   = Math.PI;
       bordersScene.rotation.y = Math.PI;
@@ -1483,23 +1484,22 @@ const ThreeScene = (() => {
       const borderColor = readThemeColor('--overlay-road-border-color', '#1ec3c8');
       const metroColor  = readThemeColor('--overlay-metro-color',       '#dcaa28');
 
-      // Normal depth-tested pass — surface roads/borders sit correctly in scene.
+      // Normal depth-tested pass: surface roads/borders sit correctly in scene.
       // Flat unlit Basic so the infographic colour stays uniform across the
-      // whole road network. (Tried receiving sun shadows in this PR — both via
-      // a manual `materialColor × shadow()` multiply on Basic and via Lambert +
-      // receiveShadow — and both looked wrong: the multiply gave black-stripe
-      // acne on the coplanar road geometry, and Lambert sun-direction-tinted
-      // the network into something that read as 3D rather than infographic.
-      // Scrapped — buildings/terrain still receive shadows, decals don't.)
+      // whole road network. (Do not add sun-shadow receiving here: a manual
+      // `materialColor × shadow()` multiply on Basic gives black-stripe acne
+      // on the coplanar road geometry, and Lambert + receiveShadow
+      // sun-direction-tints the network into something that reads as 3D
+      // rather than infographic. Buildings/terrain receive shadows, decals don't.)
       // Blend + opacity here are decoded constants, not tuning. 3d_map_solid.mt
       // has a fixed One/One additive PSO; the per-material AdditiveAlphaBlend flag
       // decides whether the additive contribution is pre-scaled by Color.Alpha.
       // Roads = AdditiveAlphaBlend 0 / alpha 255, borders = AdditiveAlphaBlend 1 /
       // alpha 255 → both full-strength additive. (Roads were Normal-blend opacity
-      // 0.8 — an eyeballed guess that also let the road colour drift with whatever
+      // 0.8, an eyeballed guess that also let the road colour drift with whatever
       // sat under it; additive is the game-faithful blend.)
       // Surface roads/borders over-stamp stencil=STENCIL_OCCLUDER where they
-      // are the visible surface — the same pattern terrain/cliffs/buildings
+      // are the visible surface, the same pattern terrain/cliffs/buildings
       // use in the opaque pass. This makes the surface and SeeThrough copies
       // mutually exclusive per pixel: where the surface copy draws (passes
       // depth), the stencil is no longer STENCIL_WATER, so the SeeThrough
@@ -1510,23 +1510,23 @@ const ThreeScene = (() => {
         stencilWrite: true, stencilRef: NCZ.STENCIL_OCCLUDER,
         stencilFunc: THREE.AlwaysStencilFunc, stencilZPass: THREE.ReplaceStencilOp,
       };
-      // Depth pre-pass + Equal colour pass — additive layers can't occlude
+      // Depth pre-pass + Equal colour pass: additive layers can't occlude
       // themselves (every overlapping fragment adds), so overlapping road
       // decks / crossing borders drew twice (bright hot spots at any angle:
       // draw order within a tier is buffer order, not per-fragment depth).
       // Each layer first lays down its nearest-surface depth (colorWrite off,
-      // transparent:true keeps it in the transparent pass AFTER water — an
+      // transparent:true keeps it in the transparent pass AFTER water; an
       // opaque prepass would depth-block water under bridges and shift the
       // additive base colour), then the colour pass draws with
       // depthFunc:Equal so exactly one surface per pixel receives colour.
-      // The vertex path is identical between the two passes, so rasterized
+      // The vertex path is identical between the two passes, so rasterised
       // depth matches exactly.
       const depthPrepassMat = new THREE.MeshBasicNodeMaterial({ transparent: true, colorWrite: false });
       // r185 routes material.depthFunc through ReversedDepthFuncs under
       // reversedDepthBuffer and wrongly inverts EqualDepth → NotEqualDepth
       // (equality is direction-independent; the upstream map blanket-inverts
       // every comparator). Hand it NotEqual so the broken inversion lands on
-      // the Equal we actually want — the same pre-compensation pattern as the
+      // the Equal we actually want, the same pre-compensation pattern as the
       // render-list sort comparators above. Symptom if this regresses: roads
       // invisible over terrain/water but visible through buildings.
       // Remove together with the sort compensation when upstream fixes.
@@ -1537,7 +1537,7 @@ const ThreeScene = (() => {
       applyMaterial(roadsScene,   normalRoadsMat);
       applyMaterial(bordersScene, normalBordersMat);
 
-      // Explicit transparent-pass tiers — the whole water/roads/metro chain is
+      // Explicit transparent-pass tiers: the whole water/roads/metro chain is
       // order-dependent, and any two overlays sharing a renderOrder fall back
       // to per-object centroid-z ties that flip with camera angle (the cause
       // of the old "road borders vanish over water at some angles" bug):
@@ -1551,7 +1551,7 @@ const ThreeScene = (() => {
       roadsScene.traverse(o   => { if (o.isMesh) o.renderOrder = 2; });
       bordersScene.traverse(o => { if (o.isMesh) o.renderOrder = 4; });
 
-      // Metro: normal depth-tested, renderOrder=6 — after water (0) so it
+      // Metro: normal depth-tested, renderOrder=6, after water (0) so it
       // shows over the bay, after the road passes so it layers above both.
       //
       // LOD discard: COLOR_0 vertex attribute carries the LOD tier as one
@@ -1563,7 +1563,7 @@ const ThreeScene = (() => {
       //
       // TSL port (was `onBeforeCompile` GLSL injection on r170):
       //   - vertex color attribute pulled via `attribute('color')`
-      //   - per-frame zoom uniform via `uniform()` node — mutate `.value` from
+      //   - per-frame zoom uniform via `uniform()` node; mutate `.value` from
       //     the controls 'change' handler (lookup at top of init())
       //   - boolean expression composed with TSL methods (.greaterThan/.and/.or)
       //   - `material.maskNode` is a KEEP mask (true=keep, false=discard);
@@ -1571,17 +1571,17 @@ const ThreeScene = (() => {
       metroMat = new THREE.MeshBasicNodeMaterial({
         color: metroColor,
         transparent: true,
-        opacity: 0.235,  // 3dmap_metro Color.Alpha 60/255 — AdditiveAlphaBlend=1
+        opacity: 0.235,  // 3dmap_metro Color.Alpha 60/255; AdditiveAlphaBlend=1
         blending: THREE.AdditiveBlending,
         depthWrite: false,
       });
-      // Metro LOD — decoded from 3d_map_metro.mt's pixel shader (PIX capture).
+      // Metro LOD: decoded from 3d_map_metro.mt's pixel shader (PIX capture).
       // The metro mesh carries three
       // tiers in COLOR_0 (R dotted / G thin / B wide), one channel per vertex.
       // Each tier is fully on below its distance threshold and crossfades out
-      // over METRO_LOD_TRANSITION — the game dissolves tiers, it doesn't snap.
+      // over METRO_LOD_TRANSITION; the game dissolves tiers, it doesn't snap.
       // Driven by one CPU uniform: schema camera-to-target distance, seeded
-      // from the LIVE camera here — a constant seed showed the wrong tier on
+      // from the LIVE camera here; a constant seed showed the wrong tier on
       // the first frame until the first camera move (the load-flicker bug).
       metroDistanceUniform = uniform(camera.position.distanceTo(controls.target));
       const uMetroNear = uniform(NCZ.METRO_LOD_DISTANCE_NEAR);
@@ -1595,13 +1595,13 @@ const ThreeScene = (() => {
       const fNear = tierRamp(uMetroNear);
       const fMed  = tierRamp(uMetroMed);
       const fFar  = tierRamp(uMetroFar);
-      // Mutually-exclusive tier weights — the game's min(ramp, 1 - prevRamp)
+      // Mutually-exclusive tier weights: the game's min(ramp, 1 - prevRamp)
       // chain, so adjacent tiers crossfade and never both reach full.
       const nearW = fNear;
       const midW  = fMed.min(float(1).sub(fNear));
       const farW  = fFar.min(float(1).sub(fMed));
       // Each vertex carries exactly one tier in COLOR_0; `max` selects its
-      // weight. The result drives alpha — tiers fade in/out under additive blend.
+      // weight. The result drives alpha; tiers fade in/out under additive blend.
       const metroLOD = nearW.mul(lodColor.r)
         .max(midW.mul(lodColor.g))
         .max(farW.mul(lodColor.b));
@@ -1623,12 +1623,12 @@ const ThreeScene = (() => {
       }
 
       // SeeThrough pass: depthTest:false + stencil=EQUAL(STENCIL_WATER) → only renders where water
-      // is the visible surface at this pixel — i.e. the open bay (see the stencil-chain comment in
+      // is the visible surface at this pixel, i.e. the open bay (see the stencil-chain comment in
       // loadTerrain). Pacifica tunnel: water writes stencil=STENCIL_WATER → the tunnel road + border
       // (below the water) draw on top of it = visible through the water ✓.  Mountain / city roads:
       // terrain/cliffs/buildings over-stamp stencil=STENCIL_OCCLUDER ≠ STENCIL_WATER → hidden ✓.
       // (Bridge-over-bay double-draw is gone since the surface copies over-stamp
-      // stencil=STENCIL_OCCLUDER where visible — the SeeThrough copy only draws
+      // stencil=STENCIL_OCCLUDER where visible; the SeeThrough copy only draws
       // where water remains the visible surface, so the two copies are mutually
       // exclusive per pixel.)
       const stBase = {
@@ -1637,11 +1637,11 @@ const ThreeScene = (() => {
         stencilFunc: THREE.EqualStencilFunc, stencilRef: NCZ.STENCIL_WATER, stencilFuncMask: 0xff,
         stencilFail: THREE.KeepStencilOp, stencilZFail: THREE.KeepStencilOp, stencilZPass: THREE.KeepStencilOp,
       };
-      // SeeThrough variants match the normal pass — full-strength additive (see
+      // SeeThrough variants match the normal pass: full-strength additive (see
       // the decoded-constant note on normalRoadsMat above).
       roadsMat   = new THREE.MeshBasicNodeMaterial({ ...stBase, color: roadColor,   opacity: 1.0, blending: THREE.AdditiveBlending });
       bordersMat = new THREE.MeshBasicNodeMaterial({ ...stBase, color: borderColor, opacity: 1.0, blending: THREE.AdditiveBlending });
-      // No shadow multiply on the SeeThrough variants — they're an
+      // No shadow multiply on the SeeThrough variants; they're an
       // infographic "see the tunnel through the water" effect (depthTest:false,
       // stencil=WATER), drawing road geometry that sits BELOW the water plane
       // and surrounding terrain. Sampling the shadow map at that underwater
@@ -1659,7 +1659,7 @@ const ThreeScene = (() => {
       stRoads.traverse(o => { if (o.isMesh) o.renderOrder = 5; });
       stBorders.traverse(o => { if (o.isMesh) o.renderOrder = 5; });
 
-      // Depth pre-passes (see depthPrepassMat above) — same geometry cloned
+      // Depth pre-passes (see depthPrepassMat above): same geometry cloned
       // via makeSeeThrough with the colourless depth-writing material, drawn
       // one tier before their colour pass.
       const dpRoads   = makeSeeThrough(roadsScene,   depthPrepassMat);
@@ -1697,9 +1697,9 @@ const ThreeScene = (() => {
     registerLoadStep(); // districts
     try {
       const data = await fetch('data/subdistricts.json').then(r => r.json());
-      const outerGroup  = new THREE.Group(); // districts with subs — zoom-out only
-      const alwaysGroup = new THREE.Group(); // no-sub districts + canonical:false subs — always visible
-      const subGroup    = new THREE.Group(); // canonical subdistricts — zoom-in only
+      const outerGroup  = new THREE.Group(); // districts with subs; zoom-out only
+      const alwaysGroup = new THREE.Group(); // no-sub districts + canonical:false subs; always visible
+      const subGroup    = new THREE.Group(); // canonical subdistricts; zoom-in only
       outerGroup.name  = 'districts-outer';
       alwaysGroup.name = 'districts-always';
       subGroup.name    = 'subdistricts';
@@ -1708,7 +1708,7 @@ const ThreeScene = (() => {
       // ThreeMarkers' CSS2DRenderer pass (it traverses the whole scene). Each
       // label is tagged with the visibility GROUP of its outline, so the label
       // shows exactly when its outline tier does (handled in
-      // updateDistrictLabelVisibility — CSS2D visible doesn't cascade, so we set
+      // updateDistrictLabelVisibility; CSS2D visible doesn't cascade, so we set
       // it per-leaf). Default layer 0 → labels aren't gated by the Pins toggle.
       const labelGroup = new THREE.Group();
       labelGroup.name = 'district-labels';
@@ -1739,7 +1739,7 @@ const ThreeScene = (() => {
         const hasSubs = canonicalSubs.length > 0;
         const distGroup = hasSubs ? outerGroup : alwaysGroup;
 
-        // District outline — always group if no canonical subs, outer group otherwise
+        // District outline: always group if no canonical subs, outer group otherwise
         if (dist.polygon?.length) {
           const line = buildLine(dist.polygon, color, window.NCZ.DISTRICT_LINE_WIDTH);
           line.name = `district-outline-${dist.id}`;
@@ -1755,7 +1755,7 @@ const ThreeScene = (() => {
             const labelEl = addLabel(dist.name, pos, colorHex, distGroup, 'district');
             // No outline to hover, so register each subdistrict polygon as a
             // district-tier, label-only hover region pointing at the Badlands
-            // label — hovering the badlands area emphasises the name.
+            // label; hovering the badlands area emphasises the name.
             for (const sub of dist.subdistricts || []) {
               if (sub.polygon?.length) registerDistrictHover(sub.polygon, null, distGroup, labelEl, dist.id, null);
             }
@@ -1766,7 +1766,7 @@ const ThreeScene = (() => {
           if (!sub.polygon?.length) continue;
           const line = buildLine(sub.polygon, color, window.NCZ.SUBDISTRICT_LINE_WIDTH);
           line.name = `subdistrict-outline-${dist.id}/${sub.id}`;
-          // canonical:false (casino etc) — always visible; otherwise zoom-gated.
+          // canonical:false (casino etc): always visible; otherwise zoom-gated.
           const group = sub.canonical === false ? alwaysGroup : subGroup;
           group.add(line);
           const labelEl = addLabel(sub.name, NCZ.polygonCentroid(sub.polygon), colorHex, group, 'subdistrict');
@@ -1812,7 +1812,7 @@ const ThreeScene = (() => {
   const LANDMARK_META = [
     // { file, cetX, cetY, cetZ, qi, qj, qk, qr }
     // XY from cp2077_extract_footprints.py --list-landmarks (CET world space)
-    // Z from ent localTransform.Position.z (Bits/131072) — CET height = Three.js Y
+    // Z from ent localTransform.Position.z (Bits/131072); CET height = Three.js Y
     // qi/qj/qk/qr from ent Orientation [i,j,k,r]
     { file: '3dmap_obelisk.glb',                   cetX: -1714.5, cetY: -2331.3, cetZ:  35.68, qi: -0.0436, qj: -0.0019, qk:  0.9981, qr:  0.0436 },
     { file: 'monument_ave_pyramid.glb',             cetX: -1595.2, cetY: -2344.3, cetZ:  55.74, qi:  0.0000, qj:  0.0000, qk:  0.0000, qr:  1.0000 },
@@ -1854,10 +1854,10 @@ const ThreeScene = (() => {
         source.traverse(child => {
           if (!child.isMesh) return;
           const mesh = new THREE.Mesh(child.geometry, mat);
-          // Preserve the source mesh's local transform — for meshopt-compressed
+          // Preserve the source mesh's local transform; for meshopt-compressed
           // GLBs this carries the KHR_mesh_quantization dequant translate/scale
           // that maps int16 vertex positions back to mesh-local-space coords.
-          // Without this, vertices render at raw quantized scale (0–65535).
+          // Without this, vertices render at raw quantised scale (0–65535).
           mesh.position.copy(child.position);
           mesh.quaternion.copy(child.quaternion);
           mesh.scale.copy(child.scale);
@@ -1885,9 +1885,10 @@ const ThreeScene = (() => {
   async function loadBuildings() {
     registerLoadStep(DISTRICT_META.length); // one step per district
     try {
-      // Source geometry — single unit cube reused by every district. Wrapped in
-      // an InstancedBufferGeometry per-district so Three.js draws `instanceCount`
-      // copies; the per-instance matrix lookup happens in our positionNode via
+      // Source geometry: single unit cube reused by every district. Cloned
+      // into a regular BufferGeometry per-district and driven by an indirect
+      // draw buffer (NOT an InstancedBufferGeometry; see the clone site
+      // below); the per-instance matrix lookup happens in our positionNode via
       // the storage buffer (`instanceMatricesBuffer.element(instanceIndex)`).
       const baseGeo = new THREE.BoxGeometry(1, 1, 1);
       const group   = new THREE.Group();
@@ -1901,14 +1902,14 @@ const ThreeScene = (() => {
       const assetSet = (typeof localStorage !== 'undefined' && localStorage.getItem(NCZ.ASSET_SET_KEY)) || NCZ.ASSET_SET_DEFAULT;
 
       // Debug aid: ?only=<district> renders only that DISTRICT_META entry by
-      // name (e.g. ?only=my_district, ?only=ugly_building) — isolates a single
+      // name (e.g. ?only=my_district, ?only=ugly_building); isolates a single
       // building cloud for diagnosing placement/content. Sibling of ?debug /
       // ?gamelight / ?webgpuprobe.
       const _only = new URLSearchParams(location.search).get('only');
       for (const meta of DISTRICT_META) {
         if (_only && meta.name !== _only) continue;
         // Fixed-only entries (e.g. the my_district corrections overlay) exist
-        // only in the Fixed asset set — skip them entirely in CDPR mode.
+        // only in the Fixed asset set; skip them entirely in CDPR mode.
         if (meta.fixedOnly && assetSet !== 'fixed') continue;
         setLoadingText(`Loading buildings [${meta.name}]…`);
 
@@ -1930,7 +1931,7 @@ const ThreeScene = (() => {
             const ri = (y * texW + x + blockW)  * 4;   // rotation block
             const si = (y * texW + x + 2*blockW)* 4;   // scale block
 
-            // Empty-cell detection — two encodings exist. Base-game textures
+            // Empty-cell detection: two encodings exist. Base-game textures
             // mark empties with near-zero position-block ALPHA; malgalad's
             // "3D World Map Fixed" textures keep alpha full and mark empties
             // with ZERO SCALE instead (see docs/3dmap-fixed-assets.md).
@@ -1964,7 +1965,7 @@ const ThreeScene = (() => {
             dummy.updateMatrix();
             // Pack the 16 floats of the matrix at offset (validCount * 16).
             // Three.js stores Matrix4.elements in column-major order, which
-            // matches WGSL's mat4x4f memory layout — direct copy, no transpose.
+            // matches WGSL's mat4x4f memory layout: direct copy, no transpose.
             matrixData.set(dummy.matrix.elements, validCount * 16);
             validCount++;
           }
@@ -1981,7 +1982,7 @@ const ThreeScene = (() => {
         // get the original instance ID, then fetches the matrix at that index.
         const visibleIndicesBuffer = instancedArray(validCount, 'uint');
 
-        // Indirect draw struct — written by reset+cull computes, consumed by
+        // Indirect draw struct: written by reset+cull computes, consumed by
         // `drawIndexedIndirect`. Layout follows the WebGPU indexed-draw spec:
         // [indexCount, instanceCount, firstIndex, baseVertex, firstInstance].
         // `instanceCount` is atomic so concurrent threads can append safely.
@@ -1995,7 +1996,7 @@ const ThreeScene = (() => {
         }, `IndirectDraw_${meta.name}`);
         const drawStorage = storage(indirectAttribute, indirectStruct, 1);
 
-        // (init compute) Run once at scene setup — writes the static draw
+        // (init compute) Run once at scene setup; writes the static draw
         // fields (everything except instanceCount, which the cull pass owns).
         const baseGeoIndexCount = baseGeo.index ? baseGeo.index.count : baseGeo.attributes.position.count;
         const initFn = Fn(() => {
@@ -2016,7 +2017,7 @@ const ThreeScene = (() => {
         // (cull compute) Per frame, N threads (one per instance). Each thread
         // tests its instance's bounding sphere against TWO 6-plane frusta:
         // the camera frustum AND the sun's shadow frustum. The instance is
-        // visible if it passes either — that way off-screen buildings still
+        // visible if it passes either; that way off-screen buildings still
         // inside the shadow ortho box get into the indirect buffer and cast
         // shadows into the visible area (the original camera-only test
         // dropped them, making shadows pop at screen edges on pan).
@@ -2068,13 +2069,13 @@ const ThreeScene = (() => {
         mat.userData.visibleIndicesBuffer   = visibleIndicesBuffer;
         mat.userData.indirectAttribute      = indirectAttribute;
 
-        // Per-district geometry — clone the unit cube (sharing would tie all
+        // Per-district geometry: clone the unit cube (sharing would tie all
         // districts to a single indirect buffer) and wire up the indirect-
         // draw buffer. Critically NOT an `InstancedBufferGeometry`: when both
         // `instanceCount` and `setIndirect()` are set, Three.js picks the
         // former and silently ignores the indirect buffer. Regular
         // `BufferGeometry.clone()` + `setIndirect()` matches the canonical
-        // `webgpu_struct_drawindirect` example — instance count comes solely
+        // `webgpu_struct_drawindirect` example; instance count comes solely
         // from the indirect buffer's `instanceCount` field, which the cull
         // compute writes each frame.
         const geo = baseGeo.clone();
@@ -2087,8 +2088,9 @@ const ThreeScene = (() => {
         // Three.js's default frustum cull was already broken for our cube-
         // at-origin setup. The
         // storage-buffer pattern moves all positioning to the GPU, so the host
-        // bounding sphere is even more meaningless — disable cull explicitly
-        // until Phase 2B's compute pass owns visibility.
+        // bounding sphere is even more meaningless; disable cull explicitly.
+        // Visibility is owned by the Phase 2B cull compute pass writing the
+        // indirect buffer's instanceCount each frame.
         mesh.frustumCulled = false;
 
         group.add(mesh);
@@ -2121,15 +2123,15 @@ const ThreeScene = (() => {
   //
   //   0. Per-instance positioning + normals (vertex stage, via `geometryNode`)
   //      The buildings group is rendered as a non-instanced `Mesh` backed by
-  //      an `InstancedBufferGeometry` whose instance matrices live in an
-  //      `instancedArray` storage buffer (see `loadBuildings()`).
+  //      a regular `BufferGeometry` with an indirect draw buffer; the instance
+  //      matrices live in an `instancedArray` storage buffer (see `loadBuildings()`).
   //      `material.geometryNode` runs BEFORE the standard pipeline and
-  //      mutates `positionLocal`/`normalLocal` in place — the same pattern
+  //      mutates `positionLocal`/`normalLocal` in place, the same pattern
   //      `InstanceNode.setup()` uses for `InstancedMesh`. After it runs
   //      every downstream computation (positionWorld, normalView, lighting,
   //      shadow depth) sees the instance-transformed values automatically.
-  //      Phase 2B compute culling will slot a `visibleIndices` lookup
-  //      between `instanceIndex` and the matrix fetch with no other changes.
+  //      Phase 2B compute culling slots a `visibleIndices` lookup between
+  //      `instanceIndex` and the matrix fetch (see the dereference below).
   //
   //   1. `_m.dds` surface modulation (pre-lighting, via `colorNode`)
   //      Original GLSL hook: `#include <color_fragment>`
@@ -2137,7 +2139,7 @@ const ThreeScene = (() => {
   //      and multiplies the diffuse colour. Because `geometryNode` already
   //      put the instance-transformed position into `positionLocal`,
   //      `positionWorld` (= modelWorldMatrix · positionLocal) gives the
-  //      correct world position automatically — same code path as Phase 1.
+  //      correct world position automatically; same code path as Phase 1.
   //
   //   2. Edge highlight (pre-lighting, via `colorNode`)
   //      The game's gbuffer shader lerps EdgeColor into the ALBEDO before
@@ -2159,16 +2161,16 @@ const ThreeScene = (() => {
     const uOffset        = uniform(new THREE.Vector2(meta.offset[0], meta.offset[1]));
     const uEdgeColor     = uniform(readThemeColor('--scene-buildings-edge', '#ffffff'));
     // Edge highlight constants, decoded from 3d_map_cubes.mt (per-district):
-    //   uEdgeSharpness — EdgeSharpnessPower (30 / 50): the exponent of the
+    //   uEdgeSharpness = EdgeSharpnessPower (30 / 50): the exponent of the
     //                  pow(X, power) edge gradient.
-    //   uEdgeCamCoeff — the camera-distance widening, k = camDist·0.002·
+    //   uEdgeCamCoeff: the camera-distance widening, k = camDist·0.002·
     //                  EdgeThickness, pre-divided by cubeSize (the game divides
-    //                  by the per-face world size; cubeSize is its stand-in —
+    //                  by the per-face world size; cubeSize is its stand-in;
     //                  the term is sub-pixel at map zoom regardless).
     const uEdgeSharpness = uniform(meta.edgeSharpness);
     const uEdgeCamCoeff = uniform(NCZ.BUILDING_EDGE_CAMDIST_K * meta.edgeThickness / meta.cubeSize);
     // Edge "glow": when on, the edge highlight is also written to emissiveNode
-    // so it stays lit regardless of sun/shadow — neon, strongest at dawn/dusk
+    // so it stays lit regardless of sun/shadow: neon, strongest at dawn/dusk
     // (a true halo needs the bloom pass; this is the cheap self-lit version).
     // Binary on/off at the fixed NCZ.EDGE_GLOW_INTENSITY; per-theme default from
     // --scene-edge-glow, overridable via the Settings toggle (_edgeGlowOn).
@@ -2176,19 +2178,19 @@ const ThreeScene = (() => {
     // uEdgeColor + uEdgeGlow need runtime mutation (theme rewire / flyover tweens).
     mat.userData.tslUniforms = { uEdgeColor, uEdgeGlow };
 
-    // (0) Per-instance positioning + normals — explicit space transforms.
+    // (0) Per-instance positioning + normals: explicit space transforms.
     //
     // `material.normalNode` is consumed by `NodeMaterial.setupNormal()` as:
-    //   `vec3(this.normalNode).normalize()` — used DIRECTLY for lighting
+    //   `vec3(this.normalNode).normalize()`, used DIRECTLY for lighting
     //   without any further matrix transforms. So whatever we provide must
     //   already be in VIEW space.
     //
     // Composition:
-    //   1. `transformNormal(normalLocal, instMatrix)` — applies the instance
+    //   1. `transformNormal(normalLocal, instMatrix)`: applies the instance
     //      matrix to the local normal using the inverse-transpose form
     //      (handles non-uniform building scale). Output is in WORLD space
     //      because our matrices encode world transforms (group at origin).
-    //   2. `transformNormalToView(...)` — applies modelNormalMatrix
+    //   2. `transformNormalToView(...)`: applies modelNormalMatrix
     //      (identity for our group) and cameraViewMatrix.transformDirection
     //      to take world → view. This is the same helper Three.js uses
     //      internally for the default `normalLocal → normalView` path.
@@ -2196,7 +2198,7 @@ const ThreeScene = (() => {
     // Earlier attempts that set `normalNode` directly to a world-space
     // value (via `transformNormal` alone or `mat3(M).mul(normalLocal)`)
     // produced view-dependent lighting because lighting was computing
-    // dot(world_normal, view_lightDir) — values in different coordinate
+    // dot(world_normal, view_lightDir), values in different coordinate
     // spaces.
     // Phase 2B: `instanceIndex` is the COMPACTED draw index (0..visibleCount).
     // We dereference through `visibleIndicesBuffer` to get the original
@@ -2208,11 +2210,11 @@ const ThreeScene = (() => {
     const worldNormal = transformNormal(normalLocal, instMatrix); // also drives the _m slope guard below
     mat.normalNode   = transformNormalToView(worldNormal);
 
-    // World-space planar UV — XZ plane, normalised against the district's CET
+    // World-space planar UV: XZ plane, normalised against the district's CET
     // bounds. Original GLSL: vMUv = ((wx - off.x - min.x)/(max.x - min.x),
     //                                (-wz - off.y - min.y)/(max.y - min.y))
     // We read the instance-transformed world position directly from the
-    // matrix multiplication chain rather than `positionWorld` — under WebGPU
+    // matrix multiplication chain rather than `positionWorld`; under WebGPU
     // with a custom `positionNode`, `positionWorld` evaluates to
     // `modelWorldMatrix · positionLocal` (without the instance transform).
     const instWorldPos4 = instMatrix.mul(vec4(positionLocal, 1));
@@ -2224,14 +2226,14 @@ const ThreeScene = (() => {
     );
 
     // Sloped-face guard: ~12.5% of instances have oblique quaternions
-    // (_data.dds census — 32k of 255k tilted >2° off any 90° multiple), and on
+    // (_data.dds census: 32k of 255k tilted >2° off any 90° multiple), and on
     // their slanted faces the fragment-position planar UV paints a recognisable
-    // 2-D patch of the district map — a top-down projection landing on a
+    // 2-D patch of the district map: a top-down projection landing on a
     // non-horizontal surface. The game has the same latent artifact (its
     // vertical-AO gbuffer term ships disabled, and its near-top-down map camera
     // never shows walls), but our tilting camera does. Steep faces therefore
-    // sample _m at the instance's own centre instead — each building's walls
-    // and slopes carry their own roof texel, which cannot image — blended by
+    // sample _m at the instance's own centre instead (each building's walls
+    // and slopes carry their own roof texel, which cannot image), blended by
     // the world normal's up-ness so flat roofs keep the exact decoded planar
     // sample.
     const instCenter4 = instMatrix.mul(vec4(0, 0, 0, 1)); // unit-cube origin = box centre
@@ -2246,20 +2248,20 @@ const ThreeScene = (() => {
     );
     const mUv = mix(centerUv, planarUv, upness);
 
-    // (1) Diffuse modulation — sample _m, scale base colour. The game's
+    // (1) Diffuse modulation: sample _m, scale base colour. The game's
     // gbuffer shader applies `surface = 0.4 + 0.5·m` to the albedo (decoded from
     // a PIX capture; the shader's vertical-AO term is disabled by the default
     // DebugScaleOffset, so it collapses to floor+range).
     const mVal = texture(mTex, mUv.clamp(0, 1)).r;
     const modulation = float(NCZ.BUILDING_TEX_FLOOR).add(mVal.mul(NCZ.BUILDING_TEX_RANGE));
 
-    // (2) Edge highlight — the decoded game algorithm with fwidth AA standing
+    // (2) Edge highlight: the decoded game algorithm with fwidth AA standing
     // in for the game's TAA (see `buildingEdgeCoverage`). The game lerps the
     // edge into the gbuffer ALBEDO before lighting, so we mix on `colorNode`,
     // before the _m modulation, to match. `camTerm` = the game's
     // camDist·0.002·EdgeThickness/cubeSize widening.
     //
-    // The game's edge tint is `EdgeColor · 2 · luma(BaseColorScale)` — a
+    // The game's edge tint is `EdgeColor · 2 · luma(BaseColorScale)`, a
     // brightness boost that drives the rim toward (clamped) white. The HUE
     // stays theme-driven (uEdgeColor); only the 2·luma scale is the game's.
     // Dropping it (an earlier port did) leaves the rim far too dim vs the
@@ -2282,11 +2284,11 @@ const ThreeScene = (() => {
     return mat;
   }
 
-  // District line materials — stored so resolution can be updated on resize
+  // District line materials, stored so resolution can be updated on resize
   const districtLineMaterials = [];
 
   // Per-ring stencil refs for the joint self-overlap dedup (see
-  // district-line-material.js header). Values 3..255 — 1 (OCCLUDER) and 2
+  // district-line-material.js header). Values 3..255; 1 (OCCLUDER) and 2
   // (water) belong to the scene's SeeThrough stencil chain. Cycling is safe:
   // a collision would need two rings ~253 build-order apart sharing a border.
   let _nextLineStencilRef = 3;
@@ -2298,13 +2300,13 @@ const ThreeScene = (() => {
 
   // Drop consecutive ring vertices within ε CET units of each other. The
   // cleanup script (scripts/regenerate_subdistricts.py) runs Shapely boolean
-  // ops on subdistrict polygons and rounds the output to 2 decimal places —
+  // ops on subdistrict polygons and rounds the output to 2 decimal places;
   // when two operation-produced vertices land within 0.01 wu of each other,
   // rounding collapses them to identical coordinates, leaving a zero-length
   // edge in the ring. Line2NodeMaterial's screen-space line shader divides by
   // `length(ndcEnd - ndcStart)` to get the segment direction; degenerate
   // (or sub-pixel after projection) edges produce NaN/Inf direction vectors,
-  // which render as long colored rays across the viewport at close zoom.
+  // which render as long coloured rays across the viewport at close zoom.
   //
   // ε = 0.1 wu catches only the literally-degenerate cases observed in
   // data/subdistricts.json (0.000, 0.010, 0.020 wu edges in badlands subs);
@@ -2340,11 +2342,11 @@ const ThreeScene = (() => {
   // unstable for equal-distance coplanar lines, so the hovered (bright) line is
   // not guaranteed to paint last and a faint 0.05 neighbour can overdraw its
   // edges. The hover code promotes the hovered line's renderOrder to force it
-  // last — see setHoveredDistrict / DISTRICT_HOVER_RENDER_ORDER.
+  // last; see setHoveredDistrict / DISTRICT_HOVER_RENDER_ORDER.
   function buildLine(ring, color, lineWidth) {
     const cleaned = dedupRing(ring);
     if (cleaned.length < 3) {
-      // Degenerate polygon after dedup — can't draw a meaningful ring. Build
+      // Degenerate polygon after dedup; can't draw a meaningful ring. Build
       // an empty Line2 so the caller's group structure is preserved.
       const empty = new LineGeometry();
       empty.setPositions([]);
@@ -2361,7 +2363,7 @@ const ThreeScene = (() => {
     const geometry = new LineGeometry();
     geometry.setPositions(positions);
 
-    // Our own TSL wide-line material (#775) — real alpha blending instead of
+    // Our own TSL wide-line material (#775): real alpha blending instead of
     // Line2NodeMaterial's NoBlending + opaque-backdrop fake, which was the
     // shared root of the #771 resize wedge, the unhovered colour regression
     // and the alphaToCoverage quantisation. Reads the viewport from a TSL
@@ -2387,11 +2389,11 @@ const ThreeScene = (() => {
   // whole-city framing. Replaces the old fitCameraToBox opening: that fit
   // distance always exceeded controls.maxDistance (the terrain box is far
   // taller than the ~6650 wu the FOV can frame at maxDistance), so the map
-  // silently opened fully zoomed out — the "opens too far" bug E5 closes.
+  // silently opened fully zoomed out: the "opens too far" bug E5 closes.
 
   // Camera pose for the intro: position offset from the framing target by
   // `distance` at `tiltDeg` off vertical, along the fixed intro azimuth.
-  // The target is SCHEMA_INTRO_REST_CENTER ([cetX, cetY]) or world centre —
+  // The target is SCHEMA_INTRO_REST_CENTER ([cetX, cetY]) or world centre:
   // the same point for the start and rest poses, so the fly-in is a straight
   // top-down descent with no sideways pan. (Three spherical: phi = polar
   // angle from +Y, theta = azimuth.)
@@ -2414,7 +2416,7 @@ const ThreeScene = (() => {
     u < 0.5 ? 4 * u * u * u : 1 - Math.pow(-2 * u + 2, 3) / 2;
 
   // Start the intro fly-in. When a ?mod= deep-link is present the intro is
-  // skipped — the camera snaps straight to the rest pose so app.js's
+  // skipped; the camera snaps straight to the rest pose so app.js's
   // deep-link handler flies to the pin from a sensible whole-city framing.
   function playIntro() {
     if (!controls || !camera) return;
@@ -2441,7 +2443,7 @@ const ThreeScene = (() => {
   }
 
   // Advance the intro fly-in one frame. Called at the top of frame() so
-  // the camera mutation lands before controls.update() reconciles it — that
+  // the camera mutation lands before controls.update() reconciles it; that
   // reconcile fires the 'change' listener, refreshing district zoom, metro
   // LOD, the shadow camera, scale bar and cull frustum as the camera moves.
   function updateIntroTween() {
@@ -2462,12 +2464,12 @@ const ThreeScene = (() => {
 
   const tiltDisplay = document.getElementById('scene-tilt-display');
 
-  // Debug instrumentation — only active when URL has ?debug=1.
+  // Debug instrumentation: only active when URL has ?debug=1.
   // stats.js panels (vertical stack, all visible): FPS / MS / MB / draw calls / triangles.
   const DEBUG_MODE = new URLSearchParams(window.location.search).has('debug');
   let stats = null, statsCallsPanel = null, statsTrisPanel = null;
 
-  // Rolling time-based buffer of frame intervals — feeds dumpDebugInfo() with
+  // Rolling time-based buffer of frame intervals; feeds dumpDebugInfo() with
   // avg/p50/p95. The window is *time*, not frame count: a count-based cap was
   // 0.4s on a 280fps machine and 4s on a 15fps machine, defeating the point of
   // a "wait a few seconds and click" workflow. 5s is enough to smooth jitter
@@ -2483,7 +2485,7 @@ const ThreeScene = (() => {
     // Anchor inside #map-3d so the panel sits below the page header automatically,
     // regardless of header height. top-right keeps it clear of the scene-tilt display.
     // Flex-column stacks the visible panels vertically so the rightmost ones don't
-    // overflow into the viewport edge — Stats.addPanel()'d entries (Calls, Tris/k)
+    // overflow into the viewport edge; Stats.addPanel()'d entries (Calls, Tris/k)
     // bypass the built-in showPanel(0) cycling and stay permanently visible.
     stats.dom.style.position      = 'absolute';
     stats.dom.style.top           = '16px';
@@ -2495,17 +2497,17 @@ const ThreeScene = (() => {
     stats.dom.style.gap           = '4px';
     // pointer-events:none disables stats.js's built-in click-to-cycle handler
     // (so all panels stay visible always) AND lets mouse drags pass through
-    // to the canvas underneath — useful since the panel sits over the 3D map.
+    // to the canvas underneath, useful since the panel sits over the 3D map.
     stats.dom.style.pointerEvents = 'none';
     statsCallsPanel = stats.addPanel(new Stats.Panel('Calls',  '#ff8', '#221'));
     statsTrisPanel  = stats.addPanel(new Stats.Panel('Tris/k', '#f8f', '#212'));
-    // Force every panel visible — the constructor calls showPanel(0) which
+    // Force every panel visible; the constructor calls showPanel(0) which
     // hides MS and MB. We want all five (FPS / MS / MB / Calls / Tris/k) on
     // screen at once so the user can read every metric without interaction.
     for (const child of stats.dom.children) child.style.display = 'block';
     container.appendChild(stats.dom);
 
-    // "Copy debug info" button — sits below the 5 stats panels.
+    // "Copy debug info" button: sits below the 5 stats panels.
     // Stats height: 5 × 48px panels + 4 × 4px gaps = 256px → button starts at 16+256+8 = 280px.
     const dumpBtn = document.createElement('button');
     dumpBtn.textContent  = 'Copy debug info';
@@ -2531,19 +2533,19 @@ const ThreeScene = (() => {
     console.log('  NCZ.ThreeScene.dumpDebugInfo()       → full diagnostic snapshot (also bound to the "Copy debug info" button)');
   }
 
-  // Render-on-demand over renderer.setAnimationLoop — the WebGPU-native frame
+  // Render-on-demand over renderer.setAnimationLoop: the WebGPU-native frame
   // driver (issue #768; the WebGL-era manual rAF chain is retired). The loop
   // fn stays armed while work exists and early-returns on non-dirty ticks;
   // after IDLE_DISARM_MS of consecutive idle ticks it disarms itself via
   // setAnimationLoop(null), so a truly idle map costs zero renders AND zero
-  // rAF wakeups. requestRender() marks the frame dirty and re-arms — hook it
+  // rAF wakeups. requestRender() marks the frame dirty and re-arms; hook it
   // into any state mutation that affects pixels. The grace window (rather
   // than disarm-on-first-idle-tick) keeps bursty input (wheel ticks, hover
   // in/out) on a warm loop instead of churning setAnimationLoop.
   // Damping continuation is detected from controls.update()'s return value
   // (true = state still interpolating).
   //
-  // _suppressed — flyover stops the schema loop and drives frames through
+  // _suppressed: flyover stops the schema loop and drives frames through
   // _flyoverFrame (setFlyoverFrame below) on this same animation loop. Beat-
   // driven transitionToColors still fires requestRender during the flyover,
   // which would otherwise mark the schema path dirty and race the flyover
@@ -2556,7 +2558,7 @@ const ThreeScene = (() => {
   let _loopArmed = false;
   let _idleSince = 0;
   let _flyoverFrame = null;   // showcase per-frame callback; loop persists while set
-  let _framesRendered = 0;    // lifetime renderer.render count — idle verification
+  let _framesRendered = 0;    // lifetime renderer.render count; idle verification
 
   function armLoop() {
     if (_loopArmed || !renderer) return;
@@ -2573,14 +2575,14 @@ const ThreeScene = (() => {
   function frame(time) {
     if (_flyoverFrame) { _flyoverFrame(time); return; }
     if (_suppressed || (!_frameDirty && _continuousRenderRefs === 0)) {
-      // Idle tick — nothing changed since the last render. Disarm once the
+      // Idle tick: nothing changed since the last render. Disarm once the
       // grace window has passed with no new work.
       if ((time ?? performance.now()) - _idleSince > IDLE_DISARM_MS) disarmLoop();
       return;
     }
     _frameDirty = false;
     if (stats) stats.begin();
-    updateIntroTween();   // E5 intro fly-in — mutate the camera before controls.update() reconciles
+    updateIntroTween();   // E5 intro fly-in: mutate the camera before controls.update() reconciles
     stepDistrictHoverFade(performance.now()); // district outline opacity tween
     const dampingActive = controls.update();
     // Phase 2B: dispatch per-district reset+cull computes BEFORE render.
@@ -2605,7 +2607,7 @@ const ThreeScene = (() => {
       stats.end();
     }
     // Frame-time sampling for dumpDebugInfo(). Cap dt so a long idle gap
-    // between render-on-demand frames doesn't poison the rolling average —
+    // between render-on-demand frames doesn't poison the rolling average;
     // anything over 1s is treated as "loop was paused, ignore this delta".
     const _now = performance.now();
     if (_lastFrameTime) {
@@ -2631,7 +2633,7 @@ const ThreeScene = (() => {
     else _idleSince = performance.now();
   }
 
-  // Schedule one frame. Idempotent — multiple calls within the same tick
+  // Schedule one frame. Idempotent: multiple calls within the same tick
   // collapse to a single dirty flag. Hook into any state change that affects
   // pixels. Re-arms the animation loop if it has idle-disarmed.
   function requestRender() {
@@ -2642,8 +2644,8 @@ const ThreeScene = (() => {
   }
 
   // Hold the loop open across an arbitrary number of frames. Counter-based so
-  // multiple animations (theme dissolve + sun arc + beat pulse) compose cleanly
-  // — each pairs a true/false call. Flyover doesn't use this; it bypasses the
+  // multiple animations (theme dissolve + sun arc + beat pulse) compose cleanly;
+  // each pairs a true/false call. Flyover doesn't use this; it bypasses the
   // schema frame body entirely via its setFlyoverFrame callback.
   function setContinuousRender(active) {
     _continuousRenderRefs = Math.max(0, _continuousRenderRefs + (active ? 1 : -1));
@@ -2651,7 +2653,7 @@ const ThreeScene = (() => {
   }
 
   // Showcase frame driver (issue #768). While a callback is set, the shared
-  // animation loop invokes it every tick instead of the schema frame body —
+  // animation loop invokes it every tick instead of the schema frame body;
   // a cinematic is continuous by nature, so no dirty flag and no idle disarm.
   // Clearing it falls back to the schema path, which (still _suppressed until
   // startRenderLoop) idles out through the normal grace window.
@@ -2660,18 +2662,18 @@ const ThreeScene = (() => {
     if (_flyoverFrame) armLoop();
   }
 
-  // Backward-compat shims — external callers (app.js view switch, flyover
+  // Backward-compat shims: external callers (app.js view switch, flyover
   // restart) still talk to start/stop. start = "ensure at least one frame
   // renders soon" which on-demand satisfies via a single requestRender.
   // start also clears the flyover suppression flag in case stopRenderLoop
   // was the call that engaged it; stop sets it so any in-flight requestRender
-  // (e.g. from a still-running color tween) doesn't mark the schema path dirty.
+  // (e.g. from a still-running colour tween) doesn't mark the schema path dirty.
   function startRenderLoop() {
     _suppressed = false;
     // The showcase flyover fits the shadow camera, the cull-frustum uniforms,
     // and the metro LOD pseudo-zoom to its own PerspectiveCamera (renderFrame
     // below). When it hands control back, snap all three back to the schema
-    // camera's view before the next schema frame — otherwise the cull's first
+    // camera's view before the next schema frame; otherwise the cull's first
     // post-showcase dispatch would test against the flyCamera's last frustum
     // and the metro LOD would be stuck on the synthetic perspective zoom
     // until the user moved the camera (firing the controls 'change' reset).
@@ -2686,7 +2688,7 @@ const ThreeScene = (() => {
   function stopRenderLoop() {
     _suppressed = true;
     _frameDirty = false;
-    // Disarm now unless the flyover is (about to be) driving frames — in the
+    // Disarm now unless the flyover is (about to be) driving frames; in the
     // flyover start sequence setFlyoverFrame() follows immediately and re-arms.
     if (!_flyoverFrame) disarmLoop();
     _lastFrameTime = 0; // Reset so the next frame after restart doesn't sample the gap
@@ -2694,11 +2696,11 @@ const ThreeScene = (() => {
 
   // ── Debug helpers (always exposed; useful from DevTools console) ───────
 
-  // Snapshot of renderer.info — counts that explain CPU vs GPU bottlenecks.
+  // Snapshot of renderer.info: counts that explain CPU vs GPU bottlenecks.
   function getRenderInfo() {
     if (!renderer) return null;
     return {
-      // Lifetime count of frames actually rendered (schema + flyover) — poll
+      // Lifetime count of frames actually rendered (schema + flyover); poll
       // twice to verify render-on-demand idles at zero (issue #768 acceptance).
       framesRendered: _framesRendered,
       drawCalls:  renderer.info.render.calls,
@@ -2715,7 +2717,7 @@ const ThreeScene = (() => {
 
   // Phase 2B cull-effectiveness probe. `renderer.info.render.triangles` is
   // CPU-computed and never round-trips the indirect buffer's atomic
-  // instanceCount, so it reads 0 under indirect draws — the only way to know
+  // instanceCount, so it reads 0 under indirect draws; the only way to know
   // how many building instances actually survive the compute frustum cull is
   // to read the GPU copy back. `getArrayBufferAsync` maps the storage buffer
   // to the CPU; index [1] of the 5-uint IndirectDraw struct is instanceCount.
@@ -2725,7 +2727,7 @@ const ThreeScene = (() => {
     const byDistrict = [];
     let total = 0, visible = 0;
     // buildingMeshes and buildingMaterials are pushed in lockstep in loadBuildings,
-    // so the index aligns — use it for the district name (`buildings-<district>`).
+    // so the index aligns; use it for the district name (`buildings-<district>`).
     for (let i = 0; i < buildingMaterials.length; i++) {
       const mat  = buildingMaterials[i];
       const attr = mat.userData.indirectAttribute;
@@ -2755,7 +2757,7 @@ const ThreeScene = (() => {
     requestRender();
   }
 
-  // Comprehensive diagnostic snapshot — bound to the "Copy debug info" button
+  // Comprehensive diagnostic snapshot, bound to the "Copy debug info" button
   // and exposed for console use. Logs human-readable text, copies it to the
   // clipboard, and returns the structured object for programmatic use.
   function dumpDebugInfo() {
@@ -2775,7 +2777,7 @@ const ThreeScene = (() => {
       };
     }
 
-    // GPU details — two paths:
+    // GPU details (two paths):
     //   WebGPU: pull from the cached GPUAdapterInfo on the backend adapter.
     //           WGSL spec exposes `vendor` and `architecture`/`description`;
     //           Three.js caches whatever the browser surfaces at adapter request.
@@ -2785,12 +2787,12 @@ const ThreeScene = (() => {
     if (renderer) {
       try {
         if (renderer.isWebGPURenderer) {
-          // r184's WebGPUBackend keeps the GPUAdapter local to init() — it's not
+          // r184's WebGPUBackend keeps the GPUAdapter local to init(); it's not
           // on `renderer.backend`. The device, however, exposes `adapterInfo`
           // (spec-stable GPUDevice.adapterInfo). Chrome's anti-fingerprinting
           // policy blanks `device`/`description` for non-allowlisted origins, but
           // `vendor` ("nvidia", "amd"…) and `architecture` ("blackwell", "rdna3"…)
-          // still come through — same caveat the WebGL2 path's UNMASKED_* had.
+          // still come through; same caveat the WebGL2 path's UNMASKED_* had.
           const adapterInfo = renderer.backend?.device?.adapterInfo;
           if (adapterInfo) {
             gpu    = adapterInfo.description || adapterInfo.architecture || 'unknown';
@@ -2799,7 +2801,7 @@ const ThreeScene = (() => {
           const limits = renderer.backend?.device?.limits;
           if (limits) {
             maxTexture = limits.maxTextureDimension2D ?? '?';
-            // No direct renderbuffer limit in WebGPU — use storage-buffer binding size
+            // No direct renderbuffer limit in WebGPU; use storage-buffer binding size
             // as the closest analogue; surfaces under the same "how big can a single
             // GPU resource be" question as the WebGL value.
             maxRb      = limits.maxStorageBufferBindingSize ?? '?';
@@ -2814,7 +2816,7 @@ const ThreeScene = (() => {
           maxTexture = gl.getParameter(gl.MAX_TEXTURE_SIZE);
           maxRb      = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE);
         }
-      } catch (_) { /* introspection unavailable — leave defaults */ }
+      } catch (_) { /* introspection unavailable; leave defaults */ }
     }
 
     const shadowTypeNames = ['BasicShadowMap', 'PCFShadowMap', 'PCFSoftShadowMap', 'VSMShadowMap'];
@@ -2825,20 +2827,20 @@ const ThreeScene = (() => {
         // Per Three.js Info.js: `info.render.calls` = lifetime render() calls,
         // `info.render.frameCalls` = current-frame render() calls (usually 1),
         // `info.render.drawCalls` = current-frame DRAW count. Earlier Phase 1
-        // code mislabelled `calls` as "drawCalls" — it's the lifetime render
+        // code mislabelled `calls` as "drawCalls"; it's the lifetime render
         // counter, not the per-frame draw counter.
         drawCallsThisFrame: renderer.info.render.drawCalls ?? 0,
         rendersTotal:       renderer.info.render.calls,
         triangles:    renderer.info.render.triangles,
         lines:        renderer.info.render.lines,
         // Compute stats live at `info.compute.{calls, frameCalls}` on
-        // WebGPURenderer — NOT under `info.render`. WebGL2 fallback has
+        // WebGPURenderer, NOT under `info.render`. WebGL2 fallback has
         // neither, so we coalesce to 0.
         computeTotal:      renderer.info.compute?.calls ?? 0,
         computeFrameCalls: renderer.info.compute?.frameCalls ?? 0,
         geometries:   renderer.info.memory.geometries,
         textures:     renderer.info.memory.textures,
-        // Indirect-storage-buffer bytes — confirms Phase 2B's draw buffers
+        // Indirect-storage-buffer bytes: confirms Phase 2B's draw buffers
         // (5 u32s × 8 districts = 160 bytes minimum) are allocated.
         indirectBufferBytes: renderer.info.memory.indirectStorageAttributesSize ?? 0,
         // WebGPU exposes the compiled-pipeline count at info.memory.programs
@@ -2847,7 +2849,7 @@ const ThreeScene = (() => {
       } : null,
       rendererSettings: renderer ? {
         pixelRatio:     renderer.getPixelRatio(),
-        // No `getContextAttributes()` on WebGPURenderer — track from constructor
+        // No `getContextAttributes()` on WebGPURenderer; track from constructor
         // params via a sentinel set at init time. Falls back to the legacy path
         // for WebGL2 where the WebGL context exposes these directly.
         antialias:      _webgpuActive
@@ -2901,7 +2903,8 @@ const ThreeScene = (() => {
         lines.push(`Compute:       (none — running on WebGL2 fallback?)`);
       }
       lines.push(`Triangles:     ${dump.render.triangles.toLocaleString()}`);
-      // Programs is WebGL2-only — show "n/a" rather than "null" under WebGPU.
+      // info.memory.programs counts compiled pipelines on both backends;
+      // "n/a" covers dumps captured before any pipeline compiled.
       const programsField = dump.render.programs == null ? 'n/a (WebGPU)' : dump.render.programs;
       lines.push(`Geometries:    ${dump.render.geometries}    Textures: ${dump.render.textures}    Programs: ${programsField}`);
       if (dump.render.indirectBufferBytes > 0) {
@@ -2925,7 +2928,7 @@ const ThreeScene = (() => {
     // Brave, etc.); Firefox and Safari return undefined, which falls through to "unknown".
     // Where it IS supported, the value is quantised to the largest power of 2 strictly less
     // than the actual RAM (spec caps at 8 GB; Chromium ignores the cap but still applies the
-    // rounding — verified by user reports of 64 GB → 32 and 16 GB → 8). The actual RAM
+    // rounding, verified by user reports of 64 GB → 32 and 16 GB → 8). The actual RAM
     // therefore lies in (reported, 2 × reported]; we display that half-open range so readers
     // don't misread the floor as a precise figure. Phrased as "browser reports …" rather
     // than naming Chrome, since the rounding is observable in every Chromium variant.
@@ -2954,14 +2957,13 @@ const ThreeScene = (() => {
   // ── WebGPU diagnostic probe (?webgpuprobe) ─────────────────────────────
   // Three.js collapses every WebGPU negotiation failure into one opaque log
   // line ("WebGPU is not available, running under WebGL2 backend"), and r184's
-  // WebGPUBackend keeps the GPUAdapter local to its init() — so post-init we
+  // WebGPUBackend keeps the GPUAdapter local to its init(), so post-init we
   // can't see *why* it bailed. This pre-init probe replicates the exact
   // adapter/device requests Three.js makes and surfaces the real rejection.
   //
-  // Output convention follows the project's devtools `copy()` debug pattern
-  // (see learnings/shadowtrace-spacebar-marker-pattern): the full text is
+  // Output convention follows the project's devtools `copy()` debug pattern: the full text is
   // stashed on window.__webgpuProbe so the tester runs `copy(__webgpuProbe)`
-  // and pastes it back — no clipboard user-gesture needed at page load.
+  // and pastes it back; no clipboard user-gesture needed at page load.
   async function runWebGPUProbe() {
     const lines = [];
     const log = (s) => lines.push(s);
@@ -3042,7 +3044,7 @@ const ThreeScene = (() => {
           log('  → REJECTED. name=' + err.name + '  message=' + err.message);
         }
 
-        // (5) Contrast control — does the device come up at all without limits?
+        // (5) Contrast control: does the device come up at all without limits?
         log('');
         log('requestDevice() (no requiredLimits — contrast control):');
         try {
@@ -3086,26 +3088,26 @@ const ThreeScene = (() => {
       '[NCZ] WebGPU probe complete. Run  copy(__webgpuProbe)  in this console ' +
       'to copy it, then paste it back.\n\n' + text
     );
-    // Opportunistic — works if the page happens to be focused; the
+    // Opportunistic: works if the page happens to be focused; the
     // copy(__webgpuProbe) path above is the reliable one at page load.
     if (navigator.clipboard && navigator.clipboard.writeText) {
       navigator.clipboard.writeText(text).then(
         () => console.log('[NCZ] WebGPU probe — also copied to clipboard ✓'),
-        ()  => { /* expected without a user gesture — use copy(__webgpuProbe) */ }
+        ()  => { /* expected without a user gesture; use copy(__webgpuProbe) */ }
       );
     }
   }
 
   // ── Flyover API ────────────────────────────────────────────────────────
-  // Called by flyover.js — kept minimal to avoid exposing internals.
+  // Called by flyover.js; kept minimal to avoid exposing internals.
 
   function renderFrame(cam) {
     if (!renderer || !scene) return;
-    // The showcase flyover renders through its own PerspectiveCamera —
+    // The showcase flyover renders through its own PerspectiveCamera;
     // re-fit the shadow camera AND the cull-frustum uniforms to *its* view
     // each frame (the schema frame body is suppressed during showcase, so
     // nothing else is keeping these in sync). Then dispatch the per-frame
-    // Phase 2B cull computes the same way frame() does — without this,
+    // Phase 2B cull computes the same way frame() does; without this,
     // the indirect buffer's instanceCount is frozen at whatever the schema
     // cam last culled, so both the shadow pass and the main pass draw a
     // stale building set (the original symptom: shadows missing under
@@ -3143,7 +3145,7 @@ const ThreeScene = (() => {
   function resetCamera() {
     if (!controls) return;
 
-    // Snap back to the E5 intro's rest pose — the whole-city framing the
+    // Snap back to the E5 intro's rest pose: the whole-city framing the
     // camera comes to rest at on first load. Cancel an in-flight intro
     // (and release its render-loop hold) if Reset is hit during the fly-in.
     if (_introTween) { _introTween = null; setContinuousRender(false); }
@@ -3189,13 +3191,13 @@ const ThreeScene = (() => {
     if (normalBordersMat) normalBordersMat.color.copy(readThemeColor('--overlay-road-border-color', '#1ec3c8'));
     if (metroMat)   metroMat.color.copy(readThemeColor('--overlay-metro-color',        '#dcaa28'));
 
-    // Update landmark material — its own --scene-landmarks colour. The game's
+    // Update landmark material: its own --scene-landmarks colour. The game's
     // monument meshes are a separate material from the building cubes; the
     // Preem Map mod recolours buildings but leaves the monuments vanilla, so
     // landmarks must be themed independently.
     if (landmarkMat) landmarkMat.color.copy(readThemeColor('--scene-landmarks', '#7a8fa0'));
 
-    // Update building materials — MeshLambertNodeMaterial.color + TSL edge-colour uniform
+    // Update building materials: MeshLambertNodeMaterial.color + TSL edge-colour uniform
     if (buildingMaterials.length) {
       const base = readThemeColor('--scene-buildings', '#7a8fa0');
       const edge = readThemeColor('--scene-buildings-edge', '#ffffff');
@@ -3205,7 +3207,7 @@ const ThreeScene = (() => {
         if (u?.uEdgeColor) u.uEdgeColor.value.copy(edge);
       }
       // Edge-glow uniforms handled by applyEdgeGlow() above (theme default /
-      // Settings override) — uses the fixed intensity, not the raw CSS number.
+      // Settings override); uses the fixed intensity, not the raw CSS number.
     }
     requestRender();
   }
@@ -3269,7 +3271,7 @@ const ThreeScene = (() => {
     return getColorBindings().map(({ key, cssVar, fallback }) => ({ key, cssVar, fallback }));
   }
 
-  // Snapshot current material colors — call before applyTheme so the old
+  // Snapshot current material colours; call before applyTheme so the old
   // values are captured for use as the "from" end of a transition lerp.
   function captureColors() {
     const snap = {};
@@ -3277,8 +3279,8 @@ const ThreeScene = (() => {
     return snap;
   }
 
-  // Lerp scene/material colors from a snapshot to explicit THREE.Color targets.
-  // Used by the flyover beat cycle — no CSS read, no building update, no overhead.
+  // Lerp scene/material colours from a snapshot to explicit THREE.Color targets.
+  // Used by the flyover beat cycle: no CSS read, no building update, no overhead.
   function transitionToColors(from, to, durationMs = 800) {
     if (!scene) return;
     const bindings = getColorBindings();
@@ -3294,10 +3296,11 @@ const ThreeScene = (() => {
     requestAnimationFrame(step);
   }
 
-  // Smoothly lerp scene/material colors from a captured snapshot to the
-  // current CSS custom property values (new theme already applied).
-  // Buildings snap immediately via updateMaterials(); only the main scene
-  // colors are lerped to keep the per-frame cost low.
+  // Smoothly lerp scene/material colours from a captured snapshot to the
+  // current CSS custom property values (the new theme is already applied,
+  // typically via updateMaterials()): each binding is reset to the snapshot
+  // and lerped to its new value. Every getColorBindings entry participates,
+  // buildings included.
   function transitionMaterials(from, durationMs = 1000) {
     if (!scene) return;
     const bindings = getColorBindings();
@@ -3328,7 +3331,7 @@ const ThreeScene = (() => {
   // So az=0 (south) → Z+; az=π/2 (west) → X-; az=-π/2 (east) → X+
   function setSunPosition(azimuthRad, altitudeRad) {
     // Store the requested state BEFORE the lights-exist guard. getSunElevation()
-    // — and the app.js UI-sync poll that reverse-maps it onto the sun slider —
+    // (and the app.js UI-sync poll that reverse-maps it onto the sun slider)
     // must see what was requested even when this call lands before init() has
     // built the lights (the slider's initial applySunTime fires that early).
     // When the request was dropped here instead, the poll read the placeholder
@@ -3351,7 +3354,7 @@ const ThreeScene = (() => {
     flagShadowUpdate();   // sun moved ⇒ re-render the shadow depth map next frame (no-op while shadows off)
 
     // Sun + ambient colour and intensity are fixed (calibrated to 3dmap.envparam,
-    // set once at light construction) — the in-game map has no time-of-day
+    // set once at light construction); the in-game map has no time-of-day
     // variation. The slider only moves the sun's direction, above.
 
     // Move the visible sun sphere (shown during showcase only).
@@ -3359,7 +3362,7 @@ const ThreeScene = (() => {
     if (_sunSphere) {
       const SUN_SPHERE_DIST = NCZ.SUN_SPHERE_DIST;
       const nx = -Math.cos(el) * Math.sin(az);
-      const ny =  Math.sin(el); // unclamped — terrain naturally occludes it at sunrise/sunset
+      const ny =  Math.sin(el); // unclamped; terrain naturally occludes it at sunrise/sunset
       const nz =  Math.cos(el) * Math.cos(az);
       _sunSphere.position.set(
         NCZ.WORLD_CX + nx * SUN_SPHERE_DIST,
@@ -3386,11 +3389,11 @@ const ThreeScene = (() => {
     if (!_dirLight || !renderCam) return;
     const shadowCam = _dirLight.shadow.camera;
 
-    // Two fit paths — the camera shapes are too different to share one.
+    // Two fit paths; the camera shapes are too different to share one.
     //
     // Schema cam (interactive top-down perspective with controls): sphere-fit.
     // Ray-cast NDC corners → Y=0 → bounding sphere (centroid + enclosing
-    // radius). Tight, sharp, matches the user's view, and — unlike the AABB —
+    // radius). Tight, sharp, matches the user's view, and (unlike the AABB)
     // rotation-invariant, so the texel size below stays constant as you orbit
     // and the texel snap holds. Always succeeds for the schema cam because
     // controls constrain tilt below horizontal, so corners always hit ground at
@@ -3400,14 +3403,14 @@ const ThreeScene = (() => {
     // schema cam when zoomed out past the cap: a WORLD-LOCKED cap-sized box (half =
     // `SHADOW_MAX_DISTANCE + GROUND_MARGIN`) centred on the world. Since that box
     // already spans the whole ~12 km world, there's no texel-density gain from
-    // following the camera — and a camera-following centre clamps toward a world
+    // following the camera, and a camera-following centre clamps toward a world
     // edge (leaving the far side unshadowed) and crawls. World-locking gives full
     // coverage and a static centre every frame; only the moving-sun crawl remains,
     // masked by the wider showcase PCF blur (`SHADOW_RADIUS_SHOWCASE`). Coarser
     // texels than the tight schema fit, but cinematic motion masks that.
     // (History: the fly cam previously used a forward-ray-to-ground + tHit-cap
     // fit to avoid the "shadow box pop" rect-fit caused at horizon-crossing
-    // waypoints — see shadow_trace_2/3.json; world-locking subsumes that.)
+    // waypoints, see shadow_trace_2/3.json; world-locking subsumes that.)
     let half, center;
     let rectValid = false;
     if (renderCam === camera && controls) {
@@ -3416,7 +3419,7 @@ const ThreeScene = (() => {
       if (rectValid && _groundSphereRadius > NCZ.SHADOW_MAX_DISTANCE) {
         // View is larger than the shadow map can cover (zoomed out). Capping a box
         // centred on the visible footprint turns it into a camera-tracking slice
-        // that leaves the rest of the world unshadowed — the "moving shadow box":
+        // that leaves the rest of the world unshadowed, the "moving shadow box":
         // the footprint centroid even clamps to a world corner at extreme tilt.
         // Instead, cover the WHOLE WORLD from its centre. The world half-diagonal
         // (~8564 wu) is ≤ cap+margin, so a cap-sized box centred here reaches every
@@ -3430,15 +3433,15 @@ const ThreeScene = (() => {
         center = _shadowScratchV.copy(_groundSphereCenter);
       } else {
         // Degenerate (shouldn't happen for the schema cam given controls.maxPolarAngle,
-        // but the safety net stays). World-centered fallback at the cap.
+        // but the safety net stays). World-centred fallback at the cap.
         half = NCZ.SHADOW_MAX_DISTANCE + NCZ.SHADOW_GROUND_MARGIN;
         center = _shadowScratchV.set(NCZ.WORLD_CX, 0, -NCZ.WORLD_CY);
       }
     } else {
-      // External cam (showcase fly cam) — world-locked box, same as the schema
+      // External cam (showcase fly cam): world-locked box, same as the schema
       // zoomed-out case above. The box is already cap-sized (half ≈ 9200 wu),
       // which spans the whole ~12 km world, so centring it on the camera buys no
-      // texel-density gain — it only risks clamping toward a world edge (leaving
+      // texel-density gain; it only risks clamping toward a world edge (leaving
       // the far side unshadowed) and crawling as the cam moves. World-locking
       // gives full coverage every frame and a static centre (only the moving-sun
       // crawl remains, masked by SHADOW_RADIUS_SHOWCASE). This replaces the old
@@ -3453,10 +3456,10 @@ const ThreeScene = (() => {
     center.x = Math.max(NCZ.WORLD_MIN_X, Math.min(NCZ.WORLD_MAX_X, center.x));
     center.z = Math.max(-NCZ.WORLD_MAX_Y, Math.min(-NCZ.WORLD_MIN_Y, center.z));
 
-    // Stabilisation (quantise size + texel-snap centre) — SCHEMA CAM ONLY.
+    // Stabilisation (quantise size + texel-snap centre): SCHEMA CAM ONLY.
     // Both steps assume a STATIC texel grid frame-to-frame: constant texelSize AND
     // a constant light-space basis. The interactive schema cam satisfies that (the
-    // sun only moves on a slider drag). The showcase fly cam does NOT — flyover.js
+    // sun only moves on a slider drag). The showcase fly cam does NOT: flyover.js
     // arcs the sun every frame (setSunPosition), so the snap basis (built from
     // _sunDir) rotates continuously; combined with the fly cam's far forward-
     // projected centre near the horizon, a tiny basis rotation swings center·snapX
@@ -3468,8 +3471,8 @@ const ThreeScene = (() => {
       // Quantise the box size to a multiplicative ladder so texelSize is
       // piecewise-constant. The snap only cancels swim while texelSize holds; the
       // sphere fit already keeps `half` constant under pan/azimuth (congruent
-      // footprint), but TILTING toward the horizon grows the footprint continuously
-      // — without this the grid rescales every frame and edges shimmer despite the
+      // footprint), but TILTING toward the horizon grows the footprint continuously;
+      // without this the grid rescales every frame and edges shimmer despite the
       // snap. Rounding UP to the next rung holds the box across a slow tilt/zoom,
       // trading continuous swim for the odd resolution step. Capped at the diagonal.
       const rung = Math.log(half) / Math.log(NCZ.SHADOW_SIZE_QUANTUM);
@@ -3510,7 +3513,7 @@ const ThreeScene = (() => {
     shadowCam.far  = NCZ.SHADOW_CAM_FAR;
     shadowCam.updateProjectionMatrix();
     // Normal-bias the receiver samples by a few shadow texels' worth of world
-    // units — scaled with the footprint so it's the same texel offset at every
+    // units, scaled with the footprint so it's the same texel offset at every
     // zoom (a constant world bias is too small zoomed out → grazing-sun acne
     // ["the wave" on flat terrain/water], too large zoomed in → shadows detach).
     _dirLight.shadow.normalBias = NCZ.SHADOW_NORMAL_BIAS_TEXELS * (2 * half / NCZ.SHADOW_MAP_SIZE);
@@ -3527,7 +3530,7 @@ const ThreeScene = (() => {
     _dirLight.target.position.copy(center);
     _dirLight.position.copy(center).addScaledVector(_sunDir, NCZ.SUN_DIST);
 
-    // Refresh the shadow-camera frustum planes that the union cull reads —
+    // Refresh the shadow-camera frustum planes that the union cull reads;
     // off-screen casters still inside this box need to make it into the
     // building indirect-draw buffer so their shadows land in view.
     updateShadowFrustumUniforms();
@@ -3535,13 +3538,13 @@ const ThreeScene = (() => {
     flagShadowUpdate();  // shadow camera/footprint moved ⇒ re-render the depth map next frame (no-op while shadows off)
   }
 
-  // Single chokepoint for "the shadow silhouette changed — re-render the depth map
+  // Single chokepoint for "the shadow silhouette changed: re-render the depth map
   // next frame." Under WebGPURenderer the shadow pass is gated by
   // light.shadow.needsUpdate (autoUpdate is held false at init), so this is the only
   // thing that schedules a shadow render. Gated on _shadowsOn: while the Shadows
   // overlay is off we never flag, so ShadowNode.updateBefore() early-returns and the
   // 4096² depth pass is skipped entirely. Call it wherever a shadow CASTER or the
-  // sun/shadow-camera moves — updateShadowCamera (camera/resize/terrain/flyover/
+  // sun/shadow-camera moves: updateShadowCamera (camera/resize/terrain/flyover/
   // re-enable), setSunPosition, async caster loads (buildings, landmarks). NOT on
   // theme/colour changes: shadow depth is geometry-only, so those frames skip it.
   function flagShadowUpdate() {
@@ -3550,7 +3553,7 @@ const ThreeScene = (() => {
 
   function setShadowsEnabled(enabled) {
     _shadowsOn = enabled;
-    // Genuinely SKIP the shadow depth pass when off — not just dim it — without
+    // Genuinely SKIP the shadow depth pass when off (not just dim it) without
     // tearing down the depth texture (toggling castShadow / renderer.shadowMap.
     // enabled does that and crashes WebGPURenderer: "Cannot read properties of
     // null (reading 'depthTexture')").
@@ -3580,7 +3583,7 @@ const ThreeScene = (() => {
   function getShadowsEnabled() { return _shadowsOn; }
   function getSunElevation() { return _sunEl; }
 
-  // Exposure setter — driven by the time-of-day curve (applySunTime /
+  // Exposure setter, driven by the time-of-day curve (applySunTime /
   // updateFlyoverSun) and the metering harness.
   function setSceneExposure(v)    { if (renderer)   renderer.toneMappingExposure = v; requestRender(); }
   function getLightingState() {
@@ -3588,7 +3591,7 @@ const ThreeScene = (() => {
       sun:      _dirLight  ? _dirLight.intensity         : null,
       ambient:  _hemiLight ? _hemiLight.intensity        : null,
       exposure: renderer   ? renderer.toneMappingExposure : null,
-      // Stored, not live — the live value goes to 0 when the Shadows overlay
+      // Stored, not live; the live value goes to 0 when the Shadows overlay
       // is off; this returns the tuned strength regardless of on/off state.
       shadow:   _shadowIntensity,
     };
@@ -3598,7 +3601,7 @@ const ThreeScene = (() => {
   // debug logger (set NCZ.__shadowTrace = true to enable per-frame logging
   // in flyover.js). Captures everything that could explain "shadows turn
   // off at some waypoints": light pose, shadow camera bounds, fit state,
-  // renderer flags, hemisphere fill — so a post-mortem of the trace can
+  // renderer flags, hemisphere fill, so a post-mortem of the trace can
   // disambiguate any failure mode without re-instrumenting.
   function getShadowSnapshot() {
     if (!_dirLight || !renderer) return null;
@@ -3674,7 +3677,7 @@ const ThreeScene = (() => {
   }
 
   // Frame a Leaflet centre + zoom in the 3D camera (for the SAT→SCHEMA switch).
-  // Preserves the user's current azimuth/tilt — only the ground target and the
+  // Preserves the user's current azimuth/tilt; only the ground target and the
   // along-view distance move, so heading/tilt carry across the switch. Kept
   // separate from setCameraState (which restores an absolute stored pose +
   // sun state); this *derives* the pose from preserved θ/φ + computed distance.

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -1,9 +1,9 @@
 /**
- * NC Zoning Board — Pure Utility Functions
+ * NC Zoning Board: Pure Utility Functions
  * No DOM manipulation, no fetch. Operates on provided parameters + NCZ constants.
  */
 
-// HTML escape — prevents XSS from user-supplied data (Nexus API, submitted JSON)
+// HTML escape: prevents XSS from user-supplied data (Nexus API, submitted JSON)
 NCZ.escapeHtml = function (text) {
   const map = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
   return String(text).replace(/[&<>"']/g, (m) => map[m]);
@@ -22,7 +22,7 @@ NCZ.cacheGet = function (key, ttl) {
 
 NCZ.cacheSet = function (key, data) {
   try { localStorage.setItem(key, JSON.stringify({ ts: Date.now(), data })); }
-  catch { /* quota exceeded — silently skip */ }
+  catch { /* quota exceeded; silently skip */ }
 };
 
 // Convert gameId + modId → Nexus UID (composite BigInt key)
@@ -58,7 +58,7 @@ NCZ.leafletDistanceMeters = function (a, b) {
 };
 
 // View-sync bridge between the 2D Leaflet map and the 3D perspective camera.
-// Both directions match the *horizontal* visible CET width at screen centre —
+// Both directions match the *horizontal* visible CET width at screen centre:
 // exact at any camera tilt, since the camera's right vector stays in world XZ
 // (same reasoning as updateScaleBar()). The look-direction extent foreshortens
 // when tilted, so the vertical match is approximate by design; we preserve the
@@ -95,7 +95,7 @@ NCZ.clamp = function (value, min, max) {
  * Tone-mapping exposure for a given sun elevation, from NCZ.SCENE_EXPOSURE_CURVE
  * (piecewise-linear, clamped to the endpoints). Shared by the time-of-day
  * slider (applySunTime) and the showcase flyover (updateFlyoverSun) so both
- * drive exposure identically — see the curve comment in constants.js.
+ * drive exposure identically; see the curve comment in constants.js.
  * @param {number} elevationRad sun elevation above the horizon, in radians
  */
 NCZ.exposureForSunElevation = function (elevationRad) {
@@ -200,20 +200,20 @@ NCZ.pickDirectionAndPosition = function (anchorPoint, size, mapSize, config) {
  *  - lost [code] wrapper or stray styling ([spoiler]/[size]/[font]/
  *    [color], often per-line) from a copy-paste round-trip
  *  - the sentinel glued to the end of a sentence (e.g. `...Making!
- *    [code]NCZoning:` — stripping [code] fuses it onto the prose)
+ *    [code]NCZoning:`; stripping [code] fuses it onto the prose)
  *  - a false-positive "NCZoning:" mention earlier in the description
  *
  * Strategy: strip all BBCode, then treat `NCZoning:` as a token that
  * can appear anywhere (not a whole line). Every occurrence is tried as
  * a candidate; the first one whose following lines yield valid coords +
- * category wins, so the coords/category validation — not the sentinel's
- * position — is what disambiguates the real block from prose.
+ * category wins, so the coords/category validation (not the sentinel's
+ * position) is what disambiguates the real block from prose.
  */
 NCZ.parseNcZoningBlock = function (description, validTagNames) {
   if (!description) return null;
 
-  // Normalize HTML line breaks, then strip every BBCode [tag]/[/tag].
-  // This subsumes the old [spoiler] unwrap and the [code] requirement —
+  // Normalise HTML line breaks, then strip every BBCode [tag]/[/tag].
+  // This subsumes the old [spoiler] unwrap and the [code] requirement:
   // both become tag noise that disappears, leaving plain key=value text.
   const text = description
     .replace(/<br\s*\/?>/gi, "\n")
@@ -236,7 +236,7 @@ NCZ.parseNcZoningBlock = function (description, validTagNames) {
     return {
       coordinates: coordParts,
       category: data.category,
-      // tags: filter to known tags only — unknown tags silently dropped
+      // tags: filter to known tags only; unknown tags silently dropped
       tags: data.tags
         ? data.tags.split(",").map((t) => t.trim()).filter((t) => validTagNames.has(t))
         : [],
@@ -249,7 +249,7 @@ NCZ.parseNcZoningBlock = function (description, validTagNames) {
     };
   };
 
-  // `NCZoning:` is a token, not a line — authors paste it inline after
+  // `NCZoning:` is a token, not a line; authors paste it inline after
   // prose. [ \t]* (not \s*) tolerates `NCZoning :` without swallowing the
   // newline that separates it from the first field.
   const sentinel = /NCZoning[ \t]*:/gi;
@@ -272,14 +272,14 @@ NCZ.parseNcZoningBlock = function (description, validTagNames) {
     }
     const parsed = finalize(data);
     if (parsed) return parsed;
-    // Not a valid block (false-positive mention) — try the next occurrence.
+    // Not a valid block (false-positive mention); try the next occurrence.
   }
   return null;
 };
 
 // Returns true when a mod was updated on Nexus within the recent window.
 // The API computes this server-side (so the clockless in-game consumer can read
-// it too) and ships it as `recently_updated` on every record — trust that when
+// it too) and ships it as `recently_updated` on every record; trust that when
 // present. Only the client-side fallback path (API down, no bool) computes it
 // from the raw timestamp, using the effective window.
 NCZ.isRecentlyUpdated = function (mod) {
@@ -295,7 +295,7 @@ NCZ.cetToThree = function (cetX, cetY, cetZ) {
 };
 
 // Area-weighted polygon centroid (shoelace) for a ring of [x, y] vertices.
-// Center of mass, so it handles non-convex rings far better than a plain vertex
+// Centre of mass, so it handles non-convex rings far better than a plain vertex
 // average (which drifts toward dense corners). Returns [cx, cy] in the ring's
 // own space. Falls back to the vertex average for a degenerate (zero-area) ring.
 // Matches scripts/preview_district_borders.py's Shapely centroid.
@@ -317,7 +317,7 @@ NCZ.polygonCentroid = function (ring) {
   return [cx / (6 * a), cy / (6 * a)];
 };
 
-// Ray-casting point-in-polygon test. Generic over coordinate space — `point`
+// Ray-casting point-in-polygon test. Generic over coordinate space: `point`
 // and `ring` vertices are both [a, b] pairs in the SAME space (3D passes world
 // [x, -z]; 2D passes [lat, lng]). `ring` is the polygon's vertex list; the
 // closing edge back to ring[0] is handled implicitly. Returns true if the point
@@ -467,7 +467,7 @@ NCZ.computeVisibleMods = function (allMods, filters) {
   return visible;
 };
 
-// Comparator for Array.sort — orders mods by Nexus updatedAt descending.
+// Comparator for Array.sort: orders mods by Nexus updatedAt descending.
 // Mods with no Nexus date (WIP/Dummy) fall to end, sorted alphabetically.
 NCZ.sortModsByUpdated = function (a, b) {
   const tsA = a._updatedAt ? new Date(a._updatedAt).getTime() : null;

--- a/index.html
+++ b/index.html
@@ -251,7 +251,7 @@
             <button class="map-view-btn active" data-view="schema" title="3D schematic view">SCHEMA</button>
             <button class="map-view-btn" data-view="sat" title="Satellite tile view">SAT</button>
         </div>
-        <!-- Hover info panel — district readout (parity with the in-game map's
+        <!-- Hover info panel: district readout (parity with the in-game map's
              bottom-right panel). Populated by NCZ.DistrictInfo on district hover. -->
         <div id="district-info-panel" aria-hidden="true">
             <div class="di-head">
@@ -639,10 +639,10 @@
     <script src="assets/js/district-info.js"></script>
     <script src="assets/js/services.js"></script>
     <script src="assets/js/overlay.js"></script>
-    <!-- SunCalc — real sun position by date/time/location (by Vladimir Agafonkin, Leaflet author) -->
+    <!-- SunCalc: real sun position by date/time/location (by Vladimir Agafonkin, Leaflet author) -->
     <script src="https://cdn.jsdelivr.net/npm/suncalc@1.9.0/suncalc.js"></script>
 
-    <!-- Flyover showcase audio — plays during showcase, syncs beat-driven theme cycling -->
+    <!-- Flyover showcase audio: plays during showcase, syncs beat-driven theme cycling -->
     <audio id="flyover-audio" src="assets/audio/GMNC.mp3" preload="auto"></audio>
 
     <script type="module" src="assets/js/three-scene.js"></script>

--- a/scripts/build_lut.js
+++ b/scripts/build_lut.js
@@ -1,14 +1,14 @@
 /**
- * build_lut.js — extract the in-game 3D-map colour-grading LUT to a runtime asset.
+ * build_lut.js: extract the in-game 3D-map colour-grading LUT to a runtime asset.
  *
  * The CP2077 world map render-to-texture scene applies a colour grade whose
  * LDR LUT is `base/weather/24h_basic/luts/cube_cp_braindance_v001.xbm`
  * (decoded from `3dmap.envparam`).
  * That `.xbm` is a 32×32×32 RGBA-float 3D colour cube.
  *
- * Source format — a `.cube` (Adobe Cube LUT): export the `.xbm` from WolvenKit
+ * Source format: a `.cube` (Adobe Cube LUT). Export the `.xbm` from WolvenKit
  * as `.cube` and place it in assets/lut-source/. NOTE: do *not* use WolvenKit's
- * DDS export of this texture — for a 3D float volume it re-lays-out the slices
+ * DDS export of this texture; for a 3D float volume it re-lays-out the slices
  * incorrectly (verified: its texel 0 differs from the raw `.xbm` bytes). The
  * `.cube` export is byte-faithful to the engine data.
  *
@@ -16,7 +16,7 @@
  * loads straight into a THREE.Data3DTexture (RGBAFormat + FloatType) and
  * samples in the Game theme's colour-grade pass.
  *
- * Source `.cube` lives in assets/lut-source/ (gitignored — needs WolvenKit +
+ * Source `.cube` lives in assets/lut-source/ (gitignored; needs WolvenKit +
  * the game files to produce); the committed runtime asset is assets/data/.
  * Mirrors the glb-source/ → glb-meshopt/ pattern.
  *
@@ -68,7 +68,7 @@ function build() {
   }
 
   // ── emit ────────────────────────────────────────────────────────────────
-  // .cube data is R-fastest, then G, then B — identical ordering to
+  // .cube data is R-fastest, then G, then B: identical ordering to
   // THREE.Data3DTexture (x-fastest, x = R). Expand RGB → RGBA (opaque) float32.
   const out = new Float32Array(texels * 4);
   for (let i = 0; i < texels; i++) {

--- a/scripts/cp2077_3dmap_to_manifold.py
+++ b/scripts/cp2077_3dmap_to_manifold.py
@@ -38,7 +38,7 @@ path to the exported PNG and the metadata values from the .xbm JSON.
 
 
 WARNING: do NOT open/re-save the PNGs in Photoshop or any tool that
-applies colour management — the data channels must be read as raw bytes.
+applies colour management: the data channels must be read as raw bytes.
 This script uses pypng which ignores sRGB/gAMA/iCCP chunks entirely.
 
 
@@ -94,7 +94,7 @@ OUTPUT_DIR = "output"   # relative or absolute path
 #   "CUBE_SIZE" : base half-extent of one instance cube (game units)
 #   "HEIGHT"    : texture height in pixels (== number of instance rows)
 #
-# Values must be copied exactly from the source JSON — no rounding.
+# Values must be copied exactly from the source JSON, no rounding.
 
 
 DISTRICTS = {
@@ -202,7 +202,7 @@ def load_png_raw_f64(path: str) -> tuple[np.ndarray, int]:
 
 
     IMPORTANT: never pre-process the source PNG with colour-managed
-    software — any gamma correction will corrupt the encoded coordinates.
+    software; any gamma correction will corrupt the encoded coordinates.
     """
     import png
 
@@ -244,7 +244,7 @@ def lerp_f64(a: np.float64, b: np.float64, t: np.float64) -> np.float64:
 def quat_to_matrix_f64(w, x, y, z) -> np.ndarray:
     """
     Quaternion (w, x, y, z) -> 3x3 rotation matrix, float64.
-    Not normalised — consistent with the game shader and the original
+    Not normalised, consistent with the game shader and the original
     Blender import scripts.
     """
     return np.array([

--- a/scripts/cp2077_extract_footprints.py
+++ b/scripts/cp2077_extract_footprints.py
@@ -4,20 +4,20 @@ cp2077_extract_footprints.py
 Extracts 2D building footprints from CP2077 3D-minimap data textures and
 produces the following outputs for the NC Zoning Board website:
 
-  data/buildings.json              — building polygons as Leaflet [lat, lng] arrays
-  data/roads.json                  — road face polygons as Leaflet [lat, lng] arrays
-  data/metro.json                  — metro boundary edge segments as Leaflet [lat, lng] pairs
-  scripts/output/buildings.svg     — vector building footprints by district
-  scripts/output/roads.svg         — vector road surface fills
-  scripts/output/metro.svg         — vector metro track edges
-  scripts/output/district_borders.svg — district boundary outlines from trigger polygons
-  scripts/output/combined_8k.png   — 8192×8192 RGBA composite (roads + metro + borders + buildings)
+  data/buildings.json              :  building polygons as Leaflet [lat, lng] arrays
+  data/roads.json                  :  road face polygons as Leaflet [lat, lng] arrays
+  data/metro.json                  :  metro boundary edge segments as Leaflet [lat, lng] pairs
+  scripts/output/buildings.svg     :  vector building footprints by district
+  scripts/output/roads.svg         :  vector road surface fills
+  scripts/output/metro.svg         :  vector metro track edges
+  scripts/output/district_borders.svg :  district boundary outlines from trigger polygons
+  scripts/output/combined_8k.png   :  8192×8192 RGBA composite (roads + metro + borders + buildings)
 
 Usage:
-  # Pass 1 — diagnose world extent (fast, position data only)
+  # Pass 1: diagnose world extent (fast, position data only)
   python scripts/cp2077_extract_footprints.py --analyze
 
-  # Pass 2 — full output (set WORLD_MIN/MAX_X/Y constants first)
+  # Pass 2: full output (set WORLD_MIN/MAX_X/Y constants first)
   python scripts/cp2077_extract_footprints.py
 
 Dependencies:
@@ -65,7 +65,7 @@ from map_constants import (
 
 
 # ── CONFIG ─────────────────────────────────────────────────────────────────────
-# No area filter — extract ALL building instances for 1-to-1 game map replica.
+# No area filter: extract ALL building instances for 1-to-1 game map replica.
 # Previously MIN_AREA_SQ = 50.0 which discarded 37% of instances (small buildings,
 # kiosks, phone booths, etc. that are visible on the in-game map).
 
@@ -450,12 +450,12 @@ def point_in_polygon(x, y, polygon):
 
 def classify_district(cx, cy, trigger_polygons):
     """
-    Determine which district a building center (cx, cy) belongs to.
+    Determine which district a building centre (cx, cy) belongs to.
     Tests against trigger polygons in priority order (Dogtown before Pacifica,
     since Dogtown is inside the broader Pacifica texture area).
     Returns the district key or None if outside all districts.
     """
-    # Test Dogtown first — it overlaps with no main district but needs priority
+    # Test Dogtown first: it overlaps with no main district but needs priority
     # to avoid being swallowed by a broader texture decode
     priority_order = ["ep1_dogtown", "ep1_spaceport", "city_center", "watson",
                       "westbrook", "heywood", "santo_domingo", "pacifica"]
@@ -478,13 +478,13 @@ def classify_district(cx, cy, trigger_polygons):
 # Layers rendered under the building footprints (back to front).
 #
 # Rendering notes:
-#   - Water mesh: a world-scale flat plane — when filled as 2D polygons it covers
+#   - Water mesh: a world-scale flat plane; when filled as 2D polygons it covers
 #     the entire canvas. Excluded; dark background gives ocean context for free.
 #   - Road/terrain fills: 3D surface polygons are huge when projected flat.
 #     Use BOUNDARY edges only (edges belonging to exactly 1 face) to get road
 #     outlines without interior mesh triangulation artefacts.
 #   - Metro: same boundary-edge approach for clean track lines.
-#   - Landmarks: filled top-down silhouettes — faint so they don't overpower
+#   - Landmarks: filled top-down silhouettes, faint so they don't overpower
 #     building footprints, which are composited on top.
 #
 # Set to an empty list [] to produce buildings-only output.
@@ -507,18 +507,18 @@ GLB_LAYERS = [
     #
     # Roads: fill the road surface faces at low opacity → shows grey road areas
     # between buildings. Buildings are composited on top so fills only appear
-    # where there are no buildings (the streets themselves). No edges — the
+    # where there are no buildings (the streets themselves). No edges: the
     # boundary-edge approach shows mesh slab outlines, not readable roads.
     ("3dmap_roads.glb",   (45, 45, 65, 100), None,               0, "roads", None),
     ("3dmap_metro.glb",   None,              (255, 200, 0, 230), 3, "metro", None),
 
-    # Landmark meshes — filled top-down silhouettes rendered over buildings.
+    # Landmark meshes: filled top-down silhouettes rendered over buildings.
     # Both fill_rgba and edge_rgba use ("district", alpha) sentinels: colour is
     # resolved at render time from the landmark's world CET position via
     # classify_district() + DISTRICT_COLORS, so each landmark uses the same
     # colour as surrounding buildings (fill alpha=200, outline alpha=240).
     # offset_key values confirmed via --list-landmarks; update if ent changes.
-    # Note: 3dmap_cliffs.glb is excluded — terrain geometry, not a landmark, and
+    # Note: 3dmap_cliffs.glb is excluded (terrain geometry, not a landmark) and
     # obscures the map in the Dogtown/Badlands border area at 2D projection scale.
     ("3dmap_obelisk.glb",                    ("district", 200), ("district", 240), 1, "obelisk",             "obelisk"),
     ("monument_ave_pyramid.glb",             ("district", 200), ("district", 240), 1, "pyramid",             "monument_ave_pyramid"),
@@ -526,7 +526,7 @@ GLB_LAYERS = [
     ("3dmap_ext_monument_av_building_b.glb", ("district", 200), ("district", 240), 1, "av_building",         "ext_monument_av_building_b"),
     ("northoak_sign_a.glb",                  ("district", 200), ("district", 240), 1, "northoak_sign",       "northoak_sign_a"),
     ("cz_cz_building_h_icosphere.glb",       ("district", 200), ("district", 240), 1, "icosphere",           "cz_cz_building_h_icosphere"),
-    # Ferris wheel is placed twice in the ent — upright in Pacifica and collapsed.
+    # Ferris wheel is placed twice in the ent: upright in Pacifica and collapsed.
     # Both reference the same GLB; offset_key distinguishes the two instances.
     # Run --list-landmarks to find the exact component names if these don't match.
     ("rcr_park_ferris_wheel.glb",            ("district", 200), ("district", 240), 1, "ferris_wheel_upright",   "ferris_wheel_pacifica"),
@@ -538,7 +538,7 @@ def render_glb_base_layer(wbounds, mesh_transforms=None, trigger_polygons=None, 
     """
     Collect GLB mesh elements as Z-annotated draw primitives and write per-category SVG/JSON.
 
-    Returns a list of z_elements dicts — one per face or edge — for use in the
+    Returns a list of z_elements dicts (one per face or edge) for use in the
     unified Z-sorted draw pass in run_full_output().  No PIL drawing is done here.
 
     Each z_element:
@@ -564,7 +564,7 @@ def render_glb_base_layer(wbounds, mesh_transforms=None, trigger_polygons=None, 
     def verts_to_px(verts, off_x=0.0, off_y=0.0):
         """Batch-convert GLB vertices to pixel (x, y) arrays.
 
-        Axis mapping (confirmed empirically — roads 180° from buildings without this):
+        Axis mapping (confirmed empirically; roads 180° from buildings without this):
           GLB_X  -> -CET_X  (X is negated)
           GLB_Y  -> height   (used for Z depth)
           GLB_Z  -> +CET_Y  (Z maps directly to north-south, no negation)
@@ -631,7 +631,7 @@ def render_glb_base_layer(wbounds, mesh_transforms=None, trigger_polygons=None, 
             edge_rgba = (r, g, b, alpha)
 
         # Roads/metro (offset_key=None) are already in world space with orientation
-        # handled by the -GLB_X axis flip in verts_to_px — don't apply ent rotation.
+        # handled by the -GLB_X axis flip in verts_to_px; don't apply ent rotation.
         if offset_key is None:
             off_quat = (1.0, 0.0, 0.0, 0.0)
 
@@ -664,7 +664,7 @@ def render_glb_base_layer(wbounds, mesh_transforms=None, trigger_polygons=None, 
 
         px, py = verts_to_px(verts, off_x, off_y)
 
-        # Collect filled faces — Z = average vertex height (verts[:, 1] = CET_Z after rotation)
+        # Collect filled faces: Z = average vertex height (verts[:, 1] = CET_Z after rotation)
         if fill_rgba is not None:
             svg_polys = []   # list of (z, poly_str) tuples for per-file SVG
             json_polys = []  # list of {"z": float, "pts": [[lat,lng],...]}
@@ -705,11 +705,11 @@ def render_glb_base_layer(wbounds, mesh_transforms=None, trigger_polygons=None, 
                         json_fill_acc[out_key] = []
                     json_fill_acc[out_key].extend(json_polys)
 
-        # Collect BOUNDARY edges only — edges belonging to exactly 1 face.
+        # Collect BOUNDARY edges only: edges belonging to exactly 1 face.
         # Using all edges_unique draws interior mesh tessellation (triangles).
         # Boundary edges give clean road/track outlines with no interior artefacts.
         if edge_rgba is not None:
-            # faces_unique_edges: (N_faces, 3) — edge indices per face
+            # faces_unique_edges: (N_faces, 3), edge indices per face
             edge_counts = np.bincount(
                 mesh.faces_unique_edges.ravel(),
                 minlength=len(mesh.edges_unique)
@@ -768,7 +768,7 @@ def render_glb_base_layer(wbounds, mesh_transforms=None, trigger_polygons=None, 
 
         print(f"  [GLB] {label}: {len(mesh.vertices):,} verts, {len(mesh.faces):,} faces")
 
-    # Write accumulated SVG files — polygons/lines sorted by Z within each group
+    # Write accumulated SVG files: polygons/lines sorted by Z within each group
     if svg_output_dir:
         all_svg_keys = set(svg_fill_acc) | set(svg_edge_acc)
         for out_key in all_svg_keys:
@@ -802,7 +802,7 @@ def render_glb_base_layer(wbounds, mesh_transforms=None, trigger_polygons=None, 
             size_mb = os.path.getsize(svg_file) / (1024 * 1024)
             print(f"  [GLB] SVG  -> {svg_file} ({size_mb:.1f} MB)")
 
-    # Write accumulated JSON files — each element carries a "z" field.
+    # Write accumulated JSON files: each element carries a "z" field.
     # Combined (landmark) format: {label: {"faces": [{"z":,"pts":},...], "edges": [...]}}
     # Non-combined format: flat list (roads = faces, metro = edges)
     if json_output_dir:
@@ -868,18 +868,18 @@ def render_district_borders(trigger_polygons, wbounds, svg_output_dir=None):
 
     Two-tier rendering:
       - District borders: thick solid lines (width=3, alpha=180)
-      - Subdistrict borders: thin dashed lines (width=1, alpha=100), same color
+      - Subdistrict borders: thin dashed lines (width=1, alpha=100), same colour
 
     District data comes from trigger_polygons (flat dict, already loaded).
     Subdistrict data is loaded from data/subdistricts.json if it exists.
 
-    These are the actual game trigger area boundaries — much cleaner than the
+    These are the actual game trigger area boundaries, much cleaner than the
     3dmap_roads_borders.glb mesh (which is just road surface geometry).
     """
     from PIL import Image, ImageDraw
 
     # subdistricts.json uses "dogtown" / "ncx_morro_rock" as IDs, but
-    # DISTRICT_COLORS uses "ep1_dogtown" / "ep1_spaceport" — map them here.
+    # DISTRICT_COLORS uses "ep1_dogtown" / "ep1_spaceport"; map them here.
     SUBDIST_ID_TO_COLOR_KEY = {
         "dogtown":        "ep1_dogtown",
         "ncx_morro_rock": "ep1_spaceport",
@@ -978,7 +978,7 @@ def render_district_borders(trigger_polygons, wbounds, svg_output_dir=None):
 def load_png_raw_f64(path):
     """
     Load a PNG as float64 RGBA in [0,1].
-    Uses pypng which ignores sRGB/gAMA/iCCP chunks — raw bytes only.
+    Uses pypng which ignores sRGB/gAMA/iCCP chunks; raw bytes only.
     Supports 8-bit and 16-bit PNGs (WolvenKit exports TRF_DeepColor as 16-bit).
     """
     import png
@@ -1095,7 +1095,7 @@ def decode_district(name, d, positions_only=False):
             cy = tmin_y + (tmax_y - tmin_y) * pg + off_y
             wz = tmin_z + (tmax_z - tmin_z) * pb
 
-            # Scale (half-extents) — X, Y for footprint, Z for building height
+            # Scale (half-extents): X, Y for footprint, Z for building height
             sr, sg, sb = px[y, x + 2*block_w, 0], px[y, x + 2*block_w, 1], px[y, x + 2*block_w, 2]
             hx = sr * cube_val
             hy = sg * cube_val
@@ -1210,7 +1210,7 @@ def run_analyze():
             ax.scatter(xs, ys, s=0.5, c=color, alpha=0.4, label=name, rasterized=True)
 
         ax.set_aspect("equal")
-        # No invert_yaxis() — matplotlib default (positive Y at top) already = north-up
+        # No invert_yaxis(): matplotlib default (positive Y at top) already = north-up
         ax.legend(loc="upper right", fontsize=8, facecolor="#0a192f", labelcolor="white",
                   markerscale=6)
         ax.set_title("Building position scatter — all districts", color="white", fontsize=14)
@@ -1288,7 +1288,7 @@ def run_full_output():
     print("Collecting GLB landmark layer...")
     landmark_z_elems = render_glb_base_layer(wbounds, mesh_transforms=mesh_transforms, trigger_polygons=trigger_polygons, svg_output_dir=OUTPUT_DIR, json_output_dir=DATA_DIR, layers=GLB_LAYERS[2:], combined_label="landmarks")
 
-    # Render district borders from trigger polygons (always drawn topmost — not Z-sorted)
+    # Render district borders from trigger polygons (always drawn topmost, not Z-sorted)
     print("Rendering district borders from trigger polygons...")
     if trigger_polygons:
         border_layer = render_district_borders(trigger_polygons, wbounds, svg_output_dir=OUTPUT_DIR)
@@ -1337,7 +1337,7 @@ def run_full_output():
 
     print(f"  Classified: {classified}, Badlands/outside: {badlands_count}\n")
 
-    # Collect per-district building z_elements (deferred drawing — unified pass below)
+    # Collect per-district building z_elements (deferred drawing; unified pass below)
     svg_groups      = []   # per-district SVG groups for buildings.svg
     json_districts  = []   # per-district data for buildings.json
     building_z_elems = []  # z_elements for unified PNG/combined-SVG draw pass
@@ -1400,7 +1400,7 @@ def run_full_output():
     # Unified Z-sorted PNG + combined SVG
     # Merge all z_elements from roads/metro, buildings, and landmarks.
     # Sort by Z ascending so higher elements paint over lower ones (painter's algorithm).
-    # District borders are drawn on top afterwards — not Z-sorted, always topmost.
+    # District borders are drawn on top afterwards: not Z-sorted, always topmost.
     all_z_elems = sorted(
         (base_z_elems or []) + building_z_elems + (landmark_z_elems or []),
         key=lambda e: e["z"]
@@ -1440,7 +1440,7 @@ def run_full_output():
         f.write(svg_content)
     print(f"SVG  -> {svg_path}")
 
-    # Write combined.svg — all elements from all categories sorted by Z (full cross-category accuracy)
+    # Write combined.svg: all elements from all categories sorted by Z (full cross-category accuracy)
     sorted_svg_strs = [s for _, s in sorted(combined_svg_elems, key=lambda t: t[0])]
     combined_svg_path = os.path.join(OUTPUT_DIR, "combined.svg")
     with open(combined_svg_path, "w", encoding="utf-8") as f:

--- a/scripts/encode_glbs_meshopt.js
+++ b/scripts/encode_glbs_meshopt.js
@@ -16,7 +16,7 @@
  * sub-mesh-heavy GLBs, plus the decoder bundle is ~30 KB vs Draco's ~200 KB.
  * Three.js wires this up via gltfLoader.setMeshoptDecoder(MeshoptDecoder).
  *
- * Per-asset position quantization:
+ * Per-asset position quantisation:
  *   - World-coord meshes (terrain, cliffs, water, roads, metro): -vp 16 (CET 12 km extent)
  *   - Local-space landmarks: -vp 14 (small bounding box, sub-cm precision)
  */
@@ -29,7 +29,7 @@ const DEFAULT_SRC = path.join(__dirname, '..', 'assets', 'glb-source');
 const SRC = path.resolve(process.argv[2] || process.env.INPUT_GLB_DIR || DEFAULT_SRC);
 const DST = path.join(__dirname, '..', 'assets', 'glb-meshopt');
 
-// Per-asset position quantization bits — same precision targets as Draco settings.
+// Per-asset position quantisation bits: same precision targets as Draco settings.
 const PRESETS = {
   '3dmap_terrain.glb':       { vp: 16 },
   '3dmap_cliffs.glb':        { vp: 16 },
@@ -42,18 +42,18 @@ const LANDMARK_DEFAULT = { vp: 14 };
 
 // gltfpack flags shared across all assets:
 //   -cc: aggressive EXT_meshopt_compression
-//   -vn 10: normal quantization bits
-//   -vt 12: texcoord quantization bits
-//   -vc 8: vertex color quantization bits
+//   -vn 10: normal quantisation bits
+//   -vt 12: texcoord quantisation bits
+//   -vc 8: vertex colour quantisation bits
 //   -ke: keep extras (no-op for our GLBs but cheap insurance)
 //
 // Intentionally NOT using -kn (keep names): with -kn, gltfpack inserts named
-// wrapper groups above the dequantization transform nodes. Three.js r170's
+// wrapper groups above the dequantisation transform nodes. Three.js r170's
 // GLTFLoader appears to lose the child transform when the hierarchy is two
-// levels deep with quantization on the inner level — meshes render at int16
+// levels deep with quantisation on the inner level: meshes render at int16
 // scale (4–5× too large). Without -kn, gltfpack puts the dequant transform
 // directly on the root nodes, which Three.js handles correctly. Trade-off:
-// loses original mesh names like "submesh_00_LOD_1" — but our code doesn't
+// loses original mesh names like "submesh_00_LOD_1", but our code doesn't
 // reference them, so no functional impact.
 const SHARED_FLAGS = ['-cc', '-vn', '10', '-vt', '12', '-vc', '8', '-ke'];
 

--- a/scripts/extract_tweakdb_map.wscript
+++ b/scripts/extract_tweakdb_map.wscript
@@ -4,10 +4,10 @@
  * WolvenKit script to extract map-related TweakDB records for the NC Zoning Board.
  *
  * Extracts:
- *   1. WorldMapSettings — CursorBoundaryMin/Max (map viewport bounds), zoom level refs
- *   2. WorldMapZoomLevel entries — Zoom, Fov, ShowDistricts, ShowSubDistricts, etc.
- *   3. WorldMapFreeCameraSettings — ZoomMin/Max/Default, FovMin/Max
- *   4. District records — LocalizedName, UiState, UiIcon, ParentDistrict hierarchy
+ *   1. WorldMapSettings: CursorBoundaryMin/Max (map viewport bounds), zoom level refs
+ *   2. WorldMapZoomLevel entries: Zoom, Fov, ShowDistricts, ShowSubDistricts, etc.
+ *   3. WorldMapFreeCameraSettings: ZoomMin/Max/Default, FovMin/Max
+ *   4. District records: LocalizedName, UiState, UiIcon, ParentDistrict hierarchy
  *
  * Output:
  *   Saves JSON files to the project raw folder via wkit.SaveToRaw().
@@ -16,7 +16,7 @@
  * Usage:
  *   1. Open your map_data_export project in WolvenKit
  *   2. Open Script Manager, load this script
- *   3. Run — output files appear in your project's raw/ folder
+ *   3. Run; output files appear in your project's raw/ folder
  *
  * Note: TweakDB must be loaded. If GetRecords() returns empty, the script will
  *       attempt a warmup by saving/opening a temporary YAML file.
@@ -306,7 +306,7 @@ function extractDistricts(allRecords) {
 
     Logger.Info("Found " + uniquePaths.length + " potential district records");
 
-    // Extract a manageable subset — focus on known district names
+    // Extract a manageable subset: focus on known district names
     var knownDistricts = [
         "CityCenter", "Watson", "Westbrook", "Heywood",
         "SantoDomingo", "Pacifica", "Badlands", "Dogtown",

--- a/scripts/fix_coords_from_project.js
+++ b/scripts/fix_coords_from_project.js
@@ -5,11 +5,13 @@
  * overwrites X, Y (and optionally Z, Yaw) in data/locations/*.json, then marks
  * each item "Processed".
  *
- * Required project fields:
- *   X Coordinate  (number) — new CET X value (required)
- *   Y Coordinate  (number) — new CET Y value (required)
- *   Z Coordinate  (number) — new Z value (optional, keeps existing if blank)
- *   Yaw           (number) — new Yaw value (optional, keeps existing if blank)
+ * Required project fields (Number):
+ *   CET X         new CET X value
+ *   CET Y         new CET Y value
+ *   Z Coordinate  new Z value
+ *   Yaw           new Yaw value
+ * The processing loop skips any item with one of the four blank, so in
+ * practice every field must be filled in per item.
  *
  * Usage:
  *   GITHUB_TOKEN=<projects_token> node scripts/fix_coords_from_project.js
@@ -260,13 +262,14 @@ async function main() {
       const existing = JSON.parse(fs.readFileSync(filePath, 'utf8'));
       const oldCoords = existing.coordinates;
 
-      // Always update X and Y; use new Z if provided, else keep existing
+      // Always update X and Y. The missing-fields skip above guarantees z is
+      // non-null here; the keep-existing fallback is defensive only.
       const newZ = item.z !== null ? item.z : (oldCoords[2] ?? null);
       existing.coordinates = newZ !== null
         ? [item.x, item.y, newZ]
         : [item.x, item.y];
 
-      // Update Yaw if provided; remove if explicitly cleared (not applicable here — null means keep)
+      // The missing-fields skip above guarantees yaw is non-null here; the guard is defensive only.
       if (item.yaw !== null) {
         existing.yaw = item.yaw;
       }

--- a/scripts/generate_terrain_contours.py
+++ b/scripts/generate_terrain_contours.py
@@ -1,5 +1,5 @@
 """
-generate_terrain_contours.py — Terrain elevation contour lines for the NC Zoning Board map.
+generate_terrain_contours.py: Terrain elevation contour lines for the NC Zoning Board map.
 
 Loads 3dmap_terrain.glb, interpolates face heights to a grid, and extracts elevation isolines.
 
@@ -30,7 +30,7 @@ OUTPUT_DIR = os.path.join(SCRIPT_DIR, "output")
 DATA_DIR   = os.path.join(REPO_DIR, "data")
 
 # ---------------------------------------------------------------------------
-# Constants — imported from shared map_constants.py
+# Constants: imported from shared map_constants.py
 # ---------------------------------------------------------------------------
 from map_constants import (
     WORLD_MIN_X, WORLD_MAX_X, WORLD_MIN_Y, WORLD_MAX_Y,
@@ -49,16 +49,16 @@ def load_terrain_heights():
     """
     Load 3dmap_terrain.glb and return per-face centroid CET coords + heights.
 
-    Axis mapping (terrain GLB — identity transform, no world yaw):
+    Axis mapping (terrain GLB has an identity transform, no world yaw):
       CET_X = +GLB_X,  CET_Y = +GLB_Z,  height = +GLB_Y
 
-    NOTE — convention mismatch with the 3D scene:
+    NOTE (convention mismatch with the 3D scene):
       The Three.js scene and docs/coordinate-system-3d.md use GLB_Z = -CET_Y
       (negated). This script uses GLB_Z = +CET_Y (unflipped). The script
       still produces correct Leaflet output because the error cancels through
       cet_to_leaflet, but if you copy this code to query terrain heights for
       the 3D pipeline you MUST flip the Y sign on lookup.
-      Validated 2026-05-01 by in-game teleport experiment — CET Z and terrain
+      Validated 2026-05-01 by in-game teleport experiment: CET Z and terrain
       GLB Y are in the same coordinate space (within ±6m noise across 5 samples).
     """
     try:

--- a/scripts/generate_tiles.js
+++ b/scripts/generate_tiles.js
@@ -1,5 +1,5 @@
 /**
- * generate_tiles.js — Slice a map image into Leaflet-compatible WebP tiles
+ * generate_tiles.js: Slice a map image into Leaflet-compatible WebP tiles
  *
  * Usage: node scripts/generate_tiles.js
  *
@@ -21,8 +21,8 @@ const TILE_SIZE = 256;
 const MAX_ZOOM = 6; // 2^6 = 64 tiles per axis → 64×256 = 16384
 
 // WebP encoding options:
-//   quality 90 — visually indistinguishable from lossless at tile size, ~5× smaller
-//   effort 6  — maximum compression effort (slower encode, smaller files)
+//   quality 90: visually indistinguishable from lossless at tile size, ~5× smaller
+//   effort 6:   maximum compression effort (slower encode, smaller files)
 const WEBP_OPTIONS = { quality: 90, effort: 6 };
 
 function reportProgress(completedTiles, totalTiles, zoomLevel) {

--- a/scripts/map_constants.py
+++ b/scripts/map_constants.py
@@ -1,15 +1,14 @@
 """
-map_constants.py — Single source of truth for all coordinate transforms.
+map_constants.py: Single source of truth for all coordinate transforms.
 
 All Python scripts in this project should import from here instead of defining
 their own WORLD_MIN/MAX constants.
 
-The world extent values come from the game's TweakDB:
-  WorldMap.DefaultSettings.cursorBoundaryMin = Vector2(-5500, -7300)
-  WorldMap.DefaultSettings.cursorBoundaryMax = Vector2(6050,  5000)
-
-These define the in-game map viewport pan limits in CET world-space coordinates.
-The image canvas (8192×8192 pixels) maps to this exact world extent.
+The world extent values come from the Realistic Map 8k mod's terrain quad
+UV→world mapping (see the Authoritative world extent block below). TweakDB's
+WorldMap.DefaultSettings cursorBoundary values define only the in-game pan
+limit, not the render extent. The image canvas (8192×8192 pixels) maps to the
+quad's exact world extent.
 
 Leaflet uses L.CRS.Simple with tileSize=256 and maxNativeZoom=5:
   - Full image = 256 × 2^5 = 8192 pixels
@@ -33,12 +32,12 @@ Leaflet uses L.CRS.Simple with tileSize=256 and maxNativeZoom=5:
 # ---------------------------------------------------------------------------
 WORLD_MIN_X = -6298.0   # UV U=0 → CET_X (western edge)
 WORLD_MAX_X =  5815.0   # UV U=1 → CET_X (eastern edge)
-WORLD_MIN_Y = -7684.0   # UV V=0 → CET_Y (southern edge) — mod quad uses CET_Y = -GLB_Z
+WORLD_MIN_Y = -7684.0   # UV V=0 → CET_Y (southern edge); mod quad uses CET_Y = -GLB_Z
 WORLD_MAX_Y =  4427.0   # UV V=1 → CET_Y (northern edge)
 
 # Derived ranges
-WORLD_WIDTH  = WORLD_MAX_X - WORLD_MIN_X   # 11550.0
-WORLD_HEIGHT = WORLD_MAX_Y - WORLD_MIN_Y   # 12300.0
+WORLD_WIDTH  = WORLD_MAX_X - WORLD_MIN_X   # 12113.0
+WORLD_HEIGHT = WORLD_MAX_Y - WORLD_MIN_Y   # 12111.0
 
 # ---------------------------------------------------------------------------
 # Canvas / tile constants
@@ -111,8 +110,9 @@ LEAFLET_DISTRICT_ZOOM_MAX = 3      # Districts visible at zoom <= 3
 LEAFLET_SUBDISTRICT_ZOOM_MIN = 4   # Subdistricts visible at zoom >= 4
 
 # ---------------------------------------------------------------------------
-# District colors (UiState CNames from TweakDB District_Record)
-# These map to Ink widget states; actual RGB values TBD (need in-game extraction)
+# District colours (UiState CNames from TweakDB District_Record)
+# These map to Ink widget states; the extracted RGB values live in
+# DISTRICT_COLORS below.
 # ---------------------------------------------------------------------------
 DISTRICT_UI_STATES = {
     "CityCenter":   "CityCenter",
@@ -126,7 +126,7 @@ DISTRICT_UI_STATES = {
     # Badlands, NorthBadlands, SouthBadlands have UiState="None"
 }
 
-# Actual RGB colors from game Ink styles:
+# Actual RGB colours from game Ink styles:
 #   world_map_style.inkstyle → District.outlineColor → MainColors.*
 #   main_colors.inkstyle → HDR RGBA float values → clamped to 0-255
 # Default outline opacity: 0.6
@@ -143,16 +143,16 @@ DISTRICT_COLORS = {
 DISTRICT_OUTLINE_OPACITY = 0.6
 
 # ---------------------------------------------------------------------------
-# Base tile colors (theme-agnostic, used for permanent terrain tiles)
+# Base tile colours (theme-agnostic, used for permanent terrain tiles)
 # ---------------------------------------------------------------------------
-# Neutral dark grey palette — subtle land/water distinction, won't compete
+# Neutral dark grey palette: subtle land/water distinction, won't compete
 # with any theme's accent colours. These can't be changed per theme.
-TILE_TERRAIN_COLOR  = (45,   48,  55)   # #2d3037 — neutral dark grey
-TILE_WATER_COLOR    = (25,   35,  50)   # #192332 — slightly cooler/darker
-TILE_BACKGROUND     = (0,     0,   0)   # black — outside map area
+TILE_TERRAIN_COLOR  = (45,   48,  55)   # #2d3037, neutral dark grey
+TILE_WATER_COLOR    = (25,   35,  50)   # #192332, slightly cooler/darker
+TILE_BACKGROUND     = (0,     0,   0)   # black, outside map area
 
 # ---------------------------------------------------------------------------
-# Game material colors (from 3dmap Material.json files, for reference/SVGs)
+# Game material colours (from 3dmap Material.json files, for reference/SVGs)
 # ---------------------------------------------------------------------------
 TERRAIN_BASE_COLOR  = (86,  108, 136)   # 3dmap_terrain BaseColorScale
 TERRAIN_LINES_COLOR = (109, 138, 176)   # 3dmap_terrain LinesColor

--- a/scripts/measure_lighting.js
+++ b/scripts/measure_lighting.js
@@ -1,5 +1,5 @@
 /**
- * Lighting metering harness — measures scene brightness across the envelope
+ * Lighting metering harness: measures scene brightness across the envelope
  * defined in scripts/lighting-envelope.json (poses × sun times × themes).
  *
  * Drives a real installed Chrome via puppeteer-core (WebGPU needs it; no
@@ -20,11 +20,11 @@
  * Gotchas handled:
  *   - Compute culling lags camera teleports (buildings missing at the new
  *     pose). setPose() does the confirmed zoom-out/in nudge + settle waits.
- *   - Theme must be PINNED, not inherited — localStorage is seeded before the
+ *   - Theme must be PINNED, not inherited: localStorage is seeded before the
  *     app boots (a stray stored preference silently flips every measurement).
  *   - Pins/districts overlays are disabled before measuring (calibration
- *     rule: overlays off); shadows stay ON — usability mode measures the real
- *     default viewing condition.
+ *     rule: overlays off); shadows stay ON (usability mode measures the real
+ *     default viewing condition).
  */
 
 'use strict';
@@ -51,7 +51,7 @@ const VIEW = { width: 1600, height: 940 };
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// ── Static file server (no deps — the page just needs same-origin fetch) ──
+// ── Static file server (no deps; the page just needs same-origin fetch) ──
 const MIME = {
   '.html': 'text/html', '.js': 'text/javascript', '.css': 'text/css',
   '.json': 'application/json', '.png': 'image/png', '.webp': 'image/webp',
@@ -84,7 +84,7 @@ async function waitForScene(page) {
 }
 
 // Teleport with the cull-nudge workaround: compute culling can lag a camera
-// jump and leave buildings missing — zoom out ~3% and back in, with settles.
+// jump and leave buildings missing: zoom out ~3% and back in, with settles.
 async function setPose(page, pose) {
   const apply = (position) => page.evaluate((t, p) => {
     window.NCZ.ThreeScene.setCameraState({ target: t, position: p });
@@ -134,7 +134,7 @@ async function setupPage(browser, theme, port) {
 }
 
 // Solve mode: hold ONE representative view (P1 default city) at the brightness
-// the user's anchor exposure produces, and read off the exposure each sun time
+// the anchor exposure produces, and read off the exposure each sun time
 // needs. Exposure→brightness is monotonic below clip, so bisection is robust.
 // Output: a {minutes, elevationDeg, exposure} table to bake into applySunTime.
 async function runSolve(browser, port) {

--- a/scripts/monitor_api_health.js
+++ b/scripts/monitor_api_health.js
@@ -3,7 +3,7 @@
  * Data API health monitor.
  *
  * Why this exists: the website consumes /v1 with a graceful fallback to the
- * client-side merge (B7), and the API's PRIMARY consumer — in-game mods — has
+ * client-side merge (B7), and the API's PRIMARY consumer (in-game mods) has
  * NO fallback at all. So a silent website fallback would MASK an API outage:
  * the map looks fine while the mods are broken. This is the independent alarm
  * that closes that gap. It hits the live API on a schedule and pings Discord
@@ -19,17 +19,17 @@
  *      still serving last-known-good, so it's a warning, not an outage.
  *
  * NOTE: envelope.generated_at is deliberately NOT used as a freshness/liveness
- * signal — the cron only rewrites it when the dataset CONTENT changes (a few
+ * signal: the cron only rewrites it when the dataset CONTENT changes (a few
  * times a day), so a healthy-but-idle API legitimately has an hours-old
  * generated_at. There is no served "last cron ran" timestamp to check.
  *
  * Run: node scripts/monitor_api_health.js
  * Targets: API_HEALTH_TARGETS (comma-separated), default https://api.nczoning.net
- * Alerts:  NCZ_ALERTS_DISCORD_WEBHOOK_URL — the dedicated map-alerts channel,
+ * Alerts:  NCZ_ALERTS_DISCORD_WEBHOOK_URL, the dedicated map-alerts channel,
  *          kept separate from the submissions webhook (prints a preview instead
  *          of sending if unset).
  * Exit:    0 when every target is serving; 1 on any outage or infra error
- *          (so the Actions run goes red — a second signal beside Discord).
+ *          (so the Actions run goes red, a second signal beside Discord).
  */
 
 const DEFAULT_TARGETS = ["https://api.nczoning.net"];
@@ -41,14 +41,14 @@ const FETCH_TIMEOUT_MS = 15000;
 //
 // This monitor was once 403'd on every run: the zone ran Cloudflare's free Bot
 // Fight Mode, which managed-challenges automated clients from datacentre IPs
-// (the GitHub Actions runner, ASN 8075) — a false "outage" for a fully-healthy
+// (the GitHub Actions runner, ASN 8075), a false "outage" for a fully-healthy
 // API. It keyed on the request being non-interactive automation, NOT the UA
 // string, so a browser-UA disguise did nothing (verified: BFM still challenged
 // the Chrome UA). BFM is fundamentally incompatible with an Actions-based probe
 // and its protective value on a public read-only API is nil, so it was disabled
 // zone-wide (a /v1 rate-limit rule is the compensating control; DDoS + WAF stay
 // on). With BFM off the UA is unchallenged, so keep the honest, self-describing
-// one — and keep X-Health-Probe as a stable, spoof-resistant identifier for CF
+// one, and keep X-Health-Probe as a stable, spoof-resistant identifier for CF
 // logs / a future rate-limit exception.
 const PROBE_HEADERS = {
   "User-Agent": "nczoning-health-monitor",
@@ -63,7 +63,7 @@ async function fetchJson(url) {
   try {
     const res = await fetch(url, { signal: ctrl.signal, headers: PROBE_HEADERS });
     let json = null;
-    try { json = await res.json(); } catch { /* non-JSON body — leave null */ }
+    try { json = await res.json(); } catch { /* non-JSON body; leave null */ }
     return { ok: res.ok, status: res.status, json };
   } finally {
     clearTimeout(timer);
@@ -111,7 +111,7 @@ async function checkTarget(base) {
   });
   if (locationsProblem) issues.push(`/v1/locations not serving data (${locationsProblem})`);
 
-  // discovery_stale is context, not an outage — the cron self-alerts on it.
+  // discovery_stale is context, not an outage; the cron self-alerts on it.
   try {
     const { ok, json } = await fetchJson(`${base}/v1/meta`);
     if (ok && json?.data?.discovery_stale) {
@@ -140,7 +140,7 @@ async function postDiscord(results, { recovered = false } = {}) {
     }));
 
   // Three headlines: outage (page), recovery (all-clear edge), warning (soft).
-  // Outage wins if anything is currently down — recovery only applies when
+  // Outage wins if anything is currently down; recovery only applies when
   // this run is fully clean.
   let title, description, color;
   if (down.length) {
@@ -212,7 +212,7 @@ async function postDiscord(results, { recovered = false } = {}) {
     // The previous run's conclusion IS the last health state: this script
     // exits 1 on an outage (Actions run → failure) and 0 when serving
     // (→ success). The workflow reads that conclusion and passes it in, so a
-    // clean run that follows a failed one is the recovery edge — announce the
+    // clean run that follows a failed one is the recovery edge: announce the
     // all-clear ONCE (next run sees success and stays quiet). A prior infra
     // error also lands here as "was down"; a reassuring green after it is
     // harmless. Absent the flag (local run, first ever run) → no false edge.

--- a/scripts/monitor_auto_discovery.js
+++ b/scripts/monitor_auto_discovery.js
@@ -3,12 +3,12 @@
  * Auto-discovery health monitor.
  *
  * Purpose: catch NCZoning-tagged mods that AREN'T showing on the map because
- * their metadata block is missing or unparseable — so a broken block is caught
+ * their metadata block is missing or unparseable, so a broken block is caught
  * within a day instead of when an author complains.
  *
  * Since B7 the block parsing + merge runs SERVER-SIDE (the Data API cron), and
  * the API exposes the result at `/v1/meta.skipped`: every mod tagged NCZoning
- * that isn't excluded, isn't a manual entry, and whose block didn't parse —
+ * that isn't excluded, isn't a manual entry, and whose block didn't parse:
  * exactly the "tagged but not on the map" set. Reading that instead of
  * re-parsing client-side means ONE source of truth (no client/server parser
  * drift) and no live Nexus fetch. Before B7 this script ran the client-side
@@ -17,7 +17,7 @@
  *
  * Run: node scripts/monitor_auto_discovery.js
  * Target: API_META_URL (default https://api.nczoning.net/v1/meta)
- * Alerts: NCZ_ALERTS_DISCORD_WEBHOOK_URL — the dedicated map-alerts channel,
+ * Alerts: NCZ_ALERTS_DISCORD_WEBHOOK_URL, the dedicated map-alerts channel,
  *         separate from submissions (prints a preview instead if unset).
  * Exit 0 on a clean run OR flagged mods (it's a report, not a gate); exit 1
  * only on an infrastructure error.
@@ -46,7 +46,7 @@ async function postDiscord(skipped) {
           `BBCode Generator, add a manual registry entry if it belongs on the map, or add the ` +
           `id to \`data/excluded_mods.json\` to stop this alert.\n\n` +
           lines.join("\n"),
-        color: 15105570, // amber/orange — warning, not error
+        color: 15105570, // amber/orange: warning, not error
         footer: { text: "NC Zoning Board • source: /v1/meta.skipped" },
       },
     ],
@@ -77,7 +77,7 @@ async function postDiscord(skipped) {
     if (!Array.isArray(skipped)) throw new Error("meta.skipped missing or not an array");
 
     if (json.data.discovery_stale) {
-      // Still worth reporting — the last-known-good skipped list is what the map reflects.
+      // Still worth reporting: the last-known-good skipped list is what the map reflects.
       console.log("Note: discovery_stale=true — the API is serving last-known-good data.");
     }
 
@@ -89,7 +89,7 @@ async function postDiscord(skipped) {
     console.log(`❌ ${skipped.length} tagged mod(s) skipped by the API:`);
     for (const m of skipped) console.log(`   - ${m.nexus_id}  ${m.name}`);
     await postDiscord(skipped);
-    // exitCode stays 0 — this is a report, not a gate.
+    // exitCode stays 0: this is a report, not a gate.
   } catch (err) {
     console.error("Monitor failed (infrastructure error):", err.message);
     process.exitCode = 1;

--- a/scripts/preview_district_borders.py
+++ b/scripts/preview_district_borders.py
@@ -3,9 +3,9 @@ Quick preview: render district_borders.svg from data/subdistricts.json.
 
 Rendering approach:
   - Districts: solid thick outline, no fill
-  - Subdistricts: subtle filled polygon (same district color, low opacity)
+  - Subdistricts: subtle filled polygon (same district colour, low opacity)
     with a thin dashed outline. The edge of each filled zone IS the visible
-    dividing line — no explicit midline computation required.
+    dividing line; no explicit midline computation required.
   - Labels: subdistrict names at geometric centroid, district names larger
 
 Output: scripts/output/district_borders.svg
@@ -24,7 +24,7 @@ from map_constants import (
     IMG_SIZE, cet_to_pixel,
 )
 
-# Colors from game Ink styles (see docs/district-hierarchy.md)
+# Colours from game Ink styles (see docs/district-hierarchy.md)
 DISTRICT_COLORS = {
     "city_center":    "#ffd741",   # MainColors.Yellow
     "watson":         "#ff3e34",   # MainColors.CombatRed
@@ -52,7 +52,7 @@ def pts_str(coords):
 def polygon_centroid(coords):
     """Compute the geometric centroid of a polygon in pixel space using Shapely.
 
-    Shapely's centroid is the center of mass, which handles non-convex and
+    Shapely's centroid is the centre of mass, which handles non-convex and
     irregular polygons correctly (unlike a simple vertex average).
     """
     shape = ShapelyPolygon(coords)
@@ -124,14 +124,14 @@ def main():
                     f'opacity="0.9">{sub["name"]}</text>'
                 )
         else:
-            # No subdistricts (Dogtown, NCX) — fill the district itself
+            # No subdistricts (Dogtown, NCX): fill the district itself
             if district.get("polygon"):
                 lines.append(
                     f'    <polygon points="{pts_str(district["polygon"])}" '
                     f'fill="{color}" fill-opacity="0.15" stroke="none"/>'
                 )
 
-        # District outline on top — solid, no fill, always visible
+        # District outline on top: solid, no fill, always visible
         if district.get("polygon"):
             lines.append(
                 f'    <polygon points="{pts_str(district["polygon"])}" '
@@ -146,7 +146,7 @@ def main():
                 f'opacity="0.7">{district["name"]}</text>'
             )
         elif is_badlands and subs:
-            # Badlands has no single polygon — place label halfway between
+            # Badlands has no single polygon; place label halfway between
             # Red Peaks and Vasquez Pass on X axis, use union centroid for Y
             from shapely.ops import unary_union
             union = unary_union([ShapelyPolygon(s["polygon"]).buffer(0) for s in subs])

--- a/scripts/r185_resize_spike.html
+++ b/scripts/r185_resize_spike.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- SCRATCH SPIKE — r185 resize/destroyed-texture investigation. Delete after. -->
+<!-- SCRATCH SPIKE: r185 resize/destroyed-texture investigation. Delete after. -->
 <html>
 <head><meta charset="utf-8"><title>r185 resize spike</title>
 <style>html,body{margin:0;height:100%;background:#0a192f;overflow:hidden}#c{width:100vw;height:100vh}</style>
@@ -90,7 +90,7 @@ container.appendChild(renderer.domElement);
 
 await renderer.init();
 
-// Optional compute pass — mimics our per-frame building cull (instancedArray + compute()).
+// Optional compute pass: mimics our per-frame building cull (instancedArray + compute()).
 let computeNode = null;
 if (COMPUTE) {
   const buf = instancedArray(1024, 'vec4');

--- a/scripts/regenerate_subdistricts.py
+++ b/scripts/regenerate_subdistricts.py
@@ -4,7 +4,7 @@ Regenerate data/subdistricts.json with proper parent-chain transforms.
 Walks the full parent transform chain for each trigger component, applying
 rotation and translation at each level. This correctly handles:
   - Pacifica (65 degree yaw rotation in pacifica_transform)
-  - Pacifica sub-districts (coastview, west_wind_estate — also rotated)
+  - Pacifica sub-districts (coastview, west_wind_estate, also rotated)
   - NCX/Spaceport (parented to morro_rock_trigger)
   - Dogtown (chains through pacifica_data0633)
 
@@ -12,7 +12,7 @@ City sub-district polygons are clipped to their parent district boundary
 via Shapely intersection.
 
 Badlands sub-district polygons are extracted from streaming sector files
-(worldLocationAreaNode binary buffers) — these zones aren't in 3dmap_view.ent
+(worldLocationAreaNode binary buffers); these zones aren't in 3dmap_view.ent
 because they don't appear on the in-game map.
 """
 import base64
@@ -91,7 +91,7 @@ DISTRICT_STRUCTURE = [
         "subdistricts": []
     },
     {
-        # NCX trigger and morro_rock_trigger share the exact same outline —
+        # NCX trigger and morro_rock_trigger share the exact same outline:
         # NCX is parented to morro_rock_trigger. They're the same area.
         "id": "ncx_morro_rock", "name": "NCX Spaceport / Morro Rock", "trigger": "ncx_trigger",
         "subdistricts": []
@@ -407,7 +407,7 @@ def main():
             })
 
     # ── Pass 1: Subtract city districts from Badlands subdistricts ───────
-    # City district shapes are authoritative — Badlands zones must not overlap them.
+    # City district shapes are authoritative: Badlands zones must not overlap them.
     if badlands_entry["subdistricts"] and city_district_shapes:
         print("\n--- Pass 1: Clipping Badlands against city districts ---")
         city_union = unary_union(city_district_shapes)
@@ -431,7 +431,7 @@ def main():
                     print(f"  {sub['id']:25s} clipped {pct:.0f}%")
 
     # ── Pass 2: Resolve inter-subdistrict overlaps ────────────────────────
-    # Process smallest first — smaller/more specific zones take priority.
+    # Process smallest first: smaller/more specific zones take priority.
     if badlands_entry["subdistricts"]:
         print("\n--- Pass 2: Resolving Badlands inter-subdistrict overlaps ---")
         subs = badlands_entry["subdistricts"]
@@ -462,7 +462,7 @@ def main():
                 pct = (1 - shape.area / original_area) * 100
                 if pct > 0.1:
                     print(f"  {sub['id']:25s} trimmed {pct:.0f}% (overlap with smaller neighbors)")
-            # Add the ORIGINAL (unclipped) shape to processed list —
+            # Add the ORIGINAL (unclipped) shape to processed list:
             # this means later (larger) subs subtract the full original zone,
             # not the already-trimmed version
             processed_shapes.append(ShapelyPolygon(subs[idx]["polygon"]))
@@ -509,7 +509,7 @@ def main():
                 bl_shapes[sid] = merged
                 print(f"  -> Merged gap ({gap.area:.0f} sq) into {sid}")
             else:
-                # Split gap: each neighbor claims the portion closer to it
+                # Split gap: each neighbour claims the portion closer to it
                 for sid, shape, _ in neighbors:
                     claim = gap
                     for other_sid, other_shape, _ in neighbors:
@@ -529,13 +529,13 @@ def main():
                 print(f"  -> Split gap ({gap.area:.0f} sq) between: {[n[0] for n in neighbors]}")
 
         # Note: The gap between Biotechnica Flats, Dogtown, and West Wind Estate
-        # cannot be filled — the void lies inside Dogtown's city district polygon,
+        # cannot be filled; the void lies inside Dogtown's city district polygon,
         # and city district polygons are authoritative and cannot be modified.
 
         # Write updated polygons back, cleaning geometry with buffer(0)
         for sub in badlands_entry["subdistricts"]:
             if sub["id"] in bl_shapes:
-                shape = bl_shapes[sub["id"]].buffer(0)  # clean floating-point artifacts
+                shape = bl_shapes[sub["id"]].buffer(0)  # clean floating-point artefacts
                 if shape.geom_type == "MultiPolygon":
                     shape = max(shape.geoms, key=lambda g: g.area)
                 if not shape.is_empty and shape.geom_type == "Polygon":
@@ -546,7 +546,7 @@ def main():
         output["districts"].append(badlands_entry)
 
     # ── North Oaks Casino (optional, cut-content district) ───────────────
-    # The North Oaks Casino is cut content — a district void between North Oak
+    # The North Oaks Casino is cut content: a district void between North Oak
     # (Westbrook), Red Peaks, and Rocky Ridge. It exists as empty space in-game
     # and is the target of a community restoration mod led by Kao.
     #

--- a/scripts/validate_3dmap_assets.js
+++ b/scripts/validate_3dmap_assets.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
- * validate_3dmap_assets.js — sanity-check the 3D-map building DDS textures.
+ * validate_3dmap_assets.js: sanity-check the 3D-map building DDS textures.
  *
  * Run after dropping in new/updated assets (e.g. a malgalad "3D World Map Fixed"
- * release — see docs/3dmap-fixed-assets.md). Read-only; no encoding.
+ * release; see docs/3dmap-fixed-assets.md). Read-only; no encoding.
  *
  * Checks, per _data.dds:
  *   - DX10 header present, format R16G16B16A16_UNORM (the point-cloud format)

--- a/scripts/webgpu_reverse_z_spike.html
+++ b/scripts/webgpu_reverse_z_spike.html
@@ -69,7 +69,7 @@ const sun = new THREE.DirectionalLight(0xffffff, 0.8);
 sun.position.set(20, 50, 30);
 scene.add(sun);
 
-// 200 near-coplanar cubes — depth-precision stress
+// 200 near-coplanar cubes: depth-precision stress
 const cubeGeo = new THREE.BoxGeometry(2, 0.3, 2);
 const cubeMat = new THREE.MeshLambertNodeMaterial({ color: 0x556677 });
 for (let i = 0; i < 200; i++) {
@@ -82,7 +82,7 @@ for (let i = 0; i < 200; i++) {
   scene.add(c);
 }
 
-// Far landmark — far-frustum precision check
+// Far landmark: far-frustum precision check
 const farMat = new THREE.MeshLambertNodeMaterial({ color: 0xffb300 });
 const far = new THREE.Mesh(new THREE.BoxGeometry(200, 200, 200), farMat);
 far.position.set(0, 100, -20000);

--- a/scripts/webgpu_stencil_spike.html
+++ b/scripts/webgpu_stencil_spike.html
@@ -113,7 +113,7 @@ try {
     opacity: 0.85,
     depthTest:    false,        // SeeThrough renders even where occluded
     stencilWrite: true,
-    stencilWriteMask: 0x00,     // read-only — don't modify stencil
+    stencilWriteMask: 0x00,     // read-only: don't modify stencil
     stencilFunc:      THREE.EqualStencilFunc,
     stencilRef:       2,
     stencilFuncMask:  0xff,

--- a/worker/src/districts.js
+++ b/worker/src/districts.js
@@ -1,9 +1,9 @@
 /**
- * District/subdistrict assignment — server-side port of the client logic
+ * District/subdistrict assignment: server-side port of the client logic
  * (assets/js/utils.js pointInPolygon/polygonCentroid + the resolveArea
  * rule in assets/js/district-info.js). Polygons come from
  * data/subdistricts.json and are in CET world coordinates, the same space
- * as location `coordinates` — no transforms anywhere.
+ * as location `coordinates`; no transforms anywhere.
  */
 
 /** Ray-casting point-in-polygon. `point` and `ring` vertices share a space. */
@@ -40,7 +40,7 @@ export function polygonCentroid(ring) {
   return [cx / (6 * a), cy / (6 * a)];
 }
 
-/** Absolute shoelace area — smallest containing polygon wins. */
+/** Absolute shoelace area; smallest containing polygon wins. */
 function polyArea(ring) {
   let a = 0;
   for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
@@ -83,7 +83,7 @@ export function resolveArea(pt, districts) {
 
 /**
  * The game's default district: anywhere outside every district polygon is
- * Badlands (which is why it has no polygon of its own — its subdistricts
+ * Badlands (which is why it has no polygon of its own: its subdistricts
  * are trigger areas transformed into polygons for the map, but the parent
  * is the catch-all). The API mirrors that rule so in-game consumers and
  * the game itself can never disagree.
@@ -109,7 +109,7 @@ export function assignDistrict(coordinates, districts) {
 
 /**
  * /v1/districts payload: hierarchy with names, centroids and FLATTENED
- * boundaries ([x1,y1,x2,y2,...]) — the DTO contract forbids
+ * boundaries ([x1,y1,x2,y2,...]): the DTO contract forbids
  * arrays-of-arrays (RedData FromJson limit).
  */
 export function districtsPayload(districts) {

--- a/worker/src/docs.js
+++ b/worker/src/docs.js
@@ -1,7 +1,7 @@
 /**
  * Interactive API docs served from the Worker root. The OpenAPI spec
  * (worker/openapi.json) is the source of truth; the root page renders it
- * with Scalar (loaded from a CDN — this is a human docs page, not a
+ * with Scalar (loaded from a CDN; this is a human docs page, not a
  * CSP-restricted context). Modders browsing to api.nczoning.net land here.
  */
 

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -1,5 +1,5 @@
 /**
- * NC Zoning Data API — read-only Worker serving the mod registry to
+ * NC Zoning Data API: read-only Worker serving the mod registry to
  * Cyberpunk 2077 mods (and, later, the website itself).
  *
  * Contract rules (frozen, see docs/data-api-plan.md):
@@ -63,7 +63,7 @@ function notFound() {
   return json(envelope({ error: 'not_found' }, null), { status: 404 });
 }
 
-/** Before the first successful cron, KV is empty — say so, don't 404. */
+/** Before the first successful cron, KV is empty; say so, don't 404. */
 function notReady() {
   return json(envelope({ error: 'not_ready' }, null), {
     status: 503,
@@ -107,7 +107,7 @@ const routes = {
   'GET /v1/health': (request, env) =>
     json(envelope({ status: 'ok', version: env.API_VERSION }, null)),
 
-  // One representation: the full records as an array — every field the DTO
+  // One representation: the full records as an array, every field the DTO
   // consumer needs, RedData-mappable. `?full=1` is accepted as a no-op alias so
   // existing consumers (the website and the in-game NCZoningCore mod, which both
   // request it) keep working; there is no leaner shape to opt out to.
@@ -123,7 +123,7 @@ const routes = {
   'GET /v1/tags': (request, env) =>
     serveDataset(request, env, (e) => e.DATASET.get(KEYS.tags, 'json')),
 
-  // Operational metadata only — health flags the monitors read. No aggregate
+  // Operational metadata only: health flags the monitors read. No aggregate
   // counts: consumers derive those from the per-location records.
   'GET /v1/meta': (request, env) =>
     serveDataset(request, env, (e, meta) => ({
@@ -132,7 +132,7 @@ const routes = {
     })),
 };
 
-/** GET /v1/locations/{id} — full entry, or 404. */
+/** GET /v1/locations/{id}: full entry, or 404. */
 function locationById(request, env, id) {
   return serveDataset(request, env, async (e) => {
     const full = await e.DATASET.get(KEYS.full, 'json');

--- a/worker/src/merge.js
+++ b/worker/src/merge.js
@@ -1,5 +1,5 @@
 /**
- * Dataset builder — the server-side version of the merge the browser does
+ * Dataset builder: the server-side version of the merge the browser does
  * in assets/js/services.js (fetchNexusTaggedMods) + app.js concat.
  *
  * Pure function: all inputs are plain data, no fetching, no KV. The cron
@@ -50,7 +50,7 @@ export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, distr
 
   const nexusThumbs = {}; // manual-entry image/updatedAt backfill, keyed by nexus_id
   const autoEntries = [];
-  const skipped = []; // tagged mods with no valid block — surfaced for monitoring
+  const skipped = []; // tagged mods with no valid block, surfaced for monitoring
 
   for (const node of nexusNodes || []) {
     const nexusId = String(node.modId);
@@ -122,7 +122,7 @@ export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, distr
 
   // One representation: the full record, keyed by id (the by-id endpoint reads
   // full[id]; the list endpoint serves Object.values(full), which keeps the
-  // alphabetical order of `all`). No separate slim array — consumers derive any
+  // alphabetical order of `all`). No separate slim array; consumers derive any
   // aggregate (counts, category breakdown) by grouping these records locally.
   const cutoffMs = nowMs - RECENTLY_UPDATED_DAYS * 86400000;
   const full = {};
@@ -132,7 +132,7 @@ export function buildDataset({ manualMods, tagsDict, excluded, nexusNodes, distr
     const thumbs = resolveThumbs(entry);
     // Server-computed polyfill for the clockless in-game consumer. Content ×
     // wall-clock, so it must ride the periodically-rehashed content (refresh.js
-    // recomputes it every cron tick) — never materialize-once. NaN (bad/absent
+    // recomputes it every cron tick), never materialise-once. NaN (bad/absent
     // date) → false.
     const recently_updated = thumbs.updated_at
       ? Date.parse(thumbs.updated_at) > cutoffMs

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -1,5 +1,5 @@
 /**
- * Nexus V2 GraphQL auto-discovery fetch — server-side port of the
+ * Nexus V2 GraphQL auto-discovery fetch: server-side port of the
  * pagination loop in assets/js/services.js fetchNexusTaggedMods, minus
  * the merge (that lives in merge.js) and the localStorage cache (KV plays
  * that role, in the B3 cron).
@@ -34,7 +34,7 @@ const QUERY = `
 `;
 
 /**
- * Fetch every mod tagged NCZoning for CP2077. Throws on any page failure —
+ * Fetch every mod tagged NCZoning for CP2077. Throws on any page failure:
  * a partial node list must never be mistaken for the full tag population
  * (missing mods would be dropped from the map).
  *
@@ -85,7 +85,7 @@ export async function fetchTaggedModNodes(fetchImpl = fetch) {
 
 /**
  * Composite UID Nexus expects for modsByUid: (gameId << 32) + modId, as a
- * single decimal string — NOT "gameId:modId". Must match the site's
+ * single decimal string, NOT "gameId:modId". Must match the site's
  * NCZ.toNexusUid (assets/js/utils.js) exactly, or Nexus silently drops the
  * UIDs and returns no images.
  */
@@ -145,7 +145,7 @@ export async function fetchModsByUidThumbs(fetchImpl = fetch, numericIds = []) {
       }
       return map;
     } catch {
-      return {}; // cosmetic — swallow and let the caller serve what it has
+      return {}; // cosmetic: swallow and let the caller serve what it has
     }
   };
 

--- a/worker/src/parse.js
+++ b/worker/src/parse.js
@@ -1,5 +1,5 @@
 /**
- * NCZoning metadata-block parser — server-side port of
+ * NCZoning metadata-block parser: server-side port of
  * assets/js/utils.js NCZ.parseNcZoningBlock (keep the two in sync; the
  * client version's comment block documents the real-world breakage this
  * strategy survives).
@@ -7,8 +7,8 @@
  * Strategy: strip all BBCode, then treat `NCZoning:` as a token that can
  * appear anywhere (not a whole line). Every occurrence is tried as a
  * candidate; the first one whose following lines yield valid coords +
- * category wins, so the coords/category validation — not the sentinel's
- * position — is what disambiguates the real block from prose.
+ * category wins, so the coords/category validation (not the sentinel's
+ * position) is what disambiguates the real block from prose.
  */
 
 const RECOGNIZED = new Set(['coords', 'category', 'tags', 'yaw', 'credits', 'authors']);

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -1,5 +1,5 @@
 /**
- * Refresh orchestrator — the body of the 5-minute cron. Fetches the CDN
+ * Refresh orchestrator: the body of the 5-minute cron. Fetches the CDN
  * source files + Nexus auto-discovery, rebuilds the dataset, and writes to
  * KV only when the content hash changes.
  *
@@ -103,7 +103,7 @@ export async function runRefresh(env, fetchImpl = fetch) {
 
     // Manual-mod thumbnails: the tagged query only backfills manual mods that
     // are themselves NCZoning-tagged, so pull the rest via modsByUid. Cosmetic
-    // and non-throwing — a failure here just leaves some images null this
+    // and non-throwing: a failure here just leaves some images null this
     // cycle, it never marks the dataset stale.
     const manualNumericIds = manualMods
       .map((m) => String(m.nexus_id))
@@ -118,7 +118,7 @@ export async function runRefresh(env, fetchImpl = fetch) {
 
     // Hash the content that actually varies (not generated_at). Tags are
     // included so a tags.json edit propagates through the ETag. `full` carries
-    // the recently_updated bool, so its clock-driven flips move the ETag —
+    // the recently_updated bool, so its clock-driven flips move the ETag;
     // that is deliberate (a location aging past the window must invalidate
     // caches even though nothing on Nexus changed). This is why the cron
     // rebuilds every tick against a fresh clock, with no Nexus short-circuit.

--- a/worker/src/store.js
+++ b/worker/src/store.js
@@ -1,12 +1,13 @@
 /**
  * KV storage layer for the dataset. Keys under `dataset:v1*`:
- * - dataset:v1:full      { id: fullEntry } map — the one location
+ * - dataset:v1:full      { id: fullEntry } map: the one location
  *                        representation. /v1/locations serves its values;
  *                        /v1/locations/{id} reads full[id].
  * - dataset:v1:districts /v1/districts payload
  * - dataset:v1:tags      tag dictionary ({ tagId: description })
  * - dataset:v1:meta      { schema, generated_at, dataset_version,
- *                          discovery_stale, skipped }
+ *                          discovery_stale, skipped }; a failed cycle also
+ *                          writes last_error and last_error_at
  *
  * dataset_version is a content hash: the cron writes only when it changes,
  * and it doubles as the ETag for the read path.
@@ -32,9 +33,10 @@ export async function readMeta(env) {
 }
 
 /**
- * Persist a freshly built dataset. Writes all keys; callers only reach here
- * when the hash changed, so the per-key 1 write/s limit is never a risk
- * (cron runs every 5 min).
+ * Persist a freshly built dataset. Writes all keys; callers reach here when
+ * the hash changed, or unchanged-but-recovering (a prior cycle left
+ * discovery_stale). Either way it is at most one write per cron cycle, so
+ * the per-key 1 write/s limit is never a risk (cron runs every 5 min).
  */
 export async function writeDataset(env, { full, districts, tags, meta }) {
   await Promise.all([

--- a/worker/test/districts.test.js
+++ b/worker/test/districts.test.js
@@ -30,7 +30,7 @@ test('real subdistricts.json loads with the expected shape', () => {
   assert.ok(districts.length >= 8, `expected >=8 districts, got ${districts.length}`);
   for (const d of districts) {
     assert.equal(typeof d.name, 'string');
-    // Badlands has no parent polygon — only subdistrict polygons.
+    // Badlands has no parent polygon, only subdistrict polygons.
     const hasOwnRing = Array.isArray(d.polygon) && d.polygon.length >= 3;
     const hasSubRings = (d.subdistricts || []).some(
       (s) => Array.isArray(s.polygon) && s.polygon.length >= 3,

--- a/worker/test/merge.test.js
+++ b/worker/test/merge.test.js
@@ -29,13 +29,13 @@ const MANUAL = [
 ];
 
 const NODES = [
-  { // duplicate of the manual entry — must only contribute thumbs
+  { // duplicate of the manual entry; must only contribute thumbs
     modId: 12345, name: 'Zeta Manual Loft (Nexus page)', summary: 'dup',
     description: 'NCZoning:\ncoords=1,1\ncategory=other',
     pictureUrl: 'pic-dup', thumbnailUrl: 'thumb-dup', updatedAt: '2026-07-01',
     uploader: { name: 'Spud' },
   },
-  { // excluded — never appears even with a valid block
+  { // excluded: never appears even with a valid block
     modId: 777, name: 'Mistagged Mod', summary: 'oops',
     description: 'NCZoning:\ncoords=2,2\ncategory=other',
     uploader: { name: 'Someone' },
@@ -46,7 +46,7 @@ const NODES = [
     pictureUrl: 'pic-888', thumbnailUrl: 'thumb-888', updatedAt: '2026-07-02',
     uploader: { name: 'Uploader888' },
   },
-  { // tagged but no valid block — skipped, surfaced in meta
+  { // tagged but no valid block: skipped, surfaced in meta
     modId: 999, name: 'Blockless Mod', summary: 'no block',
     description: 'Just prose.', uploader: { name: 'Nobody' },
   },
@@ -91,7 +91,7 @@ test('manual full entry carries images from the tagged-query backfill', () => {
 });
 
 test('WIP manual entry resolves to null images (shape stays stable)', () => {
-  const full = dataset.full['bbbb-2222']; // nexus_id WIP — no Nexus page
+  const full = dataset.full['bbbb-2222']; // nexus_id WIP: no Nexus page
   assert.equal(full.thumbnail_url, null);
   assert.equal(full.picture_url, null);
   assert.equal(full.updated_at, null);

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -92,7 +92,7 @@ test('modsByUid: a thrown fetch degrades to empty, never throws', async () => {
 
 test('modsByUid: sends the composite (gameId<<32)+modId UID (not "gameId:modId")', async () => {
   // Wire-contract guard: Nexus silently drops UIDs in the wrong format and
-  // returns no images — a bug the shape-only tests above can't catch.
+  // returns no images, a bug the shape-only tests above can't catch.
   let sentUids = null;
   const impl = async (url, init) => {
     sentUids = JSON.parse(init.body).variables.uids;

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -98,7 +98,7 @@ test('first run writes the full dataset (changed=true)', async () => {
   assert.ok(locs.every((l) => typeof l.recently_updated === 'boolean'));
   const meta = await env.DATASET.get(KEYS.meta, 'json');
   assert.equal(meta.discovery_stale, false);
-  assert.ok(!('counts' in meta)); // aggregates removed — consumers derive their own
+  assert.ok(!('counts' in meta)); // aggregates removed; consumers derive their own
   assert.equal(meta.dataset_version, r.version);
 });
 

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -1,4 +1,4 @@
-// NC Zoning Data API — Cloudflare Worker config.
+// NC Zoning Data API: Cloudflare Worker config.
 // Deploys independently of the Pages site; shares only the nczoning.net zone.
 // See docs/data-api-plan.md for the architecture.
 //
@@ -8,7 +8,7 @@
 //   `wrangler deploy --env staging`   → STAGING (env.staging)
 //                                       nczoning-api-staging @ api-dev.nczoning.net
 // CI (.github/workflows/deploy-api.yml) deploys prod from `main`, staging
-// from `dev`. Named environments do NOT inherit vars/kv/routes/triggers —
+// from `dev`. Named environments do NOT inherit vars/kv/routes/triggers;
 // each is declared in full.
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
@@ -44,7 +44,7 @@
 		}
 	],
 	// Rebuild the dataset every 5 minutes (faster mod propagation after a
-	// submission). Nexus load stays well under limits — see docs/nexus-api-reference.md.
+	// submission). Nexus load stays well under limits; see docs/nexus-api-reference.md.
 	"triggers": {
 		"crons": [
 			"*/5 * * * *"
@@ -55,7 +55,7 @@
 	//   wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL --env staging
 	// Falls back to the legacy DISCORD_WEBHOOK_URL secret if the new one isn't
 	// set (no alerting gap during the move). Secrets aren't committed here.
-	// Optional — refresh runs without either.
+	// Optional: refresh runs without either.
 
 	"env": {
 		// Staging: pulls source files from the dev site, writes to a separate


### PR DESCRIPTION
## What

The shipped-code-comment half of the house-style adoption (the markdown halves were #831/#833). Comments only; no executable line changes.

- **863 em-dashes rewritten** in comments with real punctuation (colon/semicolon/comma/parentheses/sentence split; zero blanket \`--\`), across js, css, html, py, wscript, jsonc, workflow yml and .gitignore.
- **Australian English** in comment prose (colours, centre, -ise); identifiers, API names (\`material.color\`, \`getCenter\`), CSS properties and JSON keys untouched. No licence/license misuses found.
- **Residue sweep** over the same files:
  - 4 shipped wiki citations dropped, constraints kept inline (constants.js, district-line-material.js, three-scene.js x2).
  - Conversation-anchored notes removed ("per request", "paste back here", quoted informal bug-report titles; the mechanism descriptions stay).
  - ~20 stale comments corrected against the code they sit on. Highlights: three-scene.js claimed the buildings use an \`InstancedBufferGeometry\` in two places while the code explicitly must NOT use one; \`map_constants.py\`'s docstring credited TweakDB cursorBoundary for the world extent that actually comes from the Realistic Map quad UVs, and its derived width/height comments still showed the old TweakDB extents (11550/12300 vs the real 12113/12111); \`fix_coords_from_project.js\` documented field names that don't exist on the Project.

## Deliberately untouched

- Em-dashes in **string literals** (66: console output, UI titles, thrown errors) and **rendered markup** (17 in index.html, plus spike-page markup): content, not comments.
- The \` — \` separators quoted in \`auto-pr-submission.yml\` / \`modify-location-submission.yml\` comments: they document the literal checkbox-label separator the adjacent code splits on.
- Issue/PR/plan-code references (#656, #771, B7, E5): resolvable provenance, kept.
- Removed-feature history with anti-regression value (spiderfy notes in app.js, BFM incident history in monitor_api_health.js): kept; they explain why the code is shaped the way it is.

## TODOs found in comments (tracked here, not deleted)

- \`three-scene.js:662\` "TEMP: verification only, remove before dev→main" (?forcewebgl gate) — release gate.
- \`theme.css\` Preem theme "attribution required at ship time" — release gate.
- \`scripts/r185_resize_spike.html\` self-labelled "SCRATCH SPIKE ... Delete after", still tracked.
- \`constants.js\` TODO(pix) exact engine lux; CSM revisit; union-frustum cull follow-up (already board-tracked as E5/E6 per comments).
- \`map_constants.py\` zoom thresholds "(to be fine-tuned)".

## Proof it is comments-only

- Comment-stripped old vs new sources are **byte-identical** for all 40 js/css/html/jsonc/wscript/gitignore files (string-aware state machine; strings and template literals preserved).
- Python: **ASTs identical** with docstrings nulled (6/6); docstrings were styled deliberately (none are consumed at runtime).
- YAML: 4 changed lines, inspected by hand, all comments (one is a JS comment inside a \`script:\` block string, same class as docstrings).
- Line endings preserved (numstat symmetric, Edit-tool-only changes).
- Worker tests 63/63; \`node --check\` clean on all edited JS.

Merging to dev will redeploy the staging API Worker (deploy-api.yml path-matches \`worker/**\`): a no-op redeploy, behaviour is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)