### PR TITLE
feat(api): recover archive names for new-scheme files via file-manifests host

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -106,9 +106,9 @@ A location record:
   against the player's `archive/pc/mod/` folder to detect which location mods are
   installed.** Names are the bare filename (`Atari AIO.archive`), not a path, so
   a case-sensitive set-membership test against the folder listing is all a
-  consumer needs. It's always present — `[]` means "not determinable", never
-  "ships no archives" (see the note below: some mods' files have no public
-  contents preview, and freshly added mods fill in over a few cron ticks).
+  consumer needs. It's always present — `[]` means "not determinable / not yet
+  fetched", never "ships no archives" (freshly added mods fill in over a few
+  cron ticks; see the note below).
 
 ## Caching
 
@@ -188,9 +188,9 @@ re-downloading unchanged data.
   names are (re)fetched only when its Nexus `updated_at` changes, and a fresh
   dataset back-fills them a batch per cron tick rather than all at once. A newly
   added mod can therefore show `archives: []` for a short window before its names
-  land. A minority of mods (~6%) stay `[]` permanently because none of their
-  files expose a public contents preview on Nexus. Either way, treat `[]` as
-  "unknown", never "ships no archives".
+  land. A small residual stays `[]` (loose-file mods with no `.archive`, or
+  WIP/Dummy entries with no Nexus page). Either way, treat `[]` as "unknown",
+  never "ships no archives".
 - `recently_updated` rides the content hash: because it depends on the clock,
   a location crossing the `recently_updated_days` boundary changes
   `dataset_version` (and the `ETag`) even when nothing on Nexus changed, so a

