### PR TITLE
chore: sweep hardcoded spuddeh/nc-zoning-board refs to the org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ For a permanent, manually curated entry. See **[docs/adding-mods.md](docs/adding
 **Short version:**
 
 1. Get your in-game coordinates from the CET console: `print(GetPlayer():GetWorldPosition())`
-2. Go to [Issues → New Issue → 📍 Submit a New Mod Location](https://github.com/spuddeh/nc-zoning-board/issues/new/choose)
+2. Go to [Issues → New Issue → 📍 Submit a New Mod Location](https://github.com/nczoning/nc-zoning-board/issues/new/choose)
 3. Fill in the form, and the bot creates a PR automatically
 4. A maintainer reviews and merges it → your pin appears on the live map
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The NC Zoning Board is a side project of the Locations Hub. Visit the **#nc-zoni
 
 ```bash
 # Clone the repo
-git clone https://github.com/spuddeh/nc-zoning-board.git
+git clone https://github.com/nczoning/nc-zoning-board.git
 cd nc-zoning-board
 
 # Install dependencies (only needed for tile generation)

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -266,7 +266,7 @@ NCZ.buildPopupHtml = function (mod, catStyle, nexusThumbs, tagsDict) {
 
   const [cX, cY, cZ] = mod.coordinates;
   const yawParam = mod.yaw != null ? `&yaw=${mod.yaw}` : "";
-  const editUrl = `https://github.com/spuddeh/nc-zoning-board/issues/new?template=modify_location.yml&location_id=${mod.id}&mod_name=${encodeURIComponent(mod.name)}&authors=${encodeURIComponent(mod.authors.join(", "))}&coord_x=${cX}&coord_y=${cY}&coord_z=${cZ ?? ""}&yaw=${mod.yaw ?? ""}${yawParam}`;
+  const editUrl = `https://github.com/nczoning/nc-zoning-board/issues/new?template=modify_location.yml&location_id=${mod.id}&mod_name=${encodeURIComponent(mod.name)}&authors=${encodeURIComponent(mod.authors.join(", "))}&coord_x=${cX}&coord_y=${cY}&coord_z=${cZ ?? ""}&yaw=${mod.yaw ?? ""}${yawParam}`;
 
   const nexusThumb = nexusThumbs[String(mod.nexus_id)];
   const thumbSrc = nexusThumb?.thumbnailUrl || null;

--- a/docs/adding-mods.md
+++ b/docs/adding-mods.md
@@ -65,7 +65,7 @@ See the [Coordinate System docs](coordinate-system.md) for more details and a pr
 
 Best for modders who don't use Git:
 
-1. Go to the [Issues tab](https://github.com/spuddeh/nc-zoning-board/issues)
+1. Go to the [Issues tab](https://github.com/nczoning/nc-zoning-board/issues)
 2. Click **New Issue** → **"📍 Submit a New Mod Location"**
 3. Fill in the form fields
 4. Submit. The automated bot creates a PR (with `validate-json` running automatically)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -171,7 +171,7 @@ the three changes already made survive as `0.3.0`.
 
 **Honesty note:** the marker was a static `0.1.0` until the SemVer policy landed,
 so live deploys through the site's 1.6.0 release all reported `0.1.0` regardless
-of shape ([#857](https://github.com/spuddeh/nc-zoning-board/issues/857)). The
+of shape ([#857](https://github.com/nczoning/nc-zoning-board/issues/857)). The
 policy backfilled it to `1.3.0`, which shipped in 1.7.0 — and it has now been
 rolled back to `0.3.0`. The middle column above is a reconstruction (what each
 deploy *should* have served); the right-hand column is what the API serves today.

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -54,7 +54,7 @@ The staging deployment is hosted on Cloudflare Pages under the project `nc-zonin
 |---------|-------|
 | Platform | Cloudflare Pages |
 | Project name | `nc-zoning-board-dev` |
-| Connected repository | `spuddeh/nc-zoning-board` |
+| Connected repository | `nczoning/nc-zoning-board` |
 | Production branch | `dev` |
 | Build command | `node scripts/build_mods.js` |
 | Build output directory | `/` |

--- a/index.html
+++ b/index.html
@@ -402,7 +402,7 @@
                             <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0Z"></path>
                             <circle cx="12" cy="10" r="3"></circle>
                         </svg>Submit a New Mod Location</a>
-                    <a href="https://github.com/spuddeh/nc-zoning-board/issues/new?template=bug_report.yml"
+                    <a href="https://github.com/nczoning/nc-zoning-board/issues/new?template=bug_report.yml"
                         target="_blank" class="terminal-link">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
@@ -413,14 +413,14 @@
                             <path d="M20 12h-4"></path><path d="M4 12h4"></path>
                             <path d="m10 6-1-4"></path><path d="m14 6 1-4"></path>
                         </svg>Report a Bug</a>
-                    <a href="https://github.com/spuddeh/nc-zoning-board/issues/new?template=feedback.yml"
+                    <a href="https://github.com/nczoning/nc-zoning-board/issues/new?template=feedback.yml"
                         target="_blank" class="terminal-link">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                             style="vertical-align: text-bottom; margin-right: 6px;">
                             <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"></path>
                         </svg>General Feedback</a>
-                    <a href="https://github.com/spuddeh/nc-zoning-board/issues/new?template=feature_request.yml"
+                    <a href="https://github.com/nczoning/nc-zoning-board/issues/new?template=feature_request.yml"
                         target="_blank" class="terminal-link">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
@@ -503,7 +503,7 @@
                 </button>
             </div>
             <div class="terminal-body bbcode-modal-body">
-                <a href="https://github.com/spuddeh/nc-zoning-board/blob/main/docs/nczoning-auto-discovery.md" target="_blank" rel="noopener" class="terminal-link bbcode-doc-link">&gt; Full auto-discovery documentation</a>
+                <a href="https://github.com/nczoning/nc-zoning-board/blob/main/docs/nczoning-auto-discovery.md" target="_blank" rel="noopener" class="terminal-link bbcode-doc-link">&gt; Full auto-discovery documentation</a>
                 <ol class="bbcode-steps">
                     <li><strong>ACQUIRE COORDINATES</strong> — Open CET in-game, run the command below in the console. Copy the output and paste the values below:
                         <div class="bbcode-cet-command-block">

--- a/package.json
+++ b/package.json
@@ -12,16 +12,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/spuddeh/nc-zoning-board.git"
+    "url": "git+https://github.com/nczoning/nc-zoning-board.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "bugs": {
-    "url": "https://github.com/spuddeh/nc-zoning-board/issues"
+    "url": "https://github.com/nczoning/nc-zoning-board/issues"
   },
-  "homepage": "https://github.com/spuddeh/nc-zoning-board#readme",
+  "homepage": "https://github.com/nczoning/nc-zoning-board#readme",
   "dependencies": {
     "sharp": "^0.34.5"
   },

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "NC Zoning Data API",
     "version": "0.3.0",
-    "description": "Read-only API serving the NC Zoning Board mod registry (Cyberpunk 2077 location mods) to in-game mods and the website. Every response is wrapped in a versioned envelope. Coordinates are raw CET world values [X, Y, Z], usable in-game with no transform. The JSON stays DTO-mappable for the in-game RedData parser: no arrays-of-arrays, property names are case-sensitive. See https://github.com/spuddeh/nc-zoning-board for the project.",
+    "description": "Read-only API serving the NC Zoning Board mod registry (Cyberpunk 2077 location mods) to in-game mods and the website. Every response is wrapped in a versioned envelope. Coordinates are raw CET world values [X, Y, Z], usable in-game with no transform. The JSON stays DTO-mappable for the in-game RedData parser: no arrays-of-arrays, property names are case-sensitive. See https://github.com/nczoning/nc-zoning-board for the project.",
     "contact": { "name": "NC Zoning Board", "url": "https://nczoning.net" }
   },
   "servers": [


### PR DESCRIPTION
Post-transfer cleanup. **14 references across 9 files.** They all worked on GitHub's redirect, so nothing was broken — but a redirect isn't a plan, and the `openapi.json` one is published to API consumers.

| File | Refs |
| --- | --- |
| `index.html` | 4 (issue templates + auto-discovery doc link) |
| `package.json` | 3 (repository, bugs, homepage) |
| `assets/js/utils.js` | 1 (the "modify location" issue link) |
| `worker/openapi.json` | 1 (`info.description`) |
| `README.md`, `CONTRIBUTING.md`, `docs/adding-mods.md`, `docs/api-reference.md`, `docs/dev-environment.md` | 1 each |

## Deliberately left alone

**`CHANGELOG.md` — 6 issue links.** Historical entries recording what shipped, and the links resolve via the redirect. Same reasoning that left the `1.3.0` entry intact during the API_VERSION rollback: a changelog is a record, not a statement of current state.

**The 6 `users/spuddeh/projects/1` links + `PROJECT_OWNER` in `scripts/fix_coords_from_project.js`.** The **board has not moved yet** — Projects v2 has no transfer, only a lossy copy, and that is still queued. Repointing these now would break every link. They move with the board.

## Two corrections to the runbook's "15 refs across 11 files"

- It's **14 across 9**. The count included `CLAUDE.md`, which is **untracked** in this repo (local only) — so it can't be swept by a commit. It still describes `origin` as `spuddeh/nc-zoning-board`, and needs fixing by hand.
- One of the "four files under `docs/`" holds a **Project** link, not a repo link, so it correctly stays.

## Testing

- Worker suite **90/90**; `api-version.mjs` reports `in sync`.
- Shape hash unmoved at `799ed624…` — `info.description` isn't hashed (the canonicaliser covers `paths` + `components` only).
- `git grep` confirms zero `spuddeh/nc-zoning-board` outside `CHANGELOG.md`, and all 6 Project refs plus `PROJECT_OWNER` untouched.

Includes code (`utils.js`, `index.html`, `package.json`), so leaving the merge to you rather than self-merging as a docs-only change.
