### PR TITLE
API_VERSION: real SemVer for the API surface + shape drift guard (#857)

### DIFF
--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -1,0 +1,40 @@
+name: Test Data API Worker
+
+# The PR gate for worker/**. deploy-api.yml also runs `npm test`, but only on
+# push to main/dev — that is the DEPLOY gate, and it fires after the merge has
+# already landed. This workflow runs the same suite on the PR, so a failure
+# blocks the merge instead of breaking the next deploy.
+#
+# It notably covers the API_VERSION drift guard (test/api-version.test.js, see
+# issue #857): changing openapi.json's shape without bumping the version must
+# fail review, not production.
+
+on:
+  pull_request:
+    branches: [main, dev]
+    paths: ['worker/**', '.github/workflows/test-api.yml']
+
+concurrency:
+  group: test-api-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install
+        run: npm ci
+        working-directory: worker
+
+      - name: Test
+        run: npm test
+        working-directory: worker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The API's `version` (served at `/v1/health`) is now real SemVer for the API surface — MINOR on an additive field or route, MAJOR on a break — instead of a static `0.1.0`. Backfilled to **1.3.0** for the three additive changes already shipped: `recently_updated` (1.1.0), `archives` (1.2.0), the cron heartbeat (1.3.0). It is not the in-game `ApiVersion()`, which gates only on breaking changes. ([#857](https://github.com/spuddeh/nc-zoning-board/issues/857))
-- The deploy gate now fails if `openapi.json`'s shape changes without an `API_VERSION` bump, or if the four places the version is declared disagree. ([#857](https://github.com/spuddeh/nc-zoning-board/issues/857))
+- CI now fails if `openapi.json`'s shape changes without an `API_VERSION` bump, or if the four places the version is declared disagree. The worker suite also runs on pull requests now, not only at deploy. ([#857](https://github.com/spuddeh/nc-zoning-board/issues/857))
 
 ## [1.6.0] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The API's `version` (served at `/v1/health`) is now real SemVer for the API surface — MINOR on an additive field or route, MAJOR on a break — instead of a static `0.1.0`. Backfilled to **1.3.0** for the three additive changes already shipped: `recently_updated` (1.1.0), `archives` (1.2.0), the cron heartbeat (1.3.0). It is not the in-game `ApiVersion()`, which gates only on breaking changes. ([#857](https://github.com/spuddeh/nc-zoning-board/issues/857))
+- The deploy gate now fails if `openapi.json`'s shape changes without an `API_VERSION` bump, or if the four places the version is declared disagree. ([#857](https://github.com/spuddeh/nc-zoning-board/issues/857))
+
 ## [1.6.0] - 2026-07-21
 
 ### Added

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -52,7 +52,8 @@ parser:
 - **`district` is never null**: anywhere outside every district polygon is
   Badlands (the game's own default). `subdistrict` may be null.
 - **Additive versioning:** new fields may appear within `/v1/`; breaking
-  changes would ship as `/v2/`.
+  changes would ship as `/v2/`. Which additive changes have landed is readable
+  from `/v1/health`'s `version` — see [Versioning](#versioning).
 
 ## Routes
 
@@ -111,6 +112,63 @@ A location record:
   consumer needs. It's always present — `[]` means "not determinable / not yet
   fetched", never "ships no archives" (freshly added mods fill in over a few
   cron ticks; see the note below).
+
+## Versioning
+
+Three separate numbers travel with this API. They answer different questions,
+so don't substitute one for another:
+
+| Signal | Where | Moves when |
+| --- | --- | --- |
+| `/v1` path prefix | every route | **only** on a breaking change (→ `/v2`) |
+| `version` | `GET /v1/health` | the API's *shape* changes — SemVer, see below |
+| `dataset_version` | every envelope | the *content* changes (it's a hash, and the `ETag`) |
+
+`version` is SemVer for the API surface:
+
+- **MAJOR** — a breaking change. This also moves `/v1` → `/v2`, so a consumer
+  pinned to a path prefix never silently breaks.
+- **MINOR** — an additive field or route. Safe: existing consumers are
+  unaffected, but a new field is now available.
+- **PATCH** — a behaviour or performance fix worth marking a deploy for, with
+  no change to the shape.
+
+So a consumer can read `/v1/health` once and know whether the field it wants
+exists yet, without probing for it.
+
+| `version` | Added |
+| --- | --- |
+| 1.0.0 | the initial `/v1` surface |
+| 1.1.0 | `recently_updated`, `recently_updated_days` |
+| 1.2.0 | `archives` |
+| 1.3.0 | `last_refresh_at`, `refresh_age_seconds` on `/v1/health` |
+
+**Honesty note:** the marker was a static `0.1.0` until the policy landed, so
+live deploys through the site's 1.6.0 release all reported `0.1.0` regardless of
+shape ([#857](https://github.com/spuddeh/nc-zoning-board/issues/857)). The table
+above is the reconstructed history — what each deploy *should* have served. From
+1.3.0 on, the number is real and CI enforces it.
+
+### Not to be confused with `ApiVersion()`
+
+The in-game **NCZoningCore** mod exposes its own `ApiVersion()` — an integer
+that increments **only on a breaking change**, so redscript consumers can gate
+on compatibility. This API's `version` is a *deploy and shape marker* that moves
+on additive changes too. They are unrelated numbers and will not match.
+
+### For maintainers
+
+`API_VERSION` is declared in four places that must agree — `wrangler.jsonc`
+(production **and** staging; named Wrangler environments don't inherit `vars`),
+`openapi.json` `info.version`, and `package.json`. After bumping all four:
+
+```bash
+cd worker && npm run version:lock
+```
+
+`worker/test/api-version.test.js` fails the deploy gate if the four disagree, or
+if `openapi.json`'s machine-readable shape moved without a bump. Prose-only
+edits (descriptions, summaries, examples) don't count as a shape change.
 
 ## Caching
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -81,12 +81,12 @@ npx wrangler kv key get "dataset:v1:meta" --binding DATASET --local
 | --- | --- |
 | `GET /` | interactive docs (Scalar, renders `openapi.json`) |
 | `GET /openapi.json` | the OpenAPI 3.1 spec |
-| `GET /v1/health` | `{ status, version }` (uncached) |
-| `GET /v1/locations` | slim location array |
-| `GET /v1/locations/{id}` | one full entry (adds description/credits), or 404 |
+| `GET /v1/health` | `{ status, version, last_refresh_at, refresh_age_seconds }` (uncached) |
+| `GET /v1/locations` | all locations, full records, as an array |
+| `GET /v1/locations/{id}` | one full record, or 404 |
 | `GET /v1/districts` | district/subdistrict hierarchy (flat boundaries) |
 | `GET /v1/tags` | tag dictionary |
-| `GET /v1/meta` | `{ counts, discovery_stale, skipped }` |
+| `GET /v1/meta` | `{ discovery_stale, skipped }` (no aggregate counts) |
 
 Every response uses the envelope
 `{ schema, generated_at, dataset_version, data }`. Dataset routes carry
@@ -99,6 +99,29 @@ Docs: `openapi.json` is the source of truth (drift-guarded by
 `test/openapi.test.js`: every served route must be documented and vice
 versa). The human-facing reference with redscript/CET snippets is
 [docs/api-reference.md](../docs/api-reference.md).
+
+## Versioning
+
+`API_VERSION` (served as `version` on `/v1/health`) is SemVer for the API
+*surface*: **MINOR** on an additive field or route, **MAJOR** on a break (which
+also moves `/v1` → `/v2`), **PATCH** on a behaviour fix. It is not
+`dataset_version` (a content hash), and not the in-game NCZoningCore mod's
+`ApiVersion()` integer (a breaking-change gate). Rationale and the backfilled
+history: [docs/api-reference.md#versioning](../docs/api-reference.md#versioning).
+
+It is declared in **four** places that must agree — `wrangler.jsonc` production
+*and* staging (named environments don't inherit `vars`), `openapi.json`
+`info.version`, `package.json`. Bump all four, then:
+
+```bash
+npm run version:lock     # rewrites api-version.lock.json
+```
+
+`test/api-version.test.js` fails the deploy gate when the four disagree, or when
+`openapi.json`'s machine-readable shape moved without a bump. Prose-only edits
+(`description`, `summary`, `example`) don't count as a shape change — but field
+*names* inside a `properties` map do, even when a field is called
+`description`.
 
 ## Rate limiting
 

--- a/worker/api-version.lock.json
+++ b/worker/api-version.lock.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.3.0",
+  "shape_hash": "sha256:799ed6247b85a33f3e167b57c3be48004275f1da2ae77458024d0e9c09873145"
+}

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "NC Zoning Data API",
-    "version": "0.1.0",
+    "version": "1.3.0",
     "description": "Read-only API serving the NC Zoning Board mod registry (Cyberpunk 2077 location mods) to in-game mods and the website. Every response is wrapped in a versioned envelope. Coordinates are raw CET world values [X, Y, Z], usable in-game with no transform. The JSON stays DTO-mappable for the in-game RedData parser: no arrays-of-arrays, property names are case-sensitive. See https://github.com/spuddeh/nc-zoning-board for the project.",
     "contact": { "name": "NC Zoning Board", "url": "https://nczoning.net" }
   },
@@ -22,7 +22,7 @@
               "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
                 "data": { "type": "object", "properties": {
                   "status": { "type": "string", "const": "ok" },
-                  "version": { "type": "string", "example": "0.1.0" },
+                  "version": { "type": "string", "example": "1.3.0", "description": "SemVer for the API surface: MINOR on an additive field or route, MAJOR on a break (which also moves /v1 to /v2), PATCH on a behaviour fix. Read it to tell whether a field you want exists yet. Distinct from dataset_version (a content hash) and from the in-game NCZoningCore mod's ApiVersion() integer, which gates only on breaking changes." },
                   "last_refresh_at": { "type": ["string", "null"], "format": "date-time", "description": "When the refresh cron last ran (heartbeat), or null before the first tick." },
                   "refresh_age_seconds": { "type": ["integer", "null"], "description": "Server-computed age of last_refresh_at in seconds, or null before the first tick. A clock-free freshness read for the in-game consumer." }
                 } } } }]

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,13 +1,14 @@
 {
   "name": "nczoning-api",
-  "version": "0.1.0",
+  "version": "1.3.0",
   "private": true,
   "description": "NC Zoning Data API worker (api.nczoning.net)",
   "type": "module",
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "test": "node --test"
+    "test": "node --test",
+    "version:lock": "node scripts/api-version.mjs --write"
   },
   "devDependencies": {
     "wrangler": "^4.107.0"

--- a/worker/scripts/api-version.mjs
+++ b/worker/scripts/api-version.mjs
@@ -1,0 +1,101 @@
+// API_VERSION tooling: the shape hash behind the drift guard, and the CLI that
+// re-locks it.
+//
+// Why this exists: API_VERSION sat at 0.1.0 from its introduction through the
+// site's 1.6.0 release, across three additive API changes, because nothing ever
+// forced a bump (issue #857). The guard below makes forgetting a test failure.
+//
+//   node scripts/api-version.mjs          # print the current + locked hashes
+//   npm run version:lock                  # rewrite api-version.lock.json
+//
+// Bump API_VERSION first, THEN re-lock — the lock records the version the
+// current shape shipped under.
+//
+// Version lives in three places that must agree (see test/api-version.test.js):
+//   wrangler.jsonc  vars.API_VERSION   — what /v1/health serves (per environment)
+//   openapi.json    info.version       — what the published spec claims
+//   package.json    version            — the npm-side marker
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const WORKER_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+export const PATHS = {
+  spec: join(WORKER_DIR, 'openapi.json'),
+  lock: join(WORKER_DIR, 'api-version.lock.json'),
+  wrangler: join(WORKER_DIR, 'wrangler.jsonc'),
+  pkg: join(WORKER_DIR, 'package.json'),
+};
+
+// Prose keys carry no machine-readable shape: editing a description or an
+// example is documentation work, not an API change, and must not demand a
+// version bump. Everything else in `paths` + `components` does count.
+const PROSE_KEYS = new Set(['description', 'summary', 'example', 'examples']);
+
+// ...but ONLY outside a `properties` map, where the keys are field names rather
+// than prose. LocationFull genuinely has a field called `description`; stripping
+// it as prose would let a rename or removal of a real API field pass the guard.
+const FIELD_NAME_MAPS = new Set(['properties', 'patternProperties']);
+
+// Canonical form: prose stripped, object keys sorted, so the hash depends on the
+// API's shape and not on JSON key order or formatting.
+function canonicalise(value, isFieldNameMap = false) {
+  if (Array.isArray(value)) return value.map((v) => canonicalise(v));
+  if (value === null || typeof value !== 'object') return value;
+  const out = {};
+  for (const key of Object.keys(value).sort()) {
+    if (!isFieldNameMap && PROSE_KEYS.has(key)) continue;
+    out[key] = canonicalise(value[key], FIELD_NAME_MAPS.has(key));
+  }
+  return out;
+}
+
+/** sha256 over the machine-readable surface of an OpenAPI spec. */
+export function shapeHash(spec) {
+  const surface = canonicalise({ paths: spec.paths, components: spec.components ?? {} });
+  return `sha256:${createHash('sha256').update(JSON.stringify(surface)).digest('hex')}`;
+}
+
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf8'));
+
+export const readSpec = () => readJson(PATHS.spec);
+export const readLock = () => readJson(PATHS.lock);
+
+/**
+ * Every declared API_VERSION, by where it is declared. wrangler.jsonc is JSONC
+ * (comments), so it is read by anchored regex rather than parsed — one entry per
+ * `vars` block, plus the spec and package markers.
+ */
+export function declaredVersions() {
+  const wrangler = readFileSync(PATHS.wrangler, 'utf8');
+  const found = [...wrangler.matchAll(/"API_VERSION"\s*:\s*"([^"]+)"/g)].map((m) => m[1]);
+  return {
+    wrangler: found,
+    // How many `vars` blocks exist at all — a new environment that forgets
+    // API_VERSION would otherwise deploy serving `undefined` at /v1/health.
+    wranglerVarsBlocks: [...wrangler.matchAll(/"vars"\s*:/g)].length,
+    spec: readSpec().info.version,
+    pkg: readJson(PATHS.pkg).version,
+  };
+}
+
+// CLI: `npm run version:lock` writes the lock to match the current spec +
+// declared version. Bare invocation just reports, so it is safe to run.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const hash = shapeHash(readSpec());
+  const versions = declaredVersions();
+  const version = versions.spec;
+
+  if (process.argv.includes('--write')) {
+    writeFileSync(PATHS.lock, `${JSON.stringify({ version, shape_hash: hash }, null, 2)}\n`);
+    console.log(`locked ${version} → ${hash}`);
+  } else {
+    const lock = readLock();
+    console.log(`declared: wrangler=${versions.wrangler.join(',')} spec=${versions.spec} pkg=${versions.pkg}`);
+    console.log(`locked:   ${lock.version} → ${lock.shape_hash}`);
+    console.log(`current:  ${version} → ${hash}`);
+    console.log(lock.shape_hash === hash && lock.version === version ? 'in sync' : 'DRIFT — bump API_VERSION, then `npm run version:lock`');
+  }
+}

--- a/worker/test/api-version.test.js
+++ b/worker/test/api-version.test.js
@@ -1,0 +1,55 @@
+// Drift guard for API_VERSION (issue #857).
+//
+// The marker sat at 0.1.0 across three additive API changes because nothing
+// forced a bump. These tests are that force: change the shape of openapi.json
+// without bumping the version and `npm test` — which gates every deploy
+// (.github/workflows/deploy-api.yml) — fails.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { shapeHash, readSpec, readLock, declaredVersions } from '../scripts/api-version.mjs';
+
+const SEMVER = /^\d+\.\d+\.\d+$/;
+
+test('API_VERSION agrees across every place it is declared', () => {
+  const v = declaredVersions();
+
+  assert.ok(v.wrangler.length > 0, 'no API_VERSION found in wrangler.jsonc');
+  assert.equal(
+    v.wrangler.length,
+    v.wranglerVarsBlocks,
+    `wrangler.jsonc has ${v.wranglerVarsBlocks} vars block(s) but ${v.wrangler.length} API_VERSION declaration(s) — ` +
+      'named environments do not inherit vars, so every environment needs its own',
+  );
+
+  const all = [...v.wrangler, v.spec, v.pkg];
+  assert.ok(all.every((x) => SEMVER.test(x)), `API_VERSION must be plain SemVer, got ${all.join(', ')}`);
+  assert.equal(
+    new Set(all).size,
+    1,
+    `API_VERSION disagrees: wrangler=[${v.wrangler.join(', ')}] openapi.json=${v.spec} package.json=${v.pkg}`,
+  );
+});
+
+test('the API shape has not changed without an API_VERSION bump', () => {
+  const lock = readLock();
+  const current = shapeHash(readSpec());
+
+  assert.equal(
+    current,
+    lock.shape_hash,
+    `openapi.json's machine-readable shape changed since ${lock.version} was locked.\n` +
+      `  locked  ${lock.shape_hash} (${lock.version})\n` +
+      `  current ${current}\n` +
+      '  → bump API_VERSION (MINOR for an additive field/route, MAJOR for a break),\n' +
+      '    then run `npm run version:lock`.\n' +
+      '  Prose-only edits (description/summary/example) do not move this hash.',
+  );
+});
+
+test('the lock records the version currently declared', () => {
+  assert.equal(
+    readLock().version,
+    declaredVersions().spec,
+    'api-version.lock.json is stale — run `npm run version:lock` after bumping API_VERSION',
+  );
+});

--- a/worker/test/index.test.js
+++ b/worker/test/index.test.js
@@ -32,7 +32,7 @@ const TAGS = { apartment: 'a place', corpo: 'suits' };
 
 function seededEnv() {
   return {
-    API_VERSION: '0.1.0',
+    API_VERSION: '9.9.9-test',
     DATASET: fakeKV({
       [KEYS.meta]: META, [KEYS.full]: FULL,
       [KEYS.districts]: DISTRICTS, [KEYS.tags]: TAGS,
@@ -49,14 +49,14 @@ test('GET /v1/health returns ok + version + cron heartbeat, uncached, no ETag', 
   assert.equal(res.headers.get('Cache-Control'), 'no-store'); // probe always reads origin
   const body = await res.json();
   assert.equal(body.data.status, 'ok');
-  assert.equal(body.data.version, '0.1.0');
+  assert.equal(body.data.version, '9.9.9-test');
   assert.equal(body.data.last_refresh_at, META.last_refresh_at); // liveness heartbeat (#849)
   assert.equal(typeof body.data.refresh_age_seconds, 'number');
   assert.ok(body.data.refresh_age_seconds >= 0);
 });
 
 test('GET /v1/health before the first cron: alive, heartbeat null (not 503)', async () => {
-  const env = { API_VERSION: '0.1.0', DATASET: fakeKV() };
+  const env = { API_VERSION: '9.9.9-test', DATASET: fakeKV() };
   const res = await worker.fetch(GET('/v1/health'), env);
   assert.equal(res.status, 200); // the Worker itself is up, even with empty KV
   const body = await res.json();
@@ -143,7 +143,7 @@ test('GET /v1/meta returns health flags only — no aggregate counts', async () 
 });
 
 test('empty KV (pre-first-cron) → 503 not_ready', async () => {
-  const env = { API_VERSION: '0.1.0', DATASET: fakeKV() };
+  const env = { API_VERSION: '9.9.9-test', DATASET: fakeKV() };
   const res = await worker.fetch(GET('/v1/locations'), env);
   assert.equal(res.status, 503);
   assert.equal(res.headers.get('Retry-After'), '60');

--- a/worker/test/openapi.test.js
+++ b/worker/test/openapi.test.js
@@ -36,7 +36,7 @@ test('every documented v1 path is actually served (no stale spec paths)', () => 
 });
 
 test('GET / serves the HTML docs page', async () => {
-  const res = await worker.fetch(new Request('https://api.nczoning.net/'), { API_VERSION: '0.1.0' });
+  const res = await worker.fetch(new Request('https://api.nczoning.net/'), { API_VERSION: '9.9.9-test' });
   assert.equal(res.status, 200);
   assert.match(res.headers.get('Content-Type'), /text\/html/);
   const body = await res.text();
@@ -45,7 +45,7 @@ test('GET / serves the HTML docs page', async () => {
 });
 
 test('GET /openapi.json serves the spec', async () => {
-  const res = await worker.fetch(new Request('https://api.nczoning.net/openapi.json'), { API_VERSION: '0.1.0' });
+  const res = await worker.fetch(new Request('https://api.nczoning.net/openapi.json'), { API_VERSION: '9.9.9-test' });
   assert.equal(res.status, 200);
   const body = await res.json();
   assert.equal(body.openapi, '3.1.0');

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -28,8 +28,12 @@
 		}
 	],
 	"vars": {
-		// Bumped manually on releases; reported by /v1/health.
-		"API_VERSION": "0.1.0",
+		// SemVer for the API *surface*, reported by /v1/health. MINOR on an
+		// additive field/route, MAJOR on a break (which also moves /v1 → /v2),
+		// PATCH on a behaviour fix worth marking. Bump here, in the staging
+		// block below, in openapi.json and package.json, then run
+		// `npm run version:lock` — test/api-version.test.js enforces all four.
+		"API_VERSION": "1.3.0",
 		// Origin the cron pulls source files from (mods.json, tags, subdistricts).
 		"SITE_ORIGIN": "https://nczoning.net"
 	},
@@ -69,7 +73,7 @@
 				}
 			],
 			"vars": {
-				"API_VERSION": "0.1.0",
+				"API_VERSION": "1.3.0",
 				"SITE_ORIGIN": "https://dev.nczoning.net"
 			},
 			// dashboard title: nczoning-api-dataset-staging


### PR DESCRIPTION
Closes #857.

## Why

`API_VERSION` stood at `0.1.0` from introduction through the 1.6.0 release — across three additive API changes — because nothing ever forced a bump. A consumer polling `/v1/health` had no way to tell that `recently_updated`, `archives`, or the cron heartbeat had appeared. Neither of the other signals moves on an additive change: `/v1` moves only on a break, `dataset_version` tracks content, not shape.

## Backfill

Per the discussion on the issue, the shipped `/v1` surface is treated as **1.0.0** — it has a public consumer (NCZoningCore) and a documented no-break promise — with a MINOR per additive milestone:

| `version` | Added |
| --- | --- |
| 1.0.0 | initial `/v1` surface |
| 1.1.0 | `recently_updated`, `recently_updated_days` (site 1.4.0) |
| 1.2.0 | `archives` (site 1.5.0, #841) |
| 1.3.0 | `last_refresh_at`, `refresh_age_seconds` (site 1.6.0, #849) |

We can't rewrite what past deploys served, so `docs/api-reference.md` carries an explicit honesty note saying so. From 1.3.0 the number is real.

## The guard

The issue asked for a check that fails when `openapi.json`'s schema changes without a bump. Diffing against a base ref in CI is fragile, so this is a **lockfile** instead: `worker/api-version.lock.json` pins `{version, shape_hash}`, and `worker/test/api-version.test.js` recomputes the hash from the spec's `paths` + `components`. It runs under `npm test`, which already gates every deploy in `deploy-api.yml`, and works on any checkout with no git access.

The hash is over a canonical form — keys sorted, prose stripped — so reformatting and doc edits don't demand a bump.

**One subtlety worth flagging for review.** Stripping every key named `description` was wrong: `LocationFull` has both a schema-level `description` (prose) *and* a `properties.description` — a real API field consumers read. The first version of the canonicaliser removed both, so deleting or renaming that field would have passed the guard silently — the exact failure class the guard exists to catch. Fixed by only treating prose keys as prose *outside* a `properties` / `patternProperties` map.

Verified against four deliberate mutations with the version left unbumped:

| Mutation | Expected | Got |
| --- | --- | --- |
| new additive field on `LocationFull` | fail | ✔ fail |
| remove the real `description` field | fail | ✔ fail |
| prose-only reword | pass | ✔ pass |
| reformat + key reorder | pass | ✔ pass |

The second row is the one that would have slipped through before the fix.

Hashing is over *parsed* JSON, so CRLF-vs-LF between Windows and the Linux runner can't move it.

The suite also asserts the four declaration sites agree — `wrangler.jsonc` production **and** staging, `openapi.json` `info.version`, `package.json` — and that every `vars` block declares one, since named Wrangler environments don't inherit `vars` and a new env could otherwise deploy serving `undefined`.

## Docs

`docs/api-reference.md` gains a **Versioning** section: the three-signals table (`/v1` vs `version` vs `dataset_version`), the SemVer rules, the backfilled history, and an explicit *"not to be confused with `ApiVersion()`"* subsection — the in-game NCZoningCore integer gates only on breaking changes, so the two numbers will never match. Keeping them distinct is what the issue asked for.

## Incidental

- Test env stubs moved from `'0.1.0'` to `'9.9.9-test'`. They're arbitrary values the Worker echoes back; leaving a real-looking version there invites someone to "update" them on every bump.
- `worker/README.md`'s route table was stale since 1.5.0/1.6.0 — missing the health heartbeat fields, still calling `/v1/locations` a "slim array", still listing `counts` on `/v1/meta` which `index.js` explicitly doesn't serve. Corrected while in the file; happy to split this out if you'd rather keep the diff pure.

## Follow-up (not in this PR)

The Academy course still describes `API_VERSION` as a static deploy marker, which was correct until now. The glossary term, m06, and the `/v1/health` examples need updating to `1.3.0` and the new policy — tracked in the issue, lives in `spuddeh/nczoning-academy`.

## Testing

`npm test` in `worker/` — 88/88 pass (85 existing + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
