### PR TITLE
chore: sync docs + repo-reference sweep to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ For a permanent, manually curated entry. See **[docs/adding-mods.md](docs/adding
 **Short version:**
 
 1. Get your in-game coordinates from the CET console: `print(GetPlayer():GetWorldPosition())`
-2. Go to [Issues → New Issue → 📍 Submit a New Mod Location](https://github.com/spuddeh/nc-zoning-board/issues/new/choose)
+2. Go to [Issues → New Issue → 📍 Submit a New Mod Location](https://github.com/nczoning/nc-zoning-board/issues/new/choose)
 3. Fill in the form, and the bot creates a PR automatically
 4. A maintainer reviews and merges it → your pin appears on the live map
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The NC Zoning Board is a side project of the Locations Hub. Visit the **#nc-zoni
 
 ```bash
 # Clone the repo
-git clone https://github.com/spuddeh/nc-zoning-board.git
+git clone https://github.com/nczoning/nc-zoning-board.git
 cd nc-zoning-board
 
 # Install dependencies (only needed for tile generation)

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -266,7 +266,7 @@ NCZ.buildPopupHtml = function (mod, catStyle, nexusThumbs, tagsDict) {
 
   const [cX, cY, cZ] = mod.coordinates;
   const yawParam = mod.yaw != null ? `&yaw=${mod.yaw}` : "";
-  const editUrl = `https://github.com/spuddeh/nc-zoning-board/issues/new?template=modify_location.yml&location_id=${mod.id}&mod_name=${encodeURIComponent(mod.name)}&authors=${encodeURIComponent(mod.authors.join(", "))}&coord_x=${cX}&coord_y=${cY}&coord_z=${cZ ?? ""}&yaw=${mod.yaw ?? ""}${yawParam}`;
+  const editUrl = `https://github.com/nczoning/nc-zoning-board/issues/new?template=modify_location.yml&location_id=${mod.id}&mod_name=${encodeURIComponent(mod.name)}&authors=${encodeURIComponent(mod.authors.join(", "))}&coord_x=${cX}&coord_y=${cY}&coord_z=${cZ ?? ""}&yaw=${mod.yaw ?? ""}${yawParam}`;
 
   const nexusThumb = nexusThumbs[String(mod.nexus_id)];
   const thumbSrc = nexusThumb?.thumbnailUrl || null;

--- a/docs/adding-mods.md
+++ b/docs/adding-mods.md
@@ -65,7 +65,7 @@ See the [Coordinate System docs](coordinate-system.md) for more details and a pr
 
 Best for modders who don't use Git:
 
-1. Go to the [Issues tab](https://github.com/spuddeh/nc-zoning-board/issues)
+1. Go to the [Issues tab](https://github.com/nczoning/nc-zoning-board/issues)
 2. Click **New Issue** → **"📍 Submit a New Mod Location"**
 3. Fill in the form fields
 4. Submit. The automated bot creates a PR (with `validate-json` running automatically)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -171,7 +171,7 @@ the three changes already made survive as `0.3.0`.
 
 **Honesty note:** the marker was a static `0.1.0` until the SemVer policy landed,
 so live deploys through the site's 1.6.0 release all reported `0.1.0` regardless
-of shape ([#857](https://github.com/spuddeh/nc-zoning-board/issues/857)). The
+of shape ([#857](https://github.com/nczoning/nc-zoning-board/issues/857)). The
 policy backfilled it to `1.3.0`, which shipped in 1.7.0 — and it has now been
 rolled back to `0.3.0`. The middle column above is a reconstruction (what each
 deploy *should* have served); the right-hand column is what the API serves today.

--- a/docs/dev-branch-maintainer-guide.md
+++ b/docs/dev-branch-maintainer-guide.md
@@ -220,7 +220,12 @@ When all 7 phases are complete and verified on `dev.nczoning.net`:
 
 ## Related documentation
 
-- [GitHub Project](https://github.com/users/spuddeh/projects/1): current phase-by-phase work, organised by Stream (WebGPU Migration / Three.js Parity / Roadmap / Bugs) and Release (Schema map / Post schema map / Future / Ongoing)
+- [GitHub Project](https://github.com/users/spuddeh/projects/1): current phase-by-phase work.
+  Every item carries **Stream**, **Status** and **Release** — an empty one is a bug.
+  Field options, read from the live board 2026-07-26:
+  - **Stream** — Upstream & Platform / 3D Scene / Site & Registry / Bugs
+  - **Status** — Ideas / Todo / In progress / In review / Done / Blocked
+  - **Release** — Schema map / Post schema map / Future / Ongoing / API
 - [`three-js-scene.md`](three-js-scene.md): Current implementation reference
 - [`coordinate-system-3d.md`](coordinate-system-3d.md): CET/GLB/instance texture coordinate details
 - [`3dmap-asset-reference.md`](3dmap-asset-reference.md): Game asset inventory and transform chains

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -54,7 +54,7 @@ The staging deployment is hosted on Cloudflare Pages under the project `nc-zonin
 |---------|-------|
 | Platform | Cloudflare Pages |
 | Project name | `nc-zoning-board-dev` |
-| Connected repository | `spuddeh/nc-zoning-board` |
+| Connected repository | `nczoning/nc-zoning-board` |
 | Production branch | `dev` |
 | Build command | `node scripts/build_mods.js` |
 | Build output directory | `/` |

--- a/index.html
+++ b/index.html
@@ -402,7 +402,7 @@
                             <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0Z"></path>
                             <circle cx="12" cy="10" r="3"></circle>
                         </svg>Submit a New Mod Location</a>
-                    <a href="https://github.com/spuddeh/nc-zoning-board/issues/new?template=bug_report.yml"
+                    <a href="https://github.com/nczoning/nc-zoning-board/issues/new?template=bug_report.yml"
                         target="_blank" class="terminal-link">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
@@ -413,14 +413,14 @@
                             <path d="M20 12h-4"></path><path d="M4 12h4"></path>
                             <path d="m10 6-1-4"></path><path d="m14 6 1-4"></path>
                         </svg>Report a Bug</a>
-                    <a href="https://github.com/spuddeh/nc-zoning-board/issues/new?template=feedback.yml"
+                    <a href="https://github.com/nczoning/nc-zoning-board/issues/new?template=feedback.yml"
                         target="_blank" class="terminal-link">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                             style="vertical-align: text-bottom; margin-right: 6px;">
                             <path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"></path>
                         </svg>General Feedback</a>
-                    <a href="https://github.com/spuddeh/nc-zoning-board/issues/new?template=feature_request.yml"
+                    <a href="https://github.com/nczoning/nc-zoning-board/issues/new?template=feature_request.yml"
                         target="_blank" class="terminal-link">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
@@ -503,7 +503,7 @@
                 </button>
             </div>
             <div class="terminal-body bbcode-modal-body">
-                <a href="https://github.com/spuddeh/nc-zoning-board/blob/main/docs/nczoning-auto-discovery.md" target="_blank" rel="noopener" class="terminal-link bbcode-doc-link">&gt; Full auto-discovery documentation</a>
+                <a href="https://github.com/nczoning/nc-zoning-board/blob/main/docs/nczoning-auto-discovery.md" target="_blank" rel="noopener" class="terminal-link bbcode-doc-link">&gt; Full auto-discovery documentation</a>
                 <ol class="bbcode-steps">
                     <li><strong>ACQUIRE COORDINATES</strong> — Open CET in-game, run the command below in the console. Copy the output and paste the values below:
                         <div class="bbcode-cet-command-block">

--- a/package.json
+++ b/package.json
@@ -12,16 +12,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/spuddeh/nc-zoning-board.git"
+    "url": "git+https://github.com/nczoning/nc-zoning-board.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "bugs": {
-    "url": "https://github.com/spuddeh/nc-zoning-board/issues"
+    "url": "https://github.com/nczoning/nc-zoning-board/issues"
   },
-  "homepage": "https://github.com/spuddeh/nc-zoning-board#readme",
+  "homepage": "https://github.com/nczoning/nc-zoning-board#readme",
   "dependencies": {
     "sharp": "^0.34.5"
   },

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "NC Zoning Data API",
     "version": "0.3.0",
-    "description": "Read-only API serving the NC Zoning Board mod registry (Cyberpunk 2077 location mods) to in-game mods and the website. Every response is wrapped in a versioned envelope. Coordinates are raw CET world values [X, Y, Z], usable in-game with no transform. The JSON stays DTO-mappable for the in-game RedData parser: no arrays-of-arrays, property names are case-sensitive. See https://github.com/spuddeh/nc-zoning-board for the project.",
+    "description": "Read-only API serving the NC Zoning Board mod registry (Cyberpunk 2077 location mods) to in-game mods and the website. Every response is wrapped in a versioned envelope. Coordinates are raw CET world values [X, Y, Z], usable in-game with no transform. The JSON stays DTO-mappable for the in-game RedData parser: no arrays-of-arrays, property names are case-sensitive. See https://github.com/nczoning/nc-zoning-board for the project.",
     "contact": { "name": "NC Zoning Board", "url": "https://nczoning.net" }
   },
   "servers": [


### PR DESCRIPTION
Carries #868 and #869 to production. **No version stamp** — `[Unreleased]` is empty because neither is user-facing.

| PR | |
| --- | --- |
| **#868** | Corrected the Project field options in the maintainer guide. Three of four Streams listed did not exist, `Release` was missing `API`, and `Status` was absent entirely. |
| **#869** | Swept 14 hardcoded `spuddeh/nc-zoning-board` refs to `nczoning` across 9 files. |

## Why this is worth landing rather than waiting

The `openapi.json` reference is **published to API consumers** at `GET /openapi.json`, so it is the one ref in the sweep that is externally visible. The rest were working on GitHub's redirect.

Deliberately untouched, and this stays true on `main`:

- `CHANGELOG.md`'s 6 issue links — historical record, links resolve via redirect.
- The 6 `users/spuddeh/projects/1` links and `PROJECT_OWNER` — **the board has not moved yet**. Repointing before the copy would break every link.

## Testing

Worker suite 90/90 on both PRs; `api-version.mjs` in sync at `0.3.0`; shape hash unmoved (`info.description` is not hashed).

Merge commit per [[merge-commits-into-main-squash-into-dev]].