### PR TITLE
release: 1.7.0 — API_VERSION SemVer + shape drift guard (#857)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-07-22
+
 ### Changed
 
 - The API's `version` (served at `/v1/health`) is now real SemVer for the API surface — MINOR on an additive field or route, MAJOR on a break — instead of a static `0.1.0`. Backfilled to **1.3.0** for the three additive changes already shipped: `recently_updated` (1.1.0), `archives` (1.2.0), the cron heartbeat (1.3.0). It is not the in-game `ApiVersion()`, which gates only on breaking changes. ([#857](https://github.com/spuddeh/nc-zoning-board/issues/857))


### PR DESCRIPTION
Cuts the `[Unreleased]` section to **1.7.0**. CHANGELOG only, no code — same shape as the 1.6.0 release commit (`dd41bdf`).

Contents of the release (all from #858, already on `dev`):

- `API_VERSION` is real SemVer for the API surface, backfilled to **1.3.0**.
- A shape lockfile fails CI when `openapi.json`'s shape moves without a bump.
- The worker suite now runs on PRs, not only at deploy.

Next step after this merges: the `dev` → `main` release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)