### PR TITLE
feat(d1): Phase 1 — schema, one-time import, and a parity gate that can fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ assets/lut-source/
 
 # Wrangler local dev state
 worker/.wrangler/
+
+# Generated D1 seed SQL: rebuild with `node worker/scripts/import-locations.mjs`
+worker/.import/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- D1 databases (production + staging) with the location registry schema, and a one-time import of all 296 locations plus the single exclusion. Nothing reads D1 yet — `mods.json` is still the live source.
+- A parity gate that rebuilds `/v1/locations` from D1 and diffs it byte-for-byte against the live API, with negative controls that prove the diff can fail.
+
 ## [1.7.2] - 2026-07-26
 
 ### Changed

--- a/worker/README.md
+++ b/worker/README.md
@@ -113,6 +113,32 @@ Unlike KV, this content is **not derived** — losing it loses data. D1 Time
 Travel covers 30 days; `data/locations/` in git is the longer backstop until
 the nightly export lands.
 
+### What staging is for (and what it is not)
+
+**`nczoning-data-staging` is a write sandbox, not a preview of production.** It
+does not mirror prod, and there is deliberately **no sync job**. It exists so the
+Phase 4/5 admin operations — approve, reject, hide, dismiss — can be run once
+against throwaway data before they touch the real registry.
+
+It is empty until then, on purpose. Note that staging has **no cron** and the
+health monitor does not watch it, so nothing there refreshes or is observed;
+`?api=dev` tests API *code*, never API *data*.
+
+Seed it when you want a realistic starting point, then treat it as disposable:
+
+```bash
+# either regenerate from the repo...
+node scripts/import-locations.mjs --out .import/seed.sql
+npx wrangler d1 execute nczoning-data-staging --env staging --remote --file .import/seed.sql
+
+# ...or copy production across
+npx wrangler d1 export nczoning-data --remote --output .import/prod.sql
+npx wrangler d1 execute nczoning-data-staging --env staging --remote --file .import/prod.sql
+```
+
+Full reasoning, including why the Phase 2 soak cannot run here: the
+`staging-is-a-write-sandbox-not-a-preview` decision in the project wiki.
+
 ### One-time import + the parity gate
 
 ```bash

--- a/worker/README.md
+++ b/worker/README.md
@@ -86,6 +86,47 @@ KV keys: `dataset:v1:full`, `dataset:v1:districts`, `dataset:v1:tags`,
 `.archive` names, not part of any served payload). There is no longer a slim
 `dataset:v1`: the slim/full fork was collapsed to one representation.
 
+## D1 (`DB` binding)
+
+The location registry. **Phase 1 only populates and verifies it — nothing reads
+it yet**, and the cron still sources from `mods.json`.
+
+Two databases, because named Wrangler environments inherit nothing: production
+is `nczoning-data`, staging is `nczoning-data-staging`. **Every migration must
+be applied to both**, and to remote as well as local — `--local` and `--remote`
+are entirely separate stores that answer the same command, which is exactly how
+a "verified" migration ends up missing in production.
+
+```bash
+export CLOUDFLARE_ACCOUNT_ID=b9937d8d595fad7de8d1549b22390281
+npx wrangler d1 migrations apply nczoning-data         --remote
+npx wrangler d1 migrations apply nczoning-data-staging --remote
+```
+
+Unlike KV, this content is **not derived** — losing it loses data. D1 Time
+Travel covers 30 days; `data/locations/` in git is the longer backstop until
+the nightly export lands.
+
+### One-time import + the parity gate
+
+```bash
+node scripts/import-locations.mjs --out .import/0001-seed.sql   # 287 manual + 9 auto, + 1 dismissal
+npx wrangler d1 execute nczoning-data --remote --file .import/0001-seed.sql
+node scripts/parity-check.mjs                                   # the gate
+```
+
+`parity-check.mjs` rebuilds `/v1/locations` from D1 via `src/materialize.js` and
+diffs it **byte-for-byte** against what the live API is serving. It rebuilds the
+14 fields D1 owns (including `district`/`subdistrict`, recomputed from D1's own
+coordinates) and feeds in the 4 Nexus-derived ones it does not own until Phase 2
+— and it **fails on any served field that falls into neither set**, so a new
+`/v1` field cannot slip past as "not compared".
+
+It then mutates a row five ways and asserts the diff catches each one. A green
+run that did not also prove it can go red exits non-zero: the header comment
+explains what the check does and does not cover, and is worth reading before
+trusting a pass.
+
 ### Test the cron locally
 
 ```bash

--- a/worker/README.md
+++ b/worker/README.md
@@ -99,9 +99,15 @@ a "verified" migration ends up missing in production.
 
 ```bash
 export CLOUDFLARE_ACCOUNT_ID=b9937d8d595fad7de8d1549b22390281
-npx wrangler d1 migrations apply nczoning-data         --remote
-npx wrangler d1 migrations apply nczoning-data-staging --remote
+npx wrangler d1 migrations apply nczoning-data --remote
+npx wrangler d1 migrations apply nczoning-data-staging --env staging --remote
 ```
+
+**`--env staging` is not optional on the second line.** Wrangler resolves
+database names from the top-level config only, so without it the staging
+database does not exist as far as the command is concerned and you get
+`Couldn't find a D1 DB with the name or binding` — which is the mechanism by
+which "apply it to both" quietly becomes "applied to one".
 
 Unlike KV, this content is **not derived** — losing it loses data. D1 Time
 Travel covers 30 days; `data/locations/` in git is the longer backstop until

