### PR TITLE
release: 1.5.0 CHANGELOG cut + openapi .xl/AMM coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-20
+
 ### Added
 
 - Each `/v1` location record now carries an `archives` array — the `.archive` and `.xl` filenames the mod installs to `archive/pc/mod/` (so removal-only mods are detectable too) — letting an in-game mod detect which location mods a player has installed. ([#841](https://github.com/spuddeh/nc-zoning-board/issues/841))

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -190,7 +190,7 @@
             "thumbnail_url": { "type": ["string", "null"], "description": "Nexus thumbnail image URL, or null (unknown / WIP / Dummy)." },
             "picture_url": { "type": ["string", "null"], "description": "Nexus full-size image URL, or null." },
             "updated_at": { "type": ["string", "null"], "format": "date-time", "description": "Nexus last-updated timestamp, or null." },
-            "archives": { "type": "array", "items": { "type": "string" }, "description": "The .archive filenames this mod ships, unioned across every downloadable file (main + optional). Match against the player's archive/pc/mod/ folder to detect installed location mods. Empty when unknown (WIP/Dummy, no Nexus files, or not yet fetched by the cron).", "example": ["Atari AIO.archive"] }
+            "archives": { "type": "array", "items": { "type": "string" }, "description": "The mod's detectable install files: .archive load files AND .xl (ArchiveXL) files, both of which land in archive/pc/mod/ and are readable by an in-game mod (.xl is the only fingerprint a removal-only mod has). Bare filenames, not paths. Match against the player's archive/pc/mod/ folder to detect installed location mods. Excludes CET/AMM .json files (they load into CET's sandboxed folder and are not readable by other mods). Empty when not determinable (an AMM-only mod, a WIP/Dummy entry with no Nexus page, a mod whose Nexus file preview is unavailable, or not yet fetched by the cron) — never 'ships nothing'.", "example": ["Atari Canyon AIO.archive", "atari_aio.xl"] }
           } }
         ]
       },


### PR DESCRIPTION
Release prep for the archive-detection promotion (#850, dev→main). Small, feeds #850 once merged to dev.

- **CHANGELOG:** cut `[Unreleased]` → `[1.5.0] - 2026-07-20` (additive feature = minor; last was 1.4.1).
- **openapi.json `archives`:** the description listed only `.archive`. Now documents that the field carries `.archive` **and** `.xl` (ArchiveXL — the only fingerprint a removal-only mod has), and **excludes** CET/AMM `.json` files (sandboxed CET folder, unreadable by other mods). Example updated to show both.

82 worker tests pass (openapi spec still valid + served).

🤖 Generated with [Claude Code](https://claude.com/claude-code)