### PR TITLE
chore: repoint Project links to the org board, and fix the stale stream names

### DIFF
--- a/docs/dev-branch-maintainer-guide.md
+++ b/docs/dev-branch-maintainer-guide.md
@@ -28,7 +28,7 @@ Both environments are separate Cloudflare Pages projects on the same repo (prod 
 
 ## Contributing to a phase
 
-The migration is structured as discrete phases with clear goals and verification criteria. Current phase-by-phase work is tracked in the [GitHub Project](https://github.com/users/spuddeh/projects/1) under the **WebGPU Migration** stream.
+The migration is structured as discrete phases with clear goals and verification criteria. Current phase-by-phase work is tracked in the [GitHub Project](https://github.com/orgs/nczoning/projects/1) under the **3D Scene** stream.
 
 ### Starting a new phase
 
@@ -220,7 +220,7 @@ When all 7 phases are complete and verified on `dev.nczoning.net`:
 
 ## Related documentation
 
-- [GitHub Project](https://github.com/users/spuddeh/projects/1): current phase-by-phase work.
+- [GitHub Project](https://github.com/orgs/nczoning/projects/1): current phase-by-phase work.
   Every item carries **Stream**, **Status** and **Release** — an empty one is a bug.
   Field options, read from the live board 2026-07-26:
   - **Stream** — Upstream & Platform / 3D Scene / Site & Registry / Bugs

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -139,4 +139,4 @@ npx serve .
 
 The `dev` branch exists specifically to support the Three.js 3D map migration. Each phase ships as a PR into `dev`. The full feature will not touch `main` until all phases are complete and verified.
 
-Current phase-by-phase work is tracked in the [GitHub Project](https://github.com/users/spuddeh/projects/1): see the **WebGPU Migration** and **Three.js Parity** streams. For the current implementation reference see [`three-js-scene.md`](three-js-scene.md).
+Current phase-by-phase work is tracked in the [GitHub Project](https://github.com/orgs/nczoning/projects/1): see the **3D Scene** stream. For the current implementation reference see [`three-js-scene.md`](three-js-scene.md).

--- a/docs/three-js-scene.md
+++ b/docs/three-js-scene.md
@@ -1,6 +1,6 @@
 # Three.js 3D Scene: Reference Documentation
 
-Full documentation for the Three.js schematic view. For pending phase-by-phase work see the [GitHub Project](https://github.com/users/spuddeh/projects/1) (WebGPU Migration stream). For the overall app architecture see [`architecture.md`](architecture.md).
+Full documentation for the Three.js schematic view. For pending phase-by-phase work see the [GitHub Project](https://github.com/orgs/nczoning/projects/1) (3D Scene stream). For the overall app architecture see [`architecture.md`](architecture.md).
 
 ---
 

--- a/docs/three-markers.md
+++ b/docs/three-markers.md
@@ -9,7 +9,7 @@ Style for both views shared via [`assets/css/style.css`](../assets/css/style.css
 Cross-view glue (sidebar, filter, cluster panel, deep-link) lives in
 [`assets/js/app.js`](../assets/js/app.js).
 
-For pending parity work and open questions, see the [GitHub Project](https://github.com/users/spuddeh/projects/1)
+For pending parity work and open questions, see the [GitHub Project](https://github.com/orgs/nczoning/projects/1)
 under the **Three.js Parity** stream. For 3D scene infrastructure (renderer,
 terrain, buildings, camera), see [`three-js-scene.md`](three-js-scene.md).
 
@@ -212,6 +212,6 @@ from sharing the renderer.
 ## Related documents
 
 - [three-js-scene.md](three-js-scene.md): 3D scene infrastructure (renderer, GLBs, camera, lighting, shadows). ThreeMarkers attaches to it.
-- [GitHub Project](https://github.com/users/spuddeh/projects/1): current pending parity work, tracked under the Three.js Parity stream.
+- [GitHub Project](https://github.com/orgs/nczoning/projects/1): current pending parity work, tracked under the 3D Scene stream.
 - [coordinate-system-3d.md](coordinate-system-3d.md): CET ↔ Three.js coordinate spaces, including the validated CET-Z = terrain-GLB-Y finding that lets `pinYFor()` work without a raycast.
 - [architecture.md](architecture.md): repo-wide file structure and module loading order.

--- a/scripts/fix_coords_from_project.js
+++ b/scripts/fix_coords_from_project.js
@@ -1,6 +1,21 @@
 /**
  * fix_coords_from_project.js
  *
+ * ⚠️ HISTORICAL — THIS SCRIPT NO LONGER RUNS. Its board, user Project #3
+ * (the Z/Yaw migration), was completed and deleted on 2026-07-26. `PROJECT_OWNER`
+ * and `PROJECT_NUMBER` below therefore point at nothing, and the GraphQL query
+ * will return `user.projectV2: null` rather than an obvious error.
+ *
+ * It was deliberately NOT repointed during the 2026-07-26 move of the NC Zoning
+ * Board project to the `nczoning` org. That move concerns Project #1; this
+ * script never referenced it. Swapping the owner here would aim a finished
+ * one-off at a live board.
+ *
+ * Kept for the record of how the Z/Yaw backfill was done. To revive it for a
+ * different board, note the query below uses `user(login:)` — an ORG-owned
+ * project needs `organization(login:)` instead, which is a different root field,
+ * not a string swap.
+ *
  * Reads all "Incorrect Coords" items from the Z/Yaw migration GitHub Project,
  * overwrites X, Y (and optionally Z, Yaw) in data/locations/*.json, then marks
  * each item "Processed".


### PR DESCRIPTION
The GitHub Project moved to the `nczoning` org on 2026-07-26. Six links across four docs, deliberately left out of #869 because the board hadn't moved yet.

## The URL shape changes, not just the owner

- user projects → `/users/<login>/projects/N`
- org projects → `/orgs/<org>/projects/N`

Replacing `spuddeh` → `nczoning` alone gives a 404. Confirmed against the API, which reports `https://github.com/orgs/nczoning/projects/1` as canonical.

## Stale stream names on the same lines

Those links also named streams that don't exist. **WebGPU Migration** and **Three.js Parity** were replaced by **3D Scene** when the streams were reorganised — the real set is `Upstream & Platform / 3D Scene / Site & Registry / Bugs`, as corrected in the maintainer guide by #868. Fixed while in the same sentences rather than leaving half a stale reference behind.

## `fix_coords_from_project.js` — deliberately NOT repointed

It targets **user Project #3** (the Z/Yaw migration), which was finished and **deleted** on 2026-07-26. So its `PROJECT_OWNER`/`PROJECT_NUMBER` point at nothing, and the GraphQL query returns `user.projectV2: null` rather than an obvious error.

It never referenced Project #1. Aiming a finished one-off at a live board would be actively worse than leaving it broken, so instead its header now records that the board is gone — and that reviving it for an org board needs `organization(login:)` rather than `user(login:)`, which is a **different GraphQL root field, not a string swap**.

## One thing worth knowing

Both the old and new URLs **404 anonymously** — the board is private (`public: False` on source *and* target, so the copy didn't change it). These are public docs linking somewhere an outside contributor can't reach. Pre-existing rather than a regression, but flagging it rather than leaving it discovered later.

Docs and comments only, no functional code — self-merging per the docs PR policy.
