### PR TITLE
chore(worker): point the Data API at the project-owned Cloudflare account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The Data API Worker deploys to the project-owned Cloudflare account, with its production and staging KV namespaces repointed to match.
+
 ## [1.7.1] - 2026-07-25
 
 ### Changed

--- a/worker/scripts/seed-archives.mjs
+++ b/worker/scripts/seed-archives.mjs
@@ -12,12 +12,19 @@
  * refetches (by then the file is usually on the readable UUID path). One-off per
  * environment — re-run on production after a dev -> main promotion.
  *
- * STAGING (ns ac85bf5c0b6f47afac35085408857d4b):
- *   npx wrangler kv key get --remote --namespace-id ac85bf5c0b6f47afac35085408857d4b dataset:v1:archives > cache.json
- *   node scripts/seed-archives.mjs https://api-dev.nczoning.net cache.json merged.json
- *   npx wrangler kv key put --remote --namespace-id ac85bf5c0b6f47afac35085408857d4b dataset:v1:archives --path merged.json
+ * Both accounts are reachable from one wrangler login, so `kv` commands need
+ * CLOUDFLARE_ACCOUNT_ID set or they abort with "More than one account
+ * available". `--remote` is equally mandatory: without it wrangler reads local
+ * miniflare storage and reports an empty namespace for a full one.
  *
- * PRODUCTION (ns d86735e00790417e948e423c3df01d68): same three steps, swapping
+ *   export CLOUDFLARE_ACCOUNT_ID=b9937d8d595fad7de8d1549b22390281
+ *
+ * STAGING (ns 9fe7b7d13d6348d1913b8a01aca1fef6):
+ *   npx wrangler kv key get --remote --namespace-id 9fe7b7d13d6348d1913b8a01aca1fef6 dataset:v1:archives > cache.json
+ *   node scripts/seed-archives.mjs https://api-dev.nczoning.net cache.json merged.json
+ *   npx wrangler kv key put --remote --namespace-id 9fe7b7d13d6348d1913b8a01aca1fef6 dataset:v1:archives --path merged.json
+ *
+ * PRODUCTION (ns 2f547f4c22ab4d5fb2cf4636e50a2559): same three steps, swapping
  *   the namespace id and https://api.nczoning.net for the api base.
  *
  * The next cron tick republishes the dataset with the seeded values attached.

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -18,7 +18,7 @@
 	// Set so CI's scoped API token doesn't need User→Memberships→Read to
 	// discover the account (wrangler skips the /memberships lookup). Account
 	// IDs are not secret. Inherited by all environments.
-	"account_id": "ab7ff2fad6832c2db0a25d22e3287227",
+	"account_id": "b9937d8d595fad7de8d1549b22390281",
 	// Custom domain: deploying creates the DNS record + cert on the zone
 	// automatically (the zone must be on the same Cloudflare account).
 	"routes": [
@@ -44,7 +44,7 @@
 	"kv_namespaces": [
 		{
 			"binding": "DATASET",
-			"id": "d86735e00790417e948e423c3df01d68"
+			"id": "2f547f4c22ab4d5fb2cf4636e50a2559"
 		}
 	],
 	// Rebuild the dataset every 5 minutes (faster mod propagation after a
@@ -96,7 +96,7 @@
 			"kv_namespaces": [
 				{
 					"binding": "DATASET",
-					"id": "ac85bf5c0b6f47afac35085408857d4b"
+					"id": "9fe7b7d13d6348d1913b8a01aca1fef6"
 				}
 			],
 			// MUST be an explicit empty array, not an omitted block. Wrangler


### PR DESCRIPTION
Part of the Cloudflare account migration (Part G). Repoints the committed Worker config at the project-owned account so CI deploys to the right place once the zone transfer completes.

## What changes

Three values in `worker/wrangler.jsonc`:

| | source | target |
| --- | --- | --- |
| `account_id` | `ab7ff2fa…` | `b9937d8d…` |
| `DATASET` (production) | `d86735e0…` | `2f547f4c…` |
| `DATASET` (staging) | `ac85bf5c…` | `9fe7b7d1…` |

Verified against the live target rather than copied from a plan: both namespaces exist, and the production one is being refreshed **now** by the pre-staged cron — `dataset:v1:meta` showed `generated_at 2026-07-26T01:20:25Z` against the source's `01:25:10Z`, with `skipped: []` and `discovery_stale: false`.

The target namespace holds 5 keys to the source's 6. The missing one is the legacy `dataset:v1`, which nothing writes any more since `decisions/api-per-location-records` collapsed it. Its absence is correct, not a gap.

## `routes` stays exactly as committed

The pre-stage deploy used an **out-of-tree** config with the `routes` block removed, because the zone was still on the source account and a Custom Domain cannot attach to a zone the account does not own. That was a property of the deploy, not of the file. Once the zone lands on the target, the committed shape is correct again — so this PR deliberately does **not** touch `routes`, and both `custom_domain: true` entries are unchanged.

## `seed-archives.mjs` — the part that would have failed silently

Its header documented the **old** namespace ids as copy-paste `wrangler kv` commands. Both source namespaces keep existing through the rollback week, so after cutover those instructions would have succeeded, written to the dead account, and left production untouched with no error anywhere.

Also documented there, because it cost real time today:

- **`CLOUDFLARE_ACCOUNT_ID` is now required.** With both accounts reachable from one login, `wrangler kv` aborts with *"More than one account available"*. That one at least fails loudly.
- **`--remote` remains mandatory.** Without it wrangler reads local miniflare storage and reports `[]` for a full namespace. Re-proved while writing this: the academy namespace returned `[]`, and the production dataset namespace returned 6 keys on the identical command shape — so this time the empty answer means something.

## Testing

- `wrangler.jsonc` parses after comment-stripping; all three values read back correctly.
- `git grep` for the three old ids across the repo: no matches remain.
- Both `custom_domain` route entries still present.
- No `API_VERSION` change, so the four-way version lock is untouched.

## Not in this PR

Custom domain attachment, Worker secrets, `CLOUDFLARE_API_TOKEN` reissue and Web Analytics re-enablement are all window work and need either the active zone or credentials. The 15 hardcoded `spuddeh/nc-zoning-board` references are a deliberate post-window sweep.

Targets `dev`, not `main`: `main` requires a PR with a green `validate-json`, and the repo transfer cleared the ruleset's admin bypass list.