--- a/docs/nexus-api-reference.md
+++ b/docs/nexus-api-reference.md
@@ -178,39 +178,52 @@ query ModFiles($modId: ID!, $gameId: ID!) {
 - Returns a flat array of files (main + optional). We take every file's `uri`
   (e.g. `Atari Canyon AIO-27618-1-0-1771273179.7z`).
 
-**Hop 2 — file contents.** For each file, fetch the S3-backed "Preview file
-contents" tree:
+**Hop 2 — file contents.** Each file's contents live at **one of two hosts**,
+because Nexus changed its storage scheme around mid-2026. Route by the shape of
+the file's `uri`:
 
-```text
-https://file-metadata.nexusmods.com/file/nexus-files-s3-meta/{gameId}/{modId}/{uri}.json
-```
+- **Old scheme — `uri` is the friendly filename** (`Atari Canyon AIO-27618-…-.7z`):
 
-The response is a recursive tree of `{ name, type: "directory"|"file", children }`
-nodes (root is `{ children: [...] }`). We walk it and collect every `type:"file"`
-whose `name` ends in `.archive`, unioned across the mod's fetched files, deduped
-and sorted. `.xl` (ArchiveXL) and other files are ignored.
+  ```text
+  https://file-metadata.nexusmods.com/file/nexus-files-s3-meta/{gameId}/{modId}/{uri}.json
+  ```
 
-**Which files we fetch (a measured coverage limit):** the `uri` comes in two
-forms. Older files carry the **friendly filename**
-(`Atari Canyon AIO-27618-1-0-1771273179.7z`) and **have** a contents preview.
-Newer files carry a **UUID storage path** (`uri` contains `/`, e.g.
-`b9/e3/70/b9e37068-…`) and **have no preview** at the file-metadata path — it
-404s regardless of slash-encoding (`scanned`/`scannedV2` are `VERIFIED` in both
-cases, so they don't predict it). So the fetch:
+  A recursive **tree** of `{ name, type: "directory"|"file", children }` (root is
+  `{ children: [...] }`). Walk it; collect every `type:"file"` whose `name` ends
+  in `.archive`.
 
-- **skips UUID-path files entirely** (no wasted subrequest, no false failure);
-- **prefers current categories** (`MAIN`/`OPTIONAL`/`UPDATE`), falling back to an
-  older friendly file (`ARCHIVED`/`OLD_VERSION`) only when a mod has no current
-  previewable file;
-- caps contents fetches per mod (`ARCHIVE_FILES_PER_MOD`) so one mod with many
-  optional variants can't exhaust the run's subrequest budget.
+- **New scheme — `uri` is a UUID storage path** (contains `/`, e.g.
+  `b9/e3/70/b9e37068-…`):
 
-Measured against the live population, **~94% of mods still yield ≥1 `.archive`**;
-the rest (only UUID files, no friendly copy) resolve to `[]`.
+  ```text
+  https://file-manifests.nexusmods.com/{uri}.json
+  ```
+
+  A **flat array** of `{ file_path, file_size, file_hashes }`. Take the basename
+  of each `file_path` ending in `.archive` (e.g.
+  `archive/pc/mod/Foo.archive` → `Foo.archive`).
+
+(The friendly `uri` does *not* work on the manifest host and vice-versa — each
+scheme is served by exactly one host.) Names are unioned across the mod's fetched
+files, deduped and sorted; `.xl` (ArchiveXL) and other files are ignored.
+
+**Which files we fetch:** both schemes are fetchable, so we **prefer current
+categories** (`MAIN`/`OPTIONAL`/`UPDATE`), falling back to older files
+(`ARCHIVED`/`OLD_VERSION`) only when a mod has no current file, and cap contents
+fetches per mod (`ARCHIVE_FILES_PER_MOD`) so one mod with many optional variants
+can't exhaust the run's subrequest budget. Coverage is **near-total**; the
+residual `[]` are loose-file mods with no `.archive`, WIP/Dummy entries (no Nexus
+page), or not-yet-filled records.
+
+> **History:** the first cut fetched *all* files via the file-metadata host and
+> got `[]` for every mod, because new-scheme (UUID) files 404 there. A second cut
+> skipped UUID files (~94% coverage). The `file-manifests` host — which serves the
+> new scheme — closed the gap to near-total. See
+> [[NC-Zoning-Board/wiki/learnings/nexus-file-contents-two-hosts-by-scheme]].
 
 **Output field:** `archives: string[]` on each `LocationFull` record (bare
-filenames, not paths). Always present; `[]` means "not determinable" (all-UUID
-files, or not yet fetched), never "ships no archives".
+filenames, not paths). Always present; `[]` means "not determinable / not yet
+fetched", never "ships no archives".
 
 **Caching & cadence (the load-bearing part):** archive names are near-static —
 they only change on a re-upload, which bumps the mod's `updatedAt`. So the cron

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -13,9 +13,11 @@ export const NEXUS_GQL_ENDPOINT = 'https://api.nexusmods.com/v2/graphql';
 // Newer public router endpoint that exposes modFiles (the V2 endpoint above
 // does not). Both are unauthenticated; see docs/nexus-api-reference.md.
 export const NEXUS_ROUTER_ENDPOINT = 'https://api-router.nexusmods.com/graphql';
-// S3-backed file-contents preview: the tree Nexus shows under "Preview file
-// contents" on a mod's Files tab. Keyed by game/mod/<uri>.json.
+// File-contents preview, TWO schemes (see the archive section note below):
+// - old scheme (friendly-filename uri): file-metadata host, nested {children} tree.
 export const FILE_METADATA_BASE = 'https://file-metadata.nexusmods.com/file/nexus-files-s3-meta';
+// - new scheme (UUID-path uri, ~mid-2026+): file-manifests host, flat file_path array.
+export const FILE_MANIFEST_BASE = 'https://file-manifests.nexusmods.com';
 export const NEXUS_GAME_ID = 3333; // Cyberpunk 2077
 export const NEXUS_BATCH_SIZE = 50;
 const ARCHIVE_UA = 'nczoning-data-api (+https://nczoning.net)';
@@ -180,20 +182,20 @@ export async function fetchModsByUidThumbs(fetchImpl = fetch, numericIds = []) {
 // a Nexus hiccup returns { ok:false } and the caller keeps last-known-good, it
 // never marks the whole dataset stale.
 //
-// Coverage limitation (measured, not assumed): only files whose modFiles `uri`
-// is the friendly filename (e.g. `Atari Canyon AIO-27618-1-0-….7z`) have a
-// contents preview at the file-metadata path. Files stored under a UUID path
-// (`uri` contains `/`, e.g. `b9/e3/70/b9e3…`) return 404 there regardless of
-// slash-encoding — the preview simply isn't published for them. So we fetch
-// ONLY friendly-uri files and skip UUID ones (no wasted subrequests, no false
-// failures). ~94% of the mod population still yields ≥1 `.archive`; the rest
-// resolve to `[]` (unknown), which the API already documents as "not
-// determinable", never "ships no archives".
+// A file's contents preview lives at ONE OF TWO hosts, chosen by the shape of
+// its modFiles `uri` (Nexus changed its storage scheme ~mid-2026):
+//   - OLD scheme — `uri` is the friendly filename (`Atari…-27618-1-0-….7z`):
+//     file-metadata host, keyed by game/mod/<uri>.json, a nested {children} tree.
+//   - NEW scheme — `uri` is a UUID storage path (contains `/`, `b9/e3/70/b9e3…`):
+//     file-manifests host, keyed by <uri>.json, a FLAT array of { file_path }.
+// Both are covered (see fetchArchiveNamesForFile), so coverage is near-total;
+// `[]` means WIP/Dummy (no Nexus page), a loose-file mod with no `.archive`, or
+// not-yet-fetched — never "ships no archives".
 
 // Download-file categories that represent the mod's *current* files. We prefer
 // these; ARCHIVED/OLD_VERSION are superseded and only used as a fallback when a
-// mod has no current friendly-uri file (keeps the archive names current and the
-// per-mod subrequest count low).
+// mod has no current file (keeps the archive names current and the per-mod
+// subrequest count low).
 const CURRENT_FILE_CATEGORIES = new Set(['MAIN', 'OPTIONAL', 'UPDATE']);
 // Hard cap on file-contents fetches per mod, so one mod with many optional
 // variants can't blow the run's subrequest budget on its own.
@@ -222,6 +224,21 @@ function collectArchiveNames(node, out) {
     out.add(node.name);
   }
   if (Array.isArray(node.children)) collectArchiveNames(node.children, out);
+}
+
+/**
+ * Collect `.archive` file names from a new-scheme manifest: a FLAT array of
+ * { file_path, file_size, file_hashes }, where file_path is the full in-archive
+ * path (`archive/pc/mod/Foo.archive`). We take the basename of each `.archive`.
+ */
+function collectArchiveNamesFromManifest(entries, out) {
+  if (!Array.isArray(entries)) return;
+  for (const entry of entries) {
+    const p = entry?.file_path;
+    if (typeof p === 'string' && p.toLowerCase().endsWith('.archive')) {
+      out.add(p.split(/[\\/]/).pop());
+    }
+  }
 }
 
 /**
@@ -261,23 +278,29 @@ export async function fetchModFileUris(fetchImpl, modId) {
 
 /**
  * Fetch one downloadable file's contents preview and return its `.archive` file
- * names. Returns { names, ok }; ok is false on any failure (see fetchModFileUris
- * for why the caller needs the distinction). Only call this for friendly-uri
- * files — UUID-path uris have no preview and always 404 (see the section note).
+ * names. Routes by `uri` shape to the right host/parser: a UUID storage path
+ * (contains `/`) → file-manifests host (flat file_path array); a friendly
+ * filename → file-metadata host (nested children tree). Returns { names, ok };
+ * ok is false on any failure (see fetchModFileUris for why the caller needs the
+ * distinction).
  *
  * @param {typeof fetch} fetchImpl injectable for tests
  * @param {string|number} modId numeric Nexus mod id
- * @param {string} uri the download file's friendly-name uri (from modFiles)
+ * @param {string} uri the download file's uri (from modFiles)
  * @returns {Promise<{names: string[], ok: boolean}>}
  */
 export async function fetchArchiveNamesForFile(fetchImpl, modId, uri) {
   try {
-    const url = `${FILE_METADATA_BASE}/${NEXUS_GAME_ID}/${modId}/${encodeURIComponent(uri)}.json`;
+    const isUuidPath = uri.includes('/');
+    const url = isUuidPath
+      ? `${FILE_MANIFEST_BASE}/${uri}.json`
+      : `${FILE_METADATA_BASE}/${NEXUS_GAME_ID}/${modId}/${encodeURIComponent(uri)}.json`;
     const res = await fetchImpl(url, { headers: { 'User-Agent': ARCHIVE_UA } });
     if (!res.ok) return { names: [], ok: false };
     const json = await res.json();
     const names = new Set();
-    collectArchiveNames(json, names);
+    if (isUuidPath) collectArchiveNamesFromManifest(json, names);
+    else collectArchiveNames(json, names);
     return { names: [...names], ok: true };
   } catch {
     return { names: [], ok: false };
@@ -285,12 +308,12 @@ export async function fetchArchiveNamesForFile(fetchImpl, modId, uri) {
 }
 
 /**
- * All `.archive` file names a mod ships, unioned across its previewable files,
- * deduped and sorted. Only friendly-uri files are fetched (UUID-path files have
- * no preview); current-category files (MAIN/OPTIONAL/UPDATE) are preferred, with
- * older friendly files used only as a fallback when a mod has no current one.
- * At most ARCHIVE_FILES_PER_MOD contents fetches, so one mod can't exhaust the
- * caller's per-run subrequest budget.
+ * All `.archive` file names a mod ships, unioned across its files, deduped and
+ * sorted. Both storage schemes are fetchable (fetchArchiveNamesForFile routes by
+ * uri shape), so current-category files (MAIN/OPTIONAL/UPDATE) are preferred,
+ * with older files (ARCHIVED/OLD_VERSION) used only as a fallback when a mod has
+ * no current file. At most ARCHIVE_FILES_PER_MOD contents fetches, so one mod
+ * can't exhaust the caller's per-run subrequest budget.
  *
  * `ok` is true only if the modFiles call AND every attempted contents call
  * succeeded, so the caller never caches a partial listing from a transient
@@ -306,12 +329,10 @@ export async function fetchModArchiveNames(fetchImpl, modId) {
   let ok = filesRes.ok;
   let subrequests = 1; // the modFiles call itself
 
-  // Friendly-uri files only (UUID paths have no derivable preview). Prefer the
-  // mod's current files; fall back to any friendly file (older ARCHIVED/
-  // OLD_VERSION) when none of the current ones are previewable.
-  const friendly = filesRes.files.filter((f) => !f.uri.includes('/'));
-  const current = friendly.filter((f) => CURRENT_FILE_CATEGORIES.has(f.category));
-  const chosen = (current.length ? current : friendly).slice(0, ARCHIVE_FILES_PER_MOD);
+  // Prefer the mod's current files; fall back to all files (older ARCHIVED/
+  // OLD_VERSION) only when it has no current-category file.
+  const current = filesRes.files.filter((f) => CURRENT_FILE_CATEGORIES.has(f.category));
+  const chosen = (current.length ? current : filesRes.files).slice(0, ARCHIVE_FILES_PER_MOD);
 
   const all = new Set();
   for (const f of chosen) {

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -130,13 +130,29 @@ const tree = (...names) => ({
   ] }],
 });
 
-// Routes api-router (modFiles) and file-metadata (contents) by host. `trees`
-// maps a file uri → its contents tree, or { ok:false }/Error to simulate failure.
-function archiveFetch({ modFiles = [], trees = {}, routerOk = true } = {}) {
+// A new-scheme manifest: the flat file_path array the file-manifests host
+// returns (confirmed live). One entry per file, name under archive/pc/mod/.
+const manifest = (...names) => names.map((n) => ({
+  file_path: `archive/pc/mod/${n}`, file_size: 1, file_hashes: {},
+}));
+
+// Routes the three hosts by URL. `trees` maps a friendly uri → its file-metadata
+// tree; `manifests` maps a UUID uri → its file-manifests array. Either value can
+// be { ok:false }/Error to simulate failure.
+function archiveFetch({ modFiles = [], trees = {}, manifests = {}, routerOk = true } = {}) {
   return async (url, init) => {
     if (url.includes('api-router.nexusmods.com')) {
       if (!routerOk) return { ok: false, status: 503, json: async () => ({}) };
       return { ok: true, json: async () => ({ data: { modFiles } }) };
+    }
+    if (url.includes('file-manifests.nexusmods.com')) {
+      const uri = decodeURIComponent(
+        url.replace('https://file-manifests.nexusmods.com/', '').replace(/\.json$/, ''),
+      );
+      const m = manifests[uri];
+      if (m instanceof Error) throw m;
+      if (m && m.ok === false) return { ok: false, status: 404, json: async () => ({}) };
+      return { ok: true, json: async () => m ?? [] };
     }
     if (url.includes('file-metadata.nexusmods.com')) {
       const uri = decodeURIComponent(url.match(/\/[^/]+\/([^/]+)\.json$/)[1]);
@@ -163,27 +179,55 @@ test('archives: unions .archive names across current files, deduped + sorted', a
   assert.equal(res.subrequests, 3); // 1 modFiles + 2 files
 });
 
-test('archives: skips UUID-path files (no preview) — fetches only friendly uris', async () => {
-  // Real Nexus data: newer files carry a UUID storage uri (slashes) with no
-  // contents preview; only friendly-name uris are previewable.
-  const metaHits = [];
-  const impl = async (url, init) => {
+test('archives: fetches UUID-path files from the file-manifests host (flat manifest)', async () => {
+  // New-scheme files (uri is a UUID storage path) have a flat manifest at the
+  // file-manifests host — we take the .archive basename from file_path.
+  const impl = archiveFetch({
+    modFiles: [{ uri: 'ab/cd/ef/uuid-1', category: 'MAIN' }],
+    manifests: { 'ab/cd/ef/uuid-1': manifest('New.archive', 'thing.xl') },
+  });
+  const res = await fetchModArchiveNames(impl, 1);
+  assert.deepEqual(res.archives, ['New.archive']); // basename; .xl ignored
+  assert.equal(res.ok, true);
+});
+
+test('archives: unions across both hosts (friendly tree + UUID manifest)', async () => {
+  const impl = archiveFetch({
+    modFiles: [
+      { uri: 'Main-1.7z', category: 'MAIN' },
+      { uri: 'x/y/z/uuid-opt', category: 'OPTIONAL' },
+    ],
+    trees: { 'Main-1.7z': tree('a.archive') },
+    manifests: { 'x/y/z/uuid-opt': manifest('b.archive') },
+  });
+  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['a.archive', 'b.archive']);
+});
+
+test('archives: routes uri by shape (UUID→file-manifests, friendly→file-metadata)', async () => {
+  const urls = [];
+  const impl = async (url) => {
     if (url.includes('api-router')) {
       return { ok: true, json: async () => ({ data: { modFiles: [
         { uri: 'Friendly-1.7z', category: 'MAIN' },
-        { uri: 'b9/e3/70/b9e37068-uuid', category: 'MAIN' },
+        { uri: 'aa/bb/cc/uuid', category: 'OPTIONAL' },
       ] } }) };
     }
-    metaHits.push(url);
-    return { ok: true, json: async () => tree('good.archive') };
+    urls.push(url);
+    if (url.includes('file-manifests')) return { ok: true, json: async () => manifest('u.archive') };
+    return { ok: true, json: async () => tree('f.archive') };
   };
-  const res = await fetchModArchiveNames(impl, 1);
-  assert.deepEqual(res.archives, ['good.archive']);
-  assert.equal(res.subrequests, 2); // modFiles + the one friendly file only
-  assert.ok(!metaHits.some((u) => u.includes('uuid')), 'UUID file never requested');
+  await fetchModArchiveNames(impl, 27618);
+  assert.ok(
+    urls.includes('https://file-manifests.nexusmods.com/aa/bb/cc/uuid.json'),
+    'UUID uri → file-manifests host, path un-encoded',
+  );
+  assert.ok(
+    urls.includes('https://file-metadata.nexusmods.com/file/nexus-files-s3-meta/3333/27618/Friendly-1.7z.json'),
+    'friendly uri → file-metadata host',
+  );
 });
 
-test('archives: prefers current-category files over archived when both are friendly', async () => {
+test('archives: prefers current-category files over older versions', async () => {
   const impl = archiveFetch({
     modFiles: [
       { uri: 'Current-1-0.7z', category: 'MAIN' },
@@ -195,13 +239,10 @@ test('archives: prefers current-category files over archived when both are frien
   assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['current.archive']);
 });
 
-test('archives: falls back to an older friendly file when no current file is previewable', async () => {
+test('archives: falls back to older files when no current-category file exists', async () => {
   const impl = archiveFetch({
-    modFiles: [
-      { uri: 'aa/bb/cc/uuid-current', category: 'MAIN' }, // current but UUID → not previewable
-      { uri: 'Old-1-0.zip', category: 'OLD_VERSION' }, // only friendly file left
-    ],
-    trees: { 'Old-1-0.zip': tree('legacy.archive') },
+    modFiles: [{ uri: 'gg/hh/ii/uuid-old', category: 'OLD_VERSION' }],
+    manifests: { 'gg/hh/ii/uuid-old': manifest('legacy.archive') },
   });
   assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['legacy.archive']);
 });


### PR DESCRIPTION
Follow-up to #845/#846. Pushes archive-name coverage from ~94% to **near-total**.

## The find (credit: maintainer)

Nexus serves the file-contents preview from **two hosts**, one per storage scheme — I'd only found the first:

| Scheme | `modFiles` `uri` | Preview host | Shape |
|---|---|---|---|
| old (pre ~mid-2026) | friendly filename `Atari…-27618-….7z` | `file-metadata.nexusmods.com/…/{game}/{mod}/{uri}.json` | nested `{children}` tree |
| new (~mid-2026+) | UUID storage path `b9/e3/70/…` | `file-manifests.nexusmods.com/{uri}.json` | flat `{file_path,…}` array |

#846 concluded the new-scheme (UUID) files had no preview and skipped them (that's the ~6% gap). They *do* have a preview — at the other host, which the mod page's own "Preview file contents" button calls.

## Change

`fetchArchiveNamesForFile` routes by uri shape (UUID → file-manifests + flat parser; friendly → file-metadata + tree parser). We no longer skip UUID files; still prefer current categories with an older-file fallback, still cap per mod.

## Verification

- 79 worker tests pass (+ routing and manifest-parse cases).
- **Staging** (`api-dev.nczoning.net`): after clearing the archive KV cache to refill with the new logic, the previously-empty all-UUID mods populate via the manifest host — e.g. Arroyo Petrochem Backlot → `Arroyo Petrochem Backlot.archive`, Neon Isolation → `Neon Isolation v10.archive`. Confirms Worker egress reaches `file-manifests`.

## Deploy note

The KV archive cache (`dataset:v1:archives`) is `updatedAt`-gated, so mods the friendly-only version cached as `[]` won't refetch until their `updatedAt` moves. On promotion to prod, clear the cache once so it refills:
`wrangler kv key delete --remote --namespace-id <prod-ns> dataset:v1:archives`. (Prod hasn't run the feature yet, so its cache is empty — this only matters for envs that ran #846.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)