--- a/worker/migrations/0001_initial_schema.sql
+++ b/worker/migrations/0001_initial_schema.sql
@@ -1,0 +1,95 @@
+-- D1 schema, Phase 1. Source of truth for the location registry; the KV
+-- dataset stays the read path (materialized from here, see docs/data-api-plan.md).
+--
+-- Applied to BOTH databases. Named Wrangler environments do not inherit
+-- bindings, so staging has its own database and every migration runs twice:
+--   npx wrangler d1 migrations apply nczoning-data         --remote
+--   npx wrangler d1 migrations apply nczoning-data-staging --remote
+--
+-- Phase 1 populates `locations` and `dismissed_candidates` only. The remaining
+-- tables are created now because they are one schema, not because anything
+-- writes them yet.
+
+-- Replaces data/locations/*.json. (excluded_mods.json is NOT a location state --
+-- it becomes dismissed_candidates below.)
+CREATE TABLE locations (
+  id          TEXT PRIMARY KEY,   -- existing UUIDs preserved; nexus-<id> for imports
+  name        TEXT NOT NULL,
+  nexus_id    TEXT,
+  category    TEXT NOT NULL,
+  x REAL NOT NULL, y REAL NOT NULL, z REAL, yaw REAL,
+  description TEXT, credits TEXT,
+  authors     TEXT,               -- JSON array
+  tags        TEXT,               -- JSON array at Phase 1 (imported as-is);
+                                  -- normalised to location_tags at Phase 4
+  -- How the record first reached the map. NOT in the plan's schema listing,
+  -- added because `source` is a *served* field on every /v1 record
+  -- (worker/src/merge.js) -- the source of truth has to hold it or the Phase 1
+  -- parity gate cannot reproduce the output. Deriving it from an `id LIKE
+  -- 'nexus-%'` prefix would work today and rot the first time an admin-created
+  -- record is given a nexus id.
+  source      TEXT NOT NULL DEFAULT 'manual' CHECK (source IN ('manual', 'auto')),
+  status      TEXT NOT NULL DEFAULT 'published'
+              CHECK (status IN ('published', 'hidden', 'draft')),
+                                  -- hidden = pulled from the map, record kept
+                                  -- (e.g. mod deleted from Nexus)
+  admin_notes TEXT,               -- admin-only, never served on /v1
+  owner_id    INTEGER,            -- NULL for now; the author-self-service hook
+  created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+
+-- The materializer filters on status and the candidates query anti-joins on
+-- nexus_id; both run on every cron tick.
+CREATE INDEX idx_locations_status ON locations (status);
+CREATE INDEX idx_locations_nexus_id ON locations (nexus_id);
+
+CREATE TABLE submissions (
+  id INTEGER PRIMARY KEY,
+  kind TEXT NOT NULL,             -- create | edit | remove
+  location_id TEXT,               -- NULL for create
+  payload TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  submitter_note TEXT, submitter_contact TEXT, submitter_ip_hash TEXT,
+  reviewed_by TEXT, reviewed_at TEXT, review_note TEXT,
+  created_at TEXT NOT NULL
+);
+
+-- Append-only. This is what replaces `git log` for data changes.
+CREATE TABLE audit_log (
+  id INTEGER PRIMARY KEY, at TEXT NOT NULL,
+  actor TEXT NOT NULL,            -- github login, or 'system' for cron
+  action TEXT NOT NULL,           -- location.update | submission.approve | ...
+  target TEXT, before TEXT, after TEXT
+);
+
+-- A Nexus mod we have looked at and decided not to put on the map. NOT a
+-- location: it has no coordinates, no category, and never was one. Its only
+-- job is to keep the mod out of the candidates list. Replaces excluded_mods.json.
+CREATE TABLE dismissed_candidates (
+  nexus_id TEXT PRIMARY KEY,
+  reason   TEXT,                  -- admin-only, same handling as admin_notes
+  dismissed_by TEXT NOT NULL, dismissed_at TEXT NOT NULL
+);
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,         -- github user id
+  login TEXT NOT NULL, is_collaborator INTEGER NOT NULL,
+  checked_at TEXT NOT NULL, first_seen_at TEXT NOT NULL
+);
+
+-- Every alert that was posted to Discord, so the dashboard can show history
+-- Discord buries. Written by the Worker as it fans out.
+CREATE TABLE alerts (
+  id INTEGER PRIMARY KEY, at TEXT NOT NULL,
+  source TEXT NOT NULL,           -- api-health | refresh | submissions | quota
+  severity TEXT NOT NULL,         -- info | warn | error | recovery
+  title TEXT NOT NULL, body TEXT,
+  acknowledged_by TEXT, acknowledged_at TEXT
+);
+
+-- Nexus-derived cache. Absorbs today's dataset:v1:archives KV blob,
+-- removing a KV read+write per cron tick.
+CREATE TABLE nexus_cache (
+  nexus_id TEXT PRIMARY KEY, updated_at TEXT,
+  thumbnail_url TEXT, picture_url TEXT, archives TEXT, fetched_at TEXT NOT NULL
+);

--- a/worker/scripts/import-locations.mjs
+++ b/worker/scripts/import-locations.mjs
@@ -1,0 +1,178 @@
+/**
+ * One-time Phase 1 import: data/locations/*.json + the live auto-discovered
+ * records -> D1 `locations`; data/excluded_mods.json -> `dismissed_candidates`.
+ *
+ * Emits SQL rather than executing it, for three reasons: the 296 rows are
+ * reviewable before they land, `wrangler d1 execute --file` is the same command
+ * in CI as by hand, and re-running the generator is free.
+ *
+ *   node worker/scripts/import-locations.mjs --out worker/.import/0001-seed.sql
+ *   npx wrangler d1 execute nczoning-data --remote --file worker/.import/0001-seed.sql
+ *
+ * Deliberately plain INSERTs, no upsert and no leading DELETE: running this
+ * twice must FAIL on the primary key rather than quietly duplicate or quietly
+ * wipe. Re-importing means recreating the table via migrations.
+ *
+ * IDS ARE PRESERVED EXACTLY. `?mod=` deep links resolve to the numeric nexus_id
+ * when there is one and the UUID otherwise (assets/js/utils.js, modLinkId), so
+ * every link ever shared in Discord or on a Nexus page depends on these strings
+ * surviving the move unchanged. There is no tidy-up step here, and
+ * parity-check.mjs asserts the id set afterwards.
+ *
+ * The two source paths are deliberately different: manual records are read from
+ * the JSON files (their source of truth), auto-discovered records from the live
+ * API (theirs -- they have never existed as files). The live API is the
+ * still-running reference system, which is exactly what makes it the right
+ * thing to import from.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const LOCATIONS_DIR = path.join(REPO_ROOT, 'data', 'locations');
+const EXCLUDED_FILE = path.join(REPO_ROOT, 'data', 'excluded_mods.json');
+const LIVE_API = process.env.NCZ_API_ORIGIN || 'https://api.nczoning.net';
+
+/**
+ * SQLite string literal. Doubling the single quote is the whole escape --
+ * embedded newlines and unicode are legal inside a literal. A NUL byte is not
+ * representable and would truncate the statement silently, so it throws.
+ */
+function sql(value) {
+  if (value === null || value === undefined) return 'NULL';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error(`non-finite number: ${value}`);
+    return String(value);
+  }
+  const str = String(value);
+  if (str.includes('\0')) throw new Error(`NUL byte in value: ${str.slice(0, 60)}`);
+  return `'${str.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Map a location record (either source) onto a `locations` row.
+ * `coordinates` may legally be [x, y] or [x, y, z]; a missing Z stays NULL
+ * rather than becoming 0, so the materializer can rebuild the shorter array.
+ */
+function toRow(rec, source, stamp) {
+  const [x, y, z] = rec.coordinates;
+  if (typeof x !== 'number' || typeof y !== 'number') {
+    throw new Error(`${rec.id}: coordinates must be numeric, got ${JSON.stringify(rec.coordinates)}`);
+  }
+  return {
+    id: rec.id,
+    name: rec.name,
+    nexus_id: String(rec.nexus_id),
+    category: rec.category,
+    x, y,
+    z: z === undefined ? null : z,
+    yaw: rec.yaw === undefined ? null : rec.yaw,
+    description: rec.description ?? '',
+    // Empty-string credits mean "none" in the JSON files, the same thing a
+    // missing key means. Stored as NULL so `credits IS NOT NULL` is a truthful
+    // query in D1. Parity-neutral by construction: merge.js and materialize.js both
+    // gate on truthiness, so '' and NULL alike omit the key from /v1.
+    credits: rec.credits ? rec.credits : null,
+    authors: JSON.stringify(rec.authors ?? []),
+    tags: JSON.stringify(rec.tags ?? []),
+    source,
+    status: 'published',
+    created_at: stamp,
+    updated_at: stamp,
+  };
+}
+
+const COLUMNS = [
+  'id', 'name', 'nexus_id', 'category', 'x', 'y', 'z', 'yaw',
+  'description', 'credits', 'authors', 'tags', 'source', 'status',
+  'created_at', 'updated_at',
+];
+
+function insertLocation(row) {
+  const values = COLUMNS.map((c) => sql(row[c])).join(', ');
+  return `INSERT INTO locations (${COLUMNS.join(', ')}) VALUES (${values});`;
+}
+
+/** Manual records: one JSON file each, UUID filenames. */
+function readManual(stamp) {
+  const files = fs.readdirSync(LOCATIONS_DIR).filter((f) => f.endsWith('.json'));
+  return files.map((f) => {
+    const rec = JSON.parse(fs.readFileSync(path.join(LOCATIONS_DIR, f), 'utf8'));
+    return toRow(rec, 'manual', stamp);
+  });
+}
+
+/** Auto-discovered records, from the live dataset they currently live in. */
+async function readAuto(stamp) {
+  const res = await fetch(`${LIVE_API}/v1/locations`);
+  if (!res.ok) throw new Error(`GET /v1/locations -> HTTP ${res.status}`);
+  const body = await res.json();
+  const records = body.data;
+  if (!Array.isArray(records) || records.length === 0) {
+    throw new Error('live /v1/locations returned no records');
+  }
+  return records.filter((r) => r.source === 'auto').map((r) => toRow(r, 'auto', stamp));
+}
+
+/**
+ * The exclusion list. Each entry is a decision about a Nexus mod that was never
+ * a location, so it becomes a dismissal, not a `locations` row with a special
+ * status. `dismissed_by` is 'system': the repo records no author for these, and
+ * inventing one would be a fabrication.
+ */
+function readDismissed(stamp) {
+  const excluded = JSON.parse(fs.readFileSync(EXCLUDED_FILE, 'utf8'));
+  return Object.entries(excluded).map(([nexusId, reason]) => (
+    `INSERT INTO dismissed_candidates (nexus_id, reason, dismissed_by, dismissed_at) `
+    + `VALUES (${sql(nexusId)}, ${sql(reason)}, ${sql('system')}, ${sql(stamp)});`
+  ));
+}
+
+async function main() {
+  const outIdx = process.argv.indexOf('--out');
+  if (outIdx === -1 || !process.argv[outIdx + 1]) {
+    console.error('usage: import-locations.mjs --out <file.sql>');
+    process.exit(1);
+  }
+  const outPath = path.resolve(process.argv[outIdx + 1]);
+  const stamp = new Date().toISOString();
+
+  const manual = readManual(stamp);
+  const auto = await readAuto(stamp);
+  const rows = [...manual, ...auto];
+
+  // Duplicate ids would be caught by the primary key on execute, but failing
+  // here names both records instead of just the id.
+  const seen = new Map();
+  for (const r of rows) {
+    if (seen.has(r.id)) throw new Error(`duplicate id ${r.id}: "${seen.get(r.id)}" and "${r.name}"`);
+    seen.set(r.id, r.name);
+  }
+
+  const dismissed = readDismissed(stamp);
+
+  const body = [
+    `-- Phase 1 seed, generated ${stamp} by worker/scripts/import-locations.mjs`,
+    `-- ${manual.length} manual + ${auto.length} auto = ${rows.length} locations,`,
+    `-- ${dismissed.length} dismissed candidate(s). Plain INSERTs: re-running fails.`,
+    '',
+    ...rows.map(insertLocation),
+    '',
+    ...dismissed,
+    '',
+  ].join('\n');
+
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, body);
+  console.log(
+    `wrote ${outPath}\n  ${manual.length} manual + ${auto.length} auto = ${rows.length} locations`
+    + `\n  ${dismissed.length} dismissed candidate(s)`,
+  );
+}
+
+main().catch((err) => {
+  console.error(String(err.stack || err));
+  process.exit(1);
+});

--- a/worker/scripts/parity-check.mjs
+++ b/worker/scripts/parity-check.mjs
@@ -1,0 +1,263 @@
+/**
+ * The Phase 1 gate: materialize /v1/locations from D1 and diff it BYTE-FOR-BYTE
+ * against what the live API serves right now.
+ *
+ *   node worker/scripts/parity-check.mjs                    # production DB vs live API
+ *   node worker/scripts/parity-check.mjs --db nczoning-data-staging
+ *
+ * Exit 0 only if the bytes match AND the harness proved itself capable of
+ * failing on the same run. Anything else exits non-zero.
+ *
+ * ---------------------------------------------------------------------------
+ * WHAT THIS CHECK CAN AND CANNOT CATCH -- read before trusting a green run.
+ *
+ * The live API is the still-running reference system. 13 of the 18 served
+ * fields are rebuilt from D1 and compared; the other 5 are Nexus-derived and
+ * are NOT D1's job until Phase 2, so they are fed in from the live record:
+ *
+ *   REBUILT FROM D1   id, name, nexus_id, coordinates, yaw, category, tags,
+ *                     authors, source, description, credits  (D1 columns)
+ *                     district, subdistrict                  (recomputed from
+ *                                                             D1's OWN x/y/z,
+ *                                                             which is what
+ *                                                             catches a mangled
+ *                                                             coordinate)
+ *                     recently_updated                       (recomputed from
+ *                                                             updated_at against
+ *                                                             the envelope's
+ *                                                             generated_at clock)
+ *   FED IN FROM LIVE  thumbnail_url, picture_url, updated_at  (Nexus images,
+ *                                                             via the same
+ *                                                             manualThumbs
+ *                                                             channel the cron
+ *                                                             uses)
+ *                     archives                                (KV-cached Nexus
+ *                                                             file listing)
+ *
+ * A field in NEITHER set fails the run (see assertKeyCoverage). That is what
+ * stops a newly added /v1 field from silently slipping past the gate as
+ * "not compared".
+ *
+ * The 5 fed-in fields are therefore unverified BY THIS CHECK, by construction
+ * and on purpose -- Phase 2 moves them into `nexus_cache` and they become
+ * D1's problem then.
+ * ---------------------------------------------------------------------------
+ */
+
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { materializeFromD1 } from '../src/materialize.js';
+
+const WORKER_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+// Wrangler's JS entrypoint, not `npx`: node >=20 refuses to spawn a .cmd shim
+// without a shell (EINVAL), and a shell would re-split the SQL on its spaces.
+const WRANGLER = path.join(WORKER_DIR, 'node_modules', 'wrangler', 'bin', 'wrangler.js');
+
+const API = process.env.NCZ_API_ORIGIN || 'https://api.nczoning.net';
+const SITE = process.env.NCZ_SITE_ORIGIN || 'https://nczoning.net';
+const ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID || 'b9937d8d595fad7de8d1549b22390281';
+
+const REBUILT_KEYS = new Set([
+  'id', 'name', 'nexus_id', 'coordinates', 'yaw', 'category', 'tags', 'authors',
+  'source', 'description', 'credits', 'district', 'subdistrict', 'recently_updated',
+]);
+const FED_IN_KEYS = new Set(['thumbnail_url', 'picture_url', 'updated_at', 'archives']);
+
+const fail = (msg) => { console.error(`\n❌ ${msg}`); process.exit(1); };
+
+// --local runs against the miniflare database in worker/.wrangler/. It proves
+// the HARNESS works; it proves nothing about production data, because local and
+// remote D1 are entirely separate stores that answer the same command.
+const LOCAL = process.argv.includes('--local');
+
+/** Run one SQL statement against the database and return its rows. */
+function query(db, statement) {
+  const out = execFileSync(
+    process.execPath,
+    [WRANGLER, 'd1', 'execute', db, LOCAL ? '--local' : '--remote', '--json', '--command', statement],
+    {
+      cwd: WORKER_DIR,
+      env: { ...process.env, CLOUDFLARE_ACCOUNT_ID: ACCOUNT_ID },
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+      // NOT shell:true -- the shell re-splits the SQL on its spaces and wrangler
+      // sees "SELECT" plus a pile of unknown arguments.
+    },
+  );
+  // wrangler prints a banner before the JSON even with --json.
+  const start = out.indexOf('[');
+  if (start === -1) throw new Error(`no JSON in wrangler output:\n${out.slice(0, 400)}`);
+  const parsed = JSON.parse(out.slice(start));
+  const result = Array.isArray(parsed) ? parsed[0] : parsed;
+  if (!result?.success) throw new Error(`query failed: ${statement}`);
+  return result.results;
+}
+
+async function getJson(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
+  return res.json();
+}
+
+/**
+ * Rebuild the manualThumbs channel from the live records. Keyed by nexus_id,
+ * which WIP/Dummy entries share -- so assert that colliding keys agree rather
+ * than letting the last one win silently.
+ */
+function thumbsFromLive(records) {
+  const thumbs = {};
+  for (const r of records) {
+    const key = String(r.nexus_id);
+    const value = {
+      thumbnailUrl: r.thumbnail_url,
+      pictureUrl: r.picture_url,
+      updatedAt: r.updated_at,
+    };
+    const prev = thumbs[key];
+    if (prev && JSON.stringify(prev) !== JSON.stringify(value)) {
+      throw new Error(`nexus_id ${key} appears twice with different images -- cannot key thumbs by it`);
+    }
+    thumbs[key] = value;
+  }
+  return thumbs;
+}
+
+/** Every served key must be classified, or the gate has a blind spot. */
+function assertKeyCoverage(records) {
+  const unclassified = new Set();
+  for (const r of records) {
+    for (const k of Object.keys(r)) {
+      if (!REBUILT_KEYS.has(k) && !FED_IN_KEYS.has(k)) unclassified.add(k);
+    }
+  }
+  if (unclassified.size) {
+    fail(
+      `/v1 serves field(s) this check neither rebuilds nor feeds in: ${[...unclassified].join(', ')}.\n`
+      + '   Classify them in REBUILT_KEYS or FED_IN_KEYS before trusting a green run.',
+    );
+  }
+}
+
+/** Attach the fed-in Nexus fields, in the position refresh.js appends them. */
+function withArchives(record, liveRecord) {
+  return { ...record, archives: liveRecord.archives };
+}
+
+function buildFromRows(rows, dismissedIds, tagsDict, districts, liveRecords, nowMs) {
+  const { full } = materializeFromD1({
+    rows,
+    dismissed: dismissedIds,
+    tagsDict,
+    nexusNodes: [], // nothing auto-publishes; images arrive via manualThumbs
+    districts,
+    manualThumbs: thumbsFromLive(liveRecords),
+    nowMs,
+  });
+  const byId = new Map(liveRecords.map((r) => [r.id, r]));
+  return Object.values(full).map((rec) => withArchives(rec, byId.get(rec.id) ?? {}));
+}
+
+async function main() {
+  const dbIdx = process.argv.indexOf('--db');
+  const db = dbIdx === -1 ? 'nczoning-data' : process.argv[dbIdx + 1];
+
+  console.log(`reference: ${API}/v1/locations`);
+  console.log(`candidate: D1 ${db} (${LOCAL ? 'LOCAL miniflare -- proves the harness, not production' : 'remote'})\n`);
+
+  const [envelope, subdistricts, tagsDict] = await Promise.all([
+    getJson(`${API}/v1/locations`),
+    getJson(`${SITE}/data/subdistricts.json`),
+    getJson(`${SITE}/data/tags.json`),
+  ]);
+  const liveRecords = envelope.data;
+  const nowMs = Date.parse(envelope.generated_at);
+  if (!Number.isFinite(nowMs)) fail('envelope.generated_at is not a date -- cannot reproduce recently_updated');
+
+  assertKeyCoverage(liveRecords);
+
+  const rows = query(db, 'SELECT * FROM locations ORDER BY id');
+  const dismissedRows = query(db, 'SELECT nexus_id FROM dismissed_candidates');
+
+  // A truncated result set is the failure mode that looks like success, so
+  // compare the rows returned against a count the database computed itself.
+  const [{ n }] = query(db, 'SELECT COUNT(*) AS n FROM locations');
+  if (rows.length !== n) {
+    fail(`D1 returned ${rows.length} rows but COUNT(*) is ${n} -- the result set was truncated`);
+  }
+  console.log(`D1: ${rows.length} locations (COUNT(*) agrees), ${dismissedRows.length} dismissed`);
+  console.log(`live: ${liveRecords.length} records, generated_at ${envelope.generated_at}\n`);
+
+  const dismissedIds = new Set(dismissedRows.map((r) => String(r.nexus_id)));
+  const candidate = buildFromRows(rows, dismissedIds, tagsDict, subdistricts.districts, liveRecords, nowMs);
+
+  // --- ID assertion (the deep-link contract) ----------------------------
+  const liveIds = new Set(liveRecords.map((r) => r.id));
+  const candIds = new Set(candidate.map((r) => r.id));
+  const missing = [...liveIds].filter((id) => !candIds.has(id));
+  const extra = [...candIds].filter((id) => !liveIds.has(id));
+  if (missing.length || extra.length) {
+    console.error('\n❌ ID SET MISMATCH -- every shared ?mod= link depends on these strings.');
+    if (missing.length) {
+      console.error(`   in live but not D1 (${missing.length}): ${missing.slice(0, 10).join(', ')}`);
+      console.error('   if these are newly auto-discovered mods, the import is stale -- re-import, do not wave this through.');
+    }
+    if (extra.length) console.error(`   in D1 but not live (${extra.length}): ${extra.slice(0, 10).join(', ')}`);
+    process.exit(1);
+  }
+
+  // --- the byte-for-byte diff -------------------------------------------
+  const compare = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+  if (!compare(candidate, liveRecords)) {
+    console.error('\n❌ BYTE MISMATCH. First differing records:\n');
+    let shown = 0;
+    for (let i = 0; i < Math.max(candidate.length, liveRecords.length) && shown < 5; i += 1) {
+      const c = JSON.stringify(candidate[i]);
+      const l = JSON.stringify(liveRecords[i]);
+      if (c !== l) {
+        console.error(`  [${i}] ${liveRecords[i]?.id ?? candidate[i]?.id}`);
+        console.error(`    live: ${l}`);
+        console.error(`    D1  : ${c}\n`);
+        shown += 1;
+      }
+    }
+    process.exit(1);
+  }
+  const bytes = JSON.stringify(liveRecords).length;
+  console.log(`✅ byte-for-byte identical: ${candidate.length} records, ${bytes} bytes`);
+
+  // --- negative control -------------------------------------------------
+  // A green result above is worthless unless this comparison can go red. Prove
+  // it on the same run, against the same code path, with the same data.
+  console.log('\nnegative control (the check must FAIL on each of these):');
+  const controls = [
+    ['id changed', (r) => ({ ...r, id: `${r.id}-x` })],
+    ['name changed', (r) => ({ ...r, name: `${r.name} ` })],
+    ['coordinate nudged', (r) => ({ ...r, x: r.x + 0.0001 })],
+    ['z dropped to NULL', (r) => ({ ...r, z: null })],
+    ['tag removed', (r) => ({ ...r, tags: JSON.stringify(JSON.parse(r.tags).slice(1)) })],
+  ];
+  let controlsPassed = 0;
+  for (const [label, mutate] of controls) {
+    const mutated = rows.map((r, i) => (i === 0 ? mutate(r) : r));
+    let differs;
+    try {
+      const out = buildFromRows(mutated, dismissedIds, tagsDict, subdistricts.districts, liveRecords, nowMs);
+      differs = !compare(out, liveRecords);
+    } catch {
+      differs = true; // a throw is also a detection
+    }
+    console.log(`  ${differs ? '✓' : '✗'} ${label}${differs ? ' -> detected' : ' -> NOT DETECTED'}`);
+    if (differs) controlsPassed += 1;
+  }
+  if (controlsPassed !== controls.length) {
+    fail(`${controls.length - controlsPassed} negative control(s) went undetected -- this gate cannot fail, so its green result means nothing.`);
+  }
+
+  console.log(`\n✅ PARITY GATE PASSED (${controls.length}/${controls.length} negative controls detected)`);
+}
+
+main().catch((err) => {
+  console.error(String(err.stack || err));
+  process.exit(1);
+});

--- a/worker/src/materialize.js
+++ b/worker/src/materialize.js
@@ -1,0 +1,145 @@
+/**
+ * Materializer: D1 `locations` rows -> the served /v1 record map.
+ *
+ * The D1-sourced counterpart to buildDataset() in merge.js. Phase 1 only
+ * *verifies* it (scripts/parity-check.mjs diffs its output against the live
+ * API byte-for-byte); the cron does not call it until Phase 2.
+ *
+ * WHAT CHANGES vs merge.js, and why the shape does not:
+ * - Locations no longer come from mods.json + parsed Nexus blocks. They all
+ *   come from D1, including the 9 records that originally arrived via
+ *   auto-discovery (imported at Phase 1, `source='auto'` preserved).
+ * - Nothing auto-publishes any more. A tagged Nexus mod with a valid block is
+ *   a *candidate*, not a location. So the Nexus loop here only ever backfills
+ *   images and collects `skipped`; it never creates a record. That is the
+ *   plan's model, and it is why `dismissed_candidates` alone replaces the dual
+ *   role excluded_mods.json used to play.
+ *
+ * The record key ORDER below is load-bearing: /v1 responses are compared
+ * byte-for-byte at the Phase 1 gate, and JSON.stringify emits insertion order.
+ * It mirrors merge.js:141-157 deliberately, and the parity diff is what proves
+ * the mirror is faithful. `archives` is appended by the caller (as refresh.js
+ * does today), so it is absent here by design, not by omission.
+ */
+
+import { parseNcZoningBlock } from './parse.js';
+import { assignDistrict } from './districts.js';
+import { RECENTLY_UPDATED_DAYS } from './config.js';
+
+/**
+ * Decode one D1 row into the intermediate entry shape.
+ *
+ * Two round-trip details that a byte-for-byte diff will catch and a "looks
+ * right" review will not:
+ * - A NULL `z` must produce a 2-element `[x, y]`, not `[x, y, null]`. Every
+ *   current record has a Z, but the schema and mods.schema.json both still
+ *   permit the legacy pair, so the decoder has to.
+ * - NULL `yaw` / `credits` must OMIT the key rather than emit null, matching
+ *   merge.js's conditional spreads.
+ */
+export function rowToEntry(row) {
+  return {
+    id: row.id,
+    name: row.name,
+    nexus_id: row.nexus_id,
+    coordinates: row.z === null || row.z === undefined
+      ? [row.x, row.y]
+      : [row.x, row.y, row.z],
+    yaw: row.yaw,
+    category: row.category,
+    tags: JSON.parse(row.tags ?? '[]'),
+    authors: JSON.parse(row.authors ?? '[]'),
+    source: row.source,
+    description: row.description ?? '',
+    credits: row.credits,
+  };
+}
+
+/**
+ * @param {object} input
+ * @param {Array}  input.rows          D1 `locations` rows (all statuses; filtered here)
+ * @param {Set|Array} input.dismissed  nexus_ids from `dismissed_candidates`
+ * @param {object} input.tagsDict      data/tags.json, for block validation
+ * @param {Array}  input.nexusNodes    raw nodes from the NCZoning GraphQL query
+ * @param {Array}  input.districts     data/subdistricts.json `districts[]`
+ * @param {object} [input.manualThumbs] modsByUid image/updatedAt, keyed by nexus_id
+ * @param {number} [input.nowMs]       clock the recently_updated bool is computed against
+ * @returns {{full: Object<string, object>, meta: object}}
+ */
+export function materializeFromD1({
+  rows, dismissed, tagsDict, nexusNodes, districts, manualThumbs = {}, nowMs = Date.now(),
+}) {
+  const validTagNames = new Set(Object.keys(tagsDict));
+  const dismissedIds = dismissed instanceof Set ? dismissed : new Set(dismissed || []);
+
+  // Only published records reach the map. `hidden` keeps the row but pulls the
+  // pin (the Nexus-deletion case); `draft` has never been published.
+  const published = rows.filter((r) => r.status === 'published');
+
+  // Every record's nexus_id, not just the manual ones -- the auto-discovered
+  // records are rows now, so they suppress their own re-creation for free.
+  const existingNexusIds = new Set(
+    published
+      .map((r) => String(r.nexus_id))
+      .filter((id) => id && !['wip', 'dummy'].includes(id.toLowerCase())),
+  );
+
+  const nexusThumbs = {};
+  const skipped = [];
+
+  for (const node of nexusNodes || []) {
+    const nexusId = String(node.modId);
+    if (dismissedIds.has(nexusId)) continue;
+    if (existingNexusIds.has(nexusId)) {
+      nexusThumbs[nexusId] = {
+        pictureUrl: node.pictureUrl || null,
+        thumbnailUrl: node.thumbnailUrl || null,
+        updatedAt: node.updatedAt || null,
+      };
+      continue;
+    }
+    // Not a location and not dismissed: a candidate. Surfaced on /v1/meta as
+    // `skipped` exactly as before when it has no valid block. A mod WITH a
+    // valid block is also not published here -- see the header note.
+    const parsed = parseNcZoningBlock(node.description, validTagNames);
+    if (!parsed) skipped.push({ nexus_id: nexusId, name: node.name || 'Unknown Mod' });
+  }
+
+  const all = published.map(rowToEntry).sort((a, b) => a.name.localeCompare(b.name));
+
+  const cutoffMs = nowMs - RECENTLY_UPDATED_DAYS * 86400000;
+  const full = {};
+
+  for (const entry of all) {
+    const { district, subdistrict } = assignDistrict(entry.coordinates, districts);
+    const t = manualThumbs[String(entry.nexus_id)] || nexusThumbs[String(entry.nexus_id)] || null;
+    const thumbs = {
+      thumbnail_url: t?.thumbnailUrl ?? null,
+      picture_url: t?.pictureUrl ?? null,
+      updated_at: t?.updatedAt ?? null,
+    };
+    const recently_updated = thumbs.updated_at
+      ? Date.parse(thumbs.updated_at) > cutoffMs
+      : false;
+
+    full[entry.id] = {
+      id: entry.id,
+      name: entry.name,
+      nexus_id: String(entry.nexus_id),
+      coordinates: entry.coordinates,
+      ...(entry.yaw !== undefined && entry.yaw !== null ? { yaw: entry.yaw } : {}),
+      category: entry.category,
+      tags: entry.tags,
+      authors: entry.authors,
+      source: entry.source,
+      district,
+      subdistrict,
+      recently_updated,
+      description: entry.description ?? '',
+      ...(entry.credits ? { credits: entry.credits } : {}),
+      ...thumbs,
+    };
+  }
+
+  return { full, meta: { skipped, nexus_thumbs: nexusThumbs } };
+}

--- a/worker/test/materialize.test.js
+++ b/worker/test/materialize.test.js
@@ -1,0 +1,154 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { materializeFromD1, rowToEntry } from '../src/materialize.js';
+
+// These cover the shapes the Phase 1 parity diff structurally CANNOT reach:
+// every record in production today is published, has a Z and (mostly) a yaw, so
+// the legacy/edge branches never execute against real data. The parity gate
+// proves the happy path on 296 real records; this proves the rest.
+
+const DISTRICTS = [
+  {
+    id: 50, name: 'Testville',
+    polygon: [[0, 0], [1000, 0], [1000, 1000], [0, 1000]],
+    subdistricts: [
+      { id: 54, name: 'Little Fixture', polygon: [[0, 0], [500, 0], [500, 500], [0, 500]] },
+    ],
+  },
+];
+
+const TAGS = { apartment: 'a place' };
+
+/** A published row with everything set; override per test. */
+const row = (over = {}) => ({
+  id: 'aaaa-1111', name: 'Alpha', nexus_id: '12345', category: 'new-location',
+  x: 250, y: 250, z: 10, yaw: 90,
+  description: 'A record.', credits: 'Thanks',
+  authors: '["Spud"]', tags: '["apartment"]',
+  source: 'manual', status: 'published',
+  admin_notes: null, owner_id: null,
+  created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+  ...over,
+});
+
+const build = (rows, over = {}) => materializeFromD1({
+  rows, dismissed: [], tagsDict: TAGS, nexusNodes: [], districts: DISTRICTS,
+  nowMs: Date.parse('2026-01-10T00:00:00Z'), ...over,
+});
+
+test('a NULL z rebuilds the legacy 2-element coordinate pair, not [x, y, null]', () => {
+  const { full } = build([row({ z: null })]);
+  assert.deepEqual(full['aaaa-1111'].coordinates, [250, 250]);
+  // The serialised bytes are what the gate compares, so assert those too.
+  assert.match(JSON.stringify(full['aaaa-1111']), /"coordinates":\[250,250\]/);
+});
+
+test('a NULL yaw omits the key entirely rather than serialising null', () => {
+  const { full } = build([row({ yaw: null })]);
+  assert.equal('yaw' in full['aaaa-1111'], false);
+  assert.equal(JSON.stringify(full['aaaa-1111']).includes('yaw'), false);
+});
+
+test('NULL and empty-string credits both omit the key', () => {
+  for (const credits of [null, '']) {
+    const { full } = build([row({ credits })]);
+    assert.equal('credits' in full['aaaa-1111'], false, `credits=${JSON.stringify(credits)}`);
+  }
+});
+
+test('key order matches merge.js, because the gate compares bytes', () => {
+  const { full } = build([row()]);
+  assert.deepEqual(Object.keys(full['aaaa-1111']), [
+    'id', 'name', 'nexus_id', 'coordinates', 'yaw', 'category', 'tags', 'authors',
+    'source', 'district', 'subdistrict', 'recently_updated', 'description', 'credits',
+    'thumbnail_url', 'picture_url', 'updated_at',
+  ]);
+});
+
+test('only published rows are served; hidden and draft are withheld', () => {
+  const { full } = build([
+    row({ id: 'pub', status: 'published' }),
+    row({ id: 'hid', status: 'hidden' }),
+    row({ id: 'dft', status: 'draft' }),
+  ]);
+  assert.deepEqual(Object.keys(full), ['pub']);
+});
+
+test('records are ordered by name, matching the live array order', () => {
+  const { full } = build([
+    row({ id: 'c', name: 'Charlie' }),
+    row({ id: 'a', name: 'alpha' }),
+    row({ id: 'b', name: 'Bravo' }),
+  ]);
+  assert.deepEqual(Object.values(full).map((r) => r.name), ['alpha', 'Bravo', 'Charlie']);
+});
+
+test('nothing auto-publishes: a tagged mod with a valid block is not a location', () => {
+  const nexusNodes = [{
+    modId: 999, name: 'Brand New Mod', summary: 'shiny',
+    description: 'NCZoning:\ncoords=100,100\ncategory=other',
+    uploader: { name: 'Someone' },
+  }];
+  const { full, meta } = build([row()], { nexusNodes });
+  assert.deepEqual(Object.keys(full), ['aaaa-1111'], 'must not create a record');
+  // A valid block is a candidate, so it is not "skipped" either.
+  assert.deepEqual(meta.skipped, []);
+});
+
+test('a tagged mod with NO valid block is still surfaced as skipped', () => {
+  const nexusNodes = [{ modId: 888, name: 'Mistagged', summary: '', description: 'no block here' }];
+  const { meta } = build([row()], { nexusNodes });
+  assert.deepEqual(meta.skipped, [{ nexus_id: '888', name: 'Mistagged' }]);
+});
+
+test('a dismissed candidate is not even reported as skipped', () => {
+  const nexusNodes = [{ modId: 888, name: 'Mistagged', summary: '', description: 'no block' }];
+  const { meta } = build([row()], { nexusNodes, dismissed: ['888'] });
+  assert.deepEqual(meta.skipped, []);
+});
+
+test('an existing record suppresses its own re-creation and contributes thumbs', () => {
+  const nexusNodes = [{
+    modId: 12345, name: 'Alpha (Nexus page)', summary: 'dup',
+    description: 'NCZoning:\ncoords=1,1\ncategory=other',
+    pictureUrl: 'pic', thumbnailUrl: 'thumb', updatedAt: '2026-01-08T00:00:00Z',
+    uploader: { name: 'Spud' },
+  }];
+  const { full } = build([row()], { nexusNodes });
+  assert.equal(Object.keys(full).length, 1);
+  assert.equal(full['aaaa-1111'].thumbnail_url, 'thumb');
+  assert.equal(full['aaaa-1111'].picture_url, 'pic');
+  // 2026-01-08 is 2 days before the 2026-01-10 clock, inside the 7-day window.
+  assert.equal(full['aaaa-1111'].recently_updated, true);
+});
+
+test('recently_updated is false outside the window and for an unknown date', () => {
+  const stale = [{
+    modId: 12345, name: 'x', summary: '', description: '',
+    updatedAt: '2025-01-01T00:00:00Z', uploader: { name: 'Spud' },
+  }];
+  assert.equal(build([row()], { nexusNodes: stale }).full['aaaa-1111'].recently_updated, false);
+  // No node at all: updated_at null, so the bool is false rather than NaN-ish.
+  assert.equal(build([row()]).full['aaaa-1111'].recently_updated, false);
+});
+
+test('WIP and Dummy nexus ids never match a Nexus node', () => {
+  const nexusNodes = [{
+    modId: 'WIP', name: 'nope', summary: '', description: '',
+    thumbnailUrl: 'leaked', uploader: { name: 'x' },
+  }];
+  const { full } = build([row({ nexus_id: 'WIP' })], { nexusNodes });
+  assert.equal(full['aaaa-1111'].thumbnail_url, null);
+});
+
+test('rowToEntry parses the JSON array columns', () => {
+  const entry = rowToEntry(row({ authors: '["A","B"]', tags: '["x"]' }));
+  assert.deepEqual(entry.authors, ['A', 'B']);
+  assert.deepEqual(entry.tags, ['x']);
+});
+
+test('rowToEntry tolerates NULL authors/tags columns', () => {
+  const entry = rowToEntry(row({ authors: null, tags: null }));
+  assert.deepEqual(entry.authors, []);
+  assert.deepEqual(entry.tags, []);
+});

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -60,6 +60,22 @@
 			"id": "2f547f4c22ab4d5fb2cf4636e50a2559"
 		}
 	],
+	// Location registry (source of truth from Phase 2; Phase 1 imports and
+	// verifies it while mods.json is still the live source). Unlike KV, this
+	// content is NOT derived — losing it loses data, so it is never "recreate
+	// at any time". D1 Time Travel covers 30 days; the git mirror of
+	// data/locations/ is the longer backstop until Part C's nightly export.
+	//
+	// STAGING HAS ITS OWN DATABASE (see env.staging). Named environments do not
+	// inherit bindings, so `wrangler d1 migrations apply` must be run against
+	// BOTH database names, every time.
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "nczoning-data",
+			"database_id": "4365740b-76be-4a99-b985-16641e68703a"
+		}
+	],
 	// Rebuild the dataset every 5 minutes (faster mod propagation after a
 	// submission). Nexus load stays well under limits; see docs/nexus-api-reference.md.
 	// Production is the ONLY environment with a cron (see env.staging below).
@@ -111,6 +127,17 @@
 				{
 					"binding": "DATASET",
 					"id": "9fe7b7d13d6348d1913b8a01aca1fef6"
+				}
+			],
+			// Same binding name as production, different database. Declared in
+			// full because named environments inherit nothing — omitting this
+			// block does not fall back to the production database, it leaves
+			// env.DB undefined and every query throws at runtime.
+			"d1_databases": [
+				{
+					"binding": "DB",
+					"database_name": "nczoning-data-staging",
+					"database_id": "43bc0232-5f32-49c3-863d-ff3e53422827"
 				}
 			],
 			// MUST be an explicit empty array, not an omitted block. Wrangler


### PR DESCRIPTION
Phase 1 of the D1 admin dashboard: stand up the location registry and prove it
reproduces the live API exactly, **without changing what anything reads**.
`mods.json` is still the source; the cron does not touch D1 until Phase 2.

## The gate, run against production D1

```
reference: https://api.nczoning.net/v1/locations
candidate: D1 nczoning-data (remote)

