### PR TITLE
docs: sync regenerated roadmap to main

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,14 +6,12 @@ The NC Zoning Board is an interactive map and coordinate registry for Cyberpunk 
 
 ### What Works
 
+#### Map and data
+
 - ✅ 16k WebP tiled map with zoom levels 0–8 (native to 6, upscaled to 8)
 - ✅ Transparent map background: tiles regenerated from source
 - ✅ CET coordinate transform (16-point calibrated, linear, accurate)
 - ✅ Mod pins with clickable popups (name, authors, description, Nexus link)
-- ✅ Cyberpunk-themed UI (Orbitron/Rajdhani fonts, dark theme)
-- ✅ mods.json schema validation (CI via GitHub Actions)
-- ✅ Automated mod submission via GitHub Issue form → PR pipeline
-- ✅ Cloudflare Pages deployment
 - ✅ Tile generation script (`scripts/generate_tiles.js`)
 - ✅ **Data refactor**: split `mods.json` into individual JSON files for cleaner management
 - ✅ **Custom pin icons**: colour-coded by mod category
@@ -27,40 +25,96 @@ The NC Zoning Board is an interactive map and coordinate registry for Cyberpunk 
 - ✅ **Dynamic popup positioning**: popups stay within map bounds with directional arrows
 - ✅ **NCZoning auto-discovery**: automatic pin creation from Nexus-tagged mods via GraphQL API, with BBCode generator modal
 - ✅ **Mod update indicator**: API-driven badge for recently updated mods (within 7 days)
-- ✅ **Preferences menu**: in-app theme selection (Night Corp, Arasaka, Militech, Aldecaldos)
 - ✅ **Sort by last updated**: locations list sortable by most recently updated
 - ✅ **Discover a location button**: quick-jump UI to find a random or nearby pin
 - ✅ **Progressive cluster colours**: smooth colour gradients across cluster size tiers
 - ✅ **Less restrictive map panning**: map edge allows movement up to halfway across the screen
-- ✅ **Nexus API documentation**: full reference for queries, fields, caching, and known limitations
 - ✅ **Deep links to mod pins**: URL param (e.g. `?mod=13821`) jumps directly to a pin on the map; Copy Link button copies shareable URLs
+
+#### 3D scene
+
+- ✅ **3D map view**: live Three.js scene rendering the game's terrain, roads, metro and buildings, switchable with the 2D satellite view
+- ✅ **Native WebGPU renderer**: TSL materials, storage buffers, and GPU compute-shader instance culling, with a WebGL2 fallback
+- ✅ **Outdoor lighting and shadows**: fitted shadow map with texel snapping, shadow-aware cull frustum, and a working Shadows toggle
+- ✅ **Game-matched colour pipeline**: ACES output transform ported from the in-game 3D map, plus bloom
+- ✅ **Building shading**: game flat-AO base with sun and shadows layered on top
+- ✅ **See-through roads**: stencil-masked road rendering through open water (the Pacifica tunnel)
+- ✅ **Fixed-asset integration**: 3D World Map Fixed community assets
+- ✅ **Cinematic intro camera** on first load, and a showcase fly-through
+- ✅ **Three.js r185**: render loop on `setAnimationLoop`, custom TSL line material for district outlines
+
+#### Districts
+
+- ✅ **District overlays**: district and subdistrict boundary outlines, zoom-switchable
+- ✅ **District name labels and icons** at polygon centroids, from the game's own atlas
+- ✅ **District hover info panel**, with a 250 ms brighten fade on the outlines
+
+#### Data API
+
+- ✅ **Read-only `/v1` API** at `api.nczoning.net` — locations, districts, tags and meta, served from a Cloudflare Worker
+- ✅ **Server-side merge engine** with district enrichment, refreshed to KV by cron with last-known-good and Discord alerting
+- ✅ **Mod file names**: each record lists the `.archive`/`.xl` files it installs, so in-game mods can detect what a player has
+- ✅ **Published API docs**: OpenAPI spec rendered at the API root, plus a written reference
+- ✅ **The website consumes `/v1`** rather than querying Nexus client-side
+
+#### Presentation and infrastructure
+
+- ✅ Cyberpunk-themed UI (Orbitron/Rajdhani fonts, dark theme)
+- ✅ **Preferences menu**: in-app theme selection
+- ✅ **Themes**: Night Corp, Arasaka, Militech, Aldecaldos, Default Game (matching the in-game map palette), and Preem Map
+- ✅ **Attribution footer**: CDPR Fan Policy and mod credits
+- ✅ **Nexus API documentation**: full reference for queries, fields, caching, and known limitations
+- ✅ mods.json schema validation (CI via GitHub Actions)
+- ✅ Automated mod submission via GitHub Issue form → PR pipeline
+- ✅ Cloudflare Pages deployment
 
 ### In Progress
 
