### PR TITLE
feat(ci): self-heal a wedged Data API cron via redeploy (#849 Phase 2)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -10,6 +10,11 @@ on:
   push:
     branches: [main, dev]
     paths: ['worker/**', '.github/workflows/deploy-api.yml']
+  # Manual / automated redeploy. The monitor-api-health self-heal dispatches
+  # this (per ref) to revive a wedged refresh cron — a redeploy re-registers the
+  # Cron Trigger (see #849). Env is chosen by the ref, exactly as for push:
+  # dispatch on main → production, on dev → staging.
+  workflow_dispatch:
 
 concurrency:
   group: deploy-api-${{ github.ref }}

--- a/.github/workflows/monitor-api-health.yml
+++ b/.github/workflows/monitor-api-health.yml
@@ -12,7 +12,11 @@ on:
 
 permissions:
   contents: read
-  actions: read   # read this workflow's own run history to detect the recovery edge
+  # write (implies read): read this workflow's own history for the recovery edge,
+  # read deploy-api.yml history for the self-heal budget, and dispatch it to
+  # redeploy a wedged cron (#849 Phase 2). workflow_dispatch fires even from
+  # GITHUB_TOKEN, so no PAT is needed.
+  actions: write
 
 # A slow/queued run shouldn't stack; keep only the latest.
 concurrency:
@@ -49,13 +53,19 @@ jobs:
             echo "prev_outage=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Probe /v1 and alert on outage
+      - name: Probe /v1, alert, and self-heal a wedged cron
         env:
           # Dedicated map-alerts channel, kept separate from submissions.
           NCZ_ALERTS_DISCORD_WEBHOOK_URL: ${{ secrets.NCZ_ALERTS_DISCORD_WEBHOOK_URL }}
           # Was the API down last run? A clean run after a down one is the
           # recovery edge → the script posts a green all-clear exactly once.
           API_HEALTH_PREV_OUTAGE: ${{ steps.prev.outputs.prev_outage }}
+          # Self-heal: on a wedged cron, dispatch deploy-api.yml (per env) to
+          # revive it, budget-guarded (#849 Phase 2). GH_TOKEN authorises the
+          # dispatch + the budget read; GITHUB_REPOSITORY/GITHUB_API_URL are set
+          # by Actions automatically.
+          API_HEALTH_SELF_HEAL: 'true'
+          GH_TOKEN: ${{ github.token }}
           # Both matter: prod (api.nczoning.net) is what in-game mods hit;
           # staging (api-dev) is what the dev site consumes during the B7 bake,
           # where an outage would otherwise be hidden by the client fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `/v1/health` now reports the refresh cron's liveness: `last_refresh_at` (stamped every cron cycle, unlike the content-driven `generated_at`) and a server-computed `refresh_age_seconds`. The health monitor alerts on the map-alerts Discord when the heartbeat stops advancing, so a wedged-but-still-serving cron no longer freezes the dataset silently. ([#849](https://github.com/spuddeh/nc-zoning-board/issues/849))
+- The health monitor now self-heals a wedged cron: it redeploys the affected Worker (which re-registers the Cron Trigger), capped at 2 attempts/env/hour before escalating to a "manual fix needed" alert. ([#849](https://github.com/spuddeh/nc-zoning-board/issues/849))
 
 ## [1.5.0] - 2026-07-20
 

--- a/scripts/monitor_api_health.js
+++ b/scripts/monitor_api_health.js
@@ -27,13 +27,22 @@
  * EVERY cron cycle regardless of content. If it stops advancing, scheduled() has
  * stopped executing and the API is silently serving stale data (issue #849).
  *
+ * SELF-HEAL (#849 Phase 2): a redeploy re-registers the Cron Trigger and revives
+ * a wedged cron, so on detected staleness the script dispatches deploy-api.yml on
+ * the matching ref (main → prod, dev → staging), budget-guarded to
+ * SELF_HEAL_MAX_PER_HOUR redeploys per env per rolling hour before it stops and
+ * escalates for a human. Off unless API_HEALTH_SELF_HEAL=true with a GH token,
+ * so local/detect-only runs are unaffected.
+ *
  * Run: node scripts/monitor_api_health.js
  * Targets: API_HEALTH_TARGETS (comma-separated), default https://api.nczoning.net
  * Alerts:  NCZ_ALERTS_DISCORD_WEBHOOK_URL, the dedicated map-alerts channel,
  *          kept separate from the submissions webhook (prints a preview instead
  *          of sending if unset).
- * Exit:    0 when every target is serving; 1 on any outage or infra error
- *          (so the Actions run goes red, a second signal beside Discord).
+ * Self-heal env: API_HEALTH_SELF_HEAL=true + GH_TOKEN (+ GITHUB_REPOSITORY,
+ *          GITHUB_API_URL — set by Actions). Absent → alert only.
+ * Exit:    0 when every target is serving fresh data; 1 on any outage, a wedged
+ *          cron, or an infra error (so the Actions run goes red too).
  */
 
 const DEFAULT_TARGETS = ["https://api.nczoning.net"];
@@ -44,6 +53,41 @@ const FETCH_TIMEOUT_MS = 15000;
 // 20 min = 4× the cadence: tolerates one missed tick plus stale-while-revalidate,
 // without waiting so long that in-game consumers eat a stale dataset for an hour.
 const MAX_REFRESH_AGE_S = 20 * 60;
+
+// ── Self-heal (#849 Phase 2) ────────────────────────────────────────────────
+// A redeploy re-registers the Cron Trigger and reliably revives a wedged cron,
+// so on detected staleness we dispatch deploy-api.yml on the matching ref. Off
+// unless API_HEALTH_SELF_HEAL=true AND a GH token is present (so local runs and
+// the Phase-1 detect-only posture are unaffected). Dispatch uses the workflow's
+// GITHUB_TOKEN — workflow_dispatch is the one event GITHUB_TOKEN may fire that
+// still creates a run, so no PAT is needed (it does need `actions: write`).
+const SELF_HEAL_WORKFLOW = "deploy-api.yml";
+// Each monitored target's hostname → the deploy ref that redeploys it.
+// deploy-api.yml gates the env off the ref (main → production, dev → staging), so
+// dispatching on the ref ships the CORRECT code to each env (a bare
+// `wrangler deploy` from here would push main's code to staging). Overridable via
+// API_HEALTH_SELF_HEAL_MAP (JSON) so the mapping can change without a code edit.
+const DEFAULT_SELF_HEAL_TARGETS = {
+  "api.nczoning.net": { env: "production", ref: "main" },
+  "api-dev.nczoning.net": { env: "staging", ref: "dev" },
+};
+const SELF_HEAL_TARGETS = (() => {
+  const raw = process.env.API_HEALTH_SELF_HEAL_MAP;
+  if (!raw) return DEFAULT_SELF_HEAL_TARGETS;
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    console.warn(`API_HEALTH_SELF_HEAL_MAP is not valid JSON (${err.message}) — using defaults`);
+    return DEFAULT_SELF_HEAL_TARGETS;
+  }
+})();
+// Redeploys per env per rolling hour before we stop and escalate to a human, so
+// a redeploy that doesn't fix it can't loop and mask a real outage. A prior
+// MANUAL deploy counts too (event=workflow_dispatch), so a hands-on fix pauses
+// the auto-heal. Normal push-triggered deploys are event=push and don't count.
+const SELF_HEAL_MAX_PER_HOUR = 2;
+// Actions sets GITHUB_API_URL; the override also lets tests point at a mock.
+const GH_API = process.env.GITHUB_API_URL || "https://api.github.com";
 
 // Request headers for the probe.
 //
@@ -124,10 +168,9 @@ async function checkTarget(base) {
   // never stale — it must not page.
   const age = health?.refresh_age_seconds;
   if (typeof age === "number" && age > MAX_REFRESH_AGE_S) {
-    stale =
-      `cron heartbeat frozen — last refresh ${Math.round(age / 60)} min ago ` +
-      `(threshold ${MAX_REFRESH_AGE_S / 60} min). Redeploy the Worker ` +
-      "(`wrangler deploy [--env staging]`) to revive the cron.";
+    // State the fact only — remediation (auto-redeploy vs manual) is context that
+    // the alert description fills in, so it isn't stale/contradictory here.
+    stale = `cron heartbeat frozen — last refresh ${Math.round(age / 60)} min ago (threshold ${MAX_REFRESH_AGE_S / 60} min)`;
   }
 
   const locationsProblem = await withRetry("locations", async () => {
@@ -150,13 +193,110 @@ async function checkTarget(base) {
   return { base, issues, warnings, stale };
 }
 
+// ── Self-heal implementation ────────────────────────────────────────────────
+
+/** True only when self-heal is enabled AND we have what we need to call the API. */
+function selfHealEnabled() {
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  return process.env.API_HEALTH_SELF_HEAL === "true" && !!token && !!process.env.GITHUB_REPOSITORY;
+}
+
+/** GitHub REST call against the current repo, authed with the workflow token. */
+async function ghApi(path, init = {}) {
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  const res = await fetch(`${GH_API}/repos/${process.env.GITHUB_REPOSITORY}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "nczoning-health-monitor",
+      ...(init.headers || {}),
+    },
+  });
+  return res;
+}
+
+/**
+ * Count deploy-api.yml runs redeployed for `ref` via workflow_dispatch in the
+ * last hour — the rolling budget the loop guard checks. Counts manual dispatches
+ * too; excludes push-triggered deploys (event filter). Throws on an API error so
+ * the caller escalates rather than redeploying blind.
+ */
+async function recentSelfHealCount(ref) {
+  const sinceIso = new Date(Date.now() - 60 * 60 * 1000).toISOString().replace(/\.\d{3}Z$/, "Z");
+  const query = `event=workflow_dispatch&branch=${encodeURIComponent(ref)}` +
+    `&created=${encodeURIComponent(`>=${sinceIso}`)}&per_page=100`;
+  const res = await ghApi(`/actions/workflows/${SELF_HEAL_WORKFLOW}/runs?${query}`);
+  if (!res.ok) throw new Error(`runs list HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  const json = await res.json();
+  return (json.workflow_runs || []).length;
+}
+
+/** Dispatch deploy-api.yml on `ref` (main → prod, dev → staging). Throws on error. */
+async function dispatchRedeploy(ref) {
+  const res = await ghApi(`/actions/workflows/${SELF_HEAL_WORKFLOW}/dispatches`, {
+    method: "POST",
+    body: JSON.stringify({ ref }),
+  });
+  if (!res.ok) throw new Error(`dispatch HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`);
+}
+
+/**
+ * For each stale target, redeploy its Worker (revives the cron) unless the
+ * rolling-hour budget is spent, in which case escalate for a human. Returns
+ * { healed:[{env,ref,attempt}], escalated:[{env,ref,reason}] } for the alert.
+ * Any per-env API failure escalates that env rather than silently doing nothing.
+ */
+async function selfHeal(results) {
+  const healed = [];
+  const escalated = [];
+  for (const r of results.filter((t) => t.stale)) {
+    const host = new URL(r.base).hostname;
+    const cfg = SELF_HEAL_TARGETS[host];
+    if (!cfg) {
+      console.log(`  self-heal: no deploy mapping for ${host} — cannot redeploy`);
+      escalated.push({ env: host, ref: null, reason: "no deploy mapping for this target" });
+      continue;
+    }
+    try {
+      const count = await recentSelfHealCount(cfg.ref);
+      if (count >= SELF_HEAL_MAX_PER_HOUR) {
+        console.log(`  self-heal: ${cfg.env} budget spent (${count}/${SELF_HEAL_MAX_PER_HOUR} this hour) — escalating`);
+        escalated.push({ ...cfg, reason: `${count} redeploy(s) in the last hour did not clear it` });
+        continue;
+      }
+      await dispatchRedeploy(cfg.ref);
+      console.log(`  self-heal: redeployed ${cfg.env} (attempt ${count + 1}/${SELF_HEAL_MAX_PER_HOUR})`);
+      healed.push({ ...cfg, attempt: count + 1 });
+    } catch (err) {
+      console.error(`  self-heal: ${cfg.env} failed — ${err.message}`);
+      escalated.push({ ...cfg, reason: `redeploy could not be dispatched (${err.message})` });
+    }
+  }
+  return { healed, escalated };
+}
+
 // `recovered` = the previous run reported an outage and this one is clean, so
 // this post is the down→up edge (a green all-clear) rather than a page.
-async function postDiscord(results, { recovered = false } = {}) {
+// `selfHeal` = { healed, escalated } from an auto-redeploy attempt this run.
+async function postDiscord(results, { recovered = false, selfHeal: heal = null } = {}) {
   const url = process.env.NCZ_ALERTS_DISCORD_WEBHOOK_URL;
   const down = results.filter((r) => r.issues.length);
   const frozen = results.filter((r) => r.stale);
   const anyWarning = results.some((r) => r.warnings.length);
+
+  // Self-heal outcome lines, folded into whichever alert fires this run so it's
+  // one post: what we redeployed, and what needs a human.
+  const healLines = [
+    ...(heal?.healed || []).map(
+      (h) => `🔧 **Self-heal:** redeployed **${h.env}** to revive the cron (attempt ${h.attempt}/${SELF_HEAL_MAX_PER_HOUR}) — should recover next tick.`,
+    ),
+    ...(heal?.escalated || []).map(
+      (e) => `⛔ **Manual fix needed (${e.env}):** ${e.reason}. Redeploy: \`wrangler deploy${e.ref === "dev" ? " --env staging" : ""}\`.`,
+    ),
+  ];
+  const escalatedAny = (heal?.escalated || []).length > 0;
 
   const fields = results
     .filter((r) => r.issues.length || r.stale || r.warnings.length)
@@ -169,10 +309,11 @@ async function postDiscord(results, { recovered = false } = {}) {
       ].join("\n"),
     }));
 
-  // Four headlines, in severity order: outage (not serving, page), stale (cron
-  // wedged but serving, page), recovery (all-clear edge), warning (soft). Outage
-  // wins over stale if both fire; recovery only applies when this run is fully
-  // clean (no outage AND no staleness).
+  // Headlines in severity order: outage (not serving, page), escalated self-heal
+  // (auto-redeploy exhausted/failed — a human must act, page RED), stale (cron
+  // wedged but auto-heal dispatched, page ORANGE), recovery (all-clear edge),
+  // warning (soft). Outage wins if anything is down; recovery only applies when
+  // this run is fully clean (no outage AND no staleness).
   let title, description, color;
   if (down.length) {
     title = `🔴 Data API outage — ${down.length} environment${down.length === 1 ? "" : "s"} not serving`;
@@ -180,12 +321,19 @@ async function postDiscord(results, { recovered = false } = {}) {
       "The API is not usable by consumers (in-game mods have no fallback). " +
       "The website may look fine via its client-side fallback — this is that hidden failure surfacing.";
     color = 15158332; /* red */
+  } else if (frozen.length && escalatedAny) {
+    const n = heal.escalated.length;
+    title = `🔴 Data API stale — self-heal exhausted on ${n} environment${n === 1 ? "" : "s"}`;
+    description =
+      "The refresh cron is wedged and automatic redeploys have not cleared it — " +
+      "manual intervention is needed (see below). Consumers are being served a frozen snapshot.";
+    color = 15158332; /* red */
   } else if (frozen.length) {
     title = `🟠 Data API stale — refresh cron wedged on ${frozen.length} environment${frozen.length === 1 ? "" : "s"}`;
     description =
       "The API is still serving, but its 5-minute refresh cron has stopped advancing, " +
-      "so consumers (in-game mods have no fallback) are getting a frozen snapshot. " +
-      "Interim fix: redeploy the Worker to revive the cron. See issue #849.";
+      "so consumers (in-game mods have no fallback) are getting a frozen snapshot. See issue #849." +
+      (heal ? "" : " Interim fix: redeploy the Worker to revive the cron.");
     color = 16753920; /* orange */
   } else if (recovered) {
     title = `✅ Data API recovered — serving normally again`;
@@ -198,6 +346,9 @@ async function postDiscord(results, { recovered = false } = {}) {
     description = "The API is serving but a soft signal fired (see below).";
     color = 15105570; /* amber */
   }
+
+  // Fold the self-heal outcome into the alert body (one post per run).
+  if (healLines.length) description += `\n\n${healLines.join("\n")}`;
 
   const body = {
     embeds: [
@@ -249,6 +400,19 @@ async function postDiscord(results, { recovered = false } = {}) {
     const anyStale = results.some((r) => r.stale);
     const anyWarning = results.some((r) => r.warnings.length);
 
+    // Self-heal: a wedged cron is revived by a redeploy (#849 Phase 2). Only
+    // acts on staleness (not a not-serving outage — a redeploy won't fix that),
+    // and only when enabled with a usable GH token. Budget-guarded per env.
+    let heal = null;
+    if (anyStale) {
+      if (selfHealEnabled()) {
+        console.log("\nSelf-heal: attempting to revive wedged cron(s) via redeploy…");
+        heal = await selfHeal(results);
+      } else if (process.env.API_HEALTH_SELF_HEAL === "true") {
+        console.log("\nSelf-heal enabled but no GH token / repo in env — skipping (alert only).");
+      }
+    }
+
     // The previous run's conclusion IS the last health state: this script
     // exits 1 on an outage (Actions run → failure) and 0 when serving
     // (→ success). The workflow reads that conclusion and passes it in, so a
@@ -261,7 +425,7 @@ async function postDiscord(results, { recovered = false } = {}) {
     const prevOutage = process.env.API_HEALTH_PREV_OUTAGE === "true";
     const recovered = prevOutage && !anyOutage && !anyStale;
 
-    if (anyOutage || anyStale || anyWarning || recovered) await postDiscord(results, { recovered });
+    if (anyOutage || anyStale || anyWarning || recovered) await postDiscord(results, { recovered, selfHeal: heal });
 
     if (anyOutage || anyStale) {
       console.error(


### PR DESCRIPTION
Builds on #854 (Phase 1, merged). Implements **Phase 2 — Self-heal** of #849: a wedged refresh cron now recovers without human action. Phase 3 (root cause) remains open in the issue.

## Why a redeploy

A `wrangler deploy` re-registers the Cron Trigger and reliably revives the wedged cron on the next tick (confirmed on both envs during the #841 rollout, and documented in the `data-api-cron-wedges-silently` wiki learning). Phase 1 made the freeze *visible* (the `last_refresh_at` heartbeat + alert); Phase 2 acts on it.

## How it works

- **`deploy-api.yml`** gains a `workflow_dispatch` trigger. Its existing ref-based gating is reused unchanged, so a dispatch on `main` → production and on `dev` → staging. This ships the **correct code per env** and still runs the **`npm test` gate** — a bare `wrangler deploy` from the monitor would push `main`'s code to *staging* and skip the gate.
- **`monitor_api_health.js`** — on a detected wedged cron (heartbeat age > 20 min), dispatches `deploy-api.yml` on the matching ref via the GitHub REST API, authed with the workflow's `GITHUB_TOKEN`. `workflow_dispatch` is [the one event `GITHUB_TOKEN` may fire that still creates a run](https://docs.github.com/actions/using-workflows/triggering-a-workflow), so **no PAT is needed** — just `actions: write`.
- **Loop guard**: max **2 redeploys per env per rolling hour** (counted from `deploy-api.yml`'s `workflow_dispatch` run history — so a prior *manual* redeploy also pauses the auto-heal; push-triggered deploys are `event=push` and don't count). When the budget is spent, it stops redeploying and **escalates** to a red "manual fix needed" alert rather than looping and masking a real outage.
- The self-heal outcome is folded into the **single** Discord post per run: 🔧 orange "redeployed X (attempt n/2)" when healing, ⛔ red "manual fix needed" when exhausted/failed.
- **Both prod + staging** auto-heal. Off unless `API_HEALTH_SELF_HEAL=true` with a GH token, so local and detect-only runs keep Phase-1 behaviour.

## Rollout ordering (important)

Scheduled workflows run from the **default branch (`main`)**, so the self-heal only goes fully live once this reaches `main`. Prod self-heal specifically needs `deploy-api.yml` *with* the `workflow_dispatch` trigger present on `main` (dispatch resolves the workflow file from the target ref) — that lands in the same dev→main release. During the dev soak, staging self-heal is testable by manually dispatching the monitor on `dev` (`gh workflow run monitor-api-health.yml --ref dev`); a prod-heal attempt from that soak run would escalate (main lacks the dispatch trigger yet), which is expected and harmless.

## Testing

Verified against local mocks (a stale `/v1/health` + a mock GitHub REST API):

| Scenario | Result |
| --- | --- |
| Stale, budget free (0 recent) | Dispatches `ref=main`, 🔧 orange alert (attempt 1/2), exit 1 |
| Stale, budget spent (2 recent) | No dispatch, ⛔ red "self-heal exhausted", exit 1 |
| Stale, GH API error on budget read | No dispatch, ⛔ red escalation, exit 1 |
| Stale, self-heal disabled | Alert only (Phase-1 behaviour), exit 1 |

All stale runs still exit 1, so the run goes red and the Phase-1 recovery-edge all-clear fires once the redeploy takes.

### Acceptance (#849 Phase 2)
> a frozen cron recovers without human action, with a Discord note that a self-heal fired

Met: the monitor dispatches the redeploy and posts the 🔧 note; the guard + ⛔ escalation ensure a real outage isn't masked by an endless redeploy loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)