### PR TITLE
docs: correct the Project field options — Stream and Release were both stale

### DIFF
--- a/docs/dev-branch-maintainer-guide.md
+++ b/docs/dev-branch-maintainer-guide.md
@@ -220,7 +220,12 @@ When all 7 phases are complete and verified on `dev.nczoning.net`:
 
 ## Related documentation
 
-- [GitHub Project](https://github.com/users/spuddeh/projects/1): current phase-by-phase work, organised by Stream (WebGPU Migration / Three.js Parity / Roadmap / Bugs) and Release (Schema map / Post schema map / Future / Ongoing)
+- [GitHub Project](https://github.com/users/spuddeh/projects/1): current phase-by-phase work.
+  Every item carries **Stream**, **Status** and **Release** — an empty one is a bug.
+  Field options, read from the live board 2026-07-26:
+  - **Stream** — Upstream & Platform / 3D Scene / Site & Registry / Bugs
+  - **Status** — Ideas / Todo / In progress / In review / Done / Blocked
+  - **Release** — Schema map / Post schema map / Future / Ongoing / API
 - [`three-js-scene.md`](three-js-scene.md): Current implementation reference
 - [`coordinate-system-3d.md`](coordinate-system-3d.md): CET/GLB/instance texture coordinate details
 - [`3dmap-asset-reference.md`](3dmap-asset-reference.md): Game asset inventory and transform chains


### PR DESCRIPTION
Read from the live board while prepping the Project #1 move.

| Field | Guide said | Actually |
| --- | --- | --- |
| **Stream** | WebGPU Migration / Three.js Parity / Roadmap / Bugs | Upstream & Platform / 3D Scene / Site & Registry / Bugs |
| **Release** | Schema map / Post schema map / Future / Ongoing | …/ Ongoing / **API** |
| **Status** | *not listed* | Ideas / Todo / In progress / In review / Done / Blocked |

Three of the four Streams did not exist.

## Why it mattered now

Issue #857 carries \Release: API\, which I flagged as a possible ad-hoc value because it wasn't in this list. It isn't ad-hoc — the list was wrong.

That distinction has teeth for the Project move: **a field option that doesn't exist on the destination board can't be applied**, and \gh project item-edit\ fails on it. Prepping the copy against a stale option list would have produced a failed or partial re-field on the 13 issues that have to be re-added by hand.

Docs-only, self-merging per the docs PR policy. Targets \dev\ rather than \main\ so the two don't diverge — \main\ now requires a PR anyway, since the org transfer cleared the ruleset's admin bypass.