### PR TITLE
Release: in-game archive detection API (#841)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-20
+
 ### Added
 
 - Each `/v1` location record now carries an `archives` array — the `.archive` and `.xl` filenames the mod installs to `archive/pc/mod/` (so removal-only mods are detectable too) — letting an in-game mod detect which location mods a player has installed. ([#841](https://github.com/spuddeh/nc-zoning-board/issues/841))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Each `/v1` location record now carries an `archives` array — the `.archive` filenames the mod ships — so an in-game mod can detect which location mods a player has installed. ([#841](https://github.com/spuddeh/nc-zoning-board/issues/841))
+- Each `/v1` location record now carries an `archives` array — the `.archive` and `.xl` filenames the mod installs to `archive/pc/mod/` (so removal-only mods are detectable too) — letting an in-game mod detect which location mods a player has installed. ([#841](https://github.com/spuddeh/nc-zoning-board/issues/841))
 
 ## [1.4.1] - 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Each `/v1` location record now carries an `archives` array — the `.archive` filenames the mod ships — so an in-game mod can detect which location mods a player has installed. ([#841](https://github.com/spuddeh/nc-zoning-board/issues/841))
+
 ## [1.4.1] - 2026-07-19
 
 ### Changed

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -102,9 +102,11 @@ A location record:
 - `credits` appears only when set; `thumbnail_url` / `picture_url` / `updated_at`
   are `null` when unknown (e.g. WIP/Dummy entries with no Nexus page, which are
   also never `recently_updated`).
-- `archives` is the list of `.archive` filenames the mod ships. **Match these
-  against the player's `archive/pc/mod/` folder to detect which location mods are
-  installed.** Names are the bare filename (`Atari AIO.archive`), not a path, so
+- `archives` is the list of the mod's detectable install files — `.archive` load
+  files and `.xl` (ArchiveXL) files (the latter is the only fingerprint a
+  removal-only mod has). Both live in `archive/pc/mod/`. **Match these against the
+  player's `archive/pc/mod/` folder to detect which location mods are installed.**
+  Names are the bare filename (`Atari AIO.archive`), not a path, so
   a case-sensitive set-membership test against the folder listing is all a
   consumer needs. It's always present — `[]` means "not determinable / not yet
   fetched", never "ships no archives" (freshly added mods fill in over a few

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -91,7 +91,8 @@ A location record:
   "credits": "Optional team name",
   "thumbnail_url": "https://…",
   "picture_url": "https://…",
-  "updated_at": "2026-07-02T12:00:00.000Z"
+  "updated_at": "2026-07-02T12:00:00.000Z",
+  "archives": ["Atari AIO.archive"]
 }
 ```
 
@@ -101,6 +102,13 @@ A location record:
 - `credits` appears only when set; `thumbnail_url` / `picture_url` / `updated_at`
   are `null` when unknown (e.g. WIP/Dummy entries with no Nexus page, which are
   also never `recently_updated`).
+- `archives` is the list of `.archive` filenames the mod ships, unioned across
+  every downloadable file (main + optional variants). **Match these against the
+  player's `archive/pc/mod/` folder to detect which location mods are
+  installed.** It's always present — `[]` when unknown (WIP/Dummy, no Nexus
+  files, or not yet fetched by the cron; see the note below). Names are the bare
+  filename (`Atari AIO.archive`), not a path, so a case-sensitive set membership
+  test against the folder listing is all a consumer needs.
 
 ## Caching
 
@@ -176,6 +184,11 @@ re-downloading unchanged data.
   is `true` and the last-known-good data is served.
 - `meta.skipped` lists mods tagged `NCZoning` whose metadata block didn't
   parse: useful if you're a mod author debugging why yours isn't appearing.
+- `archives` is near-static, so the cron fetches it lazily: a mod's archive
+  names are (re)fetched only when its Nexus `updated_at` changes, and a fresh
+  dataset back-fills them a batch per cron tick rather than all at once. A newly
+  added mod can therefore show `archives: []` for a short window before its names
+  land — treat an empty list as "unknown yet", not "ships no archives".
 - `recently_updated` rides the content hash: because it depends on the clock,
   a location crossing the `recently_updated_days` boundary changes
   `dataset_version` (and the `ETag`) even when nothing on Nexus changed, so a

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -102,13 +102,13 @@ A location record:
 - `credits` appears only when set; `thumbnail_url` / `picture_url` / `updated_at`
   are `null` when unknown (e.g. WIP/Dummy entries with no Nexus page, which are
   also never `recently_updated`).
-- `archives` is the list of `.archive` filenames the mod ships, unioned across
-  every downloadable file (main + optional variants). **Match these against the
-  player's `archive/pc/mod/` folder to detect which location mods are
-  installed.** It's always present — `[]` when unknown (WIP/Dummy, no Nexus
-  files, or not yet fetched by the cron; see the note below). Names are the bare
-  filename (`Atari AIO.archive`), not a path, so a case-sensitive set membership
-  test against the folder listing is all a consumer needs.
+- `archives` is the list of `.archive` filenames the mod ships. **Match these
+  against the player's `archive/pc/mod/` folder to detect which location mods are
+  installed.** Names are the bare filename (`Atari AIO.archive`), not a path, so
+  a case-sensitive set-membership test against the folder listing is all a
+  consumer needs. It's always present — `[]` means "not determinable", never
+  "ships no archives" (see the note below: some mods' files have no public
+  contents preview, and freshly added mods fill in over a few cron ticks).
 
 ## Caching
 
@@ -188,7 +188,9 @@ re-downloading unchanged data.
   names are (re)fetched only when its Nexus `updated_at` changes, and a fresh
   dataset back-fills them a batch per cron tick rather than all at once. A newly
   added mod can therefore show `archives: []` for a short window before its names
-  land — treat an empty list as "unknown yet", not "ships no archives".
+  land. A minority of mods (~6%) stay `[]` permanently because none of their
+  files expose a public contents preview on Nexus. Either way, treat `[]` as
+  "unknown", never "ships no archives".
 - `recently_updated` rides the content hash: because it depends on the clock,
   a location crossing the `recently_updated_days` boundary changes
   `dataset_version` (and the `ETag`) even when nothing on Nexus changed, so a

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -106,9 +106,9 @@ A location record:
   against the player's `archive/pc/mod/` folder to detect which location mods are
   installed.** Names are the bare filename (`Atari AIO.archive`), not a path, so
   a case-sensitive set-membership test against the folder listing is all a
-  consumer needs. It's always present — `[]` means "not determinable", never
-  "ships no archives" (see the note below: some mods' files have no public
-  contents preview, and freshly added mods fill in over a few cron ticks).
+  consumer needs. It's always present — `[]` means "not determinable / not yet
+  fetched", never "ships no archives" (freshly added mods fill in over a few
+  cron ticks; see the note below).
 
 ## Caching
 
@@ -188,9 +188,9 @@ re-downloading unchanged data.
   names are (re)fetched only when its Nexus `updated_at` changes, and a fresh
   dataset back-fills them a batch per cron tick rather than all at once. A newly
   added mod can therefore show `archives: []` for a short window before its names
-  land. A minority of mods (~6%) stay `[]` permanently because none of their
-  files expose a public contents preview on Nexus. Either way, treat `[]` as
-  "unknown", never "ships no archives".
+  land. A small residual stays `[]` (loose-file mods with no `.archive`, or
+  WIP/Dummy entries with no Nexus page). Either way, treat `[]` as "unknown",
+  never "ships no archives".
 - `recently_updated` rides the content hash: because it depends on the clock,
   a location crossing the `recently_updated_days` boundary changes
   `dataset_version` (and the `ETag`) even when nothing on Nexus changed, so a

--- a/docs/nexus-api-reference.md
+++ b/docs/nexus-api-reference.md
@@ -154,6 +154,67 @@ The function returns `{ mods, meta }` where `meta` contains image/timestamp data
 
 ---
 
+### 3. `modFiles` + file-contents: Archive-name Fetch (installed-mod detection)
+
+**Purpose:** Collect the `.archive` filenames each mod ships, published on every
+location record as `archives` so an in-game consumer can match them against the
+player's `archive/pc/mod/` folder and detect which location mods are installed.
+
+Two hops per mod, both **unauthenticated**, on **different hosts** from the V2
+endpoint above:
+
+**Hop 1 — `modFiles` (list a mod's downloadable files).** Endpoint:
+`https://api-router.nexusmods.com/graphql` (the newer public router; the
+`api.nexusmods.com/v2` endpoint does not expose `modFiles`).
+
+```graphql
+query ModFiles($modId: ID!, $gameId: ID!) {
+  modFiles(modId: $modId, gameId: $gameId) { uri }
+}
+```
+
+- **`modId` and `gameId` are `ID!`, not `Int!`** — pass them as strings
+  (`"27618"`, `"3333"`). Passing ints returns a `variableMismatch` error.
+- Returns a flat array of files (main + optional). We take every file's `uri`
+  (e.g. `Atari Canyon AIO-27618-1-0-1771273179.7z`).
+
+**Hop 2 — file contents.** For each `uri`, fetch the S3-backed "Preview file
+contents" tree:
+
+```text
+https://file-metadata.nexusmods.com/file/nexus-files-s3-meta/{gameId}/{modId}/{encodeURIComponent(uri)}.json
+```
+
+The response is a recursive tree of `{ name, type: "directory"|"file", children }`
+nodes (root is `{ children: [...] }`). We walk it and collect every `type:"file"`
+whose `name` ends in `.archive`, unioned across all of the mod's files, deduped
+and sorted. `.xl` (ArchiveXL) and other files are ignored.
+
+**Output field:** `archives: string[]` on each `LocationFull` record (bare
+filenames, not paths). Always present; `[]` when unknown.
+
+**Caching & cadence (the load-bearing part):** archive names are near-static —
+they only change on a re-upload, which bumps the mod's `updatedAt`. So the cron
+caches them in KV (`dataset:v1:archives`, keyed by `nexus_id`) and refetches a
+mod **only when its `updatedAt` moves**. Steady state makes **zero** archive
+requests. A cold cache (or a fresh dataset) is filled **incrementally**, capped
+per cron run (`ARCHIVE_MOD_BUDGET` mods / `ARCHIVE_SUBREQUEST_BUDGET`
+subrequests in [`worker/src/refresh.js`](../worker/src/refresh.js)) so archive
+work can never breach the Worker's 50-subrequest-per-invocation limit alongside
+discovery + thumbnails.
+
+**Error handling:** entirely **non-throwing / non-fatal**. `modFiles` returns
+`{ ok:false }` on failure and a partial file-contents read marks the whole mod
+`ok:false`; either way the cron leaves that mod's cached archives untouched and
+retries next run — it **never** marks the dataset `discovery_stale` (unlike the
+tagged-discovery query, whose failure is fatal). Archives are supplementary.
+
+**Implementation:** `fetchModArchiveNames()` (+ `fetchModFileUris`,
+`fetchArchiveNamesForFile`) in [`worker/src/nexus.js`](../worker/src/nexus.js);
+budgeted refresh in [`worker/src/refresh.js`](../worker/src/refresh.js).
+
+---
+
 ## Image Availability Limitation ⚠️
 
 **Only the featured/header image is available via the public API, for now.**

--- a/docs/nexus-api-reference.md
+++ b/docs/nexus-api-reference.md
@@ -178,39 +178,52 @@ query ModFiles($modId: ID!, $gameId: ID!) {
 - Returns a flat array of files (main + optional). We take every file's `uri`
   (e.g. `Atari Canyon AIO-27618-1-0-1771273179.7z`).
 
-**Hop 2 — file contents.** For each file, fetch the S3-backed "Preview file
-contents" tree:
+**Hop 2 — file contents.** Each file's contents live at **one of two hosts**,
+because Nexus changed its storage scheme around mid-2026. Route by the shape of
+the file's `uri`:
 
-```text
-https://file-metadata.nexusmods.com/file/nexus-files-s3-meta/{gameId}/{modId}/{uri}.json
-```
+- **Old scheme — `uri` is the friendly filename** (`Atari Canyon AIO-27618-…-.7z`):
 
-The response is a recursive tree of `{ name, type: "directory"|"file", children }`
-nodes (root is `{ children: [...] }`). We walk it and collect every `type:"file"`
-whose `name` ends in `.archive`, unioned across the mod's fetched files, deduped
-and sorted. `.xl` (ArchiveXL) and other files are ignored.
+  ```text
+  https://file-metadata.nexusmods.com/file/nexus-files-s3-meta/{gameId}/{modId}/{uri}.json
+  ```
 
-**Which files we fetch (a measured coverage limit):** the `uri` comes in two
-forms. Older files carry the **friendly filename**
-(`Atari Canyon AIO-27618-1-0-1771273179.7z`) and **have** a contents preview.
-Newer files carry a **UUID storage path** (`uri` contains `/`, e.g.
-`b9/e3/70/b9e37068-…`) and **have no preview** at the file-metadata path — it
-404s regardless of slash-encoding (`scanned`/`scannedV2` are `VERIFIED` in both
-cases, so they don't predict it). So the fetch:
+  A recursive **tree** of `{ name, type: "directory"|"file", children }` (root is
+  `{ children: [...] }`). Walk it; collect every `type:"file"` whose `name` ends
+  in `.archive`.
 
-- **skips UUID-path files entirely** (no wasted subrequest, no false failure);
-- **prefers current categories** (`MAIN`/`OPTIONAL`/`UPDATE`), falling back to an
-  older friendly file (`ARCHIVED`/`OLD_VERSION`) only when a mod has no current
-  previewable file;
-- caps contents fetches per mod (`ARCHIVE_FILES_PER_MOD`) so one mod with many
-  optional variants can't exhaust the run's subrequest budget.
+- **New scheme — `uri` is a UUID storage path** (contains `/`, e.g.
+  `b9/e3/70/b9e37068-…`):
 
-Measured against the live population, **~94% of mods still yield ≥1 `.archive`**;
-the rest (only UUID files, no friendly copy) resolve to `[]`.
+  ```text
+  https://file-manifests.nexusmods.com/{uri}.json
+  ```
+
+  A **flat array** of `{ file_path, file_size, file_hashes }`. Take the basename
+  of each `file_path` ending in `.archive` (e.g.
+  `archive/pc/mod/Foo.archive` → `Foo.archive`).
+
+(The friendly `uri` does *not* work on the manifest host and vice-versa — each
+scheme is served by exactly one host.) Names are unioned across the mod's fetched
+files, deduped and sorted; `.xl` (ArchiveXL) and other files are ignored.
+
+**Which files we fetch:** both schemes are fetchable, so we **prefer current
+categories** (`MAIN`/`OPTIONAL`/`UPDATE`), falling back to older files
+(`ARCHIVED`/`OLD_VERSION`) only when a mod has no current file, and cap contents
+fetches per mod (`ARCHIVE_FILES_PER_MOD`) so one mod with many optional variants
+can't exhaust the run's subrequest budget. Coverage is **near-total**; the
+residual `[]` are loose-file mods with no `.archive`, WIP/Dummy entries (no Nexus
+page), or not-yet-filled records.
+
+> **History:** the first cut fetched *all* files via the file-metadata host and
+> got `[]` for every mod, because new-scheme (UUID) files 404 there. A second cut
+> skipped UUID files (~94% coverage). The `file-manifests` host — which serves the
+> new scheme — closed the gap to near-total. See
+> [[NC-Zoning-Board/wiki/learnings/nexus-file-contents-two-hosts-by-scheme]].
 
 **Output field:** `archives: string[]` on each `LocationFull` record (bare
-filenames, not paths). Always present; `[]` means "not determinable" (all-UUID
-files, or not yet fetched), never "ships no archives".
+filenames, not paths). Always present; `[]` means "not determinable / not yet
+fetched", never "ships no archives".
 
 **Caching & cadence (the load-bearing part):** archive names are near-static —
 they only change on a re-upload, which bumps the mod's `updatedAt`. So the cron

--- a/docs/nexus-api-reference.md
+++ b/docs/nexus-api-reference.md
@@ -178,20 +178,39 @@ query ModFiles($modId: ID!, $gameId: ID!) {
 - Returns a flat array of files (main + optional). We take every file's `uri`
   (e.g. `Atari Canyon AIO-27618-1-0-1771273179.7z`).
 
-**Hop 2 — file contents.** For each `uri`, fetch the S3-backed "Preview file
+**Hop 2 — file contents.** For each file, fetch the S3-backed "Preview file
 contents" tree:
 
 ```text
-https://file-metadata.nexusmods.com/file/nexus-files-s3-meta/{gameId}/{modId}/{encodeURIComponent(uri)}.json
+https://file-metadata.nexusmods.com/file/nexus-files-s3-meta/{gameId}/{modId}/{uri}.json
 ```
 
 The response is a recursive tree of `{ name, type: "directory"|"file", children }`
 nodes (root is `{ children: [...] }`). We walk it and collect every `type:"file"`
-whose `name` ends in `.archive`, unioned across all of the mod's files, deduped
+whose `name` ends in `.archive`, unioned across the mod's fetched files, deduped
 and sorted. `.xl` (ArchiveXL) and other files are ignored.
 
+**Which files we fetch (a measured coverage limit):** the `uri` comes in two
+forms. Older files carry the **friendly filename**
+(`Atari Canyon AIO-27618-1-0-1771273179.7z`) and **have** a contents preview.
+Newer files carry a **UUID storage path** (`uri` contains `/`, e.g.
+`b9/e3/70/b9e37068-…`) and **have no preview** at the file-metadata path — it
+404s regardless of slash-encoding (`scanned`/`scannedV2` are `VERIFIED` in both
+cases, so they don't predict it). So the fetch:
+
+- **skips UUID-path files entirely** (no wasted subrequest, no false failure);
+- **prefers current categories** (`MAIN`/`OPTIONAL`/`UPDATE`), falling back to an
+  older friendly file (`ARCHIVED`/`OLD_VERSION`) only when a mod has no current
+  previewable file;
+- caps contents fetches per mod (`ARCHIVE_FILES_PER_MOD`) so one mod with many
+  optional variants can't exhaust the run's subrequest budget.
+
+Measured against the live population, **~94% of mods still yield ≥1 `.archive`**;
+the rest (only UUID files, no friendly copy) resolve to `[]`.
+
 **Output field:** `archives: string[]` on each `LocationFull` record (bare
-filenames, not paths). Always present; `[]` when unknown.
+filenames, not paths). Always present; `[]` means "not determinable" (all-UUID
+files, or not yet fetched), never "ships no archives".
 
 **Caching & cadence (the load-bearing part):** archive names are near-static —
 they only change on a re-upload, which bumps the mod's `updatedAt`. So the cron

--- a/docs/nexus-api-reference.md
+++ b/docs/nexus-api-reference.md
@@ -204,8 +204,12 @@ the file's `uri`:
   `archive/pc/mod/Foo.archive` → `Foo.archive`).
 
 (The friendly `uri` does *not* work on the manifest host and vice-versa — each
-scheme is served by exactly one host.) Names are unioned across the mod's fetched
-files, deduped and sorted; `.xl` (ArchiveXL) and other files are ignored.
+scheme is served by exactly one host.) We collect both **`.archive`** load files
+and **`.xl`** (ArchiveXL) files — both install to `archive/pc/mod/` and are
+readable by an in-game mod, and `.xl` is the only fingerprint a removal-only mod
+has. CET/AMM `.json` files are NOT collected (they live in CET's sandboxed
+folder, unreadable by other mods). Names are unioned across the mod's fetched
+files, deduped and sorted.
 
 **Which files we fetch:** both schemes are fetchable, so we **prefer current
 categories** (`MAIN`/`OPTIONAL`/`UPDATE`), falling back to older files

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -190,7 +190,7 @@
             "thumbnail_url": { "type": ["string", "null"], "description": "Nexus thumbnail image URL, or null (unknown / WIP / Dummy)." },
             "picture_url": { "type": ["string", "null"], "description": "Nexus full-size image URL, or null." },
             "updated_at": { "type": ["string", "null"], "format": "date-time", "description": "Nexus last-updated timestamp, or null." },
-            "archives": { "type": "array", "items": { "type": "string" }, "description": "The .archive filenames this mod ships, unioned across every downloadable file (main + optional). Match against the player's archive/pc/mod/ folder to detect installed location mods. Empty when unknown (WIP/Dummy, no Nexus files, or not yet fetched by the cron).", "example": ["Atari AIO.archive"] }
+            "archives": { "type": "array", "items": { "type": "string" }, "description": "The mod's detectable install files: .archive load files AND .xl (ArchiveXL) files, both of which land in archive/pc/mod/ and are readable by an in-game mod (.xl is the only fingerprint a removal-only mod has). Bare filenames, not paths. Match against the player's archive/pc/mod/ folder to detect installed location mods. Excludes CET/AMM .json files (they load into CET's sandboxed folder and are not readable by other mods). Empty when not determinable (an AMM-only mod, a WIP/Dummy entry with no Nexus page, a mod whose Nexus file preview is unavailable, or not yet fetched by the cron) — never 'ships nothing'.", "example": ["Atari Canyon AIO.archive", "atari_aio.xl"] }
           } }
         ]
       },

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -189,7 +189,8 @@
             "credits": { "type": "string" },
             "thumbnail_url": { "type": ["string", "null"], "description": "Nexus thumbnail image URL, or null (unknown / WIP / Dummy)." },
             "picture_url": { "type": ["string", "null"], "description": "Nexus full-size image URL, or null." },
