### PR TITLE
fix(api): only fetch previewable mod files for archive names

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -102,13 +102,13 @@ A location record:
 - `credits` appears only when set; `thumbnail_url` / `picture_url` / `updated_at`
   are `null` when unknown (e.g. WIP/Dummy entries with no Nexus page, which are
   also never `recently_updated`).
-- `archives` is the list of `.archive` filenames the mod ships, unioned across
-  every downloadable file (main + optional variants). **Match these against the
-  player's `archive/pc/mod/` folder to detect which location mods are
-  installed.** It's always present — `[]` when unknown (WIP/Dummy, no Nexus
-  files, or not yet fetched by the cron; see the note below). Names are the bare
-  filename (`Atari AIO.archive`), not a path, so a case-sensitive set membership
-  test against the folder listing is all a consumer needs.
+- `archives` is the list of `.archive` filenames the mod ships. **Match these
+  against the player's `archive/pc/mod/` folder to detect which location mods are
+  installed.** Names are the bare filename (`Atari AIO.archive`), not a path, so
+  a case-sensitive set-membership test against the folder listing is all a
+  consumer needs. It's always present — `[]` means "not determinable", never
+  "ships no archives" (see the note below: some mods' files have no public
+  contents preview, and freshly added mods fill in over a few cron ticks).
 
 ## Caching
 
@@ -188,7 +188,9 @@ re-downloading unchanged data.
   names are (re)fetched only when its Nexus `updated_at` changes, and a fresh
   dataset back-fills them a batch per cron tick rather than all at once. A newly
   added mod can therefore show `archives: []` for a short window before its names
-  land — treat an empty list as "unknown yet", not "ships no archives".
+  land. A minority of mods (~6%) stay `[]` permanently because none of their
+  files expose a public contents preview on Nexus. Either way, treat `[]` as
+  "unknown", never "ships no archives".
 - `recently_updated` rides the content hash: because it depends on the clock,
   a location crossing the `recently_updated_days` boundary changes
   `dataset_version` (and the `ETag`) even when nothing on Nexus changed, so a

