### PR TITLE
feat(d1): Phase 2 — cron can source from D1, behind DATA_SOURCE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - D1 databases (production + staging) with the location registry schema, and a one-time import of all 296 locations plus the single exclusion. Nothing reads D1 yet — `mods.json` is still the live source.
 - A parity gate that rebuilds `/v1/locations` from D1 and diffs it byte-for-byte against the live API, with negative controls that prove the diff can fail.
+- The refresh cron can source the registry from D1 via `DATA_SOURCE=d1`. Production stays on `mods.json` until the cutover; unset never means D1.
+- A second harness that runs both source paths head-to-head across a swept clock, and fails if the swept field never varied.
 
 ## [1.7.2] - 2026-07-26
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -159,6 +159,34 @@ run that did not also prove it can go red exits non-zero: the header comment
 explains what the check does and does not cover, and is worth reading before
 trusting a pass.
 
+### Switching the source (`DATA_SOURCE`)
+
+`DATA_SOURCE` in `wrangler.jsonc` decides where the cron reads the registry
+from: `mods` (the compiled `mods.json`) or `d1`. **Anything other than `d1`
+means `mods`, including unset** — absent config must never read as "switch
+production onto the new source".
+
+The Phase 2 cutover is that one word, and so is the rollback. That is the point
+of it being a var: reverting is a config change on a build already known to
+work, not a revert-and-redeploy while production is wrong.
+
+```bash
+node scripts/parity-ab.mjs      # both code paths, swept clock  <- run this first
+node scripts/parity-check.mjs   # D1 vs the live API, byte-for-byte
+```
+
+**`parity-ab.mjs` is the one to trust for the cutover.** `parity-check.mjs`
+compares against the live API, which only changes when the content hash does —
+so on a quiet day re-running it compares the same bytes for hours and cannot
+fail. `parity-ab.mjs` instead runs `buildDataset` and `materializeFromD1`
+head-to-head on identical Nexus input, then sweeps the clock ±365 days across
+the `recently_updated` boundary. It exercises the drift a multi-day soak was
+hoping to stumble into, in seconds, and it **fails if the swept field never
+varied** — a sweep that changed nothing tested nothing.
+
+Waiting is not a test. Do not gate the cutover on elapsed time; gate it on both
+scripts green.
+
 ### Test the cron locally
 
 ```bash

--- a/worker/README.md
+++ b/worker/README.md
@@ -191,7 +191,7 @@ scripts green.
 
 ```bash
 npm run dev
-curl "http://127.0.0.1:8787/cdn-cgi/handler/scheduled"   # trigger one refresh
+curl "http://127.0.0.1:8787/__scheduled"                 # trigger one refresh
 npx wrangler kv key get "dataset:v1:meta" --binding DATASET --local
 ```
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -124,17 +124,34 @@ It is empty until then, on purpose. Note that staging has **no cron** and the
 health monitor does not watch it, so nothing there refreshes or is observed;
 `?api=dev` tests API *code*, never API *data*.
 
-Seed it when you want a realistic starting point, then treat it as disposable:
+**Reseed it by copying production**, then treat it as disposable:
 
 ```bash