-- 🔄 **Building / road / metro overlays**: extracting game geometry and aligning to CET coordinate space
-- 🔄 **District overlays**: district and subdistrict boundary outlines rendered as GeoJSON layers, zoom-switchable
+- 🔄 **NCZoningCore framework mod**: the in-game consumer of the Data API, built in the CP2077 modding workspace
 
 ## Planned Features
 
+### High Priority
+
+- [ ] **Night Stage 2 — glowing district map**: per-district emissive lighting
+- [ ] **Night Stage 3b — lit-window facades**: procedural window lighting in TSL
+
 ### Medium Priority
 
-- [ ] **Mobile layout / optimisations**: responsive sidebar and touch-friendly markers
 - [ ] **Sort controls**: ascending/descending toggles and additional sort methods for the locations list
+- [ ] **Building/block selection editor**: interactive correction of the building segmentation
 
 ### Low Priority / Nice to Have
 
 - [ ] **SLM integration**: button on mod popup to generate a Simple Location Manager export string
+- [ ] **Mobile layout / optimisations**: responsive sidebar and touch-friendly markers
 - [ ] **Search handles credits**: location search should match against the credits field as well as name/author
-- [ ] **Unofficial district overlays**: community-recognised areas not in the base game (North/East/South Badlands subdivisions, Rocky Ridge, Casino, Sonora Canyon)
-- [ ] **New theme: Netrunner**
-- [ ] **New theme: Blade Runner**
-- [ ] **New theme: Deus Ex**
-- [ ] **Showcase editor**: GUI tool for creating custom flyover sequences (very low priority)
-- [ ] **Theme editor**: GUI tool for creating and customising themes (very low priority)
 - [ ] **Multiple coordinate sets**: support `coords`, `additional_coords`, `nav_coords` on a single mod entry
+- [ ] **Fix holes in the terrain GLB**
+- [ ] **Road borders in Pacifica/Dogtown**: over-bright and flickering triangles, caused by a defect in the vanilla mesh
 
 ### Blocked
 
-- [ ] **16k tile support**: higher zoom fidelity; blocked pending performance impact assessment
-- [ ] **32k tile support**: dependent on 16k work
 - [ ] **Click-on-map coordinates**: implemented but removed at collaborator request; revisit if consensus changes
+- [ ] **Quality presets (Low/Medium/High)**: Stage 2 of the quality work
+- [ ] **Pin occlusion during the showcase flyover**: scrapped; see the decision record
+
+## Ideas / Under Consideration
+
+Not committed to, and tracked as drafts rather than issues.
+
+- Unofficial district overlays: community-recognised areas not in the base game
+- New themes: Netrunner, Blade Runner, Deus Ex
+- Showcase editor: GUI tool for creating custom flyover sequences
+- Theme editor: GUI tool for creating and customising themes
+- Terrain contour lines in the 3D scene
+- CSM revisit: world-anchored outer cascade with camera-aligned inner cascades
+- PCSS for physical shadow penumbra (soft, distance-dependent)
+- Moon disc phase terminator (crescent shading)
+- Content-aware metric for the lighting metering harness
+- F11 fullscreen should hide all overlays and UI
+- Live player position on the web map (opt-in heartbeat)
+- Submission system Worker: authentication and a moderation queue
+- Installed-mod awareness, with in-game map pins and roulette
+- Fast travel / metro station POI extraction for the API
+- Generate our own building box cloud from streaming sectors, instead of decoding CDPR's `_data.dds`


### PR DESCRIPTION
Carries #873 to production. **No version stamp** — `[Unreleased]` is empty and this is documentation only.

First roadmap sync since the board moved to the `nczoning` org, and the first that could see the **whole** board: `sync_roadmap.js` queried `items(first: 100)` against 113 items, and GraphQL caps `first` at 100 and returns a short list with no error — so every previous run silently dropped 13 items.

Two whole areas were missing as a result. The roadmap still listed *"buildings / roads / metro overlays"* under **In Progress** — that shipped some time ago, along with the WebGPU renderer, shadows, the ACES colour pipeline, Three.js r185, district labels and the hover panel, and the entire `/v1` Data API.

- `What Works` is now grouped by area rather than one flat list of ~50 items.
- `In Progress` is down to the one real item: the NCZoningCore framework mod.
- `Planned Features` rebuilt from `Todo`; `Blocked` replaced with the board's three.
- New `Ideas / Under Consideration` section, so that long-standing entries living in `Ideas` rather than `Todo` (unofficial districts, the three extra themes, the showcase and theme editors) aren't deleted by a strict rebuild.

⚠️ **"16k tile support" and "32k tile support" are dropped** — they are not on the board in any status. Worth re-adding as drafts if they are still wanted.

Merge commit per the branch policy.