--- a/docs/nexus-api-reference.md
+++ b/docs/nexus-api-reference.md
@@ -178,20 +178,39 @@ query ModFiles($modId: ID!, $gameId: ID!) {
 - Returns a flat array of files (main + optional). We take every file's `uri`
   (e.g. `Atari Canyon AIO-27618-1-0-1771273179.7z`).
 
-**Hop 2 — file contents.** For each `uri`, fetch the S3-backed "Preview file
+**Hop 2 — file contents.** For each file, fetch the S3-backed "Preview file
 contents" tree:
 
 ```text
-https://file-metadata.nexusmods.com/file/nexus-files-s3-meta/{gameId}/{modId}/{encodeURIComponent(uri)}.json
+https://file-metadata.nexusmods.com/file/nexus-files-s3-meta/{gameId}/{modId}/{uri}.json
 ```
 
 The response is a recursive tree of `{ name, type: "directory"|"file", children }`
 nodes (root is `{ children: [...] }`). We walk it and collect every `type:"file"`
-whose `name` ends in `.archive`, unioned across all of the mod's files, deduped
+whose `name` ends in `.archive`, unioned across the mod's fetched files, deduped
 and sorted. `.xl` (ArchiveXL) and other files are ignored.
 
+**Which files we fetch (a measured coverage limit):** the `uri` comes in two
+forms. Older files carry the **friendly filename**
+(`Atari Canyon AIO-27618-1-0-1771273179.7z`) and **have** a contents preview.
+Newer files carry a **UUID storage path** (`uri` contains `/`, e.g.
+`b9/e3/70/b9e37068-…`) and **have no preview** at the file-metadata path — it
+404s regardless of slash-encoding (`scanned`/`scannedV2` are `VERIFIED` in both
+cases, so they don't predict it). So the fetch:
+
+- **skips UUID-path files entirely** (no wasted subrequest, no false failure);
+- **prefers current categories** (`MAIN`/`OPTIONAL`/`UPDATE`), falling back to an
+  older friendly file (`ARCHIVED`/`OLD_VERSION`) only when a mod has no current
+  previewable file;
+- caps contents fetches per mod (`ARCHIVE_FILES_PER_MOD`) so one mod with many
+  optional variants can't exhaust the run's subrequest budget.
+
+Measured against the live population, **~94% of mods still yield ≥1 `.archive`**;
+the rest (only UUID files, no friendly copy) resolve to `[]`.
+
 **Output field:** `archives: string[]` on each `LocationFull` record (bare
-filenames, not paths). Always present; `[]` when unknown.
+filenames, not paths). Always present; `[]` means "not determinable" (all-UUID
+files, or not yet fetched), never "ships no archives".
 
 **Caching & cadence (the load-bearing part):** archive names are near-static —
 they only change on a re-upload, which bumps the mod's `updatedAt`. So the cron

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -179,10 +179,30 @@ export async function fetchModsByUidThumbs(fetchImpl = fetch, numericIds = []) {
 // preview. Everything here is NON-THROWING: archive names are supplementary, so
 // a Nexus hiccup returns { ok:false } and the caller keeps last-known-good, it
 // never marks the whole dataset stale.
+//
+// Coverage limitation (measured, not assumed): only files whose modFiles `uri`
+// is the friendly filename (e.g. `Atari Canyon AIO-27618-1-0-….7z`) have a
+// contents preview at the file-metadata path. Files stored under a UUID path
+// (`uri` contains `/`, e.g. `b9/e3/70/b9e3…`) return 404 there regardless of
+// slash-encoding — the preview simply isn't published for them. So we fetch
+// ONLY friendly-uri files and skip UUID ones (no wasted subrequests, no false
+// failures). ~94% of the mod population still yields ≥1 `.archive`; the rest
+// resolve to `[]` (unknown), which the API already documents as "not
+// determinable", never "ships no archives".
+
+// Download-file categories that represent the mod's *current* files. We prefer
+// these; ARCHIVED/OLD_VERSION are superseded and only used as a fallback when a
+// mod has no current friendly-uri file (keeps the archive names current and the
+// per-mod subrequest count low).
+const CURRENT_FILE_CATEGORIES = new Set(['MAIN', 'OPTIONAL', 'UPDATE']);
+// Hard cap on file-contents fetches per mod, so one mod with many optional
+// variants can't blow the run's subrequest budget on its own.
+const ARCHIVE_FILES_PER_MOD = 6;
 
 const MOD_FILES_QUERY = `query ModFiles($modId: ID!, $gameId: ID!) {
   modFiles(modId: $modId, gameId: $gameId) {
     uri
+    category
   }
 }`;
 
@@ -205,14 +225,14 @@ function collectArchiveNames(node, out) {
 }
 
 /**
- * List every downloadable file's `uri` for a mod via the api-router modFiles
- * query. Returns { uris, ok }: ok is false on any HTTP/GraphQL/parse failure, so
- * the caller can distinguish "genuinely no files" (ok:true, uris:[]) from "we
- * couldn't tell" (ok:false) and avoid caching a transient failure as truth.
+ * List a mod's downloadable files (uri + category) via the api-router modFiles
+ * query. Returns { files, ok }: ok is false on any HTTP/GraphQL/parse failure,
+ * so the caller can distinguish "genuinely no files" (ok:true, files:[]) from
+ * "we couldn't tell" (ok:false) and avoid caching a transient failure as truth.
  *
  * @param {typeof fetch} fetchImpl injectable for tests
  * @param {string|number} modId numeric Nexus mod id
- * @returns {Promise<{uris: string[], ok: boolean}>}
+ * @returns {Promise<{files: Array<{uri: string, category: string}>, ok: boolean}>}
  */
 export async function fetchModFileUris(fetchImpl, modId) {
   try {
@@ -224,27 +244,30 @@ export async function fetchModFileUris(fetchImpl, modId) {
         variables: { modId: String(modId), gameId: String(NEXUS_GAME_ID) },
       }),
     });
-    if (!res.ok) return { uris: [], ok: false };
+    if (!res.ok) return { files: [], ok: false };
     const json = await res.json();
     const files = json?.data?.modFiles;
-    if (!Array.isArray(files)) return { uris: [], ok: false };
+    if (!Array.isArray(files)) return { files: [], ok: false };
     return {
-      uris: files.map((f) => f?.uri).filter((u) => typeof u === 'string' && u.length > 0),
+      files: files
+        .filter((f) => typeof f?.uri === 'string' && f.uri.length > 0)
+        .map((f) => ({ uri: f.uri, category: f.category || '' })),
       ok: true,
     };
   } catch {
-    return { uris: [], ok: false };
+    return { files: [], ok: false };
   }
 }
 
 /**
  * Fetch one downloadable file's contents preview and return its `.archive` file
  * names. Returns { names, ok }; ok is false on any failure (see fetchModFileUris
- * for why the caller needs the distinction).
+ * for why the caller needs the distinction). Only call this for friendly-uri
+ * files — UUID-path uris have no preview and always 404 (see the section note).
  *
  * @param {typeof fetch} fetchImpl injectable for tests
  * @param {string|number} modId numeric Nexus mod id
- * @param {string} uri the download file's uri (from modFiles)
+ * @param {string} uri the download file's friendly-name uri (from modFiles)
  * @returns {Promise<{names: string[], ok: boolean}>}
  */
 export async function fetchArchiveNamesForFile(fetchImpl, modId, uri) {
@@ -262,15 +285,17 @@ export async function fetchArchiveNamesForFile(fetchImpl, modId, uri) {
 }
 
 /**
- * All `.archive` file names a mod ships, unioned across every downloadable file
- * (main + optional variants), deduped and sorted. Cost is 1 modFiles call + 1
- * file-contents call per file — the caller budgets how many mods it refreshes
- * per cron run to stay under the Worker subrequest cap.
+ * All `.archive` file names a mod ships, unioned across its previewable files,
+ * deduped and sorted. Only friendly-uri files are fetched (UUID-path files have
+ * no preview); current-category files (MAIN/OPTIONAL/UPDATE) are preferred, with
+ * older friendly files used only as a fallback when a mod has no current one.
+ * At most ARCHIVE_FILES_PER_MOD contents fetches, so one mod can't exhaust the
+ * caller's per-run subrequest budget.
  *
- * `ok` is true only if the modFiles call AND every file-contents call succeeded,
- * so the caller never caches a partial listing produced by a transient failure
- * as if it were complete. `subrequests` is the number of network calls made, for
- * budgeting.
+ * `ok` is true only if the modFiles call AND every attempted contents call
+ * succeeded, so the caller never caches a partial listing from a transient
+ * failure as if it were complete. `subrequests` is the number of network calls
+ * made, for budgeting.
  *
  * @param {typeof fetch} fetchImpl injectable for tests
  * @param {string|number} modId numeric Nexus mod id
@@ -280,9 +305,17 @@ export async function fetchModArchiveNames(fetchImpl, modId) {
   const filesRes = await fetchModFileUris(fetchImpl, modId);
   let ok = filesRes.ok;
   let subrequests = 1; // the modFiles call itself
+
+  // Friendly-uri files only (UUID paths have no derivable preview). Prefer the
+  // mod's current files; fall back to any friendly file (older ARCHIVED/
+  // OLD_VERSION) when none of the current ones are previewable.
+  const friendly = filesRes.files.filter((f) => !f.uri.includes('/'));
+  const current = friendly.filter((f) => CURRENT_FILE_CATEGORIES.has(f.category));
+  const chosen = (current.length ? current : friendly).slice(0, ARCHIVE_FILES_PER_MOD);
+
   const all = new Set();
-  for (const uri of filesRes.uris) {
-    const r = await fetchArchiveNamesForFile(fetchImpl, modId, uri);
+  for (const f of chosen) {
+    const r = await fetchArchiveNamesForFile(fetchImpl, modId, f.uri);
     subrequests += 1;
     if (!r.ok) ok = false;
     for (const name of r.names) all.add(name);

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -115,6 +115,7 @@ async function refreshArchives(fetchImpl, full, cache) {
 
   let changed = false;
   let refreshed = 0;
+  let okCount = 0;
   let subrequests = 0;
   for (const r of stale) {
     if (refreshed >= ARCHIVE_MOD_BUDGET || subrequests >= ARCHIVE_SUBREQUEST_BUDGET) break;
@@ -122,8 +123,16 @@ async function refreshArchives(fetchImpl, full, cache) {
     refreshed += 1;
     subrequests += res.subrequests;
     if (!res.ok) continue; // transient failure: leave stale, retry next run
+    okCount += 1;
     cache[r.nexus_id] = { updatedAt: r.updated_at ?? null, archives: res.archives };
     changed = true;
+  }
+  if (refreshed > 0) {
+    // Ops visibility for the cold-fill / re-upload catch-up (cf. the thumbnail
+    // warnings). Silent in steady state, when nothing is stale.
+    console.log(
+      `archives: refreshed ${okCount}/${refreshed} mods (${stale.length} stale, ${subrequests} subrequests), cache=${Object.keys(cache).length}`,
+    );
   }
 
   // Evict entries for mods no longer in the dataset (deleted/hidden on Nexus) so

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -149,9 +149,9 @@ function archiveFetch({ modFiles = [], trees = {}, routerOk = true } = {}) {
   };
 }
 
-test('archives: unions .archive names across files, deduped + sorted', async () => {
+test('archives: unions .archive names across current files, deduped + sorted', async () => {
   const impl = archiveFetch({
-    modFiles: [{ uri: 'Main-1.7z' }, { uri: 'Optional-2.7z' }],
+    modFiles: [{ uri: 'Main-1.7z', category: 'MAIN' }, { uri: 'Optional-2.7z', category: 'OPTIONAL' }],
     trees: {
       'Main-1.7z': tree('b.archive', 'a.archive', 'shared.archive'),
       'Optional-2.7z': tree('shared.archive', 'c.archive'),
@@ -163,9 +163,60 @@ test('archives: unions .archive names across files, deduped + sorted', async () 
   assert.equal(res.subrequests, 3); // 1 modFiles + 2 files
 });
 
+test('archives: skips UUID-path files (no preview) — fetches only friendly uris', async () => {
+  // Real Nexus data: newer files carry a UUID storage uri (slashes) with no
+  // contents preview; only friendly-name uris are previewable.
+  const metaHits = [];
+  const impl = async (url, init) => {
+    if (url.includes('api-router')) {
+      return { ok: true, json: async () => ({ data: { modFiles: [
+        { uri: 'Friendly-1.7z', category: 'MAIN' },
+        { uri: 'b9/e3/70/b9e37068-uuid', category: 'MAIN' },
+      ] } }) };
+    }
+    metaHits.push(url);
+    return { ok: true, json: async () => tree('good.archive') };
+  };
+  const res = await fetchModArchiveNames(impl, 1);
+  assert.deepEqual(res.archives, ['good.archive']);
+  assert.equal(res.subrequests, 2); // modFiles + the one friendly file only
+  assert.ok(!metaHits.some((u) => u.includes('uuid')), 'UUID file never requested');
+});
+
+test('archives: prefers current-category files over archived when both are friendly', async () => {
+  const impl = archiveFetch({
+    modFiles: [
+      { uri: 'Current-1-0.7z', category: 'MAIN' },
+      { uri: 'Old-0-9.zip', category: 'OLD_VERSION' },
+    ],
+    trees: { 'Current-1-0.7z': tree('current.archive'), 'Old-0-9.zip': tree('old.archive') },
+  });
+  // OLD_VERSION is not fetched when a current-category file is available.
+  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['current.archive']);
+});
+
+test('archives: falls back to an older friendly file when no current file is previewable', async () => {
+  const impl = archiveFetch({
+    modFiles: [
+      { uri: 'aa/bb/cc/uuid-current', category: 'MAIN' }, // current but UUID → not previewable
+      { uri: 'Old-1-0.zip', category: 'OLD_VERSION' }, // only friendly file left
+    ],
+    trees: { 'Old-1-0.zip': tree('legacy.archive') },
+  });
+  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['legacy.archive']);
+});
+
+test('archives: caps contents fetches per mod so one mod cannot exhaust the budget', async () => {
+  const many = Array.from({ length: 12 }, (_, i) => ({ uri: `Opt-${i}.7z`, category: 'OPTIONAL' }));
+  const trees = Object.fromEntries(many.map((f, i) => [f.uri, tree(`a${i}.archive`)]));
+  const res = await fetchModArchiveNames(archiveFetch({ modFiles: many, trees }), 1);
+  assert.ok(res.subrequests <= 7, `subrequests ${res.subrequests} must be capped (1 + <=6)`);
+  assert.ok(res.archives.length <= 6);
+});
+
 test('archives: ignores non-.archive files (e.g. .xl, readme)', async () => {
   const impl = archiveFetch({
-    modFiles: [{ uri: 'M.7z' }],
+    modFiles: [{ uri: 'M.7z', category: 'MAIN' }],
     trees: { 'M.7z': tree('thing.archive', 'thing.xl', 'readme.txt') },
   });
   assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['thing.archive']);
@@ -178,7 +229,7 @@ test('archives: modFiles failure → ok:false, no archives, only the one subrequ
 
 test('archives: a file-contents failure marks ok:false but keeps what it found', async () => {
   const impl = archiveFetch({
-    modFiles: [{ uri: 'Good.7z' }, { uri: 'Bad.7z' }],
+    modFiles: [{ uri: 'Good.7z', category: 'MAIN' }, { uri: 'Bad.7z', category: 'MAIN' }],
     trees: { 'Good.7z': tree('good.archive'), 'Bad.7z': { ok: false } },
   });
   const res = await fetchModArchiveNames(impl, 1);
@@ -199,7 +250,7 @@ test('archives: sends modId/gameId as ID strings and builds the file-metadata UR
   const impl = async (url, init) => {
     if (url.includes('api-router')) {
       sentVars = JSON.parse(init.body).variables;
-      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: 'A B-1.7z' }] } }) };
+      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: 'A B-1.7z', category: 'MAIN' }] } }) };
     }
     metaUrl = url;
     return { ok: true, json: async () => tree('x.archive') };

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -77,7 +77,7 @@ function fakeFetch({ failNexus = false, failMods = false, discordSink, archiveCa
       archiveCalls?.push('router');
       if (failArchives) return { ok: false, status: 503 };
       const modId = JSON.parse(init.body).variables.modId;
-      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: `mod-${modId}.7z` }] } }) };
+      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: `mod-${modId}.7z`, category: 'MAIN' }] } }) };
     }
     if (url.includes('file-metadata.nexusmods.com')) {
       archiveCalls?.push('file');
@@ -229,7 +229,7 @@ test('archive refresh is budgeted per run and cold-fills over multiple runs', as
     if (url.includes('/subdistricts.json')) return { ok: true, json: async () => SUBDISTRICTS };
     if (url.includes('api-router.nexusmods.com')) {
       archiveCalls.push('router');
-      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: 'a.7z' }] } }) };
+      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: 'a.7z', category: 'MAIN' }] } }) };
     }
     if (url.includes('file-metadata.nexusmods.com')) {
       archiveCalls.push('file');


### PR DESCRIPTION
Follow-up to #845. On `dev`/staging, the new `archives` field came back **empty for every mod** — the field attached correctly (295/295) but no names populated. Live diagnosis on `api-dev.nczoning.net` found the cause.

## Root cause

`modFiles` returns each file's `uri` in **two forms**:
- **friendly filename** (`Atari Canyon AIO-27618-1-0-….7z`) → has a `file-metadata` contents preview (200)
- **UUID storage path** (`b9/e3/70/b9e37068-…`, `uri` contains `/`) → **no preview**, 404s regardless of slash-encoding (`scanned`/`scannedV2` are `VERIFIED` in both cases, so they don't discriminate)

The first pass fetched *all* files, so newer/UUID-stored files 404'd, marked the mod `ok:false`, and nothing cached → `[]` everywhere. (Non-fatal by design: `discovery_stale` stayed `false` throughout.)

## Fix

- Fetch **only friendly-uri files**; skip UUID paths entirely (no wasted subrequest, no false failure).
- **Prefer current categories** (`MAIN`/`OPTIONAL`/`UPDATE`); fall back to an older friendly file (`ARCHIVED`/`OLD_VERSION`) only when a mod has no current previewable file.
- **Cap** contents fetches per mod so one mod can't exhaust the run's subrequest budget.
- Drop the temporary diagnostic logging; keep a concise per-run summary line.

Measured across the live population: **~94% of mods yield ≥1 `.archive`**; the rest have no public preview and resolve to `[]` (documented as "unknown", never "ships no archives").

## Verification

- 77 worker tests pass (+4: UUID-skip, category preference, archived fallback, per-mod cap).
- **Deployed to staging and confirmed against real Nexus data** — archive names populate, including mods whose current file is UUID-only (recovered via the fallback), e.g. Glen Glass Den → `Glen Glass Den Neon Table.archive`, `Glen Glass Den Table.archive`. `discovery_stale: false` throughout the cold fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)