-# either regenerate from the repo...
-node scripts/import-locations.mjs --out .import/seed.sql
-npx wrangler d1 execute nczoning-data-staging --env staging --remote --file .import/seed.sql
-
-# ...or copy production across
-npx wrangler d1 export nczoning-data --remote --output .import/prod.sql
-npx wrangler d1 execute nczoning-data-staging --env staging --remote --file .import/prod.sql
+npx wrangler d1 export nczoning-data --remote \
+  --table locations --table dismissed_candidates --no-schema \
+  --output .import/prod-data.sql -y
+npx wrangler d1 execute nczoning-data-staging --env staging --remote \
+  --command "DELETE FROM locations; DELETE FROM dismissed_candidates;"
+npx wrangler d1 execute nczoning-data-staging --env staging --remote --file .import/prod-data.sql
 ```
+
+`--table` and `--no-schema` are both load-bearing: a full export carries the
+schema and the `d1_migrations` table, which staging already has, so it conflicts.
+
+**Do not reseed staging with `import-locations.mjs`.** That script regenerates
+from `data/locations/` plus the live API, which produces *equivalent* data, not
+a *copy* — it stamps `created_at`/`updated_at` with the import time and knows
+nothing about the D1-only columns (`admin_notes`, `owner_id`, dismissal reasons,
+`audit_log`). Seeding staging that way left it holding the same 296 records as
+production under a `created_at` almost three hours adrift.
+
+Those columns are not served on `/v1`, so this does not affect the parity gates
+today. It will matter from **Phase 4**, when D1 becomes the source of truth and
+`data/locations/` goes stale — at which point regenerating from the repo would
+actively produce wrong data.
+
+`import-locations.mjs` remains the right tool for exactly one job: the initial
+seed of an empty database, or a rebuild from git if D1 is ever lost.
 
 Full reasoning, including why the Phase 2 soak cannot run here: the
 `staging-is-a-write-sandbox-not-a-preview` decision in the project wiki.

--- a/worker/scripts/parity-ab.mjs
+++ b/worker/scripts/parity-ab.mjs
@@ -1,0 +1,200 @@
+/**
+ * A/B the two materializers head-to-head, locally, across a swept clock.
+ *
+ *   node worker/scripts/parity-ab.mjs
+ *   node worker/scripts/parity-ab.mjs --db nczoning-data-staging --local
+ *
+ * WHY THIS EXISTS, given parity-check.mjs already passes.
+ *
+ * parity-check compares D1 against the LIVE API, so it can only ever test the
+ * one dataset the world is currently producing. The cron writes KV only when
+ * the content hash changes, so on a quiet day `generated_at` does not move for
+ * hours and re-running it compares the same bytes over and over -- a check that
+ * cannot fail, dressed up as a soak.
+ *
+ * The Phase 2 gate is really asking: *do the two code paths agree?* That does
+ * not need the world to change, because both sides can be driven locally with
+ * identical inputs. So this script runs `buildDataset` (mods.json) and
+ * `materializeFromD1` (D1 rows) against the SAME Nexus data and the SAME clock,
+ * and diffs them -- then sweeps the clock across the recently_updated boundary,
+ * which is the only genuinely time-varying field either path computes.
+ *
+ * Sweeping is the point. Waiting is not a test.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildDataset } from '../src/merge.js';
+import { materializeFromD1 } from '../src/materialize.js';
+import { RECENTLY_UPDATED_DAYS } from '../src/config.js';
+
+const WORKER_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const REPO_ROOT = path.resolve(WORKER_DIR, '..');
+const WRANGLER = path.join(WORKER_DIR, 'node_modules', 'wrangler', 'bin', 'wrangler.js');
+const ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID || 'b9937d8d595fad7de8d1549b22390281';
+const SITE = process.env.NCZ_SITE_ORIGIN || 'https://nczoning.net';
+const LOCAL = process.argv.includes('--local');
+
+function query(db, statement) {
+  const out = execFileSync(
+    process.execPath,
+    [WRANGLER, 'd1', 'execute', db, LOCAL ? '--local' : '--remote', '--json', '--command', statement],
+    {
+      cwd: WORKER_DIR,
+      env: { ...process.env, CLOUDFLARE_ACCOUNT_ID: ACCOUNT_ID },
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  );
+  const parsed = JSON.parse(out.slice(out.indexOf('[')));
+  const result = Array.isArray(parsed) ? parsed[0] : parsed;
+  if (!result?.success) throw new Error(`query failed: ${statement}`);
+  return result.results;
+}
+
+async function getJson(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
+  return res.json();
+}
+
+/** mods.json, rebuilt from the JSON files so this never depends on a stale artifact. */
+function readManualMods() {
+  const dir = path.join(REPO_ROOT, 'data', 'locations');
+  return fs.readdirSync(dir)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8')))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Nexus images, taken from the live dataset rather than refetched. Both sides
+ * get the identical object, so this isolates the variable under test (do the
+ * two paths agree?) instead of adding a second moving part.
+ */
+function thumbsFromLive(records) {
+  const thumbs = {};
+  for (const r of records) {
+    thumbs[String(r.nexus_id)] = {
+      thumbnailUrl: r.thumbnail_url, pictureUrl: r.picture_url, updatedAt: r.updated_at,
+    };
+  }
+  return thumbs;
+}
+
+function diff(a, b) {
+  const A = Object.values(a);
+  const B = Object.values(b);
+  if (JSON.stringify(A) === JSON.stringify(B)) return null;
+  for (let i = 0; i < Math.max(A.length, B.length); i += 1) {
+    if (JSON.stringify(A[i]) !== JSON.stringify(B[i])) {
+      return { index: i, id: A[i]?.id ?? B[i]?.id, mods: JSON.stringify(A[i]), d1: JSON.stringify(B[i]) };
+    }
+  }
+  return { index: -1, id: '(length)', mods: `${A.length} records`, d1: `${B.length} records` };
+}
+
+async function main() {
+  const dbIdx = process.argv.indexOf('--db');
+  const db = dbIdx === -1 ? 'nczoning-data' : process.argv[dbIdx + 1];
+
+  const [envelope, subdistricts, tagsDict, excluded] = await Promise.all([
+    getJson('https://api.nczoning.net/v1/locations'),
+    getJson(`${SITE}/data/subdistricts.json`),
+    getJson(`${SITE}/data/tags.json`),
+    getJson(`${SITE}/data/excluded_mods.json`).catch(() => ({})),
+  ]);
+  const live = envelope.data;
+  const districts = subdistricts.districts;
+  const manualThumbs = thumbsFromLive(live);
+  const manualMods = readManualMods();
+  const rows = query(db, 'SELECT * FROM locations ORDER BY id');
+  const dismissed = new Set(query(db, 'SELECT nexus_id FROM dismissed_candidates').map((r) => String(r.nexus_id)));
+
+  // The tagged-mod nodes both paths consume. Reconstructed from the live auto
+  // records so the two sides are fed byte-identical Nexus input; a real fetch
+  // would introduce a second variable and could change mid-run.
+  // Reconstructing this block is lossy if any recognised key is forgotten, and
+  // the loss shows up as a false MISMATCH blamed on D1. parse.js recognises
+  // coords, category, tags, yaw, credits and authors -- all six are emitted
+  // here, and `authors` is the *additional* authors only, because merge.js
+  // prepends the uploader itself.
+  const nexusNodes = live.filter((r) => r.source === 'auto').map((r) => {
+    const extraTags = r.tags.filter((t) => t !== 'nczoning');
+    const extraAuthors = r.authors.slice(1);
+    const block = [
+      'NCZoning:',
+      `coords=${r.coordinates.join(',')}`,
+      `category=${r.category}`,
+      ...(extraTags.length ? [`tags=${extraTags.join(',')}`] : []),
+      ...(r.yaw !== undefined && r.yaw !== null ? [`yaw=${r.yaw}`] : []),
+      ...(r.credits ? [`credits=${r.credits}`] : []),
+      ...(extraAuthors.length ? [`authors=${extraAuthors.join(',')}`] : []),
+    ].join('\n');
+    return {
+      modId: Number(r.nexus_id),
+      name: r.name,
+      summary: r.description,
+      description: block,
+      pictureUrl: r.picture_url,
+      thumbnailUrl: r.thumbnail_url,
+      updatedAt: r.updated_at,
+      uploader: { name: r.authors[0] },
+    };
+  });
+
+  console.log(`A: buildDataset  (${manualMods.length} manual mods + ${nexusNodes.length} tagged nodes)`);
+  console.log(`B: materializeFromD1 (${rows.length} rows, ${dismissed.size} dismissed)  db=${db}${LOCAL ? ' [local]' : ''}\n`);
+
+  // Sweep the clock across the recently_updated boundary. Every mod's
+  // updated_at sits somewhere on this line, so stepping the clock forward flips
+  // records from recent to not-recent a few at a time -- which is exactly the
+  // drift a multi-day soak was hoping to stumble into.
+  const base = Date.parse(envelope.generated_at);
+  const day = 86400000;
+  const offsets = [-90, -30, -RECENTLY_UPDATED_DAYS, -1, 0, 1, RECENTLY_UPDATED_DAYS, 30, 90, 365];
+
+  let failures = 0;
+  for (const days of offsets) {
+    const nowMs = base + days * day;
+    const a = buildDataset({ manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs, nowMs }).full;
+    const b = materializeFromD1({ rows, dismissed, tagsDict, nexusNodes, districts, manualThumbs, nowMs }).full;
+    const d = diff(a, b);
+    const recent = Object.values(a).filter((r) => r.recently_updated).length;
+    const label = `clock ${days >= 0 ? '+' : ''}${days}d`.padEnd(12);
+    if (d) {
+      failures += 1;
+      console.log(`  ✗ ${label} MISMATCH at [${d.index}] ${d.id}`);
+      console.log(`      mods: ${d.mods?.slice(0, 200)}`);
+      console.log(`      d1  : ${d.d1?.slice(0, 200)}`);
+    } else {
+      console.log(`  ✓ ${label} identical (${Object.keys(a).length} records, ${recent} recently_updated)`);
+    }
+  }
+
+  // The sweep is only meaningful if recently_updated actually moved across it.
+  // A sweep where every clock yields the same value proves nothing about the
+  // one time-varying field it exists to exercise.
+  const counts = offsets.map((days) => Object.values(
+    buildDataset({ manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs, nowMs: base + days * day }).full,
+  ).filter((r) => r.recently_updated).length);
+  const varied = new Set(counts).size > 1;
+  console.log(`\nrecently_updated across the sweep: ${counts.join(' -> ')}`);
+  if (!varied) {
+    console.error('❌ the swept field never changed -- this sweep exercised nothing');
+    process.exit(1);
+  }
+
+  if (failures) {
+    console.error(`\n❌ ${failures}/${offsets.length} clocks mismatched`);
+    process.exit(1);
+  }
+  console.log(`\n✅ both paths agree at all ${offsets.length} clocks, and the swept field did vary`);
+}
+
+main().catch((err) => {
+  console.error(String(err.stack || err));
+  process.exit(1);
+});

--- a/worker/scripts/parity-ab.mjs
+++ b/worker/scripts/parity-ab.mjs
@@ -37,10 +37,13 @@ const ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID || 'b9937d8d595fad7de8d1549
 const SITE = process.env.NCZ_SITE_ORIGIN || 'https://nczoning.net';
 const LOCAL = process.argv.includes('--local');
 
+// See parity-check.mjs: a staging database is invisible without --env staging.
+const envArgs = (db) => (db.endsWith('-staging') ? ['--env', 'staging'] : []);
+
 function query(db, statement) {
   const out = execFileSync(
     process.execPath,
-    [WRANGLER, 'd1', 'execute', db, LOCAL ? '--local' : '--remote', '--json', '--command', statement],
+    [WRANGLER, 'd1', 'execute', db, ...envArgs(db), LOCAL ? '--local' : '--remote', '--json', '--command', statement],
     {
       cwd: WORKER_DIR,
       env: { ...process.env, CLOUDFLARE_ACCOUNT_ID: ACCOUNT_ID },

--- a/worker/scripts/parity-check.mjs
+++ b/worker/scripts/parity-check.mjs
@@ -71,11 +71,17 @@ const fail = (msg) => { console.error(`\n❌ ${msg}`); process.exit(1); };
 // remote D1 are entirely separate stores that answer the same command.
 const LOCAL = process.argv.includes('--local');
 
+// Wrangler resolves database names from the TOP-LEVEL config only, so a staging
+// database is invisible without `--env staging` and the command fails with
+// "Couldn't find a D1 DB with the name or binding". Derived from the name so
+// `--db nczoning-data-staging` just works.
+const envArgs = (db) => (db.endsWith('-staging') ? ['--env', 'staging'] : []);
+
 /** Run one SQL statement against the database and return its rows. */
 function query(db, statement) {
   const out = execFileSync(
     process.execPath,
-    [WRANGLER, 'd1', 'execute', db, LOCAL ? '--local' : '--remote', '--json', '--command', statement],
+    [WRANGLER, 'd1', 'execute', db, ...envArgs(db), LOCAL ? '--local' : '--remote', '--json', '--command', statement],
     {
       cwd: WORKER_DIR,
       env: { ...process.env, CLOUDFLARE_ACCOUNT_ID: ACCOUNT_ID },

--- a/worker/src/d1.js
+++ b/worker/src/d1.js
@@ -1,0 +1,41 @@
+/**
+ * D1 read layer for the refresh path.
+ *
+ * Deliberately thin: the cron needs exactly two reads, and both are whole-table
+ * scans of small tables (296 rows and 1 row today). No pagination, because D1
+ * returns the full result set for a statement — but see the count guard below
+ * for why that is asserted rather than assumed.
+ */
+
+/**
+ * Every `locations` row. Status filtering happens in materializeFromD1 rather
+ * than here, so the materializer sees the same rows the admin dashboard will
+ * and there is one place that decides what "published" means.
+ *
+ * The count guard exists because a silently truncated result set is the failure
+ * that looks like success: 200 of 296 locations still renders as a working map,
+ * just a smaller one. Cheap to check, and it turns a silent data loss into a
+ * refresh failure that keeps last-known-good and alerts.
+ */
+export async function readLocationRows(env) {
+  const [rows, counted] = await Promise.all([
+    env.DB.prepare('SELECT * FROM locations').all(),
+    env.DB.prepare('SELECT COUNT(*) AS n FROM locations').first(),
+  ]);
+  const results = rows.results ?? [];
+  if (results.length !== counted.n) {
+    throw new Error(`D1 returned ${results.length} locations but COUNT(*) is ${counted.n}`);
+  }
+  if (results.length === 0) {
+    // An empty registry is never legitimate here. Throwing routes it into the
+    // last-known-good path instead of materializing an empty map.
+    throw new Error('D1 `locations` is empty -- refusing to materialize an empty dataset');
+  }
+  return results;
+}
+
+/** nexus_ids we have looked at and decided to keep off the map. */
+export async function readDismissedIds(env) {
+  const { results } = await env.DB.prepare('SELECT nexus_id FROM dismissed_candidates').all();
+  return new Set((results ?? []).map((r) => String(r.nexus_id)));
+}

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -15,6 +15,8 @@
 
 import { fetchTaggedModNodes, fetchModsByUidThumbs, fetchModArchiveNames } from './nexus.js';
 import { buildDataset } from './merge.js';
+import { materializeFromD1 } from './materialize.js';
+import { readLocationRows, readDismissedIds } from './d1.js';
 import { districtsPayload } from './districts.js';
 import { HEARTBEAT_MIN_INTERVAL_MS } from './config.js';
 import {
@@ -171,6 +173,64 @@ async function attachArchives(env, fetchImpl, full) {
 }
 
 /**
+ * Build the dataset from whichever source this environment is pointed at.
+ *
+ * `DATA_SOURCE=d1` reads the registry from D1; anything else (including unset)
+ * reads the compiled mods.json from the site origin. **Unset means mods.json on
+ * purpose** — a missing var must not silently switch production onto a new
+ * source, which is the same "absent config read as permissive" trap that
+ * attached every MCP connection to a scheduled agent.
+ *
+ * It is a var rather than a code branch so the Phase 2 cutover, and more
+ * importantly its rollback, is a config change on a known-good build instead of
+ * a revert-and-redeploy under pressure.
+ *
+ * Both paths take the same Nexus inputs and the same clock, and both return the
+ * same `{ full, meta }` shape, which is what lets parity-ab.mjs diff them
+ * head-to-head. tags/subdistricts still come from the site origin in both —
+ * they move to D1 at Phase 4.
+ */
+async function sourceAndBuild(env, fetchImpl, origin, nowMs) {
+  const [tagsDict, subdistricts] = await Promise.all([
+    fetchJson(fetchImpl, origin, '/data/tags.json'),
+    fetchJson(fetchImpl, origin, '/data/subdistricts.json'),
+  ]);
+  const districts = subdistricts.districts;
+  const nexusNodes = await fetchTaggedModNodes(fetchImpl);
+
+  if (env.DATA_SOURCE === 'd1') {
+    const [rows, dismissed] = await Promise.all([
+      readLocationRows(env),
+      readDismissedIds(env),
+    ]);
+    // Thumbnail backfill covers every published record with a numeric id, not
+    // just the "manual" ones: under D1 the auto-discovered records are rows too.
+    const numericIds = rows
+      .filter((r) => r.status === 'published')
+      .map((r) => String(r.nexus_id))
+      .filter((id) => /^\d+$/.test(id));
+    const manualThumbs = await fetchModsByUidThumbs(fetchImpl, numericIds);
+    const built = materializeFromD1({
+      rows, dismissed, tagsDict, nexusNodes, districts, manualThumbs, nowMs,
+    });
+    return { ...built, tagsDict, districts };
+  }
+
+  const [manualMods, excluded] = await Promise.all([
+    fetchJson(fetchImpl, origin, '/mods.json'),
+    fetchJson(fetchImpl, origin, '/data/excluded_mods.json').catch(() => ({})),
+  ]);
+  const manualNumericIds = manualMods
+    .map((m) => String(m.nexus_id))
+    .filter((id) => /^\d+$/.test(id));
+  const manualThumbs = await fetchModsByUidThumbs(fetchImpl, manualNumericIds);
+  const built = buildDataset({
+    manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs, nowMs,
+  });
+  return { ...built, tagsDict, districts };
+}
+
+/**
  * Run one refresh cycle.
  * @param {object} env  Worker env (DATASET KV binding, SITE_ORIGIN?, DISCORD_WEBHOOK_URL?)
  * @param {typeof fetch} fetchImpl  injectable
@@ -193,28 +253,13 @@ export async function runRefresh(env, fetchImpl = fetch) {
   const generatedAt = new Date().toISOString();
 
   try {
-    const [manualMods, tagsDict, excluded, subdistricts] = await Promise.all([
-      fetchJson(fetchImpl, origin, '/mods.json'),
-      fetchJson(fetchImpl, origin, '/data/tags.json'),
-      fetchJson(fetchImpl, origin, '/data/excluded_mods.json').catch(() => ({})),
-      fetchJson(fetchImpl, origin, '/data/subdistricts.json'),
-    ]);
-    const districts = subdistricts.districts;
-    const nexusNodes = await fetchTaggedModNodes(fetchImpl);
-
-    // Manual-mod thumbnails: the tagged query only backfills manual mods that
-    // are themselves NCZoning-tagged, so pull the rest via modsByUid. Cosmetic
-    // and non-throwing: a failure here just leaves some images null this
-    // cycle, it never marks the dataset stale.
-    const manualNumericIds = manualMods
-      .map((m) => String(m.nexus_id))
-      .filter((id) => /^\d+$/.test(id));
-    const manualThumbs = await fetchModsByUidThumbs(fetchImpl, manualNumericIds);
-
-    const { full, meta } = buildDataset({
-      manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs,
-      nowMs: Date.parse(generatedAt),
-    });
+    // Thumbnails are cosmetic and non-throwing inside this: a failure there
+    // leaves some images null for a cycle, it never marks the dataset stale.
+    // A D1 read failure, by contrast, throws and lands in the catch below --
+    // last-known-good, discovery_stale, alert. Never an empty map.
+    const { full, meta, tagsDict, districts } = await sourceAndBuild(
+      env, fetchImpl, origin, Date.parse(generatedAt),
+    );
     const districtsOut = districtsPayload(districts);
 
     // Enrich every record with its shipped .archive file names (installed-mod

--- a/worker/test/refresh-d1.test.js
+++ b/worker/test/refresh-d1.test.js
@@ -1,0 +1,228 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { runRefresh } from '../src/refresh.js';
+import { KEYS } from '../src/store.js';
+
+// Phase 2: the cron sourcing from D1 instead of mods.json. The load-bearing
+// test here is `both sources produce an identical dataset` -- the unit-scale
+// version of what parity-check.mjs does against production.
+
+function fakeKV(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    async get(key, type) {
+      const v = store.get(key);
+      if (v === undefined) return null;
+      return type === 'json' ? JSON.parse(v) : v;
+    },
+    async put(key, value) { store.set(key, value); },
+  };
+}
+
+const TAGS = { apartment: 'a place', corpo: 'suits' };
+const EXCLUDED = { 777: 'mistagged' };
+const SUBDISTRICTS = {
+  districts: [
+    {
+      id: 'testville', name: 'Testville',
+      polygon: [[0, 0], [1000, 0], [1000, 1000], [0, 1000]],
+      subdistricts: [
+        { id: 'little', name: 'Little Fixture', polygon: [[0, 0], [500, 0], [500, 500], [0, 500]] },
+      ],
+    },
+    { id: 'badlands', name: 'Badlands', subdistricts: [] },
+  ],
+};
+
+const MODS = [
+  {
+    id: 'm1', name: 'Manual Loft', authors: ['Spud'], coordinates: [250, 250, 10],
+    nexus_id: '12345', description: 'x', category: 'new-location', tags: ['apartment'],
+  },
+];
+
+// The D1 equivalent of MODS *plus* the auto entry the mods.json path derives
+// from Nexus node 888 -- because under D1 nothing auto-publishes and that
+// record is a row like any other.
+const ROWS = [
+  {
+    id: 'm1', name: 'Manual Loft', nexus_id: '12345', category: 'new-location',
+    x: 250, y: 250, z: 10, yaw: null, description: 'x', credits: null,
+    authors: '["Spud"]', tags: '["apartment"]', source: 'manual', status: 'published',
+    admin_notes: null, owner_id: null,
+    created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'nexus-888', name: 'Auto Bar', nexus_id: '888', category: 'other',
+    x: 600, y: 600, z: null, yaw: null, description: 'auto', credits: null,
+    authors: '["Up888"]', tags: '["nczoning"]', source: 'auto', status: 'published',
+    admin_notes: null, owner_id: null,
+    created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+const NEXUS_PAGE = {
+  data: {
+    mods: {
+      nodes: [
+        {
+          modId: 888, name: 'Auto Bar', summary: 'auto',
+          description: 'NCZoning:\ncoords=600,600\ncategory=other',
+          uploader: { name: 'Up888' },
+        },
+        {
+          modId: 777, name: 'Mistagged', summary: 'no',
+          description: 'NCZoning:\ncoords=1,1\ncategory=other',
+          uploader: { name: 'X' },
+        },
+      ],
+      totalCount: 2,
+    },
+  },
+};
+
+/**
+ * @param {object} opts
+ * @param {boolean} opts.banModsJson  throw if /mods.json is fetched -- proves
+ *   the D1 path does not quietly keep reading the file it replaced.
+ */
+function fakeFetch({ banModsJson = false } = {}) {
+  return async (url, init) => {
+    if (url.includes('/mods.json')) {
+      if (banModsJson) throw new Error('D1 mode must not fetch mods.json');
+      return { ok: true, json: async () => MODS };
+    }
+    if (url.includes('/tags.json')) return { ok: true, json: async () => TAGS };
+    if (url.includes('/excluded_mods.json')) return { ok: true, json: async () => EXCLUDED };
+    if (url.includes('/subdistricts.json')) return { ok: true, json: async () => SUBDISTRICTS };
+    if (url.includes('api-router.nexusmods.com')) return { ok: false, status: 503 };
+    if (url.includes('file-metadata.nexusmods.com')) return { ok: false, status: 503 };
+    if (url.includes('api.nexusmods.com')) {
+      if (JSON.parse(init.body).query.includes('modsByUid')) {
+        return { ok: true, json: async () => ({
+          data: { modsByUid: { nodes: [
+            { modId: 12345, pictureUrl: 'pm', thumbnailUrl: 'tm', updatedAt: '2026-07-08' },
+          ] } },
+        }) };
+      }
+      return { ok: true, json: async () => NEXUS_PAGE };
+    }
+    if (url.includes('discord')) return { ok: true };
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+}
+
+function fakeD1({ rows = ROWS, dismissed = [{ nexus_id: '777' }], count, fail = false } = {}) {
+  return {
+    prepare(sql) {
+      return {
+        async all() {
+          if (fail) throw new Error('D1 unavailable');
+          if (sql.includes('dismissed_candidates')) return { results: dismissed };
+          return { results: rows };
+        },
+        async first() {
+          if (fail) throw new Error('D1 unavailable');
+          return { n: count ?? rows.length };
+        },
+      };
+    },
+  };
+}
+
+test('DATA_SOURCE=d1 builds the dataset from D1, not mods.json', async () => {
+  const env = {
+    DATASET: fakeKV(), DB: fakeD1(), SITE_ORIGIN: 'https://x', DATA_SOURCE: 'd1',
+  };
+  const r = await runRefresh(env, fakeFetch({ banModsJson: true }));
+  assert.equal(r.changed, true);
+  const full = await env.DATASET.get(KEYS.full, 'json');
+  assert.deepEqual(Object.keys(full).sort(), ['m1', 'nexus-888']);
+});
+
+test('both sources produce an IDENTICAL dataset (the parity gate, in miniature)', async () => {
+  const fromMods = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const fromD1 = {
+    DATASET: fakeKV(), DB: fakeD1(), SITE_ORIGIN: 'https://x', DATA_SOURCE: 'd1',
+  };
+  await runRefresh(fromMods, fakeFetch());
+  await runRefresh(fromD1, fakeFetch());
+
+  const a = await fromMods.DATASET.get(KEYS.full, 'json');
+  const b = await fromD1.DATASET.get(KEYS.full, 'json');
+  // Byte comparison, exactly as the real gate does -- key order included.
+  assert.equal(JSON.stringify(b), JSON.stringify(a));
+  assert.ok(Object.keys(a).length > 0, 'two empty datasets would compare equal for free');
+
+  // Negative control: the comparison above is worth nothing unless it can go
+  // red. Same reasoning as parity-check.mjs, at unit scale.
+  const mutated = {
+    DATASET: fakeKV(),
+    DB: fakeD1({ rows: [{ ...ROWS[0], name: 'Manual Loft ' }, ROWS[1]] }),
+    SITE_ORIGIN: 'https://x',
+    DATA_SOURCE: 'd1',
+  };
+  await runRefresh(mutated, fakeFetch());
+  const c = await mutated.DATASET.get(KEYS.full, 'json');
+  assert.notEqual(JSON.stringify(c), JSON.stringify(a), 'a changed name must be detected');
+});
+
+test('an unset DATA_SOURCE stays on mods.json (absent config is never permissive)', async () => {
+  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  // No DB binding at all: if the default silently switched to D1 this throws.
+  const r = await runRefresh(env, fakeFetch());
+  assert.equal(r.changed, true);
+  assert.equal(r.stale, false);
+});
+
+test('a D1 failure keeps last-known-good and flags stale, never an empty map', async () => {
+  const env = {
+    DATASET: fakeKV(), DB: fakeD1(), SITE_ORIGIN: 'https://x', DATA_SOURCE: 'd1',
+  };
+  await runRefresh(env, fakeFetch());                 // seed a good dataset
+  const before = await env.DATASET.get(KEYS.full, 'json');
+
+  env.DB = fakeD1({ fail: true });
+  const r = await runRefresh(env, fakeFetch());
+  assert.equal(r.stale, true);
+
+  const after = await env.DATASET.get(KEYS.full, 'json');
+  assert.deepEqual(after, before, 'last-known-good must survive');
+  const meta = await env.DATASET.get(KEYS.meta, 'json');
+  assert.equal(meta.discovery_stale, true);
+});
+
+test('a truncated result set fails the refresh rather than shrinking the map', async () => {
+  const env = {
+    DATASET: fakeKV(),
+    DB: fakeD1({ rows: [ROWS[0]], count: 2 }), // returned 1, COUNT(*) says 2
+    SITE_ORIGIN: 'https://x',
+    DATA_SOURCE: 'd1',
+  };
+  const r = await runRefresh(env, fakeFetch());
+  assert.equal(r.stale, true);
+  assert.match(r.error, /COUNT\(\*\)/);
+});
+
+test('an empty locations table is refused, not materialized', async () => {
+  const env = {
+    DATASET: fakeKV(), DB: fakeD1({ rows: [] }), SITE_ORIGIN: 'https://x', DATA_SOURCE: 'd1',
+  };
+  const r = await runRefresh(env, fakeFetch());
+  assert.equal(r.stale, true);
+  assert.match(r.error, /empty/i);
+});
+
+test('dismissed candidates keep a mod off the map under D1', async () => {
+  const env = {
+    DATASET: fakeKV(),
+    DB: fakeD1({ dismissed: [] }), // 777 no longer dismissed
+    SITE_ORIGIN: 'https://x',
+    DATA_SOURCE: 'd1',
+  };
+  await runRefresh(env, fakeFetch());
+  const full = await env.DATASET.get(KEYS.full, 'json');
+  // Still must not appear: nothing auto-publishes any more, dismissal only
+  // controls whether it is reported as a candidate.
+  assert.equal('nexus-777' in full, false);
+});

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -135,11 +135,24 @@
 				// Pre-1.0 window — see the production block above.
 				"API_VERSION": "0.3.0",
 				"SITE_ORIGIN": "https://dev.nczoning.net",
-				// See the production block. Staging can be flipped to "d1"
-				// independently to exercise the D1 path without touching prod —
-				// but note staging has no cron, so trigger a cycle by hand
-				// (`wrangler dev --env staging --test-scheduled`).
-				"DATA_SOURCE": "mods"
+				// STAGING IS THE D1 CANARY: it runs the D1 path while production
+				// stays on mods.json, so the binding, the reads and the whole
+				// refresh cycle are exercised on a deployed Worker without the
+				// live map depending on any of it.
+				//
+				// This is the one thing unit tests and the local parity scripts
+				// cannot prove — that env.DB actually resolves at runtime in a
+				// deployed environment that inherits no bindings.
+				//
+				// Staging has no cron, so trigger a cycle by hand:
+				//   npx wrangler dev --env staging --remote --test-scheduled
+				//   curl "http://127.0.0.1:8787/__scheduled"
+				// Space repeat triggers ~60s apart: KV reads are eventually
+				// consistent, so back-to-back cycles re-read the pre-write
+				// archive cache and appear to stall.
+				// Seed its database first — an empty `locations` is refused, by
+				// design, rather than materialized as an empty map.
+				"DATA_SOURCE": "d1"
 			},
 			// dashboard title: nczoning-api-dataset-staging
 			"kv_namespaces": [

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -48,7 +48,21 @@
 		// check, so a decrease passes provided all four move together.
 		"API_VERSION": "0.3.0",
 		// Origin the cron pulls source files from (mods.json, tags, subdistricts).
-		"SITE_ORIGIN": "https://nczoning.net"
+		"SITE_ORIGIN": "https://nczoning.net",
+		// Where the LOCATION REGISTRY is read from: "mods" (the compiled
+		// mods.json on SITE_ORIGIN) or "d1" (the DB binding above).
+		//
+		// The Phase 2 cutover is this one word, and so is its rollback -- a
+		// config change on a build already known to work, rather than a revert
+		// and redeploy while production is wrong.
+		//
+		// Anything other than "d1" means mods.json, INCLUDING unset. Absent
+		// config must never read as "switch production to the new source".
+		//
+		// Do not flip until parity-ab.mjs and parity-check.mjs are both green
+		// (worker/README.md). Tags and subdistricts still come from SITE_ORIGIN
+		// either way; they move to D1 at Phase 4.
+		"DATA_SOURCE": "mods"
 	},
 	// Dataset store (dashboard title: nczoning-api-dataset). Recreate with:
 	//   npx wrangler kv namespace create nczoning-api-dataset
@@ -120,7 +134,12 @@
 			"vars": {
 				// Pre-1.0 window — see the production block above.
 				"API_VERSION": "0.3.0",
-				"SITE_ORIGIN": "https://dev.nczoning.net"
+				"SITE_ORIGIN": "https://dev.nczoning.net",
+				// See the production block. Staging can be flipped to "d1"
+				// independently to exercise the D1 path without touching prod —
+				// but note staging has no cron, so trigger a cycle by hand
+				// (`wrangler dev --env staging --test-scheduled`).
+				"DATA_SOURCE": "mods"
 			},
 			// dashboard title: nczoning-api-dataset-staging
 			"kv_namespaces": [


### PR DESCRIPTION
Adds the D1 read path to the refresh cron, plus the instrument that decides when
it is safe to switch. Closes the code half of #880.

**Production behaviour is unchanged by this PR.** `DATA_SOURCE` ships as `mods`;
the cutover is a separate one-word edit.

## The switch

`DATA_SOURCE` decides where the registry is read from — `mods` or `d1`.
**Anything other than `d1` means `mods`, including unset.** Absent config must
never read as "switch production onto the new source", which is the same trap
that attached every MCP connection to a scheduled agent by omission.

It is a var rather than a code branch so that the cutover *and its rollback* are
a config change on a build already known to work, instead of a revert-and-
redeploy while production is wrong.

## Why there is a second parity script

`parity-check.mjs` (Phase 1) compares D1 against the **live API**. The cron
writes KV only when the content hash changes, so on a quiet day `generated_at`
does not move for hours and re-running it compares the same bytes over and over.
Repeating it is not a soak — it is a check that cannot fail, run repeatedly.

`parity-ab.mjs` asks the question the gate actually cares about — *do the two
code paths agree?* — which needs no external change at all. It runs
`buildDataset` and `materializeFromD1` on identical Nexus input and an identical
clock, then **sweeps the clock ±365 days** across the `recently_updated`
boundary:

```
A: buildDataset  (287 manual mods + 9 tagged nodes)
B: materializeFromD1 (296 rows, 1 dismissed)  db=nczoning-data

  ✓ clock -90d   identical (296 records, 61 recently_updated)
  ✓ clock -30d   identical (296 records, 28 recently_updated)
  ✓ clock  -7d   identical (296 records, 10 recently_updated)
  ✓ clock  -1d   identical (296 records,  7 recently_updated)
  ✓ clock  +0d   identical (296 records,  6 recently_updated)
  ✓ clock  +1d   identical (296 records,  5 recently_updated)
  ✓ clock  +7d   identical (296 records,  0 recently_updated)
  ✓ clock +30d / +90d / +365d  identical (296 records, 0 recently_updated)

