### PR TITLE
release: 1.7.2 — Cloudflare account migration + API surface back to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-07-26
+
 ### Changed
 
 - The Data API Worker deploys to the project-owned Cloudflare account, with its production and staging KV namespaces repointed to match.


### PR DESCRIPTION
Stamps `[Unreleased]` as **1.7.2** dated 2026-07-26. No code changes — CHANGELOG only.

Contents, both already merged to `dev`:

- **#864** — the Data API Worker deploys to the project-owned Cloudflare account (new `account_id`, both KV namespace ids).
- **#865** — `API_VERSION` rolled back 1.3.0 → **0.3.0** for the pre-release window.

PATCH rather than MINOR: both entries are under `### Changed`, nothing gained a capability, and the API's *shape* is unchanged (the drift-guard hash is byte-identical). Matches the 1.7.1 precedent.

Verified on staging before stamping: `api-dev.nczoning.net/v1/health` serves `version: 0.3.0`. Production still serves 1.3.0 and will pick this up when `dev` merges to `main`.