### PR TITLE
feat(api): cron liveness heartbeat + freshness alert (#849 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `/v1/health` now reports the refresh cron's liveness: `last_refresh_at` (stamped every cron cycle, unlike the content-driven `generated_at`) and a server-computed `refresh_age_seconds`. The health monitor alerts on the map-alerts Discord when the heartbeat stops advancing, so a wedged-but-still-serving cron no longer freezes the dataset silently. ([#849](https://github.com/spuddeh/nc-zoning-board/issues/849))
+
 ## [1.5.0] - 2026-07-20
 
 ### Added

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -58,7 +58,7 @@ parser:
 
 | Route | Returns |
 | --- | --- |
-| `GET /v1/health` | `{ status, version }` (uncached) |
+| `GET /v1/health` | `{ status, version, last_refresh_at, refresh_age_seconds }` (uncached) |
 | `GET /v1/locations` | all locations (full records) as an array |
 | `GET /v1/locations?full=1` | identical to `/v1/locations` (`full=1` is a no-op alias kept for older consumers) |
 | `GET /v1/locations/{id}` | one location record, or 404 |
@@ -184,6 +184,12 @@ re-downloading unchanged data.
   rebuilds the dataset every 5 minutes and serves it from cache, so you're
   shielded from Nexus API hiccups. If a refresh fails, `meta.discovery_stale`
   is `true` and the last-known-good data is served.
+- Freshness vs. liveness: the envelope's `generated_at` is the *content* time —
+  it only moves when the dataset changes (a few times a day), so it can be hours
+  old on a perfectly healthy API. To tell whether the refresh cron is still
+  *running*, read `/v1/health.last_refresh_at` (or the server-computed
+  `refresh_age_seconds`): it advances on every cron cycle. A heartbeat that stops
+  advancing means the cron has wedged and the data is silently frozen.
 - `meta.skipped` lists mods tagged `NCZoning` whose metadata block didn't
   parse: useful if you're a mod author debugging why yours isn't appearing.
 - `archives` is near-static, so the cron fetches it lazily: a mod's archive

--- a/scripts/monitor_api_health.js
+++ b/scripts/monitor_api_health.js
@@ -11,17 +11,21 @@
  * actually usable.
  *
  * What it checks per target:
- *   1. GET /v1/health   → 200 and data.status === "ok"   (the Worker is alive)
+ *   1. GET /v1/health   → 200 and data.status === "ok"   (the Worker is alive),
+ *      AND data.refresh_age_seconds within MAX_REFRESH_AGE_S (the cron is not
+ *      wedged). A frozen heartbeat pages: serving-but-stale is a real failure.
  *   2. GET /v1/locations → 200 and a non-empty array       (KV populated; not
  *      503 not_ready, not an empty/wiped dataset)
  *   3. GET /v1/meta      → discovery_stale is reported as CONTEXT only, not a
  *      hard fail: the cron already Discord-alerts on refresh failure, and it's
  *      still serving last-known-good, so it's a warning, not an outage.
  *
- * NOTE: envelope.generated_at is deliberately NOT used as a freshness/liveness
- * signal: the cron only rewrites it when the dataset CONTENT changes (a few
- * times a day), so a healthy-but-idle API legitimately has an hours-old
- * generated_at. There is no served "last cron ran" timestamp to check.
+ * FRESHNESS vs LIVENESS: envelope.generated_at is NOT a liveness signal — the
+ * cron only rewrites it when the dataset CONTENT changes (a few times a day), so
+ * a healthy-but-idle API legitimately has an hours-old generated_at. The signal
+ * we watch is /v1/health's last_refresh_at (→ refresh_age_seconds), stamped on
+ * EVERY cron cycle regardless of content. If it stops advancing, scheduled() has
+ * stopped executing and the API is silently serving stale data (issue #849).
  *
  * Run: node scripts/monitor_api_health.js
  * Targets: API_HEALTH_TARGETS (comma-separated), default https://api.nczoning.net
@@ -36,6 +40,10 @@ const DEFAULT_TARGETS = ["https://api.nczoning.net"];
 const RETRIES = 3;        // transient blips shouldn't page anyone
 const RETRY_DELAY_MS = 4000;
 const FETCH_TIMEOUT_MS = 15000;
+// A cron heartbeat older than this means the 5-min refresh has wedged (#849).
+// 20 min = 4× the cadence: tolerates one missed tick plus stale-while-revalidate,
+// without waiting so long that in-game consumers eat a stale dataset for an hour.
+const MAX_REFRESH_AGE_S = 20 * 60;
 
 // Request headers for the probe.
 //
@@ -91,16 +99,36 @@ async function withRetry(label, check) {
 }
 
 async function checkTarget(base) {
-  const issues = [];   // hard failures → outage
+  const issues = [];   // hard failures → outage (not serving)
   const warnings = []; // soft (informational) signals
+  let stale = null;    // cron heartbeat frozen → page, but serving (see #849)
 
+  // One /v1/health fetch gives BOTH liveness (status ok?) and the cron heartbeat
+  // (refresh_age_seconds). Captured on success for the freshness check below.
+  let health = null;
   const healthProblem = await withRetry("health", async () => {
     const { ok, status, json } = await fetchJson(`${base}/v1/health`);
     if (!ok) return `HTTP ${status}`;
     if (json?.data?.status !== "ok") return `status=${JSON.stringify(json?.data?.status)}`;
+    health = json.data;
     return null;
   });
   if (healthProblem) issues.push(`/v1/health unreachable (${healthProblem})`);
+
+  // Freshness / liveness — only meaningful when /v1/health answered. The
+  // heartbeat advances every cron tick (unlike the content-driven generated_at),
+  // so an old age means the cron has WEDGED and the API is silently serving a
+  // frozen snapshot (issue #849). This pages: serving-but-stale is a real
+  // failure for the fallback-less in-game consumer. A null/absent heartbeat
+  // (pre-first-cron, or an API deployed before this field existed) is "unknown",
+  // never stale — it must not page.
+  const age = health?.refresh_age_seconds;
+  if (typeof age === "number" && age > MAX_REFRESH_AGE_S) {
+    stale =
+      `cron heartbeat frozen — last refresh ${Math.round(age / 60)} min ago ` +
+      `(threshold ${MAX_REFRESH_AGE_S / 60} min). Redeploy the Worker ` +
+      "(`wrangler deploy [--env staging]`) to revive the cron.";
+  }
 
   const locationsProblem = await withRetry("locations", async () => {
     const { ok, status, json } = await fetchJson(`${base}/v1/locations`);
@@ -119,7 +147,7 @@ async function checkTarget(base) {
     }
   } catch { /* meta is best-effort context */ }
 
-  return { base, issues, warnings };
+  return { base, issues, warnings, stale };
 }
 
 // `recovered` = the previous run reported an outage and this one is clean, so
@@ -127,21 +155,24 @@ async function checkTarget(base) {
 async function postDiscord(results, { recovered = false } = {}) {
   const url = process.env.NCZ_ALERTS_DISCORD_WEBHOOK_URL;
   const down = results.filter((r) => r.issues.length);
+  const frozen = results.filter((r) => r.stale);
   const anyWarning = results.some((r) => r.warnings.length);
 
   const fields = results
-    .filter((r) => r.issues.length || r.warnings.length)
+    .filter((r) => r.issues.length || r.stale || r.warnings.length)
     .map((r) => ({
-      name: `${r.issues.length ? "🔴" : "🟠"} ${r.base}`,
+      name: `${r.issues.length ? "🔴" : r.stale ? "🟠" : "🟡"} ${r.base}`,
       value: [
         ...r.issues.map((i) => `• **OUTAGE:** ${i}`),
+        ...(r.stale ? [`• **STALE:** ${r.stale}`] : []),
         ...r.warnings.map((w) => `• ${w}`),
       ].join("\n"),
     }));
 
-  // Three headlines: outage (page), recovery (all-clear edge), warning (soft).
-  // Outage wins if anything is currently down; recovery only applies when
-  // this run is fully clean.
+  // Four headlines, in severity order: outage (not serving, page), stale (cron
+  // wedged but serving, page), recovery (all-clear edge), warning (soft). Outage
+  // wins over stale if both fire; recovery only applies when this run is fully
+  // clean (no outage AND no staleness).
   let title, description, color;
   if (down.length) {
     title = `🔴 Data API outage — ${down.length} environment${down.length === 1 ? "" : "s"} not serving`;
@@ -149,6 +180,13 @@ async function postDiscord(results, { recovered = false } = {}) {
       "The API is not usable by consumers (in-game mods have no fallback). " +
       "The website may look fine via its client-side fallback — this is that hidden failure surfacing.";
     color = 15158332; /* red */
+  } else if (frozen.length) {
+    title = `🟠 Data API stale — refresh cron wedged on ${frozen.length} environment${frozen.length === 1 ? "" : "s"}`;
+    description =
+      "The API is still serving, but its 5-minute refresh cron has stopped advancing, " +
+      "so consumers (in-game mods have no fallback) are getting a frozen snapshot. " +
+      "Interim fix: redeploy the Worker to revive the cron. See issue #849.";
+    color = 16753920; /* orange */
   } else if (recovered) {
     title = `✅ Data API recovered — serving normally again`;
     description =
@@ -202,11 +240,13 @@ async function postDiscord(results, { recovered = false } = {}) {
       const r = await checkTarget(base);
       results.push(r);
       if (r.issues.length) console.log(`  ❌ OUTAGE: ${r.issues.join("; ")}`);
+      else if (r.stale) console.log(`  🟠 STALE: ${r.stale}`);
       else console.log("  ✅ serving");
       for (const w of r.warnings) console.log(`  ⚠️  ${w}`);
     }
 
     const anyOutage = results.some((r) => r.issues.length);
+    const anyStale = results.some((r) => r.stale);
     const anyWarning = results.some((r) => r.warnings.length);
 
     // The previous run's conclusion IS the last health state: this script
@@ -216,13 +256,19 @@ async function postDiscord(results, { recovered = false } = {}) {
     // all-clear ONCE (next run sees success and stays quiet). A prior infra
     // error also lands here as "was down"; a reassuring green after it is
     // harmless. Absent the flag (local run, first ever run) → no false edge.
+    // A prior run that exited 1 for EITHER a not-serving outage or a wedged cron
+    // counts as "was down"; a fully clean run after it is the recovery edge.
     const prevOutage = process.env.API_HEALTH_PREV_OUTAGE === "true";
-    const recovered = prevOutage && !anyOutage;
+    const recovered = prevOutage && !anyOutage && !anyStale;
 
-    if (anyOutage || anyWarning || recovered) await postDiscord(results, { recovered });
+    if (anyOutage || anyStale || anyWarning || recovered) await postDiscord(results, { recovered });
 
-    if (anyOutage) {
-      console.error("\nHealth check FAILED — at least one target is not serving.");
+    if (anyOutage || anyStale) {
+      console.error(
+        anyOutage
+          ? "\nHealth check FAILED — at least one target is not serving."
+          : "\nHealth check FAILED — at least one target's refresh cron is wedged (stale data).",
+      );
       process.exitCode = 1;
     } else {
       console.log(recovered ? "\nAll targets healthy — recovered from prior outage." : "\nAll targets healthy.");

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -13,8 +13,8 @@
   "paths": {
     "/v1/health": {
       "get": {
-        "summary": "Liveness + deployed version",
-        "description": "Uncached. Does not touch the dataset.",
+        "summary": "Liveness + deployed version + cron heartbeat",
+        "description": "Uncached (no-store). Reads only the small meta record for the cron heartbeat. status is \"ok\" whenever the Worker answers; last_refresh_at is the moment the 5-minute refresh cron last RAN (stamped every cycle, unlike the content-driven generated_at on the envelope), and refresh_age_seconds is its server-computed age. Both are null before the first cron tick. A heartbeat that stops advancing means the cron has wedged and the API is silently serving stale data.",
         "responses": {
           "200": {
             "description": "OK",
@@ -22,7 +22,9 @@
               "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
                 "data": { "type": "object", "properties": {
                   "status": { "type": "string", "const": "ok" },
-                  "version": { "type": "string", "example": "0.1.0" }
+                  "version": { "type": "string", "example": "0.1.0" },
+                  "last_refresh_at": { "type": ["string", "null"], "format": "date-time", "description": "When the refresh cron last ran (heartbeat), or null before the first tick." },
+                  "refresh_age_seconds": { "type": ["integer", "null"], "description": "Server-computed age of last_refresh_at in seconds, or null before the first tick. A clock-free freshness read for the in-game consumer." }
                 } } } }]
             } } }
           }

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -104,8 +104,32 @@ const routes = {
   'GET /openapi.json': () =>
     json(spec, { headers: { 'Cache-Control': 'public, max-age=300' } }),
 
-  'GET /v1/health': (request, env) =>
-    json(envelope({ status: 'ok', version: env.API_VERSION }, null)),
+  // Liveness + the cron heartbeat. `status` is "ok" whenever the Worker itself
+  // answers; `last_refresh_at` (the "when did the cron last RUN" stamp, written
+  // every cron cycle — see refresh.js) plus a server-computed `refresh_age_seconds`
+  // let the monitor detect a wedged-but-still-serving cron (issue #849) and give
+  // the clockless in-game consumer a freshness read too. Both are null before the
+  // first cron tick. no-store so the probe always reads origin, never an edge
+  // copy; the read is one small KV get.
+  'GET /v1/health': async (request, env) => {
+    const meta = await env.DATASET.get(KEYS.meta, 'json');
+    const lastRefreshAt = meta?.last_refresh_at ?? null;
+    const refreshAgeSeconds = lastRefreshAt
+      ? Math.max(0, Math.round((Date.now() - Date.parse(lastRefreshAt)) / 1000))
+      : null;
+    return json(
+      envelope(
+        {
+          status: 'ok',
+          version: env.API_VERSION,
+          last_refresh_at: lastRefreshAt,
+          refresh_age_seconds: refreshAgeSeconds,
+        },
+        null,
+      ),
+      { headers: { 'Cache-Control': 'no-store' } },
+    );
+  },
 
   // One representation: the full records as an array, every field the DTO
   // consumer needs, RedData-mappable. `?full=1` is accepted as a no-op alias so

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -177,6 +177,13 @@ async function attachArchives(env, fetchImpl, full) {
  */
 export async function runRefresh(env, fetchImpl = fetch) {
   const origin = env.SITE_ORIGIN || 'https://nczoning.net';
+  // This cron cycle's wall-clock instant. Serves two distinct roles: it's the
+  // content `generated_at` on a cycle that actually rewrites the dataset, AND
+  // the `last_refresh_at` liveness heartbeat stamped on EVERY completed cycle
+  // (changed, unchanged, or failed). The heartbeat is the "when did the cron
+  // last RUN" signal the freshness monitor watches — distinct from generated_at,
+  // which only advances on content change and so can legitimately be hours old.
+  // A frozen heartbeat means scheduled() has stopped executing (issue #849).
   const generatedAt = new Date().toISOString();
 
   try {
@@ -221,6 +228,11 @@ export async function runRefresh(env, fetchImpl = fetch) {
 
     const prev = await readMeta(env);
     if (prev && prev.dataset_version === version && !prev.discovery_stale) {
+      // Content unchanged, but the cron DID run: advance only the liveness
+      // heartbeat so a wedged cron is distinguishable from a healthy idle one.
+      // dataset_version/generated_at stay put, so the ETag and served envelope
+      // are untouched (no cache bust). One tiny KV write per idle tick. See #849.
+      await writeMeta(env, { ...prev, last_refresh_at: generatedAt });
       return { changed: false, version, stale: false };
     }
 
@@ -238,6 +250,7 @@ export async function runRefresh(env, fetchImpl = fetch) {
         dataset_version: version,
         skipped: meta.skipped,
         discovery_stale: false,
+        last_refresh_at: generatedAt, // liveness heartbeat (see #849)
       },
     });
     if (recovered) await alertDiscordRecovered(env, fetchImpl);
@@ -251,6 +264,9 @@ export async function runRefresh(env, fetchImpl = fetch) {
         discovery_stale: true,
         last_error: String(err).slice(0, 300),
         last_error_at: generatedAt,
+        // The cron still RAN (Nexus just didn't answer) — advance the heartbeat
+        // so this reads as "stale data" (discovery_stale), not "wedged cron".
+        last_refresh_at: generatedAt,
       });
     }
     await alertDiscord(env, fetchImpl, err);

--- a/worker/src/store.js
+++ b/worker/src/store.js
@@ -6,8 +6,12 @@
  * - dataset:v1:districts /v1/districts payload
  * - dataset:v1:tags      tag dictionary ({ tagId: description })
  * - dataset:v1:meta      { schema, generated_at, dataset_version,
- *                          discovery_stale, skipped }; a failed cycle also
- *                          writes last_error and last_error_at
+ *                          discovery_stale, skipped, last_refresh_at }; a failed
+ *                          cycle also writes last_error and last_error_at.
+ *                          last_refresh_at is the cron liveness heartbeat,
+ *                          stamped every completed cycle (unlike generated_at,
+ *                          which only moves on content change); /v1/health serves
+ *                          it so a wedged cron can be detected (issue #849).
  * - dataset:v1:archives  { [nexus_id]: { updatedAt, archives: [name, ...] } }:
  *                        a persistent cache, NOT part of the served envelope.
  *                        The cron refetches a mod's archive names only when its

--- a/worker/test/index.test.js
+++ b/worker/test/index.test.js
@@ -18,7 +18,7 @@ function fakeKV(entries = {}) {
 
 const META = {
   schema: 1, generated_at: '2026-07-04T00:00:00.000Z', dataset_version: 'abc123',
-  skipped: [], discovery_stale: false,
+  skipped: [], discovery_stale: false, last_refresh_at: '2026-07-04T00:05:00.000Z',
 };
 // The single representation: full records keyed by id (what /v1/locations serves
 // the values of, and /v1/locations/{id} reads directly). Each carries the
@@ -42,13 +42,27 @@ function seededEnv() {
 
 const GET = (path, headers) => new Request(`https://api.nczoning.net${path}`, { headers });
 
-test('GET /v1/health returns ok + version, no ETag', async () => {
+test('GET /v1/health returns ok + version + cron heartbeat, uncached, no ETag', async () => {
   const res = await worker.fetch(GET('/v1/health'), seededEnv());
   assert.equal(res.status, 200);
   assert.equal(res.headers.get('ETag'), null);
+  assert.equal(res.headers.get('Cache-Control'), 'no-store'); // probe always reads origin
   const body = await res.json();
   assert.equal(body.data.status, 'ok');
   assert.equal(body.data.version, '0.1.0');
+  assert.equal(body.data.last_refresh_at, META.last_refresh_at); // liveness heartbeat (#849)
+  assert.equal(typeof body.data.refresh_age_seconds, 'number');
+  assert.ok(body.data.refresh_age_seconds >= 0);
+});
+
+test('GET /v1/health before the first cron: alive, heartbeat null (not 503)', async () => {
+  const env = { API_VERSION: '0.1.0', DATASET: fakeKV() };
+  const res = await worker.fetch(GET('/v1/health'), env);
+  assert.equal(res.status, 200); // the Worker itself is up, even with empty KV
+  const body = await res.json();
+  assert.equal(body.data.status, 'ok');
+  assert.equal(body.data.last_refresh_at, null);    // cron hasn't run yet
+  assert.equal(body.data.refresh_age_seconds, null);
 });
 
 test('GET /v1/locations returns the full records with recently_updated + envelope window', async () => {

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -132,14 +132,44 @@ test('manual-mod images are backfilled into full via modsByUid', async () => {
   assert.equal(full.m1.updated_at, '2026-07-08');
 });
 
-test('unchanged content on the second run skips the write (changed=false)', async () => {
+test('unchanged content on the second run skips the content write (changed=false)', async () => {
   const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
   await runRefresh(env, fakeFetch());
   const before = (await env.DATASET.get(KEYS.meta, 'json')).generated_at;
   const r2 = await runRefresh(env, fakeFetch());
   assert.equal(r2.changed, false);
-  // generated_at unchanged because we didn't rewrite.
+  // generated_at (content time) is preserved — the dataset wasn't rewritten. Only
+  // the last_refresh_at heartbeat moves on an unchanged cycle (see next test).
   assert.equal((await env.DATASET.get(KEYS.meta, 'json')).generated_at, before);
+});
+
+test('every completed cycle advances the last_refresh_at heartbeat (even when unchanged)', async () => {
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  await runRefresh(env, fakeFetch());
+  const m1 = await env.DATASET.get(KEYS.meta, 'json');
+  assert.ok(m1.last_refresh_at, 'first run stamps a heartbeat');
+
+  // Pin the heartbeat to a sentinel, then run an UNCHANGED cycle: the content
+  // hash matches, so nothing is rewritten EXCEPT the heartbeat, which must
+  // advance — proving the cron ran. generated_at (content time) must NOT move.
+  // This is the #849 liveness signal: a running-but-idle cron still proves life.
+  await env.DATASET.put(KEYS.meta, JSON.stringify({ ...m1, last_refresh_at: '2000-01-01T00:00:00.000Z' }));
+  const r2 = await runRefresh(env, fakeFetch());
+  assert.equal(r2.changed, false);
+  const m2 = await env.DATASET.get(KEYS.meta, 'json');
+  assert.notEqual(m2.last_refresh_at, '2000-01-01T00:00:00.000Z'); // heartbeat advanced
+  assert.equal(m2.generated_at, m1.generated_at);                  // content time frozen
+});
+
+test('a failed refresh still advances the heartbeat (cron ran; Nexus did not answer)', async () => {
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  await runRefresh(env, fakeFetch()); // seed good
+  const seeded = await env.DATASET.get(KEYS.meta, 'json');
+  await env.DATASET.put(KEYS.meta, JSON.stringify({ ...seeded, last_refresh_at: '2000-01-01T00:00:00.000Z' }));
+  await runRefresh(env, fakeFetch({ failNexus: true }));
+  const meta = await env.DATASET.get(KEYS.meta, 'json');
+  assert.equal(meta.discovery_stale, true);                          // data is stale…
+  assert.notEqual(meta.last_refresh_at, '2000-01-01T00:00:00.000Z'); // …but the cron is alive
 });
 
 test('Nexus failure keeps last-known-good and flags stale + alerts Discord', async () => {


### PR DESCRIPTION
Closes the "Phase 1 — Detect" part of #849. Phases 2 (self-heal) and 3 (root cause) remain open in the issue as follow-ups.

## The problem

The Data API's 5-minute cron can stop firing while `/v1` keeps serving the stale snapshot — `discovery_stale: false`, no error. Nothing alerted, because of two blind spots:

1. `discovery_stale` only flags *fetch failures* (it's set in `runRefresh`'s catch). A cron that stops being **invoked** throws nothing, so the flag stays `false`.
2. The health monitor checks that `/v1` **serves**, not that it's **fresh**. A stale-but-serving API passes.

### The trap in the plan as written

The issue proposed reading `/v1/meta.generated_at` and alerting when it's old. But `generated_at` is **not a liveness signal** — and the code already knew it:

- `runRefresh` returns early and writes nothing when the content hash is unchanged, so `generated_at` only advances when dataset *content* changes (a few times a day).
- `monitor_api_health.js` even documented it: *"a healthy-but-idle API legitimately has an hours-old generated_at. There is no served 'last cron ran' timestamp to check."*

A literal implementation would false-alarm every time the data sat idle for 20 min. **Liveness ≠ freshness.** The real gap is that a wedged cron and an idle cron are indistinguishable in KV. The fix is a dedicated heartbeat.

## What this does

**Worker — the heartbeat**
- `refresh.js` stamps `last_refresh_at` on **every** completed cron cycle: the changed path, the previously-write-nothing unchanged path, and the failure path (the cron ran; Nexus just didn't answer → that's `discovery_stale`, a separate alarm). Only this field moves on an idle tick, so `dataset_version`/`generated_at` and the ETag stay content-driven — no cache bust. Cost: one small KV write per idle tick (~288/day/namespace).
- `index.js` — `/v1/health` now reads meta and returns `last_refresh_at` + a server-computed `refresh_age_seconds` (a clock-free freshness read the in-game consumer can use too), served `Cache-Control: no-store` so the probe always hits origin. Both are `null` before the first cron tick; `status` stays `ok` whenever the Worker answers, so a wedged cron reads as a stale heartbeat, not a down health.

**Monitor — the alert**
- `monitor_api_health.js` reads the heartbeat and, when age > **20 min** (4× the 5-min cadence; tolerates one missed tick + stale-while-revalidate), posts a distinct 🟠 *"refresh cron wedged"* alert (separate from the 🔴 *"not serving"* outage) and fails the run. The message carries the `wrangler deploy` interim runbook.
- An **absent/null heartbeat** (an API deployed before this field, or pre-first-cron) is treated as *unknown* — it never pages. This makes rollout safe: `deploy-api.yml` ships the worker on merge → the field appears → the monitor starts detecting. No window of false alarms.
- `monitor-api-health.yml` needed no change — it already runs the script against both prod and staging.

**Docs**: OpenAPI `/v1/health` schema, an api-reference freshness-vs-liveness note, terse `[Unreleased]` CHANGELOG bullet.

## Testing

- Worker suite: **85/85 pass** — 2 new tests (heartbeat advances on the unchanged path; advances on a failed refresh) + 2 updated `/v1/health` tests (heartbeat fields, `no-store`, pre-cron null path).
- Monitor verified against a local mock across three paths: stale heartbeat (3600s) → 🟠 page + exit 1; fresh heartbeat (120s) → clean + exit 0; **live prod** (field absent) → unknown, no false page, exit 0.

### Acceptance (#849 Phase 1)
> a deliberately-frozen dataset fires a Discord alert within ~20 min

Reproducible on staging by pausing the cron: the 15-min probe fires the stale alert on the first run past the 20-min threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)