-            "updated_at": { "type": ["string", "null"], "format": "date-time", "description": "Nexus last-updated timestamp, or null." }
+            "updated_at": { "type": ["string", "null"], "format": "date-time", "description": "Nexus last-updated timestamp, or null." },
+            "archives": { "type": "array", "items": { "type": "string" }, "description": "The .archive filenames this mod ships, unioned across every downloadable file (main + optional). Match against the player's archive/pc/mod/ folder to detect installed location mods. Empty when unknown (WIP/Dummy, no Nexus files, or not yet fetched by the cron).", "example": ["Atari AIO.archive"] }
           } }
         ]
       },

--- a/worker/scripts/archive-seeds.json
+++ b/worker/scripts/archive-seeds.json
@@ -1,0 +1,9 @@
+{
+  "_note": "Manual archive/xl seeds for mods whose Nexus 'Preview file contents' is bugged (404 / 'Content could not be loaded at this time'), so the cron cannot read them. Read from an installed copy of each mod. Injected ONCE per environment into the KV archive cache by seed-archives.mjs; NOT read by the Worker at runtime. Entries self-heal automatically when the mod re-uploads (its updatedAt changes, so the cron refetches — by then the file is usually on the new UUID path and readable). Only numeric keys are applied.",
+  "24887": ["Project-CDSM.archive", "project_cdsm_final_v1.xl", "Dedka Removal Preset.xl"],
+  "22696": ["Akira_Bodyguard.archive", "Akira_Bodyguard.archive.xl", "Mr_Blue_Eyes.archive", "Mr_Blue_Eyes.archive.xl", "Mr_Blue_Eyes.xl", "Mr_Blue_Eyes_Props.xl"],
+  "24131": ["santodomingo_overlooksafehouse.archive", "santodomingo_overlooksafehouse.xl"],
+  "21794": ["Shaitan_Black_Market.archive", "Shaitan_Black_Market.archive.xl", "Shaitan_Black_Market.xl", "Shaitan_Black_Market_Compatibility.xl", "Shaitan_Black_Market_Props.xl", "Shaitan_Black_Market_Flying_Koi_Fish.archive", "Shaitan_Black_Market_Flying_Koi_Fish.xl"],
+  "21288": ["77_glen_oasis.archive", "77_glen_oasis.xl", "77_glen_oasis_removals.xl"],
+  "28598": ["Beach_house_pacifica_shore.archive", "Beach_house_pacifica_shore.xl"]
+}