recently_updated across the sweep: 61 -> 28 -> 10 -> 7 -> 6 -> 5 -> 0 -> 0 -> 0 -> 0

✅ both paths agree at all 10 clocks, and the swept field did vary
```

That last line is a hard assertion, not decoration: **if the swept field never
varies the script exits non-zero**, because a sweep that changed nothing tested
nothing.

### It caught its own bug first

The first run reported all 10 clocks mismatching on `nexus-26011`. The cause was
in the harness, not in D1 — the reconstructed NCZoning block was dropping `yaw`
and the additional `authors`, so side A was being fed lossy input. Both are
emitted now. A sweep that had gone green immediately would have meant both sides
were being fed the same lossy input.

## Failure posture preserved

D1 reads are guarded so a bad read can never shrink the map:

- a result set that disagrees with `COUNT(*)` throws (silent truncation is the
  failure that looks like success — 200 of 296 locations still renders as a
  working map, just a smaller one)
- an empty `locations` table throws rather than materializing an empty dataset

Both land in the existing catch: last-known-good retained, `discovery_stale`
set, Discord alerted. Tested.

## Test plan

- `npm test` in `worker/` — **111 pass** (7 new).
- The load-bearing new test asserts **both sources produce a byte-identical
  dataset**, with its own negative control (a changed name must be detected) and
  a guard that two empty datasets cannot pass for free.
- Also covered: unset `DATA_SOURCE` stays on `mods.json`; D1 mode does not fetch
  `mods.json` at all; a D1 failure keeps last-known-good; truncated and empty
  result sets both fail the refresh.
- `parity-check.mjs` still green against production D1.

## Not in this PR

The cutover itself, and moving `thumbnail_url` / `picture_url` / `updated_at` /
`archives` into `nexus_cache`. Those four remain Nexus-owned and therefore still
outside the gate — see #880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
