### PR TITLE
chore(api): roll API_VERSION back to 0.3.0 for the pre-release window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The Data API Worker deploys to the project-owned Cloudflare account, with its production and staging KV namespaces repointed to match.
+- The API surface returns to pre-1.0: `version` at `/v1/health` is now **0.3.0**, down from 1.3.0. While on `0.x`, breaking changes bump MINOR, additive changes bump PATCH, and the path stays `/v1`. `1.0.0` returns when the first in-game mod ships.
 
 ## [1.7.1] - 2026-07-25
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -128,7 +128,24 @@ so don't substitute one for another:
 | `version` | `GET /v1/health` | the API's *shape* changes — SemVer, see below |
 | `dataset_version` | every envelope | the *content* changes (it's a hash, and the `ETag`) |
 
-`version` is SemVer for the API surface:
+`version` is SemVer for the API surface.
+
+> ⚠️ **The API is currently pre-1.0 (`0.3.0`), and the rules below are inverted
+> while it is.** The surface was rolled back from `1.3.0` because nothing
+> consuming it has shipped yet, and the upcoming admin/D1 work takes shape
+> changes rather than deferring them. On a 1.x line each of those would need
+> MAJOR plus a `/v1` → `/v2` move, standing up a parallel surface with no
+> consumers to preserve.
+>
+> **While on `0.x`:** breaking → **MINOR**, additive → **PATCH**, and **the path
+> stays `/v1` throughout** — SemVer permits breaking changes before 1.0, which is
+> what makes this resolve cleanly. Pin to a shape you have read, not to `/v1`
+> alone.
+>
+> `1.0.0` returns the day the first in-game mod ships, and the rules below resume
+> in full from there.
+
+From `1.0.0` onward:
 
 - **MAJOR** — a breaking change. This also moves `/v1` → `/v2`, so a consumer
   pinned to a path prefix never silently breaks.
@@ -140,18 +157,28 @@ so don't substitute one for another:
 So a consumer can read `/v1/health` once and know whether the field it wants
 exists yet, without probing for it.
 
-| `version` | Added |
-| --- | --- |
-| 1.0.0 | the initial `/v1` surface |
-| 1.1.0 | `recently_updated`, `recently_updated_days` |
-| 1.2.0 | `archives` |
-| 1.3.0 | `last_refresh_at`, `refresh_age_seconds` on `/v1/health` |
+The three additive changes the surface has taken, in order:
 
-**Honesty note:** the marker was a static `0.1.0` until the policy landed, so
-live deploys through the site's 1.6.0 release all reported `0.1.0` regardless of
-shape ([#857](https://github.com/spuddeh/nc-zoning-board/issues/857)). The table
-above is the reconstructed history — what each deploy *should* have served. From
-1.3.0 on, the number is real and CI enforces it.
+| Shape change | Under the 1.x numbering | Now |
+| --- | --- | --- |
+| the initial `/v1` surface | 1.0.0 | 0.0.0 |
+| `recently_updated`, `recently_updated_days` | 1.1.0 | 0.1.0 |
+| `archives` | 1.2.0 | 0.2.0 |
+| `last_refresh_at`, `refresh_age_seconds` on `/v1/health` | 1.3.0 | **0.3.0** *(current)* |
+
+The rollback is mechanical: the MINOR digit is preserved and the MAJOR drops, so
+the three changes already made survive as `0.3.0`.
+
+**Honesty note:** the marker was a static `0.1.0` until the SemVer policy landed,
+so live deploys through the site's 1.6.0 release all reported `0.1.0` regardless
+of shape ([#857](https://github.com/spuddeh/nc-zoning-board/issues/857)). The
+policy backfilled it to `1.3.0`, which shipped in 1.7.0 — and it has now been
+rolled back to `0.3.0`. The middle column above is a reconstruction (what each
+deploy *should* have served); the right-hand column is what the API serves today.
+
+⚠️ **`0.3.0` is numerically lower than the `1.3.0` recent deploys served.**
+Nothing compares this field numerically — verified before the rollback — but a
+consumer that starts doing so must not read the decrease as a downgrade.
 
 ### Not to be confused with `ApiVersion()`
 

--- a/worker/api-version.lock.json
+++ b/worker/api-version.lock.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.3.0",
+  "version": "0.3.0",
   "shape_hash": "sha256:799ed6247b85a33f3e167b57c3be48004275f1da2ae77458024d0e9c09873145"
 }

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "NC Zoning Data API",
-    "version": "1.3.0",
+    "version": "0.3.0",
     "description": "Read-only API serving the NC Zoning Board mod registry (Cyberpunk 2077 location mods) to in-game mods and the website. Every response is wrapped in a versioned envelope. Coordinates are raw CET world values [X, Y, Z], usable in-game with no transform. The JSON stays DTO-mappable for the in-game RedData parser: no arrays-of-arrays, property names are case-sensitive. See https://github.com/spuddeh/nc-zoning-board for the project.",
     "contact": { "name": "NC Zoning Board", "url": "https://nczoning.net" }
   },
@@ -22,7 +22,7 @@
               "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
                 "data": { "type": "object", "properties": {
                   "status": { "type": "string", "const": "ok" },
-                  "version": { "type": "string", "example": "1.3.0", "description": "SemVer for the API surface: MINOR on an additive field or route, MAJOR on a break (which also moves /v1 to /v2), PATCH on a behaviour fix. Read it to tell whether a field you want exists yet. Distinct from dataset_version (a content hash) and from the in-game NCZoningCore mod's ApiVersion() integer, which gates only on breaking changes." },
+                  "version": { "type": "string", "example": "0.3.0", "description": "SemVer for the API surface. The API is currently PRE-1.0 and the rules are inverted while it is: breaking changes bump MINOR, additive changes bump PATCH, and the path stays /v1 throughout (SemVer permits breaking changes before 1.0). Do not pin to /v1 alone - read this field and pin to a shape you have seen. From 1.0.0, which returns when the first in-game mod ships, the usual rules resume: MINOR on an additive field or route, MAJOR on a break (which also moves /v1 to /v2), PATCH on a behaviour fix. Note 0.3.0 is numerically lower than the 1.3.0 recent deploys served; that is a deliberate rollback, not a downgrade. Distinct from dataset_version (a content hash) and from the in-game NCZoningCore mod's ApiVersion() integer, which gates only on breaking changes." },
                   "last_refresh_at": { "type": ["string", "null"], "format": "date-time", "description": "When the refresh cron last ran (heartbeat), or null before the first tick." },
                   "refresh_age_seconds": { "type": ["integer", "null"], "description": "Server-computed age of last_refresh_at in seconds, or null before the first tick. A clock-free freshness read for the in-game consumer." }
                 } } } }]

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nczoning-api",
-  "version": "1.3.0",
+  "version": "0.3.0",
   "private": true,
   "description": "NC Zoning Data API worker (api.nczoning.net)",
   "type": "module",

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -28,12 +28,25 @@
 		}
 	],
 	"vars": {
-		// SemVer for the API *surface*, reported by /v1/health. MINOR on an
-		// additive field/route, MAJOR on a break (which also moves /v1 → /v2),
-		// PATCH on a behaviour fix worth marking. Bump here, in the staging
-		// block below, in openapi.json and package.json, then run
-		// `npm run version:lock` — test/api-version.test.js enforces all four.
-		"API_VERSION": "1.3.0",
+		// SemVer for the API *surface*, reported by /v1/health.
+		//
+		// PRE-1.0 WINDOW. Rolled back 1.3.0 -> 0.3.0: the surface claimed a
+		// stability it does not have, because nothing consuming it has shipped
+		// yet and the D1 work takes shape changes rather than deferring them.
+		// On a 1.x line every one of those would need MAJOR + a /v1 -> /v2 move,
+		// standing up a parallel surface with no consumers to preserve.
+		//
+		// While on 0.x:  breaking -> MINOR,  additive -> PATCH,  path stays /v1
+		// (SemVer permits breaking changes pre-1.0, which is what resolves this).
+		// Returns to 1.0.0 — and to the MINOR-additive/MAJOR-breaking rules in
+		// decisions/api-version-semver-policy — the day the first in-game mod
+		// ships. The three MINORs already made are preserved as 0.3.0.
+		//
+		// Bump here, in the staging block below, in openapi.json and
+		// package.json, then run `npm run version:lock` —
+		// test/api-version.test.js enforces all four. There is no monotonicity
+		// check, so a decrease passes provided all four move together.
+		"API_VERSION": "0.3.0",
 		// Origin the cron pulls source files from (mods.json, tags, subdistricts).
 		"SITE_ORIGIN": "https://nczoning.net"
 	},