D1: 296 locations (COUNT(*) agrees), 1 dismissed
live: 296 records, generated_at 2026-07-26T02:25:25.663Z

✅ byte-for-byte identical: 296 records, 268595 bytes

negative control (the check must FAIL on each of these):
  ✓ id changed          -> detected
  ✓ name changed        -> detected
  ✓ coordinate nudged   -> detected
  ✓ z dropped to NULL   -> detected
  ✓ tag removed         -> detected

✅ PARITY GATE PASSED (5/5 negative controls detected)
```

287 manual + 9 auto, all `published`; the single exclusion is a
`dismissed_candidates` row, not a location.

## Why the green result is worth something

The gate is built so it can fail, and proves it on every run:

- **The comparison is `JSON.stringify(array) === JSON.stringify(array)`** over the
  whole 296-record array, which folds ordering into the same check as content.
- **Row count is checked against `COUNT(*)`** computed by the database, because a
  truncated result set is the failure mode that looks like success.
- **Every served field must be classified** as rebuilt-from-D1 or fed-in-from-live.
  One that is neither fails the run, so a new `/v1` field cannot slip past as
  "not compared".
- **Five mutations are applied to a row after the pass**, and the diff must catch
  each. A green run that could not have gone red exits non-zero.

Coverage is stated rather than implied: 14 fields are rebuilt from D1 (including
`district`/`subdistrict`, recomputed from D1's *own* coordinates — that is what
catches a mangled coordinate). Four Nexus-derived fields (`thumbnail_url`,
`picture_url`, `updated_at`, `archives`) are fed in from the live record because
D1 does not own them until Phase 2, so **this check does not verify them**. The
script header says so.

The zero-byte diff also settles the float round-trip: SQLite `REAL` and JS
`number` are both IEEE-754 doubles, and a lossy trip would have shown as a diff
on all 296 records rather than none.

## 🔴 IDs pass through untouched

`?mod=` deep links resolve to the numeric `nexus_id` when there is one and the
UUID otherwise (`assets/js/utils.js`, `modLinkId`), so every link ever shared in
Discord or on a Nexus page depends on these exact strings. There is no tidy-up
step in the importer, and the gate asserts the two ID sets are identical — with
`id changed -> detected` proving that assertion works.

## Deviations from the plan, and why

- **Added a `source` column** the plan's schema omits. `source` is served on every
  `/v1` record, so the source of truth has to hold it or the gate cannot
  reproduce the output. Deriving it from an `id LIKE 'nexus-%'` prefix works
  today and rots the first time an admin-created record is given a nexus id.
- **`CHECK` constraints on `source` and `status`.** Both are closed sets the plan
  itself enumerates; a constraint makes the comment enforceable. Cost accepted:
  changing them later needs a SQLite table rebuild.
- **Empty-string `credits` imported as NULL.** `''` and a missing key mean the same
  thing in the JSON files. Parity-neutral by construction — `merge.js` and
  `materialize.js` both gate on truthiness, so either omits the key from `/v1`.
- **`tags` stays a JSON array**, as the plan requires. It normalises at Phase 4.

## Two databases, not one

Named Wrangler environments inherit no bindings, so staging has its own database
and every migration runs against both. Staging is migrated (10 tables) and
deliberately empty (0 locations).

`--env staging` is **required** on the staging migration — without it wrangler
resolves names from the top-level config only and reports `Couldn't find a D1 DB
with the name or binding`. That is the exact mechanism by which "apply to both"
becomes "applied to one", so it is called out in the README. It was found by
running the runbook, not reading it (second commit).

## Not in this PR, by design

Phase 2 (cron sources from D1), the `skipped`/`/v1/meta` parity, and anything
touching `nexus_cache`. `mods.json` keeps being built and read throughout.

## Test plan

- `npm test` in `worker/` — 104 pass (15 new).
- New `test/materialize.test.js` covers what the parity diff structurally cannot
  reach: NULL `z` rebuilding a legacy 2-element pair, NULL `yaw`/`credits`
  omitting their keys, `hidden`/`draft` withheld, key order, and that nothing
  auto-publishes any more.
- Parity gate green against production D1 (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