--- a/worker/scripts/seed-archives.mjs
+++ b/worker/scripts/seed-archives.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Merge manual archive/xl seeds (archive-seeds.json) into a dump of the KV
+ * archive cache, for mods whose Nexus "Preview file contents" is bugged (404 /
+ * "Content could not be loaded at this time") so the cron can't read them.
+ *
+ * This is a PURE merge (reads files + fetches the dataset for updated_at, writes
+ * the merged cache). It deliberately does NOT call wrangler itself — run it
+ * between a `kv key get` and a `kv key put` (below). Each seed is stamped with
+ * the mod's CURRENT updated_at, so the cron treats it as fresh and won't
+ * overwrite it; when the mod re-uploads, updated_at changes and the cron
+ * refetches (by then the file is usually on the readable UUID path). One-off per
+ * environment — re-run on production after a dev -> main promotion.
+ *
+ * STAGING (ns ac85bf5c0b6f47afac35085408857d4b):
+ *   npx wrangler kv key get --remote --namespace-id ac85bf5c0b6f47afac35085408857d4b dataset:v1:archives > cache.json
+ *   node scripts/seed-archives.mjs https://api-dev.nczoning.net cache.json merged.json
+ *   npx wrangler kv key put --remote --namespace-id ac85bf5c0b6f47afac35085408857d4b dataset:v1:archives --path merged.json
+ *
+ * PRODUCTION (ns d86735e00790417e948e423c3df01d68): same three steps, swapping
+ *   the namespace id and https://api.nczoning.net for the api base.
+ *
+ * The next cron tick republishes the dataset with the seeded values attached.
+ * Idempotent: safe to re-run.
+ *
+ * Usage: node scripts/seed-archives.mjs <api-base> <cache-in.json> <merged-out.json>
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const [apiBase, cacheIn, mergedOut] = process.argv.slice(2);
+if (!apiBase || !cacheIn || !mergedOut) {
+  console.error('Usage: node scripts/seed-archives.mjs <api-base> <cache-in.json> <merged-out.json>');
+  process.exit(1);
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const seeds = JSON.parse(readFileSync(join(here, 'archive-seeds.json'), 'utf8'));
+const ids = Object.keys(seeds).filter((k) => /^\d+$/.test(k));
+const cache = JSON.parse(readFileSync(cacheIn, 'utf8').trim() || '{}');
+
+// Current updated_at per mod, so the seed is fresh (not-stale) and self-heals.
+const locs = await fetch(`${apiBase}/v1/locations`, { headers: { 'User-Agent': 'Mozilla/5.0' } }).then((r) => r.json());
+const updatedAt = Object.fromEntries(locs.data.map((r) => [r.nexus_id, r.updated_at ?? null]));
+
+for (const id of ids) {
+  if (!(id in updatedAt)) console.warn(`  warning: ${id} not in the dataset — seeding anyway`);
+  cache[id] = { updatedAt: updatedAt[id] ?? cache[id]?.updatedAt ?? null, archives: seeds[id] };
+  console.log(`  seed ${id}: ${seeds[id].length} files`);
+}
+
+writeFileSync(mergedOut, JSON.stringify(cache));
+console.log(`Merged ${ids.length} seeds; cache now ${Object.keys(cache).length} entries -> ${mergedOut}`);

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -13,9 +13,11 @@ export const NEXUS_GQL_ENDPOINT = 'https://api.nexusmods.com/v2/graphql';
 // Newer public router endpoint that exposes modFiles (the V2 endpoint above
 // does not). Both are unauthenticated; see docs/nexus-api-reference.md.
 export const NEXUS_ROUTER_ENDPOINT = 'https://api-router.nexusmods.com/graphql';
-// S3-backed file-contents preview: the tree Nexus shows under "Preview file
-// contents" on a mod's Files tab. Keyed by game/mod/<uri>.json.
+// File-contents preview, TWO schemes (see the archive section note below):
+// - old scheme (friendly-filename uri): file-metadata host, nested {children} tree.
 export const FILE_METADATA_BASE = 'https://file-metadata.nexusmods.com/file/nexus-files-s3-meta';
+// - new scheme (UUID-path uri, ~mid-2026+): file-manifests host, flat file_path array.
+export const FILE_MANIFEST_BASE = 'https://file-manifests.nexusmods.com';
 export const NEXUS_GAME_ID = 3333; // Cyberpunk 2077
 export const NEXUS_BATCH_SIZE = 50;
 const ARCHIVE_UA = 'nczoning-data-api (+https://nczoning.net)';
@@ -180,20 +182,20 @@ export async function fetchModsByUidThumbs(fetchImpl = fetch, numericIds = []) {
 // a Nexus hiccup returns { ok:false } and the caller keeps last-known-good, it
 // never marks the whole dataset stale.
 //
-// Coverage limitation (measured, not assumed): only files whose modFiles `uri`
-// is the friendly filename (e.g. `Atari Canyon AIO-27618-1-0-….7z`) have a
-// contents preview at the file-metadata path. Files stored under a UUID path
-// (`uri` contains `/`, e.g. `b9/e3/70/b9e3…`) return 404 there regardless of
-// slash-encoding — the preview simply isn't published for them. So we fetch
-// ONLY friendly-uri files and skip UUID ones (no wasted subrequests, no false
-// failures). ~94% of the mod population still yields ≥1 `.archive`; the rest
-// resolve to `[]` (unknown), which the API already documents as "not
-// determinable", never "ships no archives".
+// A file's contents preview lives at ONE OF TWO hosts, chosen by the shape of
+// its modFiles `uri` (Nexus changed its storage scheme ~mid-2026):
+//   - OLD scheme — `uri` is the friendly filename (`Atari…-27618-1-0-….7z`):
+//     file-metadata host, keyed by game/mod/<uri>.json, a nested {children} tree.
+//   - NEW scheme — `uri` is a UUID storage path (contains `/`, `b9/e3/70/b9e3…`):
+//     file-manifests host, keyed by <uri>.json, a FLAT array of { file_path }.
+// Both are covered (see fetchArchiveNamesForFile), so coverage is near-total;
+// `[]` means WIP/Dummy (no Nexus page), a loose-file mod with no `.archive`, or
+// not-yet-fetched — never "ships no archives".
 
 // Download-file categories that represent the mod's *current* files. We prefer
 // these; ARCHIVED/OLD_VERSION are superseded and only used as a fallback when a
-// mod has no current friendly-uri file (keeps the archive names current and the
-// per-mod subrequest count low).
+// mod has no current file (keeps the archive names current and the per-mod
+// subrequest count low).
 const CURRENT_FILE_CATEGORIES = new Set(['MAIN', 'OPTIONAL', 'UPDATE']);
 // Hard cap on file-contents fetches per mod, so one mod with many optional
 // variants can't blow the run's subrequest budget on its own.
@@ -222,6 +224,21 @@ function collectArchiveNames(node, out) {
     out.add(node.name);
   }
   if (Array.isArray(node.children)) collectArchiveNames(node.children, out);
+}
+
+/**
+ * Collect `.archive` file names from a new-scheme manifest: a FLAT array of
+ * { file_path, file_size, file_hashes }, where file_path is the full in-archive
+ * path (`archive/pc/mod/Foo.archive`). We take the basename of each `.archive`.
+ */
+function collectArchiveNamesFromManifest(entries, out) {
+  if (!Array.isArray(entries)) return;
+  for (const entry of entries) {
+    const p = entry?.file_path;
+    if (typeof p === 'string' && p.toLowerCase().endsWith('.archive')) {
+      out.add(p.split(/[\\/]/).pop());
+    }
+  }
 }
 
 /**
@@ -261,23 +278,29 @@ export async function fetchModFileUris(fetchImpl, modId) {
 
 /**
  * Fetch one downloadable file's contents preview and return its `.archive` file
- * names. Returns { names, ok }; ok is false on any failure (see fetchModFileUris
- * for why the caller needs the distinction). Only call this for friendly-uri
- * files — UUID-path uris have no preview and always 404 (see the section note).
+ * names. Routes by `uri` shape to the right host/parser: a UUID storage path
+ * (contains `/`) → file-manifests host (flat file_path array); a friendly
+ * filename → file-metadata host (nested children tree). Returns { names, ok };
+ * ok is false on any failure (see fetchModFileUris for why the caller needs the
+ * distinction).
  *
  * @param {typeof fetch} fetchImpl injectable for tests
  * @param {string|number} modId numeric Nexus mod id
- * @param {string} uri the download file's friendly-name uri (from modFiles)
+ * @param {string} uri the download file's uri (from modFiles)
  * @returns {Promise<{names: string[], ok: boolean}>}
  */
 export async function fetchArchiveNamesForFile(fetchImpl, modId, uri) {
   try {
-    const url = `${FILE_METADATA_BASE}/${NEXUS_GAME_ID}/${modId}/${encodeURIComponent(uri)}.json`;
+    const isUuidPath = uri.includes('/');
+    const url = isUuidPath
+      ? `${FILE_MANIFEST_BASE}/${uri}.json`
+      : `${FILE_METADATA_BASE}/${NEXUS_GAME_ID}/${modId}/${encodeURIComponent(uri)}.json`;
     const res = await fetchImpl(url, { headers: { 'User-Agent': ARCHIVE_UA } });
     if (!res.ok) return { names: [], ok: false };
     const json = await res.json();
     const names = new Set();
-    collectArchiveNames(json, names);
+    if (isUuidPath) collectArchiveNamesFromManifest(json, names);
+    else collectArchiveNames(json, names);
     return { names: [...names], ok: true };
   } catch {
     return { names: [], ok: false };
@@ -285,12 +308,12 @@ export async function fetchArchiveNamesForFile(fetchImpl, modId, uri) {
 }
 
 /**
- * All `.archive` file names a mod ships, unioned across its previewable files,
- * deduped and sorted. Only friendly-uri files are fetched (UUID-path files have
- * no preview); current-category files (MAIN/OPTIONAL/UPDATE) are preferred, with
- * older friendly files used only as a fallback when a mod has no current one.
- * At most ARCHIVE_FILES_PER_MOD contents fetches, so one mod can't exhaust the
- * caller's per-run subrequest budget.
+ * All `.archive` file names a mod ships, unioned across its files, deduped and
+ * sorted. Both storage schemes are fetchable (fetchArchiveNamesForFile routes by
+ * uri shape), so current-category files (MAIN/OPTIONAL/UPDATE) are preferred,
+ * with older files (ARCHIVED/OLD_VERSION) used only as a fallback when a mod has
+ * no current file. At most ARCHIVE_FILES_PER_MOD contents fetches, so one mod
+ * can't exhaust the caller's per-run subrequest budget.
  *
  * `ok` is true only if the modFiles call AND every attempted contents call
  * succeeded, so the caller never caches a partial listing from a transient
@@ -306,12 +329,10 @@ export async function fetchModArchiveNames(fetchImpl, modId) {
   let ok = filesRes.ok;
   let subrequests = 1; // the modFiles call itself
 
-  // Friendly-uri files only (UUID paths have no derivable preview). Prefer the
-  // mod's current files; fall back to any friendly file (older ARCHIVED/
-  // OLD_VERSION) when none of the current ones are previewable.
-  const friendly = filesRes.files.filter((f) => !f.uri.includes('/'));
-  const current = friendly.filter((f) => CURRENT_FILE_CATEGORIES.has(f.category));
-  const chosen = (current.length ? current : friendly).slice(0, ARCHIVE_FILES_PER_MOD);
+  // Prefer the mod's current files; fall back to all files (older ARCHIVED/
+  // OLD_VERSION) only when it has no current-category file.
+  const current = filesRes.files.filter((f) => CURRENT_FILE_CATEGORIES.has(f.category));
+  const chosen = (current.length ? current : filesRes.files).slice(0, ARCHIVE_FILES_PER_MOD);
 
   const all = new Set();
   for (const f of chosen) {

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -10,8 +10,15 @@
  */
 
 export const NEXUS_GQL_ENDPOINT = 'https://api.nexusmods.com/v2/graphql';
+// Newer public router endpoint that exposes modFiles (the V2 endpoint above
+// does not). Both are unauthenticated; see docs/nexus-api-reference.md.
+export const NEXUS_ROUTER_ENDPOINT = 'https://api-router.nexusmods.com/graphql';
+// S3-backed file-contents preview: the tree Nexus shows under "Preview file
+// contents" on a mod's Files tab. Keyed by game/mod/<uri>.json.
+export const FILE_METADATA_BASE = 'https://file-metadata.nexusmods.com/file/nexus-files-s3-meta';
 export const NEXUS_GAME_ID = 3333; // Cyberpunk 2077
 export const NEXUS_BATCH_SIZE = 50;
+const ARCHIVE_UA = 'nczoning-data-api (+https://nczoning.net)';
 
 const QUERY = `
   query NCZoningMods($filter: ModsFilter!, $count: Int!, $offset: Int!) {
@@ -163,4 +170,122 @@ export async function fetchModsByUidThumbs(fetchImpl = fetch, numericIds = []) {
   }
   const results = await Promise.all(chunks.map(fetchChunk));
   return Object.assign({}, ...results);
+}
+
+// ── Archive names (installed-mod detection) ─────────────────────────────────
+// Publishes each mod's shipped `.archive` file names so an in-game consumer can
+// match them against the player's archive/pc/mod/ folder ("you have these
+// location mods installed"). Two hops per mod: modFiles → each file's contents
+// preview. Everything here is NON-THROWING: archive names are supplementary, so
+// a Nexus hiccup returns { ok:false } and the caller keeps last-known-good, it
+// never marks the whole dataset stale.
+
+const MOD_FILES_QUERY = `query ModFiles($modId: ID!, $gameId: ID!) {
+  modFiles(modId: $modId, gameId: $gameId) {
+    uri
+  }
+}`;
+
+/**
+ * Recursively collect `.archive` file names from a file-contents preview tree.
+ * Nodes look like { name, type: 'directory'|'file', children: [...] }; the root
+ * is { children: [...] }. Tolerant of shape drift: it only cares about `name`,
+ * `type`, and `children`, walking whatever nesting Nexus returns.
+ */
+function collectArchiveNames(node, out) {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const child of node) collectArchiveNames(child, out);
+    return;
+  }
+  if (node.type === 'file' && typeof node.name === 'string' && node.name.toLowerCase().endsWith('.archive')) {
+    out.add(node.name);
+  }
+  if (Array.isArray(node.children)) collectArchiveNames(node.children, out);
+}
+
+/**
+ * List every downloadable file's `uri` for a mod via the api-router modFiles
+ * query. Returns { uris, ok }: ok is false on any HTTP/GraphQL/parse failure, so
+ * the caller can distinguish "genuinely no files" (ok:true, uris:[]) from "we
+ * couldn't tell" (ok:false) and avoid caching a transient failure as truth.
+ *
+ * @param {typeof fetch} fetchImpl injectable for tests
+ * @param {string|number} modId numeric Nexus mod id
+ * @returns {Promise<{uris: string[], ok: boolean}>}
+ */
+export async function fetchModFileUris(fetchImpl, modId) {
+  try {
+    const res = await fetchImpl(NEXUS_ROUTER_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: MOD_FILES_QUERY,
+        variables: { modId: String(modId), gameId: String(NEXUS_GAME_ID) },
+      }),
+    });
+    if (!res.ok) return { uris: [], ok: false };
+    const json = await res.json();
+    const files = json?.data?.modFiles;
+    if (!Array.isArray(files)) return { uris: [], ok: false };
+    return {
+      uris: files.map((f) => f?.uri).filter((u) => typeof u === 'string' && u.length > 0),
+      ok: true,
+    };
+  } catch {
+    return { uris: [], ok: false };
+  }
+}
+
+/**
+ * Fetch one downloadable file's contents preview and return its `.archive` file
+ * names. Returns { names, ok }; ok is false on any failure (see fetchModFileUris
+ * for why the caller needs the distinction).
+ *
+ * @param {typeof fetch} fetchImpl injectable for tests
+ * @param {string|number} modId numeric Nexus mod id
+ * @param {string} uri the download file's uri (from modFiles)
+ * @returns {Promise<{names: string[], ok: boolean}>}
+ */
+export async function fetchArchiveNamesForFile(fetchImpl, modId, uri) {
+  try {
+    const url = `${FILE_METADATA_BASE}/${NEXUS_GAME_ID}/${modId}/${encodeURIComponent(uri)}.json`;
+    const res = await fetchImpl(url, { headers: { 'User-Agent': ARCHIVE_UA } });
+    if (!res.ok) return { names: [], ok: false };
+    const json = await res.json();
+    const names = new Set();
+    collectArchiveNames(json, names);
+    return { names: [...names], ok: true };
+  } catch {
+    return { names: [], ok: false };
+  }
+}
+
+/**
+ * All `.archive` file names a mod ships, unioned across every downloadable file
+ * (main + optional variants), deduped and sorted. Cost is 1 modFiles call + 1
+ * file-contents call per file — the caller budgets how many mods it refreshes
+ * per cron run to stay under the Worker subrequest cap.
+ *
+ * `ok` is true only if the modFiles call AND every file-contents call succeeded,
+ * so the caller never caches a partial listing produced by a transient failure
+ * as if it were complete. `subrequests` is the number of network calls made, for
+ * budgeting.
+ *
+ * @param {typeof fetch} fetchImpl injectable for tests
+ * @param {string|number} modId numeric Nexus mod id
+ * @returns {Promise<{archives: string[], ok: boolean, subrequests: number}>}
+ */
+export async function fetchModArchiveNames(fetchImpl, modId) {
+  const filesRes = await fetchModFileUris(fetchImpl, modId);
+  let ok = filesRes.ok;
+  let subrequests = 1; // the modFiles call itself
+  const all = new Set();
+  for (const uri of filesRes.uris) {
+    const r = await fetchArchiveNamesForFile(fetchImpl, modId, uri);
+    subrequests += 1;
+    if (!r.ok) ok = false;
+    for (const name of r.names) all.add(name);
+  }
+  return { archives: [...all].sort(), ok, subrequests };
 }

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -179,10 +179,30 @@ export async function fetchModsByUidThumbs(fetchImpl = fetch, numericIds = []) {
 // preview. Everything here is NON-THROWING: archive names are supplementary, so
 // a Nexus hiccup returns { ok:false } and the caller keeps last-known-good, it
 // never marks the whole dataset stale.
+//
+// Coverage limitation (measured, not assumed): only files whose modFiles `uri`
+// is the friendly filename (e.g. `Atari Canyon AIO-27618-1-0-….7z`) have a
+// contents preview at the file-metadata path. Files stored under a UUID path
+// (`uri` contains `/`, e.g. `b9/e3/70/b9e3…`) return 404 there regardless of
+// slash-encoding — the preview simply isn't published for them. So we fetch
+// ONLY friendly-uri files and skip UUID ones (no wasted subrequests, no false
+// failures). ~94% of the mod population still yields ≥1 `.archive`; the rest
+// resolve to `[]` (unknown), which the API already documents as "not
+// determinable", never "ships no archives".
+
+// Download-file categories that represent the mod's *current* files. We prefer
+// these; ARCHIVED/OLD_VERSION are superseded and only used as a fallback when a
+// mod has no current friendly-uri file (keeps the archive names current and the
+// per-mod subrequest count low).
+const CURRENT_FILE_CATEGORIES = new Set(['MAIN', 'OPTIONAL', 'UPDATE']);
+// Hard cap on file-contents fetches per mod, so one mod with many optional
+// variants can't blow the run's subrequest budget on its own.
+const ARCHIVE_FILES_PER_MOD = 6;
 
 const MOD_FILES_QUERY = `query ModFiles($modId: ID!, $gameId: ID!) {
   modFiles(modId: $modId, gameId: $gameId) {
     uri
+    category
   }
 }`;
 
@@ -205,14 +225,14 @@ function collectArchiveNames(node, out) {
 }
 
 /**
- * List every downloadable file's `uri` for a mod via the api-router modFiles
- * query. Returns { uris, ok }: ok is false on any HTTP/GraphQL/parse failure, so
- * the caller can distinguish "genuinely no files" (ok:true, uris:[]) from "we
- * couldn't tell" (ok:false) and avoid caching a transient failure as truth.
+ * List a mod's downloadable files (uri + category) via the api-router modFiles
+ * query. Returns { files, ok }: ok is false on any HTTP/GraphQL/parse failure,
+ * so the caller can distinguish "genuinely no files" (ok:true, files:[]) from
+ * "we couldn't tell" (ok:false) and avoid caching a transient failure as truth.
  *
  * @param {typeof fetch} fetchImpl injectable for tests
  * @param {string|number} modId numeric Nexus mod id
- * @returns {Promise<{uris: string[], ok: boolean}>}
+ * @returns {Promise<{files: Array<{uri: string, category: string}>, ok: boolean}>}
  */
 export async function fetchModFileUris(fetchImpl, modId) {
   try {
@@ -224,27 +244,30 @@ export async function fetchModFileUris(fetchImpl, modId) {
         variables: { modId: String(modId), gameId: String(NEXUS_GAME_ID) },
       }),
     });
-    if (!res.ok) return { uris: [], ok: false };
+    if (!res.ok) return { files: [], ok: false };
     const json = await res.json();
     const files = json?.data?.modFiles;
-    if (!Array.isArray(files)) return { uris: [], ok: false };
+    if (!Array.isArray(files)) return { files: [], ok: false };
     return {
-      uris: files.map((f) => f?.uri).filter((u) => typeof u === 'string' && u.length > 0),
+      files: files
+        .filter((f) => typeof f?.uri === 'string' && f.uri.length > 0)
+        .map((f) => ({ uri: f.uri, category: f.category || '' })),
       ok: true,
     };
   } catch {
-    return { uris: [], ok: false };
+    return { files: [], ok: false };
   }
 }
 
 /**
  * Fetch one downloadable file's contents preview and return its `.archive` file
  * names. Returns { names, ok }; ok is false on any failure (see fetchModFileUris
- * for why the caller needs the distinction).
+ * for why the caller needs the distinction). Only call this for friendly-uri
+ * files — UUID-path uris have no preview and always 404 (see the section note).
  *
  * @param {typeof fetch} fetchImpl injectable for tests
  * @param {string|number} modId numeric Nexus mod id
- * @param {string} uri the download file's uri (from modFiles)
+ * @param {string} uri the download file's friendly-name uri (from modFiles)
  * @returns {Promise<{names: string[], ok: boolean}>}
  */
 export async function fetchArchiveNamesForFile(fetchImpl, modId, uri) {
@@ -262,15 +285,17 @@ export async function fetchArchiveNamesForFile(fetchImpl, modId, uri) {
 }
 
 /**
- * All `.archive` file names a mod ships, unioned across every downloadable file
- * (main + optional variants), deduped and sorted. Cost is 1 modFiles call + 1
- * file-contents call per file — the caller budgets how many mods it refreshes
- * per cron run to stay under the Worker subrequest cap.
+ * All `.archive` file names a mod ships, unioned across its previewable files,
+ * deduped and sorted. Only friendly-uri files are fetched (UUID-path files have
+ * no preview); current-category files (MAIN/OPTIONAL/UPDATE) are preferred, with
+ * older friendly files used only as a fallback when a mod has no current one.
+ * At most ARCHIVE_FILES_PER_MOD contents fetches, so one mod can't exhaust the
+ * caller's per-run subrequest budget.
  *
- * `ok` is true only if the modFiles call AND every file-contents call succeeded,
- * so the caller never caches a partial listing produced by a transient failure
- * as if it were complete. `subrequests` is the number of network calls made, for
- * budgeting.
+ * `ok` is true only if the modFiles call AND every attempted contents call
+ * succeeded, so the caller never caches a partial listing from a transient
+ * failure as if it were complete. `subrequests` is the number of network calls
+ * made, for budgeting.
  *
  * @param {typeof fetch} fetchImpl injectable for tests
  * @param {string|number} modId numeric Nexus mod id
@@ -280,9 +305,17 @@ export async function fetchModArchiveNames(fetchImpl, modId) {
   const filesRes = await fetchModFileUris(fetchImpl, modId);
   let ok = filesRes.ok;
   let subrequests = 1; // the modFiles call itself
+
+  // Friendly-uri files only (UUID paths have no derivable preview). Prefer the
+  // mod's current files; fall back to any friendly file (older ARCHIVED/
+  // OLD_VERSION) when none of the current ones are previewable.
+  const friendly = filesRes.files.filter((f) => !f.uri.includes('/'));
+  const current = friendly.filter((f) => CURRENT_FILE_CATEGORIES.has(f.category));
+  const chosen = (current.length ? current : friendly).slice(0, ARCHIVE_FILES_PER_MOD);
+
   const all = new Set();
-  for (const uri of filesRes.uris) {
-    const r = await fetchArchiveNamesForFile(fetchImpl, modId, uri);
+  for (const f of chosen) {
+    const r = await fetchArchiveNamesForFile(fetchImpl, modId, f.uri);
     subrequests += 1;
     if (!r.ok) ok = false;
     for (const name of r.names) all.add(name);

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -209,10 +209,23 @@ const MOD_FILES_QUERY = `query ModFiles($modId: ID!, $gameId: ID!) {
 }`;
 
 /**
- * Recursively collect `.archive` file names from a file-contents preview tree.
- * Nodes look like { name, type: 'directory'|'file', children: [...] }; the root
- * is { children: [...] }. Tolerant of shape drift: it only cares about `name`,
- * `type`, and `children`, walking whatever nesting Nexus returns.
+ * Detectable install-folder files: `.archive` load files AND `.xl` (ArchiveXL)
+ * files. Both land in archive/pc/mod/ and are readable by an in-game mod, so
+ * both fingerprint an install. `.xl` matters for removal-only mods (e.g. an
+ * ArchiveXL "removal" that ships only `foo_removal.xl`, no `.archive`). CET/AMM
+ * `.json` files are NOT detectable (sandboxed CET folder) and are never matched.
+ */
+function isDetectableInstallFile(name) {
+  if (typeof name !== 'string') return false;
+  const lower = name.toLowerCase();
+  return lower.endsWith('.archive') || lower.endsWith('.xl');
+}
+
+/**
+ * Recursively collect detectable install file names from a file-contents preview
+ * tree. Nodes look like { name, type: 'directory'|'file', children: [...] }; the
+ * root is { children: [...] }. Tolerant of shape drift: it only cares about
+ * `name`, `type`, and `children`, walking whatever nesting Nexus returns.
  */
 function collectArchiveNames(node, out) {
   if (!node || typeof node !== 'object') return;
@@ -220,22 +233,22 @@ function collectArchiveNames(node, out) {
     for (const child of node) collectArchiveNames(child, out);
     return;
   }
-  if (node.type === 'file' && typeof node.name === 'string' && node.name.toLowerCase().endsWith('.archive')) {
+  if (node.type === 'file' && isDetectableInstallFile(node.name)) {
     out.add(node.name);
   }
   if (Array.isArray(node.children)) collectArchiveNames(node.children, out);
 }
 
 /**
- * Collect `.archive` file names from a new-scheme manifest: a FLAT array of
- * { file_path, file_size, file_hashes }, where file_path is the full in-archive
- * path (`archive/pc/mod/Foo.archive`). We take the basename of each `.archive`.
+ * Collect detectable install file names from a new-scheme manifest: a FLAT array
+ * of { file_path, file_size, file_hashes }, where file_path is the full
+ * in-archive path (`archive/pc/mod/Foo.archive`). We take each match's basename.
  */
 function collectArchiveNamesFromManifest(entries, out) {
   if (!Array.isArray(entries)) return;
   for (const entry of entries) {
     const p = entry?.file_path;
-    if (typeof p === 'string' && p.toLowerCase().endsWith('.archive')) {
+    if (typeof p === 'string' && isDetectableInstallFile(p)) {
       out.add(p.split(/[\\/]/).pop());
     }
   }
@@ -280,9 +293,10 @@ export async function fetchModFileUris(fetchImpl, modId) {
  * Fetch one downloadable file's contents preview and return its `.archive` file
  * names. Routes by `uri` shape to the right host/parser: a UUID storage path
  * (contains `/`) → file-manifests host (flat file_path array); a friendly
- * filename → file-metadata host (nested children tree). Returns { names, ok };
- * ok is false on any failure (see fetchModFileUris for why the caller needs the
- * distinction).
+ * filename → file-metadata host (nested children tree). Not every file has a
+ * published preview (many 404, on either host), so `ok` is true for a 200 OR a
+ * 404 (both are definitive: "here are the names" / "this file has none") and
+ * false only for a transient error (429/5xx/network) worth retrying.
  *
  * @param {typeof fetch} fetchImpl injectable for tests
  * @param {string|number} modId numeric Nexus mod id
@@ -296,14 +310,22 @@ export async function fetchArchiveNamesForFile(fetchImpl, modId, uri) {
       ? `${FILE_MANIFEST_BASE}/${uri}.json`
       : `${FILE_METADATA_BASE}/${NEXUS_GAME_ID}/${modId}/${encodeURIComponent(uri)}.json`;
     const res = await fetchImpl(url, { headers: { 'User-Agent': ARCHIVE_UA } });
-    if (!res.ok) return { names: [], ok: false };
+    if (!res.ok) {
+      // 404 is a DEFINITIVE answer — this file has no published preview — not a
+      // transient error. It must contribute no archives WITHOUT poisoning the
+      // mod's ok: otherwise a mod with a good MAIN and a preview-less OPTIONAL
+      // never caches, sits at the front of the newest-first queue, and starves
+      // every mod behind it (observed: cron stuck at "refreshed 0/9"). Only
+      // 429/5xx/network stay ok:false so they retry.
+      return { names: [], ok: res.status === 404 };
+    }
     const json = await res.json();
     const names = new Set();
     if (isUuidPath) collectArchiveNamesFromManifest(json, names);
     else collectArchiveNames(json, names);
     return { names: [...names], ok: true };
   } catch {
-    return { names: [], ok: false };
+    return { names: [], ok: false }; // network/parse error: transient, retry
   }
 }
 

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -115,6 +115,7 @@ async function refreshArchives(fetchImpl, full, cache) {
 
   let changed = false;
   let refreshed = 0;
+  let okCount = 0;
   let subrequests = 0;
   for (const r of stale) {
     if (refreshed >= ARCHIVE_MOD_BUDGET || subrequests >= ARCHIVE_SUBREQUEST_BUDGET) break;
@@ -122,8 +123,16 @@ async function refreshArchives(fetchImpl, full, cache) {
     refreshed += 1;
     subrequests += res.subrequests;
     if (!res.ok) continue; // transient failure: leave stale, retry next run
+    okCount += 1;
     cache[r.nexus_id] = { updatedAt: r.updated_at ?? null, archives: res.archives };
     changed = true;
+  }
+  if (refreshed > 0) {
+    // Ops visibility for the cold-fill / re-upload catch-up (cf. the thumbnail
+    // warnings). Silent in steady state, when nothing is stale.
+    console.log(
+      `archives: refreshed ${okCount}/${refreshed} mods (${stale.length} stale, ${subrequests} subrequests), cache=${Object.keys(cache).length}`,
+    );
   }
 
   // Evict entries for mods no longer in the dataset (deleted/hidden on Nexus) so

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -13,12 +13,23 @@
  * unit-testable with a fake KV + fake fetch.
  */
 
-import { fetchTaggedModNodes, fetchModsByUidThumbs } from './nexus.js';
+import { fetchTaggedModNodes, fetchModsByUidThumbs, fetchModArchiveNames } from './nexus.js';
 import { buildDataset } from './merge.js';
 import { districtsPayload } from './districts.js';
-import { KEYS, contentHash, readMeta, writeDataset, writeMeta } from './store.js';
+import {
+  KEYS, contentHash, readMeta, writeDataset, writeMeta, readArchives, writeArchives,
+} from './store.js';
 
 const SCHEMA_VERSION = 1;
+
+// Per-run limits on archive-name fetching. Archives are near-static (a mod's
+// .archive filenames only change on a re-upload, which bumps its updatedAt), so
+// steady state fetches nothing. These budgets cap the cold-start fill and any
+// re-upload burst so archive work can never breach the Worker's 50-subrequest
+// cap alongside the existing discovery + thumbnail calls. A cold cache fills
+// over ~ceil(mods / ARCHIVE_MOD_BUDGET) cron ticks.
+const ARCHIVE_MOD_BUDGET = 15; // max mods refreshed per run
+const ARCHIVE_SUBREQUEST_BUDGET = 25; // max archive subrequests per run
 
 /** Fetch a JSON file from the site origin; throws on non-200. */
 async function fetchJson(fetchImpl, origin, path) {
@@ -82,6 +93,74 @@ async function alertDiscordRecovered(env, fetchImpl) {
 }
 
 /**
+ * Refresh the archive-name cache in place, budgeted. Mutates `cache`
+ * ({ [nexus_id]: { updatedAt, archives } }) and returns { changed } so the
+ * caller knows whether to persist it.
+ *
+ * A mod is refetched only when it's absent from the cache or its updatedAt moved
+ * (the exact re-upload signal for its archive contents). Newest-updated mods are
+ * refreshed first so a re-upload beats cold-fill for the budget. A transient
+ * failure (ok:false) is left uncached so the next run retries, rather than
+ * caching an empty/partial listing as final.
+ */
+async function refreshArchives(fetchImpl, full, cache) {
+  const records = Object.values(full).filter((r) => /^\d+$/.test(r.nexus_id));
+
+  const stale = records
+    .filter((r) => {
+      const c = cache[r.nexus_id];
+      return !c || c.updatedAt !== (r.updated_at ?? null);
+    })
+    .sort((a, b) => String(b.updated_at ?? '').localeCompare(String(a.updated_at ?? '')));
+
+  let changed = false;
+  let refreshed = 0;
+  let subrequests = 0;
+  for (const r of stale) {
+    if (refreshed >= ARCHIVE_MOD_BUDGET || subrequests >= ARCHIVE_SUBREQUEST_BUDGET) break;
+    const res = await fetchModArchiveNames(fetchImpl, r.nexus_id);
+    refreshed += 1;
+    subrequests += res.subrequests;
+    if (!res.ok) continue; // transient failure: leave stale, retry next run
+    cache[r.nexus_id] = { updatedAt: r.updated_at ?? null, archives: res.archives };
+    changed = true;
+  }
+
+  // Evict entries for mods no longer in the dataset (deleted/hidden on Nexus) so
+  // the cache can't grow without bound. No fetching, just set membership.
+  const live = new Set(records.map((r) => r.nexus_id));
+  for (const id of Object.keys(cache)) {
+    if (!live.has(id)) {
+      delete cache[id];
+      changed = true;
+    }
+  }
+
+  return { changed };
+}
+
+/**
+ * Attach an `archives` string array to every full record (always present, `[]`
+ * when unknown or not yet filled), refreshing the KV-backed cache first. Wrapped
+ * so archive work can NEVER fail the refresh: on any error every record still
+ * gets at least `[]`. Mutates `full` in place; run it before the content hash so
+ * archive changes propagate to the ETag.
+ */
+async function attachArchives(env, fetchImpl, full) {
+  let cache = {};
+  try {
+    cache = await readArchives(env);
+    const { changed } = await refreshArchives(fetchImpl, full, cache);
+    if (changed) await writeArchives(env, cache);
+  } catch (err) {
+    console.warn('archive refresh failed (non-fatal):', String(err).slice(0, 200));
+  }
+  for (const rec of Object.values(full)) {
+    rec.archives = cache[rec.nexus_id]?.archives ?? [];
+  }
+}
+
+/**
  * Run one refresh cycle.
  * @param {object} env  Worker env (DATASET KV binding, SITE_ORIGIN?, DISCORD_WEBHOOK_URL?)
  * @param {typeof fetch} fetchImpl  injectable
@@ -115,6 +194,11 @@ export async function runRefresh(env, fetchImpl = fetch) {
       nowMs: Date.parse(generatedAt),
     });
     const districtsOut = districtsPayload(districts);
+
+    // Enrich every record with its shipped .archive file names (installed-mod
+    // detection). Budgeted + updatedAt-gated, and non-fatal by construction, so
+    // it slots in before the hash without touching the failure posture below.
+    await attachArchives(env, fetchImpl, full);
 
     // Hash the content that actually varies (not generated_at). Tags are
     // included so a tags.json edit propagates through the ETag. `full` carries

--- a/worker/src/store.js
+++ b/worker/src/store.js
@@ -8,6 +8,11 @@
  * - dataset:v1:meta      { schema, generated_at, dataset_version,
  *                          discovery_stale, skipped }; a failed cycle also
  *                          writes last_error and last_error_at
+ * - dataset:v1:archives  { [nexus_id]: { updatedAt, archives: [name, ...] } }:
+ *                        a persistent cache, NOT part of the served envelope.
+ *                        The cron refetches a mod's archive names only when its
+ *                        updatedAt moves (a re-upload), so this survives across
+ *                        runs; see refresh.js for the budgeted fill.
  *
  * dataset_version is a content hash: the cron writes only when it changes,
  * and it doubles as the ETag for the read path.
@@ -18,6 +23,7 @@ export const KEYS = {
   districts: 'dataset:v1:districts',
   tags: 'dataset:v1:tags',
   meta: 'dataset:v1:meta',
+  archives: 'dataset:v1:archives',
 };
 
 /** SHA-256 hex of a string, via Web Crypto (Workers + Node 24). */
@@ -50,4 +56,17 @@ export async function writeDataset(env, { full, districts, tags, meta }) {
 /** Update only the meta record (last-known-good touch on a failed refresh). */
 export async function writeMeta(env, meta) {
   await env.DATASET.put(KEYS.meta, JSON.stringify(meta));
+}
+
+/**
+ * Read the archive-name cache ({ [nexus_id]: { updatedAt, archives } }), or {}
+ * before the first fill. This is a cross-run cache, not a served payload.
+ */
+export async function readArchives(env) {
+  return (await env.DATASET.get(KEYS.archives, 'json')) || {};
+}
+
+/** Persist the archive-name cache. The caller writes only when it changed. */
+export async function writeArchives(env, cache) {
+  await env.DATASET.put(KEYS.archives, JSON.stringify(cache));
 }

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -149,9 +149,9 @@ function archiveFetch({ modFiles = [], trees = {}, routerOk = true } = {}) {
   };
 }
 
-test('archives: unions .archive names across files, deduped + sorted', async () => {
+test('archives: unions .archive names across current files, deduped + sorted', async () => {
   const impl = archiveFetch({
-    modFiles: [{ uri: 'Main-1.7z' }, { uri: 'Optional-2.7z' }],
+    modFiles: [{ uri: 'Main-1.7z', category: 'MAIN' }, { uri: 'Optional-2.7z', category: 'OPTIONAL' }],
     trees: {
       'Main-1.7z': tree('b.archive', 'a.archive', 'shared.archive'),
       'Optional-2.7z': tree('shared.archive', 'c.archive'),
@@ -163,9 +163,60 @@ test('archives: unions .archive names across files, deduped + sorted', async () 
   assert.equal(res.subrequests, 3); // 1 modFiles + 2 files
 });
 
+test('archives: skips UUID-path files (no preview) — fetches only friendly uris', async () => {
+  // Real Nexus data: newer files carry a UUID storage uri (slashes) with no
+  // contents preview; only friendly-name uris are previewable.
+  const metaHits = [];
+  const impl = async (url, init) => {
+    if (url.includes('api-router')) {
+      return { ok: true, json: async () => ({ data: { modFiles: [
+        { uri: 'Friendly-1.7z', category: 'MAIN' },
+        { uri: 'b9/e3/70/b9e37068-uuid', category: 'MAIN' },
+      ] } }) };
+    }
+    metaHits.push(url);
+    return { ok: true, json: async () => tree('good.archive') };
+  };
+  const res = await fetchModArchiveNames(impl, 1);
+  assert.deepEqual(res.archives, ['good.archive']);
+  assert.equal(res.subrequests, 2); // modFiles + the one friendly file only
+  assert.ok(!metaHits.some((u) => u.includes('uuid')), 'UUID file never requested');
+});
+
+test('archives: prefers current-category files over archived when both are friendly', async () => {
+  const impl = archiveFetch({
+    modFiles: [
+      { uri: 'Current-1-0.7z', category: 'MAIN' },
+      { uri: 'Old-0-9.zip', category: 'OLD_VERSION' },
+    ],
+    trees: { 'Current-1-0.7z': tree('current.archive'), 'Old-0-9.zip': tree('old.archive') },
+  });
+  // OLD_VERSION is not fetched when a current-category file is available.
+  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['current.archive']);
+});
+
+test('archives: falls back to an older friendly file when no current file is previewable', async () => {
+  const impl = archiveFetch({
+    modFiles: [
+      { uri: 'aa/bb/cc/uuid-current', category: 'MAIN' }, // current but UUID → not previewable
+      { uri: 'Old-1-0.zip', category: 'OLD_VERSION' }, // only friendly file left
+    ],
+    trees: { 'Old-1-0.zip': tree('legacy.archive') },
+  });
+  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['legacy.archive']);
+});
+
+test('archives: caps contents fetches per mod so one mod cannot exhaust the budget', async () => {
+  const many = Array.from({ length: 12 }, (_, i) => ({ uri: `Opt-${i}.7z`, category: 'OPTIONAL' }));
+  const trees = Object.fromEntries(many.map((f, i) => [f.uri, tree(`a${i}.archive`)]));
+  const res = await fetchModArchiveNames(archiveFetch({ modFiles: many, trees }), 1);
+  assert.ok(res.subrequests <= 7, `subrequests ${res.subrequests} must be capped (1 + <=6)`);
+  assert.ok(res.archives.length <= 6);
+});
+
 test('archives: ignores non-.archive files (e.g. .xl, readme)', async () => {
   const impl = archiveFetch({
-    modFiles: [{ uri: 'M.7z' }],
+    modFiles: [{ uri: 'M.7z', category: 'MAIN' }],
     trees: { 'M.7z': tree('thing.archive', 'thing.xl', 'readme.txt') },
   });
   assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['thing.archive']);
@@ -178,7 +229,7 @@ test('archives: modFiles failure → ok:false, no archives, only the one subrequ
 
 test('archives: a file-contents failure marks ok:false but keeps what it found', async () => {
   const impl = archiveFetch({
-    modFiles: [{ uri: 'Good.7z' }, { uri: 'Bad.7z' }],
+    modFiles: [{ uri: 'Good.7z', category: 'MAIN' }, { uri: 'Bad.7z', category: 'MAIN' }],
     trees: { 'Good.7z': tree('good.archive'), 'Bad.7z': { ok: false } },
   });
   const res = await fetchModArchiveNames(impl, 1);
@@ -199,7 +250,7 @@ test('archives: sends modId/gameId as ID strings and builds the file-metadata UR
   const impl = async (url, init) => {
     if (url.includes('api-router')) {
       sentVars = JSON.parse(init.body).variables;
-      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: 'A B-1.7z' }] } }) };
+      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: 'A B-1.7z', category: 'MAIN' }] } }) };
     }
     metaUrl = url;
     return { ok: true, json: async () => tree('x.archive') };

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -130,13 +130,29 @@ const tree = (...names) => ({
   ] }],
 });
 
-// Routes api-router (modFiles) and file-metadata (contents) by host. `trees`
-// maps a file uri → its contents tree, or { ok:false }/Error to simulate failure.
-function archiveFetch({ modFiles = [], trees = {}, routerOk = true } = {}) {
+// A new-scheme manifest: the flat file_path array the file-manifests host
+// returns (confirmed live). One entry per file, name under archive/pc/mod/.
+const manifest = (...names) => names.map((n) => ({
+  file_path: `archive/pc/mod/${n}`, file_size: 1, file_hashes: {},
+}));
+
+// Routes the three hosts by URL. `trees` maps a friendly uri → its file-metadata
+// tree; `manifests` maps a UUID uri → its file-manifests array. Either value can
+// be { ok:false }/Error to simulate failure.
+function archiveFetch({ modFiles = [], trees = {}, manifests = {}, routerOk = true } = {}) {
   return async (url, init) => {
     if (url.includes('api-router.nexusmods.com')) {
       if (!routerOk) return { ok: false, status: 503, json: async () => ({}) };
       return { ok: true, json: async () => ({ data: { modFiles } }) };
+    }
+    if (url.includes('file-manifests.nexusmods.com')) {
+      const uri = decodeURIComponent(
+        url.replace('https://file-manifests.nexusmods.com/', '').replace(/\.json$/, ''),
+      );
+      const m = manifests[uri];
+      if (m instanceof Error) throw m;
+      if (m && m.ok === false) return { ok: false, status: 404, json: async () => ({}) };
+      return { ok: true, json: async () => m ?? [] };
     }
     if (url.includes('file-metadata.nexusmods.com')) {
       const uri = decodeURIComponent(url.match(/\/[^/]+\/([^/]+)\.json$/)[1]);
@@ -163,27 +179,55 @@ test('archives: unions .archive names across current files, deduped + sorted', a
   assert.equal(res.subrequests, 3); // 1 modFiles + 2 files
 });
 
-test('archives: skips UUID-path files (no preview) — fetches only friendly uris', async () => {
-  // Real Nexus data: newer files carry a UUID storage uri (slashes) with no
-  // contents preview; only friendly-name uris are previewable.
-  const metaHits = [];
-  const impl = async (url, init) => {
+test('archives: fetches UUID-path files from the file-manifests host (flat manifest)', async () => {
+  // New-scheme files (uri is a UUID storage path) have a flat manifest at the
+  // file-manifests host — we take the .archive basename from file_path.
+  const impl = archiveFetch({
+    modFiles: [{ uri: 'ab/cd/ef/uuid-1', category: 'MAIN' }],
+    manifests: { 'ab/cd/ef/uuid-1': manifest('New.archive', 'thing.xl') },
+  });
+  const res = await fetchModArchiveNames(impl, 1);
+  assert.deepEqual(res.archives, ['New.archive']); // basename; .xl ignored
+  assert.equal(res.ok, true);
+});
+
+test('archives: unions across both hosts (friendly tree + UUID manifest)', async () => {
+  const impl = archiveFetch({
+    modFiles: [
+      { uri: 'Main-1.7z', category: 'MAIN' },
+      { uri: 'x/y/z/uuid-opt', category: 'OPTIONAL' },
+    ],
+    trees: { 'Main-1.7z': tree('a.archive') },
+    manifests: { 'x/y/z/uuid-opt': manifest('b.archive') },
+  });
+  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['a.archive', 'b.archive']);
+});
+
+test('archives: routes uri by shape (UUID→file-manifests, friendly→file-metadata)', async () => {
+  const urls = [];
+  const impl = async (url) => {
     if (url.includes('api-router')) {
       return { ok: true, json: async () => ({ data: { modFiles: [
         { uri: 'Friendly-1.7z', category: 'MAIN' },
-        { uri: 'b9/e3/70/b9e37068-uuid', category: 'MAIN' },
+        { uri: 'aa/bb/cc/uuid', category: 'OPTIONAL' },
       ] } }) };
     }
-    metaHits.push(url);
-    return { ok: true, json: async () => tree('good.archive') };
+    urls.push(url);
+    if (url.includes('file-manifests')) return { ok: true, json: async () => manifest('u.archive') };
+    return { ok: true, json: async () => tree('f.archive') };
   };
-  const res = await fetchModArchiveNames(impl, 1);
-  assert.deepEqual(res.archives, ['good.archive']);
-  assert.equal(res.subrequests, 2); // modFiles + the one friendly file only
-  assert.ok(!metaHits.some((u) => u.includes('uuid')), 'UUID file never requested');
+  await fetchModArchiveNames(impl, 27618);
+  assert.ok(
+    urls.includes('https://file-manifests.nexusmods.com/aa/bb/cc/uuid.json'),
+    'UUID uri → file-manifests host, path un-encoded',
+  );
+  assert.ok(
+    urls.includes('https://file-metadata.nexusmods.com/file/nexus-files-s3-meta/3333/27618/Friendly-1.7z.json'),
+    'friendly uri → file-metadata host',
+  );
 });
 
-test('archives: prefers current-category files over archived when both are friendly', async () => {
+test('archives: prefers current-category files over older versions', async () => {
   const impl = archiveFetch({
     modFiles: [
       { uri: 'Current-1-0.7z', category: 'MAIN' },
@@ -195,13 +239,10 @@ test('archives: prefers current-category files over archived when both are frien
   assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['current.archive']);
 });
 
-test('archives: falls back to an older friendly file when no current file is previewable', async () => {
+test('archives: falls back to older files when no current-category file exists', async () => {
   const impl = archiveFetch({
-    modFiles: [
-      { uri: 'aa/bb/cc/uuid-current', category: 'MAIN' }, // current but UUID → not previewable
-      { uri: 'Old-1-0.zip', category: 'OLD_VERSION' }, // only friendly file left
-    ],
-    trees: { 'Old-1-0.zip': tree('legacy.archive') },
+    modFiles: [{ uri: 'gg/hh/ii/uuid-old', category: 'OLD_VERSION' }],
+    manifests: { 'gg/hh/ii/uuid-old': manifest('legacy.archive') },
   });
   assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['legacy.archive']);
 });

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -1,6 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { fetchTaggedModNodes, fetchModsByUidThumbs, NEXUS_BATCH_SIZE, NEXUS_GAME_ID } from '../src/nexus.js';
+import {
+  fetchTaggedModNodes, fetchModsByUidThumbs, fetchModArchiveNames,
+  NEXUS_BATCH_SIZE, NEXUS_GAME_ID,
+} from '../src/nexus.js';
 
 function fakeFetch(pages) {
   let call = 0;
@@ -110,4 +113,101 @@ test('modsByUid: retries UIDs the first call silently dropped', async () => {
   ]);
   const map = await fetchModsByUidThumbs(impl, ['1', '2']);
   assert.ok(map['1'] && map['2'], 'both UIDs present after the retry');
+});
+
+// ── fetchModArchiveNames (installed-mod detection) ──────────────────────────
+
+// A file-contents preview tree with the given .archive/other file names under
+// archive/pc/mod/ — the real nesting confirmed against a live file-metadata
+// response (archive → pc → mod → files).
+const tree = (...names) => ({
+  children: [{ name: 'archive', type: 'directory', children: [
+    { name: 'pc', type: 'directory', children: [
+      { name: 'mod', type: 'directory', children: names.map((n) => ({
+        name: n, type: 'file', path: `archive/pc/mod/${n}`, size: '1 kB',
+      })) },
+    ] },
+  ] }],
+});
+
+// Routes api-router (modFiles) and file-metadata (contents) by host. `trees`
+// maps a file uri → its contents tree, or { ok:false }/Error to simulate failure.
+function archiveFetch({ modFiles = [], trees = {}, routerOk = true } = {}) {
+  return async (url, init) => {
+    if (url.includes('api-router.nexusmods.com')) {
+      if (!routerOk) return { ok: false, status: 503, json: async () => ({}) };
+      return { ok: true, json: async () => ({ data: { modFiles } }) };
+    }
+    if (url.includes('file-metadata.nexusmods.com')) {
+      const uri = decodeURIComponent(url.match(/\/[^/]+\/([^/]+)\.json$/)[1]);
+      const t = trees[uri];
+      if (t instanceof Error) throw t;
+      if (t && t.ok === false) return { ok: false, status: 404, json: async () => ({}) };
+      return { ok: true, json: async () => t ?? { children: [] } };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+}
+
+test('archives: unions .archive names across files, deduped + sorted', async () => {
+  const impl = archiveFetch({
+    modFiles: [{ uri: 'Main-1.7z' }, { uri: 'Optional-2.7z' }],
+    trees: {
+      'Main-1.7z': tree('b.archive', 'a.archive', 'shared.archive'),
+      'Optional-2.7z': tree('shared.archive', 'c.archive'),
+    },
+  });
+  const res = await fetchModArchiveNames(impl, 27618);
+  assert.deepEqual(res.archives, ['a.archive', 'b.archive', 'c.archive', 'shared.archive']);
+  assert.equal(res.ok, true);
+  assert.equal(res.subrequests, 3); // 1 modFiles + 2 files
+});
+
+test('archives: ignores non-.archive files (e.g. .xl, readme)', async () => {
+  const impl = archiveFetch({
+    modFiles: [{ uri: 'M.7z' }],
+    trees: { 'M.7z': tree('thing.archive', 'thing.xl', 'readme.txt') },
+  });
+  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['thing.archive']);
+});
+
+test('archives: modFiles failure → ok:false, no archives, only the one subrequest', async () => {
+  const res = await fetchModArchiveNames(archiveFetch({ routerOk: false }), 1);
+  assert.deepEqual(res, { archives: [], ok: false, subrequests: 1 });
+});
+
+test('archives: a file-contents failure marks ok:false but keeps what it found', async () => {
+  const impl = archiveFetch({
+    modFiles: [{ uri: 'Good.7z' }, { uri: 'Bad.7z' }],
+    trees: { 'Good.7z': tree('good.archive'), 'Bad.7z': { ok: false } },
+  });
+  const res = await fetchModArchiveNames(impl, 1);
+  assert.deepEqual(res.archives, ['good.archive']);
+  assert.equal(res.ok, false); // partial: caller must not cache this as final
+});
+
+test('archives: a thrown fetch degrades to ok:false, never throws', async () => {
+  const impl = async () => { throw new Error('network'); };
+  assert.deepEqual(await fetchModArchiveNames(impl, 1), { archives: [], ok: false, subrequests: 1 });
+});
+
+test('archives: sends modId/gameId as ID strings and builds the file-metadata URL', async () => {
+  // Wire-contract guard (cf. the modsByUid UID lesson): modFiles args are ID!,
+  // and the file-metadata path is game/mod/<uri-encoded>.json.
+  let sentVars = null;
+  let metaUrl = null;
+  const impl = async (url, init) => {
+    if (url.includes('api-router')) {
+      sentVars = JSON.parse(init.body).variables;
+      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: 'A B-1.7z' }] } }) };
+    }
+    metaUrl = url;
+    return { ok: true, json: async () => tree('x.archive') };
+  };
+  await fetchModArchiveNames(impl, 27618);
+  assert.deepEqual(sentVars, { modId: '27618', gameId: String(NEXUS_GAME_ID) });
+  assert.equal(
+    metaUrl,
+    'https://file-metadata.nexusmods.com/file/nexus-files-s3-meta/3333/27618/A%20B-1.7z.json',
+  );
 });

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -151,14 +151,14 @@ function archiveFetch({ modFiles = [], trees = {}, manifests = {}, routerOk = tr
       );
       const m = manifests[uri];
       if (m instanceof Error) throw m;
-      if (m && m.ok === false) return { ok: false, status: 404, json: async () => ({}) };
+      if (m && m.ok === false) return { ok: false, status: m.status ?? 404, json: async () => ({}) };
       return { ok: true, json: async () => m ?? [] };
     }
     if (url.includes('file-metadata.nexusmods.com')) {
       const uri = decodeURIComponent(url.match(/\/[^/]+\/([^/]+)\.json$/)[1]);
       const t = trees[uri];
       if (t instanceof Error) throw t;
-      if (t && t.ok === false) return { ok: false, status: 404, json: async () => ({}) };
+      if (t && t.ok === false) return { ok: false, status: t.status ?? 404, json: async () => ({}) };
       return { ok: true, json: async () => t ?? { children: [] } };
     }
     throw new Error(`unexpected fetch: ${url}`);
@@ -187,7 +187,7 @@ test('archives: fetches UUID-path files from the file-manifests host (flat manif
     manifests: { 'ab/cd/ef/uuid-1': manifest('New.archive', 'thing.xl') },
   });
   const res = await fetchModArchiveNames(impl, 1);
-  assert.deepEqual(res.archives, ['New.archive']); // basename; .xl ignored
+  assert.deepEqual(res.archives, ['New.archive', 'thing.xl']); // basenames; .xl included
   assert.equal(res.ok, true);
 });
 
@@ -255,12 +255,21 @@ test('archives: caps contents fetches per mod so one mod cannot exhaust the budg
   assert.ok(res.archives.length <= 6);
 });
 
-test('archives: ignores non-.archive files (e.g. .xl, readme)', async () => {
+test('archives: collects .archive AND .xl (ArchiveXL), ignores .json/readme', async () => {
   const impl = archiveFetch({
     modFiles: [{ uri: 'M.7z', category: 'MAIN' }],
-    trees: { 'M.7z': tree('thing.archive', 'thing.xl', 'readme.txt') },
+    trees: { 'M.7z': tree('thing.archive', 'thing.xl', 'appearance.json', 'readme.txt') },
   });
-  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['thing.archive']);
+  // .xl lands in archive/pc/mod and is readable in-game; .json (CET/AMM) is not.
+  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['thing.archive', 'thing.xl']);
+});
+
+test('archives: a removal-only mod (ships only .xl) is still detected', async () => {
+  const impl = archiveFetch({
+    modFiles: [{ uri: 'Removal.7z', category: 'MAIN' }],
+    trees: { 'Removal.7z': tree('h10_apartment_removal.xl') },
+  });
+  assert.deepEqual((await fetchModArchiveNames(impl, 1)).archives, ['h10_apartment_removal.xl']);
 });
 
 test('archives: modFiles failure → ok:false, no archives, only the one subrequest', async () => {
@@ -268,14 +277,35 @@ test('archives: modFiles failure → ok:false, no archives, only the one subrequ
   assert.deepEqual(res, { archives: [], ok: false, subrequests: 1 });
 });
 
-test('archives: a file-contents failure marks ok:false but keeps what it found', async () => {
+test('archives: a 404 file has no preview but does NOT poison the mod (ok stays true)', async () => {
+  // The starvation bug: a good MAIN + a preview-less (404) sibling must still
+  // cache the MAIN's archives, or the mod retries forever and blocks the queue.
   const impl = archiveFetch({
-    modFiles: [{ uri: 'Good.7z', category: 'MAIN' }, { uri: 'Bad.7z', category: 'MAIN' }],
-    trees: { 'Good.7z': tree('good.archive'), 'Bad.7z': { ok: false } },
+    modFiles: [{ uri: 'Good.7z', category: 'MAIN' }, { uri: 'NoPreview.7z', category: 'OPTIONAL' }],
+    trees: { 'Good.7z': tree('good.archive'), 'NoPreview.7z': { ok: false, status: 404 } },
   });
   const res = await fetchModArchiveNames(impl, 1);
   assert.deepEqual(res.archives, ['good.archive']);
-  assert.equal(res.ok, false); // partial: caller must not cache this as final
+  assert.equal(res.ok, true); // 404 is definitive, not a retry-worthy failure
+});
+
+test('archives: a transient (5xx) file failure marks ok:false so it retries', async () => {
+  const impl = archiveFetch({
+    modFiles: [{ uri: 'Good.7z', category: 'MAIN' }, { uri: 'Flaky.7z', category: 'MAIN' }],
+    trees: { 'Good.7z': tree('good.archive'), 'Flaky.7z': { ok: false, status: 503 } },
+  });
+  const res = await fetchModArchiveNames(impl, 1);
+  assert.deepEqual(res.archives, ['good.archive']);
+  assert.equal(res.ok, false); // transient: caller must not cache this as final
+});
+
+test('archives: a mod whose only file 404s caches as [] with ok:true (no starvation)', async () => {
+  const impl = archiveFetch({
+    modFiles: [{ uri: 'Gone.7z', category: 'MAIN' }],
+    trees: { 'Gone.7z': { ok: false, status: 404 } },
+  });
+  const res = await fetchModArchiveNames(impl, 1);
+  assert.deepEqual(res, { archives: [], ok: true, subrequests: 2 }); // determined empty, leaves the queue
 });
 
 test('archives: a thrown fetch degrades to ok:false, never throws', async () => {

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -59,8 +59,10 @@ const NEXUS_PAGE = {
   },
 };
 
-// fetch stub keyed by URL substring; nexus POST returns the page.
-function fakeFetch({ failNexus = false, failMods = false, discordSink } = {}) {
+// fetch stub keyed by URL substring; nexus POST returns the page. `archiveCalls`
+// (optional) records each archive subrequest so tests can assert on budgeting
+// and cache reuse; `failArchives` makes the modFiles call fail.
+function fakeFetch({ failNexus = false, failMods = false, discordSink, archiveCalls, failArchives = false } = {}) {
   return async (url, init) => {
     if (url.includes('/mods.json')) {
       return failMods ? { ok: false, status: 500 } : { ok: true, json: async () => MODS };
@@ -68,6 +70,26 @@ function fakeFetch({ failNexus = false, failMods = false, discordSink } = {}) {
     if (url.includes('/tags.json')) return { ok: true, json: async () => TAGS };
     if (url.includes('/excluded_mods.json')) return { ok: true, json: async () => EXCLUDED };
     if (url.includes('/subdistricts.json')) return { ok: true, json: async () => SUBDISTRICTS };
+    // Archive-name endpoints (installed-mod detection). Checked before the
+    // generic api.nexusmods.com branch: "api-router.nexusmods.com" and
+    // "file-metadata.nexusmods.com" are distinct hosts.
+    if (url.includes('api-router.nexusmods.com')) {
+      archiveCalls?.push('router');
+      if (failArchives) return { ok: false, status: 503 };
+      const modId = JSON.parse(init.body).variables.modId;
+      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: `mod-${modId}.7z` }] } }) };
+    }
+    if (url.includes('file-metadata.nexusmods.com')) {
+      archiveCalls?.push('file');
+      const modId = url.match(/nexus-files-s3-meta\/3333\/(\d+)\//)[1];
+      return { ok: true, json: async () => ({ children: [{ name: 'archive', type: 'directory', children: [
+        { name: 'pc', type: 'directory', children: [
+          { name: 'mod', type: 'directory', children: [
+            { name: `mod_${modId}.archive`, type: 'file', path: `archive/pc/mod/mod_${modId}.archive` },
+          ] },
+        ] },
+      ] }] }) };
+    }
     if (url.includes('api.nexusmods.com')) {
       if (failNexus) return { ok: false, status: 503 };
       // Two POST shapes hit the same endpoint: the tagged-mods query and the
@@ -159,6 +181,84 @@ test('recovery after a stale cycle rewrites and clears the stale flag', async ()
   assert.equal(r.changed, true); // stale flag forces a rewrite even if hash matches
   assert.equal(r.recovered, true);
   assert.equal((await env.DATASET.get(KEYS.meta, 'json')).discovery_stale, false);
+});
+
+// ── Archive names (installed-mod detection) ─────────────────────────────────
+
+test('archive names are fetched and attached to every record', async () => {
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const archiveCalls = [];
+  await runRefresh(env, fakeFetch({ archiveCalls }));
+  const full = await env.DATASET.get(KEYS.full, 'json');
+  assert.deepEqual(full.m1.archives, ['mod_12345.archive']); // manual mod
+  const auto = Object.values(full).find((r) => r.id === 'nexus-888');
+  assert.deepEqual(auto.archives, ['mod_888.archive']); // auto-discovered mod
+  // One modFiles call per numeric-nexus_id mod (both here).
+  assert.equal(archiveCalls.filter((c) => c === 'router').length, 2);
+});
+
+test('archive cache is reused when updatedAt is unchanged (no refetch)', async () => {
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  await runRefresh(env, fakeFetch()); // fills the cache
+  const archiveCalls = [];
+  await runRefresh(env, fakeFetch({ archiveCalls }));
+  assert.equal(archiveCalls.length, 0); // nothing stale → zero archive subrequests
+});
+
+test('archive fetch failure degrades to [] and never marks the dataset stale', async () => {
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const r = await runRefresh(env, fakeFetch({ failArchives: true }));
+  assert.equal(r.stale, false); // archives are supplementary, not load-bearing
+  assert.equal(r.changed, true);
+  const full = await env.DATASET.get(KEYS.full, 'json');
+  assert.deepEqual(full.m1.archives, []); // failed → empty, and not cached
+  assert.equal((await env.DATASET.get(KEYS.meta, 'json')).discovery_stale, false);
+});
+
+test('archive refresh is budgeted per run and cold-fills over multiple runs', async () => {
+  // 20 manual mods, all numeric nexus_ids, cold cache → all stale at once.
+  const many = Array.from({ length: 20 }, (_, i) => ({
+    id: `m${i}`, name: `Mod ${String(i).padStart(2, '0')}`, authors: ['A'],
+    coordinates: [250, 250, 10], nexus_id: String(1000 + i), description: 'x',
+    category: 'other', tags: [],
+  }));
+  const impl = (archiveCalls) => async (url, init) => {
+    if (url.includes('/mods.json')) return { ok: true, json: async () => many };
+    if (url.includes('/tags.json')) return { ok: true, json: async () => TAGS };
+    if (url.includes('/excluded_mods.json')) return { ok: true, json: async () => ({}) };
+    if (url.includes('/subdistricts.json')) return { ok: true, json: async () => SUBDISTRICTS };
+    if (url.includes('api-router.nexusmods.com')) {
+      archiveCalls.push('router');
+      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: 'a.7z' }] } }) };
+    }
+    if (url.includes('file-metadata.nexusmods.com')) {
+      archiveCalls.push('file');
+      return { ok: true, json: async () => ({ children: [] }) };
+    }
+    if (url.includes('api.nexusmods.com')) {
+      if (JSON.parse(init.body).query.includes('modsByUid')) {
+        return { ok: true, json: async () => ({ data: { modsByUid: { nodes: [] } } }) };
+      }
+      return { ok: true, json: async () => ({ data: { mods: { nodes: [], totalCount: 0 } } }) };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const run1 = [];
+  await runRefresh(env, impl(run1));
+  const refreshed1 = run1.filter((c) => c === 'router').length;
+  assert.ok(refreshed1 < 20, `run 1 refreshed ${refreshed1}: must be budgeted, not all 20`);
+
+  const run2 = [];
+  await runRefresh(env, impl(run2));
+  const refreshed2 = run2.filter((c) => c === 'router').length;
+  // Cold-fill completes: the two runs together cover exactly the 20 mods once.
+  assert.equal(refreshed1 + refreshed2, 20);
+
+  const run3 = [];
+  await runRefresh(env, impl(run3));
+  assert.equal(run3.length, 0, 'once filled, steady state fetches nothing');
 });
 
 test('recovery posts a recovery alert exactly once (edge, not every cycle)', async () => {

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -77,7 +77,7 @@ function fakeFetch({ failNexus = false, failMods = false, discordSink, archiveCa
       archiveCalls?.push('router');
       if (failArchives) return { ok: false, status: 503 };
       const modId = JSON.parse(init.body).variables.modId;
-      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: `mod-${modId}.7z` }] } }) };
+      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: `mod-${modId}.7z`, category: 'MAIN' }] } }) };
     }
     if (url.includes('file-metadata.nexusmods.com')) {
       archiveCalls?.push('file');
@@ -229,7 +229,7 @@ test('archive refresh is budgeted per run and cold-fills over multiple runs', as
     if (url.includes('/subdistricts.json')) return { ok: true, json: async () => SUBDISTRICTS };
     if (url.includes('api-router.nexusmods.com')) {
       archiveCalls.push('router');
-      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: 'a.7z' }] } }) };
+      return { ok: true, json: async () => ({ data: { modFiles: [{ uri: 'a.7z', category: 'MAIN' }] } }) };
     }
     if (url.includes('file-metadata.nexusmods.com')) {
       archiveCalls.push('file');


### PR DESCRIPTION
Promotes the `archives` feature to production. Self-contained — the diff is entirely the archive-detection work (worker + docs + seed scripts); no unrelated changes.

## What ships

Every `/v1` location record gains an `archives` array — the `.archive` and `.xl` filenames a mod installs to `archive/pc/mod/` — so an in-game mod can detect which location mods a player has installed. Fetched server-side by the cron, cached in KV (`updatedAt`-gated), served on the existing envelope.

Bundles four merged dev PRs:
- **#845** feature (per-mod `.archive`, KV cache, budgeted cold-fill)
- **#846** friendly-only fix
- **#847** two-host manifest fix (file-metadata + file-manifests)
- **#848** soak fixes: 404-is-definitive (freeze fix), `.xl` inclusion, no old-version inference, bugged-preview seed

## Verified on the dev soak (`api-dev.nczoning.net`)

- **289/295 populated.** The 6 remaining `[]` are all expected: 5 AMM mods (CET-sandboxed, undetectable by design) + 1 WIP entry (no Nexus page). Zero unexplained empties.
- `.xl` collected across the population (280/283 fetched mods carry one); removal-only mod (H10 Minimal) detectable via `.xl`.
- 6 bugged-preview mods seeded from installed copies and serving real values.
- 82 worker tests pass; cron healthy through a full cold fill.

## Release steps

1. **CHANGELOG:** cut `[Unreleased]` → `[1.5.0] - 2026-07-20` (additive feature = minor). Happy to push that commit to dev before merge — say the word.
2. **After merge, seed prod once** (prod's archive cache starts empty, so it cold-fills automatically over ~2.5h; no clear needed):
   - `npx wrangler kv key get --remote --namespace-id d86735e00790417e948e423c3df01d68 dataset:v1:archives > cache.json`
   - `node worker/scripts/seed-archives.mjs https://api.nczoning.net cache.json merged.json`
   - `npx wrangler kv key put --remote --namespace-id d86735e00790417e948e423c3df01d68 dataset:v1:archives --path merged.json`
   - (Also in `seed-archives.mjs`'s header.)
3. **Monitoring:** #849 tracks alerting on stale `generated_at` (a wedged cron the current health check wouldn't catch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)