@@ -89,7 +102,8 @@
 				}
 			],
 			"vars": {
-				"API_VERSION": "1.3.0",
+				// Pre-1.0 window — see the production block above.
+				"API_VERSION": "0.3.0",
 				"SITE_ORIGIN": "https://dev.nczoning.net"
 			},
 			// dashboard title: nczoning-api-dataset-staging


### PR DESCRIPTION
Part B (*Versioning*) of the master plan. Reverses the `1.3.0` backfill from [#857](https://github.com/spuddeh/nc-zoning-board/issues/857) / #858 for the pre-release window.

## Why

`1.3.0` claims a stability the surface does not have. Nothing consuming `/v1` has shipped yet, and the upcoming admin/D1 work establishes that shape changes should be **taken now rather than deferred**. On a 1.x line every one of those needs MAJOR plus a `/v1` → `/v2` move — standing up a parallel surface with no consumers to preserve.

`0.x` is exactly the window SemVer reserves for this.

| Version | When |
| --- | --- |
| `1.3.0` → **`0.3.0`** | now, mechanical |
| `0.4.0` | Phase 4: `/v1/tags` reshape + the F.11 surface review |
| `1.0.0` | the day the first in-game mod ships — [[api-version-semver-policy]] resumes in full |

**While on `0.x`: breaking → MINOR, additive → PATCH, and the path stays `/v1` throughout.** A pre-1.0 break does not need `/v2`, which is the whole reason this resolves cleanly.

The rollback is mechanical — the MINOR digit is preserved, the MAJOR drops — so the three additive changes already made survive as `0.3.0`.

## What changed

Five declaration sites, all moved together:

| File | |
| --- | --- |
| `worker/wrangler.jsonc` | production **and** staging (named envs don't inherit `vars`) |
| `worker/openapi.json` | `info.version` |
| `worker/package.json` | `version` |
| `worker/api-version.lock.json` | via `npm run version:lock` |

Plus `docs/api-reference.md` and the `version` field's description in `openapi.json`, both of which stated the 1.x rules and would now be actively wrong.

## The shape hash did not move

`799ed6247b85a33f3e167b57c3be48004275f1da2ae77458024d0e9c09873145`, before and after. Correct: only the number changed, not the surface.

Worth noting the `openapi.json` `version` description was **rewritten substantially** and the hash still didn't move — the canonicaliser strips prose keys (`description`, `summary`, `example`, `examples`) exactly as designed. That is the behaviour [[prose-keys-are-field-names-inside-properties]] nearly broke.

There is **no monotonicity check** in the guard, so a decrease passes CI provided all four declarations agree. They do.

## The precondition, checked

The plan flags one risk: *a consumer doing a numeric comparison would read `0.3.0` as a downgrade.*

Verified before making the change — nothing compares this field numerically. The only readers are `worker/test/*.js`, which use `9.9.9-test` fixtures and assert **equality, regex shape and hash**, never ordering. `monitor_api_health.js` reads `last_refresh_at`, not `version`.

Flagged anyway, in both `docs/api-reference.md` and the spec's own field description, since `0.3.0` is numerically lower than the `1.3.0` recent deploys served.

## Deliberately not changed

`CHANGELOG.md`'s shipped 1.7.0 entry describing the `1.3.0` backfill stays as written. It records what was released; rewriting it would make the changelog a statement of current state rather than a history.

## Follow-up (separate, different repo)

`spuddeh/nczoning-academy`'s course describes `API_VERSION` under the 1.x policy — glossary term, m06, and the `/v1/health` examples. Already listed as follow-up on [[api-version-semver-policy]]; this rollback adds the `0.x` inversion to what needs flipping.

## Testing

- `npm test` → **90/90**.
- `node scripts/api-version.mjs` → `in sync`, all four declarations `0.3.0`.
- `git grep 1.3.0` → only the historical CHANGELOG entries and the unrelated site `[1.3.0]` release heading.
