### PR TITLE
fix(api): archive-detection fixes from the dev soak (404-definitive, .xl, seeds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Each `/v1` location record now carries an `archives` array — the `.archive` filenames the mod ships — so an in-game mod can detect which location mods a player has installed. ([#841](https://github.com/spuddeh/nc-zoning-board/issues/841))
+- Each `/v1` location record now carries an `archives` array — the `.archive` and `.xl` filenames the mod installs to `archive/pc/mod/` (so removal-only mods are detectable too) — letting an in-game mod detect which location mods a player has installed. ([#841](https://github.com/spuddeh/nc-zoning-board/issues/841))
 
 ## [1.4.1] - 2026-07-19
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -102,9 +102,11 @@ A location record:
 - `credits` appears only when set; `thumbnail_url` / `picture_url` / `updated_at`
   are `null` when unknown (e.g. WIP/Dummy entries with no Nexus page, which are
   also never `recently_updated`).
-- `archives` is the list of `.archive` filenames the mod ships. **Match these
-  against the player's `archive/pc/mod/` folder to detect which location mods are
-  installed.** Names are the bare filename (`Atari AIO.archive`), not a path, so
+- `archives` is the list of the mod's detectable install files — `.archive` load
+  files and `.xl` (ArchiveXL) files (the latter is the only fingerprint a
+  removal-only mod has). Both live in `archive/pc/mod/`. **Match these against the
+  player's `archive/pc/mod/` folder to detect which location mods are installed.**
+  Names are the bare filename (`Atari AIO.archive`), not a path, so
   a case-sensitive set-membership test against the folder listing is all a
   consumer needs. It's always present — `[]` means "not determinable / not yet
   fetched", never "ships no archives" (freshly added mods fill in over a few

--- a/docs/nexus-api-reference.md
+++ b/docs/nexus-api-reference.md
@@ -204,8 +204,12 @@ the file's `uri`:
   `archive/pc/mod/Foo.archive` → `Foo.archive`).
 
 (The friendly `uri` does *not* work on the manifest host and vice-versa — each
-scheme is served by exactly one host.) Names are unioned across the mod's fetched
-files, deduped and sorted; `.xl` (ArchiveXL) and other files are ignored.
+scheme is served by exactly one host.) We collect both **`.archive`** load files
+and **`.xl`** (ArchiveXL) files — both install to `archive/pc/mod/` and are
+readable by an in-game mod, and `.xl` is the only fingerprint a removal-only mod
+has. CET/AMM `.json` files are NOT collected (they live in CET's sandboxed
+folder, unreadable by other mods). Names are unioned across the mod's fetched
+files, deduped and sorted.
 
 **Which files we fetch:** both schemes are fetchable, so we **prefer current
 categories** (`MAIN`/`OPTIONAL`/`UPDATE`), falling back to older files

--- a/worker/scripts/archive-seeds.json
+++ b/worker/scripts/archive-seeds.json
@@ -1,0 +1,9 @@
+{
+  "_note": "Manual archive/xl seeds for mods whose Nexus 'Preview file contents' is bugged (404 / 'Content could not be loaded at this time'), so the cron cannot read them. Read from an installed copy of each mod. Injected ONCE per environment into the KV archive cache by seed-archives.mjs; NOT read by the Worker at runtime. Entries self-heal automatically when the mod re-uploads (its updatedAt changes, so the cron refetches — by then the file is usually on the new UUID path and readable). Only numeric keys are applied.",
+  "24887": ["Project-CDSM.archive", "project_cdsm_final_v1.xl", "Dedka Removal Preset.xl"],
+  "22696": ["Akira_Bodyguard.archive", "Akira_Bodyguard.archive.xl", "Mr_Blue_Eyes.archive", "Mr_Blue_Eyes.archive.xl", "Mr_Blue_Eyes.xl", "Mr_Blue_Eyes_Props.xl"],
+  "24131": ["santodomingo_overlooksafehouse.archive", "santodomingo_overlooksafehouse.xl"],
+  "21794": ["Shaitan_Black_Market.archive", "Shaitan_Black_Market.archive.xl", "Shaitan_Black_Market.xl", "Shaitan_Black_Market_Compatibility.xl", "Shaitan_Black_Market_Props.xl", "Shaitan_Black_Market_Flying_Koi_Fish.archive", "Shaitan_Black_Market_Flying_Koi_Fish.xl"],
+  "21288": ["77_glen_oasis.archive", "77_glen_oasis.xl", "77_glen_oasis_removals.xl"],
+  "28598": ["Beach_house_pacifica_shore.archive", "Beach_house_pacifica_shore.xl"]
+}

--- a/worker/scripts/seed-archives.mjs
+++ b/worker/scripts/seed-archives.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Merge manual archive/xl seeds (archive-seeds.json) into a dump of the KV
+ * archive cache, for mods whose Nexus "Preview file contents" is bugged (404 /
+ * "Content could not be loaded at this time") so the cron can't read them.
+ *
+ * This is a PURE merge (reads files + fetches the dataset for updated_at, writes
+ * the merged cache). It deliberately does NOT call wrangler itself — run it
+ * between a `kv key get` and a `kv key put` (below). Each seed is stamped with
+ * the mod's CURRENT updated_at, so the cron treats it as fresh and won't
+ * overwrite it; when the mod re-uploads, updated_at changes and the cron
+ * refetches (by then the file is usually on the readable UUID path). One-off per
+ * environment — re-run on production after a dev -> main promotion.
+ *
+ * STAGING (ns ac85bf5c0b6f47afac35085408857d4b):
+ *   npx wrangler kv key get --remote --namespace-id ac85bf5c0b6f47afac35085408857d4b dataset:v1:archives > cache.json
+ *   node scripts/seed-archives.mjs https://api-dev.nczoning.net cache.json merged.json
+ *   npx wrangler kv key put --remote --namespace-id ac85bf5c0b6f47afac35085408857d4b dataset:v1:archives --path merged.json
+ *
+ * PRODUCTION (ns d86735e00790417e948e423c3df01d68): same three steps, swapping
+ *   the namespace id and https://api.nczoning.net for the api base.
+ *
+ * The next cron tick republishes the dataset with the seeded values attached.
+ * Idempotent: safe to re-run.
+ *
+ * Usage: node scripts/seed-archives.mjs <api-base> <cache-in.json> <merged-out.json>
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const [apiBase, cacheIn, mergedOut] = process.argv.slice(2);
+if (!apiBase || !cacheIn || !mergedOut) {
+  console.error('Usage: node scripts/seed-archives.mjs <api-base> <cache-in.json> <merged-out.json>');
+  process.exit(1);
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const seeds = JSON.parse(readFileSync(join(here, 'archive-seeds.json'), 'utf8'));
+const ids = Object.keys(seeds).filter((k) => /^\d+$/.test(k));
+const cache = JSON.parse(readFileSync(cacheIn, 'utf8').trim() || '{}');
+
+// Current updated_at per mod, so the seed is fresh (not-stale) and self-heals.
+const locs = await fetch(`${apiBase}/v1/locations`, { headers: { 'User-Agent': 'Mozilla/5.0' } }).then((r) => r.json());
+const updatedAt = Object.fromEntries(locs.data.map((r) => [r.nexus_id, r.updated_at ?? null]));
+
+for (const id of ids) {
+  if (!(id in updatedAt)) console.warn(`  warning: ${id} not in the dataset — seeding anyway`);
+  cache[id] = { updatedAt: updatedAt[id] ?? cache[id]?.updatedAt ?? null, archives: seeds[id] };
+  console.log(`  seed ${id}: ${seeds[id].length} files`);
+}
+
+writeFileSync(mergedOut, JSON.stringify(cache));
+console.log(`Merged ${ids.length} seeds; cache now ${Object.keys(cache).length} entries -> ${mergedOut}`);

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -338,26 +338,17 @@ export async function fetchModArchiveNames(fetchImpl, modId) {
   let ok = filesRes.ok;
   let subrequests = 1; // the modFiles call itself
 
+  // Prefer the mod's current files; fall back to all files (older ARCHIVED/
+  // OLD_VERSION) only when it has no current-category file.
   const current = filesRes.files.filter((f) => CURRENT_FILE_CATEGORIES.has(f.category));
-  const older = filesRes.files.filter((f) => !CURRENT_FILE_CATEGORIES.has(f.category));
+  const chosen = (current.length ? current : filesRes.files).slice(0, ARCHIVE_FILES_PER_MOD);
 
-  // Prefer current files (keeps names fresh, bounds cost). Only if they yield NO
-  // archives do we dip into older files (ARCHIVED/OLD_VERSION): some mods keep
-  // their .archive only in a superseded upload, or their current file has no
-  // published preview (404). Best-effort — an old name is better than none for
-  // installed-mod detection. The union stays capped across both phases.
   const all = new Set();
-  let budget = ARCHIVE_FILES_PER_MOD;
-  for (const group of [current, older]) {
-    if (all.size > 0) break; // current already produced names — skip older
-    for (const f of group) {
-      if (budget <= 0) break;
-      const r = await fetchArchiveNamesForFile(fetchImpl, modId, f.uri);
-      subrequests += 1;
-      budget -= 1;
-      if (!r.ok) ok = false;
-      for (const name of r.names) all.add(name);
-    }
+  for (const f of chosen) {
+    const r = await fetchArchiveNamesForFile(fetchImpl, modId, f.uri);
+    subrequests += 1;
+    if (!r.ok) ok = false;
+    for (const name of r.names) all.add(name);
   }
   return { archives: [...all].sort(), ok, subrequests };
 }

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -338,17 +338,26 @@ export async function fetchModArchiveNames(fetchImpl, modId) {
   let ok = filesRes.ok;
   let subrequests = 1; // the modFiles call itself
 
-  // Prefer the mod's current files; fall back to all files (older ARCHIVED/
-  // OLD_VERSION) only when it has no current-category file.
   const current = filesRes.files.filter((f) => CURRENT_FILE_CATEGORIES.has(f.category));
-  const chosen = (current.length ? current : filesRes.files).slice(0, ARCHIVE_FILES_PER_MOD);
+  const older = filesRes.files.filter((f) => !CURRENT_FILE_CATEGORIES.has(f.category));
 
+  // Prefer current files (keeps names fresh, bounds cost). Only if they yield NO
+  // archives do we dip into older files (ARCHIVED/OLD_VERSION): some mods keep
+  // their .archive only in a superseded upload, or their current file has no
+  // published preview (404). Best-effort — an old name is better than none for
+  // installed-mod detection. The union stays capped across both phases.
   const all = new Set();
-  for (const f of chosen) {
-    const r = await fetchArchiveNamesForFile(fetchImpl, modId, f.uri);
-    subrequests += 1;
-    if (!r.ok) ok = false;
-    for (const name of r.names) all.add(name);
+  let budget = ARCHIVE_FILES_PER_MOD;
+  for (const group of [current, older]) {
+    if (all.size > 0) break; // current already produced names — skip older
+    for (const f of group) {
+      if (budget <= 0) break;
+      const r = await fetchArchiveNamesForFile(fetchImpl, modId, f.uri);
+      subrequests += 1;
+      budget -= 1;
+      if (!r.ok) ok = false;
+      for (const name of r.names) all.add(name);
+    }
   }
   return { archives: [...all].sort(), ok, subrequests };
 }

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -280,9 +280,10 @@ export async function fetchModFileUris(fetchImpl, modId) {
  * Fetch one downloadable file's contents preview and return its `.archive` file
  * names. Routes by `uri` shape to the right host/parser: a UUID storage path
  * (contains `/`) → file-manifests host (flat file_path array); a friendly
- * filename → file-metadata host (nested children tree). Returns { names, ok };
- * ok is false on any failure (see fetchModFileUris for why the caller needs the
- * distinction).
+ * filename → file-metadata host (nested children tree). Not every file has a
+ * published preview (many 404, on either host), so `ok` is true for a 200 OR a
+ * 404 (both are definitive: "here are the names" / "this file has none") and
+ * false only for a transient error (429/5xx/network) worth retrying.
  *
  * @param {typeof fetch} fetchImpl injectable for tests
  * @param {string|number} modId numeric Nexus mod id
@@ -296,14 +297,22 @@ export async function fetchArchiveNamesForFile(fetchImpl, modId, uri) {
       ? `${FILE_MANIFEST_BASE}/${uri}.json`
       : `${FILE_METADATA_BASE}/${NEXUS_GAME_ID}/${modId}/${encodeURIComponent(uri)}.json`;
     const res = await fetchImpl(url, { headers: { 'User-Agent': ARCHIVE_UA } });
-    if (!res.ok) return { names: [], ok: false };
+    if (!res.ok) {
+      // 404 is a DEFINITIVE answer — this file has no published preview — not a
+      // transient error. It must contribute no archives WITHOUT poisoning the
+      // mod's ok: otherwise a mod with a good MAIN and a preview-less OPTIONAL
+      // never caches, sits at the front of the newest-first queue, and starves
+      // every mod behind it (observed: cron stuck at "refreshed 0/9"). Only
+      // 429/5xx/network stay ok:false so they retry.
+      return { names: [], ok: res.status === 404 };
+    }
     const json = await res.json();
     const names = new Set();
     if (isUuidPath) collectArchiveNamesFromManifest(json, names);
     else collectArchiveNames(json, names);
     return { names: [...names], ok: true };
   } catch {
-    return { names: [], ok: false };
+    return { names: [], ok: false }; // network/parse error: transient, retry
   }
 }
 

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -209,10 +209,23 @@ const MOD_FILES_QUERY = `query ModFiles($modId: ID!, $gameId: ID!) {
 }`;
 
 /**
- * Recursively collect `.archive` file names from a file-contents preview tree.
- * Nodes look like { name, type: 'directory'|'file', children: [...] }; the root
- * is { children: [...] }. Tolerant of shape drift: it only cares about `name`,
- * `type`, and `children`, walking whatever nesting Nexus returns.
+ * Detectable install-folder files: `.archive` load files AND `.xl` (ArchiveXL)
+ * files. Both land in archive/pc/mod/ and are readable by an in-game mod, so
+ * both fingerprint an install. `.xl` matters for removal-only mods (e.g. an
+ * ArchiveXL "removal" that ships only `foo_removal.xl`, no `.archive`). CET/AMM
+ * `.json` files are NOT detectable (sandboxed CET folder) and are never matched.
+ */
+function isDetectableInstallFile(name) {
+  if (typeof name !== 'string') return false;
+  const lower = name.toLowerCase();
+  return lower.endsWith('.archive') || lower.endsWith('.xl');
+}
+
+/**
+ * Recursively collect detectable install file names from a file-contents preview
+ * tree. Nodes look like { name, type: 'directory'|'file', children: [...] }; the
+ * root is { children: [...] }. Tolerant of shape drift: it only cares about
+ * `name`, `type`, and `children`, walking whatever nesting Nexus returns.
  */
 function collectArchiveNames(node, out) {
   if (!node || typeof node !== 'object') return;
@@ -220,22 +233,22 @@ function collectArchiveNames(node, out) {
     for (const child of node) collectArchiveNames(child, out);
     return;
   }
-  if (node.type === 'file' && typeof node.name === 'string' && node.name.toLowerCase().endsWith('.archive')) {
+  if (node.type === 'file' && isDetectableInstallFile(node.name)) {
     out.add(node.name);
   }
   if (Array.isArray(node.children)) collectArchiveNames(node.children, out);
 }
 
 /**
- * Collect `.archive` file names from a new-scheme manifest: a FLAT array of
- * { file_path, file_size, file_hashes }, where file_path is the full in-archive
- * path (`archive/pc/mod/Foo.archive`). We take the basename of each `.archive`.
+ * Collect detectable install file names from a new-scheme manifest: a FLAT array
+ * of { file_path, file_size, file_hashes }, where file_path is the full
+ * in-archive path (`archive/pc/mod/Foo.archive`). We take each match's basename.
  */
 function collectArchiveNamesFromManifest(entries, out) {
   if (!Array.isArray(entries)) return;
   for (const entry of entries) {
     const p = entry?.file_path;
-    if (typeof p === 'string' && p.toLowerCase().endsWith('.archive')) {
+    if (typeof p === 'string' && isDetectableInstallFile(p)) {
       out.add(p.split(/[\\/]/).pop());
     }
   }

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -151,14 +151,14 @@ function archiveFetch({ modFiles = [], trees = {}, manifests = {}, routerOk = tr
       );
       const m = manifests[uri];
       if (m instanceof Error) throw m;
-      if (m && m.ok === false) return { ok: false, status: 404, json: async () => ({}) };
+      if (m && m.ok === false) return { ok: false, status: m.status ?? 404, json: async () => ({}) };
       return { ok: true, json: async () => m ?? [] };
     }
     if (url.includes('file-metadata.nexusmods.com')) {
       const uri = decodeURIComponent(url.match(/\/[^/]+\/([^/]+)\.json$/)[1]);
       const t = trees[uri];
       if (t instanceof Error) throw t;
-      if (t && t.ok === false) return { ok: false, status: 404, json: async () => ({}) };
+      if (t && t.ok === false) return { ok: false, status: t.status ?? 404, json: async () => ({}) };
       return { ok: true, json: async () => t ?? { children: [] } };
     }
     throw new Error(`unexpected fetch: ${url}`);
@@ -268,14 +268,35 @@ test('archives: modFiles failure → ok:false, no archives, only the one subrequ
   assert.deepEqual(res, { archives: [], ok: false, subrequests: 1 });
 });
 
-test('archives: a file-contents failure marks ok:false but keeps what it found', async () => {
+test('archives: a 404 file has no preview but does NOT poison the mod (ok stays true)', async () => {
+  // The starvation bug: a good MAIN + a preview-less (404) sibling must still
+  // cache the MAIN's archives, or the mod retries forever and blocks the queue.
   const impl = archiveFetch({
-    modFiles: [{ uri: 'Good.7z', category: 'MAIN' }, { uri: 'Bad.7z', category: 'MAIN' }],
-    trees: { 'Good.7z': tree('good.archive'), 'Bad.7z': { ok: false } },
+    modFiles: [{ uri: 'Good.7z', category: 'MAIN' }, { uri: 'NoPreview.7z', category: 'OPTIONAL' }],
+    trees: { 'Good.7z': tree('good.archive'), 'NoPreview.7z': { ok: false, status: 404 } },
   });
   const res = await fetchModArchiveNames(impl, 1);
   assert.deepEqual(res.archives, ['good.archive']);
-  assert.equal(res.ok, false); // partial: caller must not cache this as final
+  assert.equal(res.ok, true); // 404 is definitive, not a retry-worthy failure
+});
+
+test('archives: a transient (5xx) file failure marks ok:false so it retries', async () => {
+  const impl = archiveFetch({
+    modFiles: [{ uri: 'Good.7z', category: 'MAIN' }, { uri: 'Flaky.7z', category: 'MAIN' }],
+    trees: { 'Good.7z': tree('good.archive'), 'Flaky.7z': { ok: false, status: 503 } },
+  });
+  const res = await fetchModArchiveNames(impl, 1);
+  assert.deepEqual(res.archives, ['good.archive']);
+  assert.equal(res.ok, false); // transient: caller must not cache this as final
+});
+
+test('archives: a mod whose only file 404s caches as [] with ok:true (no starvation)', async () => {
+  const impl = archiveFetch({
+    modFiles: [{ uri: 'Gone.7z', category: 'MAIN' }],
+    trees: { 'Gone.7z': { ok: false, status: 404 } },
+  });
+  const res = await fetchModArchiveNames(impl, 1);
+  assert.deepEqual(res, { archives: [], ok: true, subrequests: 2 }); // determined empty, leaves the queue
 });
 
 test('archives: a thrown fetch degrades to ok:false, never throws', async () => {

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -247,6 +247,36 @@ test('archives: falls back to older files when no current-category file exists',
   assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['legacy.archive']);
 });
 
+test('archives: falls back to older files when the CURRENT file yields no archives', async () => {
+  // Real case (Shaitan/Santo Domingo): a current file with no readable preview,
+  // the .archive living only in ARCHIVED/OLD_VERSION uploads.
+  const impl = archiveFetch({
+    modFiles: [
+      { uri: 'Current.7z', category: 'MAIN' }, // 404 — no preview / no archive
+      { uri: 'Old-1.zip', category: 'OLD_VERSION' }, // holds the archive
+    ],
+    trees: { 'Current.7z': { ok: false, status: 404 }, 'Old-1.zip': tree('legacy.archive') },
+  });
+  const res = await fetchModArchiveNames(impl, 1);
+  assert.deepEqual(res.archives, ['legacy.archive']);
+  assert.equal(res.ok, true);
+});
+
+test('archives: does NOT fetch older files when a current file already has archives', async () => {
+  let fetchedOld = false;
+  const impl = async (url) => {
+    if (url.includes('api-router')) {
+      return { ok: true, json: async () => ({ data: { modFiles: [
+        { uri: 'Cur.7z', category: 'MAIN' }, { uri: 'Old.zip', category: 'OLD_VERSION' },
+      ] } }) };
+    }
+    if (url.includes('Old.zip')) { fetchedOld = true; return { ok: true, json: async () => tree('old.archive') }; }
+    return { ok: true, json: async () => tree('cur.archive') };
+  };
+  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['cur.archive']);
+  assert.equal(fetchedOld, false, 'older upload must not be fetched when current has archives');
+});
+
 test('archives: caps contents fetches per mod so one mod cannot exhaust the budget', async () => {
   const many = Array.from({ length: 12 }, (_, i) => ({ uri: `Opt-${i}.7z`, category: 'OPTIONAL' }));
   const trees = Object.fromEntries(many.map((f, i) => [f.uri, tree(`a${i}.archive`)]));

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -187,7 +187,7 @@ test('archives: fetches UUID-path files from the file-manifests host (flat manif
     manifests: { 'ab/cd/ef/uuid-1': manifest('New.archive', 'thing.xl') },
   });
   const res = await fetchModArchiveNames(impl, 1);
-  assert.deepEqual(res.archives, ['New.archive']); // basename; .xl ignored
+  assert.deepEqual(res.archives, ['New.archive', 'thing.xl']); // basenames; .xl included
   assert.equal(res.ok, true);
 });
 
@@ -255,12 +255,21 @@ test('archives: caps contents fetches per mod so one mod cannot exhaust the budg
   assert.ok(res.archives.length <= 6);
 });
 
-test('archives: ignores non-.archive files (e.g. .xl, readme)', async () => {
+test('archives: collects .archive AND .xl (ArchiveXL), ignores .json/readme', async () => {
   const impl = archiveFetch({
     modFiles: [{ uri: 'M.7z', category: 'MAIN' }],
-    trees: { 'M.7z': tree('thing.archive', 'thing.xl', 'readme.txt') },
+    trees: { 'M.7z': tree('thing.archive', 'thing.xl', 'appearance.json', 'readme.txt') },
   });
-  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['thing.archive']);
+  // .xl lands in archive/pc/mod and is readable in-game; .json (CET/AMM) is not.
+  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['thing.archive', 'thing.xl']);
+});
+
+test('archives: a removal-only mod (ships only .xl) is still detected', async () => {
+  const impl = archiveFetch({
+    modFiles: [{ uri: 'Removal.7z', category: 'MAIN' }],
+    trees: { 'Removal.7z': tree('h10_apartment_removal.xl') },
+  });
+  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['h10_apartment_removal.xl']);
 });
 
 test('archives: modFiles failure → ok:false, no archives, only the one subrequest', async () => {

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -247,36 +247,6 @@ test('archives: falls back to older files when no current-category file exists',
   assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['legacy.archive']);
 });
 
-test('archives: falls back to older files when the CURRENT file yields no archives', async () => {
-  // Real case (Shaitan/Santo Domingo): a current file with no readable preview,
-  // the .archive living only in ARCHIVED/OLD_VERSION uploads.
-  const impl = archiveFetch({
-    modFiles: [
-      { uri: 'Current.7z', category: 'MAIN' }, // 404 — no preview / no archive
-      { uri: 'Old-1.zip', category: 'OLD_VERSION' }, // holds the archive
-    ],
-    trees: { 'Current.7z': { ok: false, status: 404 }, 'Old-1.zip': tree('legacy.archive') },
-  });
-  const res = await fetchModArchiveNames(impl, 1);
-  assert.deepEqual(res.archives, ['legacy.archive']);
-  assert.equal(res.ok, true);
-});
-
-test('archives: does NOT fetch older files when a current file already has archives', async () => {
-  let fetchedOld = false;
-  const impl = async (url) => {
-    if (url.includes('api-router')) {
-      return { ok: true, json: async () => ({ data: { modFiles: [
-        { uri: 'Cur.7z', category: 'MAIN' }, { uri: 'Old.zip', category: 'OLD_VERSION' },
-      ] } }) };
-    }
-    if (url.includes('Old.zip')) { fetchedOld = true; return { ok: true, json: async () => tree('old.archive') }; }
-    return { ok: true, json: async () => tree('cur.archive') };
-  };
-  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['cur.archive']);
-  assert.equal(fetchedOld, false, 'older upload must not be fetched when current has archives');
-});
-
 test('archives: caps contents fetches per mod so one mod cannot exhaust the budget', async () => {
   const many = Array.from({ length: 12 }, (_, i) => ({ uri: `Opt-${i}.7z`, category: 'OPTIONAL' }));
   const trees = Object.fromEntries(many.map((f, i) => [f.uri, tree(`a${i}.archive`)]));


### PR DESCRIPTION
Bundles the archive-detection fixes found during the dev soak of #841 (follow-up to #845/#846/#847). All verified on `api-dev.nczoning.net` against real Nexus data.

## 1. Freeze fix — a 404 preview is definitive, not a retry (the headline bug)
The cron froze silently at 185/295 (`discovery_stale:false`, no error). Many files have no published preview and 404; the code treated *any* non-200 as `ok:false`, so a mod with a good MAIN + a preview-less (404) sibling was never cached and — being newest — starved the budget-limited queue (`archives: refreshed 0/9`). Fix: 404 is definitive (contributes nothing, doesn't poison the mod); only 429/5xx/network retry.

## 2. `.xl` (ArchiveXL) inclusion
Collect `.archive` **and** `.xl` files (both install to `archive/pc/mod/`, both readable in-game). Removal-only mods (e.g. H10 Minimal) ship only a `*_removal.xl` — their sole fingerprint. CET/AMM `.json` files stay excluded (sandboxed CET folder, undetectable).

## 3. Reverted: no inferring current archives from old versions
A fallback that read OLD_VERSION/ARCHIVED files when the current file was unreadable was **reverted** — you install the MAIN, and archive names drift across versions (Santo Domingo: `sahideout` → `gtrsl_sdhideout` → `santodomingo_overlook`), so old names are false detection data. Mods whose MAIN preview is unreadable stay `[]` (honest).

## 4. Manual seed for bugged Nexus previews
Six mods 404 with "Content could not be loaded at this time" (Nexus-side bug). `worker/scripts/archive-seeds.json` (values read from an installed MO2 copy) + `seed-archives.mjs` inject them **directly into the KV cache**, stamped with each mod's `updatedAt` so they stick and **self-heal** when the mod re-uploads onto the readable UUID path. One-off per environment — re-run on prod after this merge.

## Verification
- 82 worker tests pass (404-definitive, .xl/removal, transient-retries, etc.).
- Staging: fill drained to 282/295; the 13 empties are all legit (7 AMM/removal-`.json`, the seeded 6, 1 WIP); the 6 seeded mods now serve their real values.

## Post-merge / rollout
- **Seed prod** after dev→main: `seed-archives.mjs` (steps in its header).
- The `.xl` change is collector-logic, so already-cached mods need a cache clear + refill to pick up their `.xl` (and the readable removal mod H10 Minimal) — done as a one-off rollout step per environment.
- **Watch:** the staging cron had wedged (frozen `gen`, revived by a redeploy). The health monitor checks *serving*, not *freshness* — worth a follow-up to alert on stale `generated_at`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)