### PR TITLE
feat(auth): Phase 3 — GitHub App sign-in and the collaborator gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 !/README.md
 !/CONTRIBUTING.md
 !/index.html
+!/admin/
 !/mods.schema.json
 !/public/
 !/assets/

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,9 @@ worker/.wrangler/
 
 # Generated D1 seed SQL: rebuild with `node worker/scripts/import-locations.mjs`
 worker/.import/
+
+# Private keys, anywhere. worker/ is whitelisted above, so a GitHub App .pem
+# dropped there would otherwise be committed. Belt and braces: keep the key
+# outside the repo entirely.
+*.pem
+*.key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A parity gate that rebuilds `/v1/locations` from D1 and diffs it byte-for-byte against the live API, with negative controls that prove the diff can fail.
 - The refresh cron can source the registry from D1 via `DATA_SOURCE=d1`. Production stays on `mods.json` until the cutover; unset never means D1.
 - A second harness that runs both source paths head-to-head across a swept clock, and fails if the swept field never varied.
+- GitHub sign-in for admins at `/admin/`, gated on repository collaborator status. Login only — there are no admin write routes yet.
 
 ## [1.7.2] - 2026-07-26
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>NC Zoning Board — Admin</title>
+<!--
+  Phase 3 stub. This exists so the collaborator gate can be tested by clicking
+  rather than by curl, and it is the shell the Phase 4 dashboard fills in.
+
+  Self-contained styling on purpose: pulling in theme.css/style.css would drag
+  the whole map layout in for one status line. It adopts the shared theme at
+  Phase 4, when there is actually a UI to theme.
+-->
+<style>
+  :root {
+    --navy: #0a192f;
+    --navy-light: #112240;
+    --cyan: #00f0ff;
+    --amber: #ffb300;
+    --text: #ccd6f6;
+    --muted: #8892b0;
+    --error: #ff5370;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    min-height: 100vh;
+    display: grid;
+    place-items: center;
+    background: var(--navy);
+    color: var(--text);
+    font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    padding: 1.5rem;
+  }
+  main {
+    width: 100%;
+    max-width: 26rem;
+    background: var(--navy-light);
+    border: 1px solid rgb(0 240 255 / 0.15);
+    border-radius: 6px;
+    padding: 2rem;
+  }
+  h1 {
+    margin: 0 0 1.5rem;
+    font-size: 1.1rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--cyan);
+  }
+  button {
+    font: inherit;
+    cursor: pointer;
+    padding: 0.6rem 1.2rem;
+    border-radius: 4px;
+    border: 1px solid var(--cyan);
+    background: transparent;
+    color: var(--cyan);
+  }
+  button:hover { background: rgb(0 240 255 / 0.1); }
+  button.secondary { border-color: var(--muted); color: var(--muted); }
+  .muted { color: var(--muted); font-size: 0.9rem; }
+  .who { color: var(--amber); font-weight: 600; }
+  .error {
+    border-left: 3px solid var(--error);
+    padding: 0.5rem 0.9rem;
+    margin-bottom: 1.25rem;
+    background: rgb(255 83 112 / 0.08);
+    font-size: 0.9rem;
+  }
+  .warn { border-left-color: var(--amber); background: rgb(255 179 0 / 0.08); }
+</style>
+</head>
+<body>
+<main>
+  <h1>NC Zoning Board — Admin</h1>
+  <div id="status" class="muted">Checking session…</div>
+</main>
+
+<script>
+// Mirrors the main site: production API from every origin, ?api=dev to opt into
+// staging when testing an API change.
+const API = new URLSearchParams(location.search).get('api') === 'dev'
+  ? 'https://api-dev.nczoning.net'
+  : 'https://api.nczoning.net';
+
+const el = document.getElementById('status');
+
+// Reasons the callback can bounce back with. `check_unavailable` is
+// deliberately worded as "cannot tell", not "denied" — GitHub being unreachable
+// is not a statement about who you are, and telling an admin they lack access
+// because of a transient blip is a lie the UI should not tell.
+const ERRORS = {
+  bad_state:         ['error', 'Login could not be verified. Start again from this page.'],
+  oauth_failed:      ['error', 'GitHub sign-in failed. Try again.'],
+  not_authorised:    ['error', 'That account is not a collaborator on the repository.'],
+  check_unavailable: ['warn',  'Could not reach GitHub to confirm access. This is not a refusal — try again shortly.'],
+};
+
+function render(html) { el.innerHTML = html; }
+
+function signInButton(label = 'Sign in with GitHub') {
+  return `<button id="signin">${label}</button>`;
+}
+
+function wire() {
+  const signin = document.getElementById('signin');
+  if (signin) {
+    signin.onclick = () => {
+      location.href = `${API}/auth/login?return_to=${encodeURIComponent(location.pathname)}`;
+    };
+  }
+  const out = document.getElementById('signout');
+  if (out) {
+    out.onclick = async () => {
+      await fetch(`${API}/auth/logout`, { method: 'POST', credentials: 'include' });
+      location.replace(location.pathname);
+    };
+  }
+}
+
+async function main() {
+  // Surface a callback error, then strip it so a refresh does not re-show it.
+  const params = new URLSearchParams(location.search);
+  const err = params.get('error');
+  let banner = '';
+  if (err) {
+    const [kind, message] = ERRORS[err] || ['error', `Sign-in failed (${err}).`];
+    banner = `<div class="error ${kind === 'warn' ? 'warn' : ''}">${message}</div>`;
+    params.delete('error');
+    history.replaceState({}, '', location.pathname + (params.toString() ? `?${params}` : ''));
+  }
+
+  let res;
+  try {
+    res = await fetch(`${API}/auth/me`, { credentials: 'include' });
+  } catch {
+    render(`${banner}<div class="error">Could not reach the API.</div>${signInButton('Retry')}`);
+    return wire();
+  }
+
+  const body = await res.json().catch(() => ({}));
+
+  if (res.status === 401) {
+    render(`${banner}<p class="muted">Sign in with a GitHub account that is a collaborator on the repository.</p>${signInButton()}`);
+  } else if (res.status === 503) {
+    // Distinct from 403 on purpose — see ERRORS above.
+    render(`${banner}<div class="error warn">Signed in as <span class="who">${body.login}</span>, but GitHub could not be reached to confirm access. Not a refusal.</div>${signInButton('Retry')}`);
+  } else if (res.status === 403) {
+    render(`${banner}<div class="error">Signed in as <span class="who">${body.login}</span>, which is not a collaborator on the repository.</div><button id="signout" class="secondary">Sign out</button>`);
+  } else {
+    render(`${banner}<p>Signed in as <span class="who">${body.login}</span> — collaborator access confirmed.</p><p class="muted">The dashboard itself arrives at Phase 4.</p><button id="signout" class="secondary">Sign out</button>`);
+  }
+  wire();
+}
+
+main();
+</script>
+</body>
+</html>

--- a/worker/README.md
+++ b/worker/README.md
@@ -204,6 +204,85 @@ varied** — a sweep that changed nothing tested nothing.
 Waiting is not a test. Do not gate the cutover on elapsed time; gate it on both
 scripts green.
 
+## Admin auth (Phase 3)
+
+Login only — there are no write routes yet. `/admin/` in the site repo is a stub
+that shows who you are signed in as.
+
+| Route | Method | Does |
+| --- | --- | --- |
+| `/auth/login` | GET | 302 to GitHub, sets a one-shot signed `state` cookie |
+| `/auth/callback` | GET | Verifies state, exchanges the code, checks collaborator status, sets the session |
+| `/auth/me` | GET | `{authenticated, login, collaborator}` |
+| `/auth/logout` | POST | Clears the session (POST so a stray link cannot sign you out) |
+
+**The repo's collaborator list is the admin list.** Adding an admin is a
+repo-collaborator change; there is no separate allowlist to drift out of step.
+
+The user's OAuth token is used for exactly one thing — reading their login — and
+is never stored. Collaborator status is checked with the **App's** installation
+token, so an admin never has to grant `repo` scope just to find out they are an
+admin.
+
+### 🔴 The collaborator check has three outcomes, not two
+
+`GET /repos/{owner}/{repo}/collaborators/{login}` answers **204 = yes**,
+**404 = no**, and a broken or under-permissioned credential answers **401/403**.
+Collapsing that third case is a security bug in *both* directions:
+
+- `not 404 → allow` — a dead credential grants everyone admin
+- `not 204 → deny` — a dead credential locks everyone out, silently
+
+So `checkCollaborator()` returns `'yes' | 'no' | 'error'`, and `'error'`:
+
+- **fails closed** for the request,
+- is **never written to the `users` cache** (caching "no" from a transient blip
+  would lock a real admin out for the full 10-minute TTL),
+- surfaces as **503 `check_unavailable`**, not 403 — "we cannot tell" is not
+  "you are not allowed", and the stub page words it that way deliberately.
+
+A consequence worth knowing: **if the App's permissions are wrong, you get
+`check_unavailable`, not a lockout that looks like a refusal.** That is the
+intended diagnosis path.
+
+### One-time setup
+
+Create a **GitHub App** in the `nczoning` org (Settings → Developer settings →
+GitHub Apps):
+
+- **Callback URLs** (add both, one App serves both environments):
+  `https://api.nczoning.net/auth/callback` and
+  `https://api-dev.nczoning.net/auth/callback`
+- **Webhook:** disable (nothing consumes one)
+- **Repository permissions:** `Administration: Read-only` — this is what the
+  collaborator endpoint requires. If it is wrong the check returns 403, which
+  surfaces as `check_unavailable`; it does not silently deny.
+- **Install it on `nczoning/nc-zoning-board`.**
+
+Then fill `GITHUB_APP_ID` and `GITHUB_OAUTH_CLIENT_ID` in `wrangler.jsonc` (both
+public, both environments) and set three secrets **per environment**:
+
+```bash
+# GitHub hands out a PKCS#1 key; WebCrypto only imports PKCS#8. Convert once:
+openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt \
+  -in downloaded-private-key.pem -out app-key-pkcs8.pem
+
+npx wrangler secret put GITHUB_APP_PRIVATE_KEY      # paste the PKCS#8 PEM
+npx wrangler secret put GITHUB_OAUTH_CLIENT_SECRET
+npx wrangler secret put SESSION_SECRET              # e.g. openssl rand -base64 48
+
+npx wrangler secret put GITHUB_APP_PRIVATE_KEY      --env staging
+npx wrangler secret put GITHUB_OAUTH_CLIENT_SECRET  --env staging
+npx wrangler secret put SESSION_SECRET              --env staging
+```
+
+**`SESSION_SECRET` must differ between production and staging.** It is the
+session signing key: share it and a staging session token is accepted as valid
+by production.
+
+Skipping the PKCS#8 conversion fails with an opaque WebCrypto `DataError`, so
+`github-app.js` detects a PKCS#1 key and says exactly this instead.
+
 ### Test the cron locally
 
 ```bash

--- a/worker/src/auth.js
+++ b/worker/src/auth.js
@@ -1,0 +1,225 @@
+/**
+ * GitHub OAuth + the collaborator gate. Phase 3: login only, no writes to
+ * anything but the `users` verdict cache.
+ *
+ * Flow:
+ *   GET /auth/login     -> 302 to GitHub, one-shot signed `state` cookie set
+ *   GET /auth/callback  -> verify state, exchange code, identify the user,
+ *                          check collaborator status server-side, set session
+ *   GET /auth/me        -> who am I, and am I allowed
+ *   POST /auth/logout   -> clear the session
+ *
+ * The user's own OAuth token is used for exactly one thing — reading their
+ * login — and is never stored. Collaborator status is checked with the App's
+ * installation token, so admins never grant `repo` scope to see whether they
+ * are admins.
+ */
+
+import {
+  SESSION_COOKIE, SESSION_TTL_S, signSession, verifySession,
+  readCookie, cookieHeader, clearCookie,
+} from './session.js';
+import { exchangeOAuthCode, fetchViewer, checkCollaborator } from './github-app.js';
+import { readCachedVerdict, recordUser } from './d1.js';
+
+const STATE_COOKIE = 'ncz_oauth_state';
+const STATE_TTL_S = 10 * 60;
+
+/**
+ * Origins allowed to call the auth/admin routes with credentials.
+ *
+ * `Access-Control-Allow-Origin: *` is illegal alongside
+ * `Allow-Credentials: true`, so these routes cannot reuse the public wildcard
+ * CORS that /v1/* serves. The origin must be echoed back exactly, and only for
+ * origins on this list.
+ */
+export const ADMIN_ORIGINS = [
+  'https://nczoning.net',
+  'https://www.nczoning.net',
+  'https://dev.nczoning.net',
+  'http://127.0.0.1:3000',
+  'http://localhost:3000',
+];
+
+export function adminCors(request) {
+  const origin = request.headers.get('Origin');
+  if (!origin || !ADMIN_ORIGINS.includes(origin)) return {};
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Credentials': 'true',
+    // Echoing the origin means caches must key on it, or one visitor's
+    // permitted origin is served to another's.
+    Vary: 'Origin',
+  };
+}
+
+const jsonResponse = (request, body, { status = 200, headers = {} } = {}) => new Response(
+  JSON.stringify(body),
+  {
+    status,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+      ...adminCors(request),
+      ...headers,
+    },
+  },
+);
+
+/**
+ * Where to send the browser after a successful login. Only paths on an allowed
+ * origin are honoured — an attacker-supplied absolute URL here would turn the
+ * login endpoint into an open redirect that launders GitHub's credibility.
+ */
+function safeReturnTo(raw) {
+  if (!raw) return '/admin/';
+  if (!raw.startsWith('/') || raw.startsWith('//')) return '/admin/';
+  return raw;
+}
+
+function siteOrigin(env) {
+  return env.ADMIN_ORIGIN || 'https://nczoning.net';
+}
+
+/** GET /auth/login */
+export async function login(request, env) {
+  const url = new URL(request.url);
+  const returnTo = safeReturnTo(url.searchParams.get('return_to'));
+
+  // CSRF: a random nonce, signed into a short-lived cookie and echoed through
+  // GitHub as `state`. The callback accepts only a state matching the cookie,
+  // so a forged callback with an attacker's code cannot log a victim in.
+  const nonce = crypto.randomUUID();
+  const stateToken = await signSession(env.SESSION_SECRET, { nonce, returnTo }, STATE_TTL_S);
+
+  const authorize = new URL('https://github.com/login/oauth/authorize');
+  authorize.searchParams.set('client_id', env.GITHUB_OAUTH_CLIENT_ID);
+  authorize.searchParams.set('redirect_uri', `${new URL(request.url).origin}/auth/callback`);
+  authorize.searchParams.set('state', nonce);
+
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: authorize.toString(),
+      'Set-Cookie': cookieHeader(STATE_COOKIE, stateToken, { maxAge: STATE_TTL_S, path: '/auth' }),
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+/** Bounce back to the dashboard with a machine-readable reason. */
+function failRedirect(env, reason) {
+  const to = new URL('/admin/', siteOrigin(env));
+  to.searchParams.set('error', reason);
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: to.toString(),
+      'Set-Cookie': clearCookie(STATE_COOKIE, '/auth'),
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+/** GET /auth/callback */
+export async function callback(request, env) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+
+  const stateToken = readCookie(request, STATE_COOKIE);
+  const stateClaims = stateToken ? await verifySession(env.SESSION_SECRET, stateToken) : null;
+  if (!code || !state || !stateClaims || stateClaims.nonce !== state) {
+    return failRedirect(env, 'bad_state');
+  }
+
+  let viewer;
+  try {
+    const userToken = await exchangeOAuthCode(env, code);
+    viewer = await fetchViewer(userToken);
+    // The user token is intentionally not stored, and goes out of scope here.
+  } catch (err) {
+    console.error('oauth callback:', String(err).slice(0, 200));
+    return failRedirect(env, 'oauth_failed');
+  }
+
+  const verdict = await checkCollaborator(env, viewer.login);
+
+  // 🔴 Indeterminate is not "no". Fail closed, but do NOT cache it and do not
+  // tell the user they lack access — a transient GitHub blip would otherwise
+  // lock a real admin out for the whole cache TTL.
+  if (verdict === 'error') return failRedirect(env, 'check_unavailable');
+
+  const isCollaborator = verdict === 'yes';
+  await recordUser(env, { id: viewer.id, login: viewer.login, isCollaborator });
+
+  if (!isCollaborator) return failRedirect(env, 'not_authorised');
+
+  const session = await signSession(env.SESSION_SECRET, {
+    sub: viewer.id, login: viewer.login, collaborator: true,
+  });
+
+  const to = new URL(safeReturnTo(stateClaims.returnTo), siteOrigin(env));
+  const headers = new Headers({ Location: to.toString(), 'Cache-Control': 'no-store' });
+  headers.append('Set-Cookie', cookieHeader(SESSION_COOKIE, session));
+  headers.append('Set-Cookie', clearCookie(STATE_COOKIE, '/auth'));
+  return new Response(null, { status: 302, headers });
+}
+
+/**
+ * Resolve the caller's session, re-checking collaborator status when the
+ * cached verdict has aged out. Returns null when unauthenticated.
+ *
+ * This is the function every future /admin/* route gates on, which is why it
+ * re-checks rather than trusting the session cookie's own `collaborator: true`:
+ * the cookie lives 8 hours, and removing someone from the repo has to take
+ * effect sooner than that.
+ */
+export async function resolveSession(request, env) {
+  const token = readCookie(request, SESSION_COOKIE);
+  if (!token) return null;
+  const claims = await verifySession(env.SESSION_SECRET, token);
+  if (!claims) return null;
+
+  const cached = await readCachedVerdict(env, claims.sub);
+  if (cached) return { ...claims, collaborator: cached.isCollaborator };
+
+  const verdict = await checkCollaborator(env, claims.login);
+  if (verdict === 'error') {
+    // Cannot answer. Fail closed for this request without recording anything.
+    return { ...claims, collaborator: false, indeterminate: true };
+  }
+  const isCollaborator = verdict === 'yes';
+  await recordUser(env, { id: claims.sub, login: claims.login, isCollaborator });
+  return { ...claims, collaborator: isCollaborator };
+}
+
+/** GET /auth/me */
+export async function me(request, env) {
+  const session = await resolveSession(request, env);
+  if (!session) {
+    return jsonResponse(request, { authenticated: false }, { status: 401 });
+  }
+  if (session.indeterminate) {
+    // 503, not 403: the answer is unknown, not negative. A dashboard that
+    // rendered "you are not authorised" here would be lying.
+    return jsonResponse(request, {
+      authenticated: true,
+      login: session.login,
+      collaborator: false,
+      error: 'check_unavailable',
+    }, { status: 503 });
+  }
+  return jsonResponse(request, {
+    authenticated: true,
+    login: session.login,
+    collaborator: session.collaborator,
+  }, { status: session.collaborator ? 200 : 403 });
+}
+
+/** POST /auth/logout */
+export function logout(request) {
+  return jsonResponse(request, { authenticated: false }, {
+    headers: { 'Set-Cookie': clearCookie(SESSION_COOKIE) },
+  });
+}

--- a/worker/src/d1.js
+++ b/worker/src/d1.js
@@ -39,3 +39,42 @@ export async function readDismissedIds(env) {
   const { results } = await env.DB.prepare('SELECT nexus_id FROM dismissed_candidates').all();
   return new Set((results ?? []).map((r) => String(r.nexus_id)));
 }
+
+/** How long a collaborator verdict is trusted before it is re-checked. */
+export const COLLABORATOR_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * A cached collaborator verdict, or null if absent or stale.
+ *
+ * Returns null rather than a stale verdict so the caller re-checks: an admin
+ * who was removed from the repo should lose access within the TTL, and a
+ * "prefer the cached answer" fallback would quietly extend it forever.
+ */
+export async function readCachedVerdict(env, userId, nowMs = Date.now()) {
+  const row = await env.DB.prepare(
+    'SELECT id, login, is_collaborator, checked_at FROM users WHERE id = ?',
+  ).bind(userId).first();
+  if (!row) return null;
+  const checkedMs = Date.parse(row.checked_at);
+  if (!Number.isFinite(checkedMs) || nowMs - checkedMs > COLLABORATOR_TTL_MS) return null;
+  return { login: row.login, isCollaborator: row.is_collaborator === 1 };
+}
+
+/**
+ * Record a verdict, preserving first_seen_at across re-checks.
+ *
+ * Only ever called with a real yes/no. An indeterminate check ('error' from
+ * checkCollaborator) must NOT reach here — caching "no" because GitHub was
+ * unreachable would lock an admin out for the full TTL over a transient blip.
+ */
+export async function recordUser(env, { id, login, isCollaborator }, nowMs = Date.now()) {
+  const now = new Date(nowMs).toISOString();
+  await env.DB.prepare(`
+    INSERT INTO users (id, login, is_collaborator, checked_at, first_seen_at)
+    VALUES (?, ?, ?, ?, ?)
+    ON CONFLICT(id) DO UPDATE SET
+      login = excluded.login,
+      is_collaborator = excluded.is_collaborator,
+      checked_at = excluded.checked_at
+  `).bind(id, login, isCollaborator ? 1 : 0, now, now).run();
+}

--- a/worker/src/github-app.js
+++ b/worker/src/github-app.js
@@ -1,0 +1,185 @@
+/**
+ * GitHub App credentials: mint an app JWT, exchange it for an installation
+ * token, and answer "is this login a collaborator on the repo?".
+ *
+ * A GitHub App rather than a PAT because a fine-grained PAT expires within a
+ * year and is tied to one person's account — so admin access would break on a
+ * date nobody remembers, in a way that looks like "everyone is suddenly not a
+ * collaborator". The installation token expires hourly and is renewed here, so
+ * there is no calendar landmine.
+ */
+
+const GITHUB_API = 'https://api.github.com';
+const UA = 'nczoning-api';
+
+// Installation token cache. Workers reuses an isolate across requests, so this
+// usually avoids the two-call handshake; a cold isolate just pays it again.
+// Correctness never depends on the cache surviving.
+let tokenCache = { token: null, expiresAtMs: 0, installationId: null };
+
+/** Reset the module-level cache. Tests only. */
+export function _resetTokenCache() {
+  tokenCache = { token: null, expiresAtMs: 0, installationId: null };
+}
+
+const enc = new TextEncoder();
+const b64url = (bytes) => btoa(String.fromCharCode(...new Uint8Array(bytes)))
+  .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+/**
+ * Import a PEM private key for RS256.
+ *
+ * GitHub hands out **PKCS#1** keys ("BEGIN RSA PRIVATE KEY"). WebCrypto only
+ * imports **PKCS#8** ("BEGIN PRIVATE KEY"), so the key must be converted once
+ * at setup:
+ *
+ *   openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt \
+ *     -in downloaded.pem -out pkcs8.pem
+ *
+ * Detected explicitly, because the raw DER-parse failure is an opaque
+ * "DataError" that gives no hint what is wrong.
+ */
+async function importPrivateKey(pem) {
+  if (!pem || typeof pem !== 'string') throw new Error('GITHUB_APP_PRIVATE_KEY is not set');
+  if (pem.includes('BEGIN RSA PRIVATE KEY')) {
+    throw new Error(
+      'GITHUB_APP_PRIVATE_KEY is PKCS#1; WebCrypto needs PKCS#8. Convert it with: '
+      + 'openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in downloaded.pem -out pkcs8.pem',
+    );
+  }
+  const body = pem.replace(/-----(BEGIN|END) PRIVATE KEY-----/g, '').replace(/\s+/g, '');
+  const der = Uint8Array.from(atob(body), (c) => c.charCodeAt(0));
+  return crypto.subtle.importKey(
+    'pkcs8', der, { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' }, false, ['sign'],
+  );
+}
+
+/**
+ * App JWT, used only to obtain an installation token. GitHub rejects an `exp`
+ * more than 10 minutes out and is strict about clock skew, hence the backdated
+ * `iat`.
+ */
+async function appJwt(env, nowMs = Date.now()) {
+  const now = Math.floor(nowMs / 1000);
+  const header = b64url(enc.encode(JSON.stringify({ alg: 'RS256', typ: 'JWT' })));
+  const claims = b64url(enc.encode(JSON.stringify({
+    iat: now - 60,        // tolerate GitHub's clock running behind ours
+    exp: now + 9 * 60,    // under GitHub's 10-minute ceiling
+    iss: env.GITHUB_APP_ID,
+  })));
+  const input = `${header}.${claims}`;
+  const key = await importPrivateKey(env.GITHUB_APP_PRIVATE_KEY);
+  const sig = await crypto.subtle.sign('RSASSA-PKCS1-v1_5', key, enc.encode(input));
+  return `${input}.${b64url(sig)}`;
+}
+
+const ghHeaders = (auth) => ({
+  Authorization: `Bearer ${auth}`,
+  Accept: 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+  'User-Agent': UA,
+});
+
+/**
+ * The App's installation id on the repo, discovered rather than configured —
+ * one less secret to set, and one less thing to be quietly wrong after a
+ * reinstall.
+ */
+async function installationId(env, fetchImpl, jwt) {
+  if (tokenCache.installationId) return tokenCache.installationId;
+  const res = await fetchImpl(`${GITHUB_API}/repos/${env.GITHUB_REPO}/installation`, {
+    headers: ghHeaders(jwt),
+  });
+  if (!res.ok) {
+    throw new Error(`installation lookup failed: HTTP ${res.status} (is the App installed on ${env.GITHUB_REPO}?)`);
+  }
+  const body = await res.json();
+  tokenCache.installationId = body.id;
+  return body.id;
+}
+
+/** A valid installation token, from cache when possible. */
+export async function getInstallationToken(env, fetchImpl = fetch, nowMs = Date.now()) {
+  // 60s of headroom so a token cannot expire mid-flight.
+  if (tokenCache.token && tokenCache.expiresAtMs - 60_000 > nowMs) return tokenCache.token;
+
+  const jwt = await appJwt(env, nowMs);
+  const id = await installationId(env, fetchImpl, jwt);
+  const res = await fetchImpl(`${GITHUB_API}/app/installations/${id}/access_tokens`, {
+    method: 'POST',
+    headers: ghHeaders(jwt),
+  });
+  if (!res.ok) throw new Error(`installation token failed: HTTP ${res.status}`);
+  const body = await res.json();
+  tokenCache.token = body.token;
+  tokenCache.expiresAtMs = Date.parse(body.expires_at);
+  return body.token;
+}
+
+/**
+ * Is `login` a collaborator on the repo?
+ *
+ * 🔴 THREE OUTCOMES, NOT TWO. The endpoint answers 204 for yes and 404 for no,
+ * and a broken or unauthorised credential answers 401/403. Folding that third
+ * case into either of the first two is a security bug in both directions:
+ *
+ *   "not 404 -> allow"  => a dead credential grants everyone admin
+ *   "not 204 -> deny"   => a dead credential locks everyone out, silently
+ *
+ * So it is returned as its own value. Callers must fail closed AND surface it —
+ * never treat 'error' as a normal no.
+ *
+ * @returns {Promise<'yes'|'no'|'error'>}
+ */
+export async function checkCollaborator(env, login, fetchImpl = fetch) {
+  let token;
+  try {
+    token = await getInstallationToken(env, fetchImpl);
+  } catch (err) {
+    console.error('collaborator check: cannot obtain installation token:', String(err).slice(0, 200));
+    return 'error';
+  }
+
+  const res = await fetchImpl(
+    `${GITHUB_API}/repos/${env.GITHUB_REPO}/collaborators/${encodeURIComponent(login)}`,
+    { headers: ghHeaders(token) },
+  );
+
+  if (res.status === 204) return 'yes';
+  if (res.status === 404) return 'no';
+
+  // 401/403/5xx: the question was not answered. Say so.
+  console.error(`collaborator check for ${login}: unexpected HTTP ${res.status}`);
+  // A 401 means the cached token is bad; drop it so the next attempt re-mints.
+  if (res.status === 401) _resetTokenCache();
+  return 'error';
+}
+
+/** Exchange an OAuth code for a user access token. */
+export async function exchangeOAuthCode(env, code, fetchImpl = fetch) {
+  const res = await fetchImpl('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'User-Agent': UA },
+    body: JSON.stringify({
+      client_id: env.GITHUB_OAUTH_CLIENT_ID,
+      client_secret: env.GITHUB_OAUTH_CLIENT_SECRET,
+      code,
+    }),
+  });
+  if (!res.ok) throw new Error(`oauth exchange failed: HTTP ${res.status}`);
+  const body = await res.json();
+  // GitHub returns 200 with an `error` field on a bad/expired code.
+  if (body.error || !body.access_token) {
+    throw new Error(`oauth exchange rejected: ${body.error || 'no access_token'}`);
+  }
+  return body.access_token;
+}
+
+/** The authenticated user's identity, from their own token. */
+export async function fetchViewer(userToken, fetchImpl = fetch) {
+  const res = await fetchImpl(`${GITHUB_API}/user`, { headers: ghHeaders(userToken) });
+  if (!res.ok) throw new Error(`viewer lookup failed: HTTP ${res.status}`);
+  const body = await res.json();
+  if (!body.login || !body.id) throw new Error('viewer lookup returned no login/id');
+  return { login: body.login, id: body.id };
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -18,6 +18,7 @@ import { runRefresh } from './refresh.js';
 import { KEYS } from './store.js';
 import { docsPage, spec } from './docs.js';
 import { RECENTLY_UPDATED_DAYS } from './config.js';
+import { login, callback, me, logout, adminCors } from './auth.js';
 
 const SCHEMA_VERSION = 1;
 
@@ -172,10 +173,34 @@ export default {
 
   async fetch(request, env) {
     const url = new URL(request.url);
+    const isAuth = url.pathname.startsWith('/auth/');
 
     if (request.method === 'OPTIONS') {
-      return new Response(null, { status: 204, headers: CORS_HEADERS });
+      // Auth routes are credentialed, so they need the caller's exact origin
+      // echoed back; the wildcard CORS used by /v1/* is illegal with
+      // Allow-Credentials and would fail the preflight.
+      return new Response(null, {
+        status: 204,
+        headers: isAuth
+          ? {
+            ...adminCors(request),
+            'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type',
+          }
+          : CORS_HEADERS,
+      });
     }
+
+    // Auth routes, before the read-only method gate below: logout is a POST
+    // deliberately, so a stray <img> or link cannot sign someone out.
+    if (isAuth) {
+      if (request.method === 'GET' && url.pathname === '/auth/login') return login(request, env);
+      if (request.method === 'GET' && url.pathname === '/auth/callback') return callback(request, env);
+      if (request.method === 'GET' && url.pathname === '/auth/me') return me(request, env);
+      if (request.method === 'POST' && url.pathname === '/auth/logout') return logout(request, env);
+      return json(envelope({ error: 'not_found' }, null), { status: 404 });
+    }
+
     if (request.method !== 'GET' && request.method !== 'HEAD') {
       return json(envelope({ error: 'method_not_allowed' }, null), { status: 405 });
     }

--- a/worker/src/session.js
+++ b/worker/src/session.js
@@ -1,0 +1,108 @@
+/**
+ * Signed session tokens (HS256 JWT) and the cookie they ride in.
+ *
+ * Deliberately not a JWT library: this issues and verifies its OWN tokens with
+ * one algorithm and one key, so the whole "alg" negotiation surface that makes
+ * JWT libraries dangerous simply does not exist here. `alg` is checked against
+ * the literal "HS256" and anything else is rejected before a signature is even
+ * computed — `alg: "none"` is not a code path.
+ *
+ * The cookie is host-only (no Domain attribute) so it is scoped to
+ * api.nczoning.net alone. SameSite=Lax is correct even though the dashboard is
+ * served from nczoning.net: SameSite is judged on the registrable domain, and
+ * nczoning.net and api.nczoning.net are the same *site* despite being different
+ * *origins*. The cross-origin part is handled by CORS, not by the cookie.
+ */
+
+export const SESSION_COOKIE = 'ncz_session';
+export const SESSION_TTL_S = 8 * 60 * 60; // 8h: a working session, not a trust anchor
+
+const enc = new TextEncoder();
+
+const b64urlEncode = (bytes) => btoa(String.fromCharCode(...new Uint8Array(bytes)))
+  .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+const b64urlDecode = (str) => {
+  const padded = str.replace(/-/g, '+').replace(/_/g, '/')
+    + '='.repeat((4 - (str.length % 4)) % 4);
+  return Uint8Array.from(atob(padded), (c) => c.charCodeAt(0));
+};
+
+async function hmacKey(secret) {
+  return crypto.subtle.importKey(
+    'raw', enc.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify'],
+  );
+}
+
+/**
+ * Mint a token. `payload` is merged with iat/exp; callers must not set those.
+ * @param {string} secret
+ * @param {object} payload
+ * @param {number} [ttlSeconds]
+ * @param {number} [nowMs] injectable clock, so tests can assert expiry
+ */
+export async function signSession(secret, payload, ttlSeconds = SESSION_TTL_S, nowMs = Date.now()) {
+  const iat = Math.floor(nowMs / 1000);
+  const body = { ...payload, iat, exp: iat + ttlSeconds };
+  const head = b64urlEncode(enc.encode(JSON.stringify({ alg: 'HS256', typ: 'JWT' })));
+  const claims = b64urlEncode(enc.encode(JSON.stringify(body)));
+  const signingInput = `${head}.${claims}`;
+  const sig = await crypto.subtle.sign('HMAC', await hmacKey(secret), enc.encode(signingInput));
+  return `${signingInput}.${b64urlEncode(sig)}`;
+}
+
+/**
+ * Verify and decode. Returns the payload, or null for ANY failure — bad shape,
+ * wrong algorithm, bad signature, expired. Callers get one answer to one
+ * question, so there is no way to accidentally treat "malformed" as "valid".
+ *
+ * crypto.subtle.verify is constant-time, which is why the comparison is done
+ * there rather than by re-signing and string-comparing.
+ */
+export async function verifySession(secret, token, nowMs = Date.now()) {
+  if (typeof token !== 'string') return null;
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const [head, claims, sig] = parts;
+
+  try {
+    const header = JSON.parse(new TextDecoder().decode(b64urlDecode(head)));
+    // Pin the algorithm. "none" and any asymmetric confusion die here.
+    if (header.alg !== 'HS256' || header.typ !== 'JWT') return null;
+
+    const ok = await crypto.subtle.verify(
+      'HMAC', await hmacKey(secret), b64urlDecode(sig), enc.encode(`${head}.${claims}`),
+    );
+    if (!ok) return null;
+
+    const payload = JSON.parse(new TextDecoder().decode(b64urlDecode(claims)));
+    if (typeof payload.exp !== 'number' || payload.exp * 1000 <= nowMs) return null;
+    return payload;
+  } catch {
+    return null; // malformed base64/JSON is just an invalid token
+  }
+}
+
+/** Read one cookie from a request. */
+export function readCookie(request, name) {
+  const header = request.headers.get('Cookie');
+  if (!header) return null;
+  for (const part of header.split(';')) {
+    const [k, ...v] = part.trim().split('=');
+    if (k === name) return v.join('=');
+  }
+  return null;
+}
+
+/**
+ * Build a Set-Cookie value. `Secure` is unconditional: these cookies only ever
+ * travel over the custom domains, which are HTTPS-only.
+ */
+export function cookieHeader(name, value, { maxAge = SESSION_TTL_S, path = '/' } = {}) {
+  return `${name}=${value}; HttpOnly; Secure; SameSite=Lax; Path=${path}; Max-Age=${maxAge}`;
+}
+
+/** Expire a cookie immediately (logout, or clearing the one-shot state cookie). */
+export function clearCookie(name, path = '/') {
+  return `${name}=; HttpOnly; Secure; SameSite=Lax; Path=${path}; Max-Age=0`;
+}

--- a/worker/test/auth.test.js
+++ b/worker/test/auth.test.js
@@ -1,0 +1,372 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  signSession, verifySession, readCookie, cookieHeader, clearCookie, SESSION_COOKIE,
+} from '../src/session.js';
+import { checkCollaborator, _resetTokenCache } from '../src/github-app.js';
+import { callback, me, resolveSession, ADMIN_ORIGINS, adminCors } from '../src/auth.js';
+import worker from '../src/index.js';
+
+const SECRET = 'test-secret-not-a-real-one';
+
+// A real PKCS#8 key, generated per run, so the RS256 signing path is actually
+// exercised rather than stubbed.
+async function pkcs8Pem() {
+  const { privateKey } = await crypto.subtle.generateKey(
+    { name: 'RSASSA-PKCS1-v1_5', modulusLength: 2048, publicExponent: new Uint8Array([1, 0, 1]), hash: 'SHA-256' },
+    true, ['sign', 'verify'],
+  );
+  const der = await crypto.subtle.exportKey('pkcs8', privateKey);
+  const b64 = Buffer.from(der).toString('base64').match(/.{1,64}/g).join('\n');
+  return `-----BEGIN PRIVATE KEY-----\n${b64}\n-----END PRIVATE KEY-----\n`;
+}
+
+function fakeUsersDb(initial = []) {
+  const rows = new Map(initial.map((r) => [r.id, r]));
+  return {
+    _rows: rows,
+    prepare(sql) {
+      const stmt = {
+        _args: [],
+        bind(...args) { stmt._args = args; return stmt; },
+        async first() {
+          if (!sql.includes('FROM users')) throw new Error(`unexpected: ${sql}`);
+          return rows.get(stmt._args[0]) ?? null;
+        },
+        async run() {
+          if (!sql.includes('INSERT INTO users')) throw new Error(`unexpected: ${sql}`);
+          const [id, login, isCollab, checkedAt, firstSeen] = stmt._args;
+          const prev = rows.get(id);
+          rows.set(id, {
+            id, login, is_collaborator: isCollab, checked_at: checkedAt,
+            first_seen_at: prev?.first_seen_at ?? firstSeen,
+          });
+        },
+      };
+      return stmt;
+    },
+  };
+}
+
+// ---------------------------------------------------------------- session ---
+
+test('a session round-trips', async () => {
+  const token = await signSession(SECRET, { sub: 1, login: 'spuddeh' });
+  const claims = await verifySession(SECRET, token);
+  assert.equal(claims.login, 'spuddeh');
+  assert.equal(claims.sub, 1);
+});
+
+test('an expired session is rejected', async () => {
+  const t0 = Date.parse('2026-01-01T00:00:00Z');
+  const token = await signSession(SECRET, { sub: 1 }, 60, t0);
+  assert.ok(await verifySession(SECRET, token, t0 + 59_000));
+  assert.equal(await verifySession(SECRET, token, t0 + 61_000), null);
+});
+
+test('a token signed with another secret is rejected', async () => {
+  const token = await signSession('other-secret', { sub: 1 });
+  assert.equal(await verifySession(SECRET, token), null);
+});
+
+test('a tampered payload is rejected', async () => {
+  const token = await signSession(SECRET, { sub: 1, collaborator: false });
+  const [h, , s] = token.split('.');
+  const forged = Buffer.from(JSON.stringify({ sub: 1, collaborator: true, exp: 9e9 }))
+    .toString('base64url');
+  assert.equal(await verifySession(SECRET, `${h}.${forged}.${s}`), null);
+});
+
+test('alg:none is rejected outright', async () => {
+  const h = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const p = Buffer.from(JSON.stringify({ sub: 1, collaborator: true, exp: 9e9 })).toString('base64url');
+  assert.equal(await verifySession(SECRET, `${h}.${p}.`), null);
+});
+
+test('garbage is rejected without throwing', async () => {
+  for (const bad of ['', 'a.b', 'a.b.c', 'not-a-token', null, undefined, 12]) {
+    assert.equal(await verifySession(SECRET, bad), null, String(bad));
+  }
+});
+
+test('the session cookie is HttpOnly, Secure and SameSite=Lax', () => {
+  const c = cookieHeader(SESSION_COOKIE, 'x');
+  assert.match(c, /HttpOnly/);
+  assert.match(c, /Secure/);
+  assert.match(c, /SameSite=Lax/);
+  assert.equal(/Domain=/.test(c), false, 'host-only: must not widen to the parent domain');
+  assert.match(clearCookie(SESSION_COOKIE), /Max-Age=0/);
+});
+
+test('readCookie picks the right cookie out of several', () => {
+  const req = new Request('https://api.nczoning.net/auth/me', {
+    headers: { Cookie: 'a=1; ncz_session=tok.en.sig; b=2' },
+  });
+  assert.equal(readCookie(req, SESSION_COOKIE), 'tok.en.sig');
+  assert.equal(readCookie(req, 'nope'), null);
+});
+
+// ------------------------------------------------------------ github-app ---
+
+const APP_ENV = async () => ({
+  GITHUB_APP_ID: '123',
+  GITHUB_APP_PRIVATE_KEY: await pkcs8Pem(),
+  GITHUB_REPO: 'nczoning/nc-zoning-board',
+  SESSION_SECRET: SECRET,
+});
+
+/** fetch stub: installation lookup + token mint always succeed; collab status varies. */
+function ghFetch(collabStatus, { tokenStatus = 200 } = {}) {
+  return async (url, init) => {
+    if (url.endsWith('/installation')) return { ok: true, status: 200, json: async () => ({ id: 42 }) };
+    if (url.includes('/access_tokens')) {
+      if (tokenStatus !== 200) return { ok: false, status: tokenStatus };
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ token: 'ghs_test', expires_at: new Date(Date.now() + 3600_000).toISOString() }),
+      };
+    }
+    if (url.includes('/collaborators/')) return { ok: collabStatus === 204, status: collabStatus };
+    throw new Error(`unexpected fetch ${url}`);
+  };
+}
+
+test('collaborator check: 204 is yes, 404 is no', async () => {
+  const env = await APP_ENV();
+  _resetTokenCache();
+  assert.equal(await checkCollaborator(env, 'spuddeh', ghFetch(204)), 'yes');
+  _resetTokenCache();
+  assert.equal(await checkCollaborator(env, 'stranger', ghFetch(404)), 'no');
+});
+
+test('a broken credential is "error" — never folded into yes or no', async () => {
+  const env = await APP_ENV();
+  for (const status of [401, 403, 500, 502]) {
+    _resetTokenCache();
+    const verdict = await checkCollaborator(env, 'spuddeh', ghFetch(status));
+    assert.equal(verdict, 'error', `HTTP ${status} must be indeterminate`);
+    assert.notEqual(verdict, 'no');
+    assert.notEqual(verdict, 'yes');
+  }
+});
+
+test('a failure to mint an installation token is "error", not "no"', async () => {
+  const env = await APP_ENV();
+  _resetTokenCache();
+  assert.equal(await checkCollaborator(env, 'spuddeh', ghFetch(204, { tokenStatus: 401 })), 'error');
+});
+
+test('a PKCS#1 key fails with an actionable message, not an opaque DataError', async () => {
+  _resetTokenCache();
+  const env = {
+    GITHUB_APP_ID: '1',
+    GITHUB_APP_PRIVATE_KEY: '-----BEGIN RSA PRIVATE KEY-----\nAAAA\n-----END RSA PRIVATE KEY-----',
+    GITHUB_REPO: 'a/b',
+  };
+  // Surfaces as 'error' to the caller; the operator-facing detail is logged.
+  assert.equal(await checkCollaborator(env, 'x', ghFetch(204)), 'error');
+});
+
+// ------------------------------------------------------------------ CORS ---
+
+test('admin CORS echoes only allowed origins, and always Varies on Origin', () => {
+  for (const origin of ADMIN_ORIGINS) {
+    const h = adminCors(new Request('https://api.nczoning.net/auth/me', { headers: { Origin: origin } }));
+    assert.equal(h['Access-Control-Allow-Origin'], origin);
+    assert.equal(h['Access-Control-Allow-Credentials'], 'true');
+    assert.equal(h.Vary, 'Origin');
+  }
+});
+
+test('an unknown origin gets no CORS headers at all', () => {
+  const h = adminCors(new Request('https://api.nczoning.net/auth/me', {
+    headers: { Origin: 'https://evil.example' },
+  }));
+  assert.deepEqual(h, {});
+  // Never the wildcard: it is illegal with credentials and would be a hole.
+  assert.equal(h['Access-Control-Allow-Origin'], undefined);
+});
+
+// ------------------------------------------------------------- callback ---
+
+/** Drive /auth/callback with a matching state cookie. */
+async function runCallback(env, { verdictStatus, nonce = 'n1', stateParam = 'n1' } = {}) {
+  const stateToken = await signSession(env.SESSION_SECRET, { nonce, returnTo: '/admin/' }, 600);
+  const req = new Request(
+    `https://api.nczoning.net/auth/callback?code=abc&state=${stateParam}`,
+    { headers: { Cookie: `ncz_oauth_state=${stateToken}` } },
+  );
+  const fetchImpl = ghFetch(verdictStatus);
+  globalThis.fetch = async (url, init) => {
+    if (String(url).includes('login/oauth/access_token')) {
+      return { ok: true, status: 200, json: async () => ({ access_token: 'gho_user' }) };
+    }
+    if (String(url).endsWith('/user')) {
+      return { ok: true, status: 200, json: async () => ({ login: 'spuddeh', id: 7 }) };
+    }
+    return fetchImpl(String(url), init);
+  };
+  return callback(req, env);
+}
+
+test('a mismatched state is refused (CSRF)', async () => {
+  const env = { ...(await APP_ENV()), DB: fakeUsersDb() };
+  _resetTokenCache();
+  const res = await runCallback(env, { verdictStatus: 204, nonce: 'n1', stateParam: 'attacker' });
+  assert.equal(res.status, 302);
+  assert.match(res.headers.get('Location'), /error=bad_state/);
+});
+
+test('a collaborator gets a session cookie', async () => {
+  const env = { ...(await APP_ENV()), DB: fakeUsersDb() };
+  _resetTokenCache();
+  const res = await runCallback(env, { verdictStatus: 204 });
+  const cookies = res.headers.getSetCookie().join('\n');
+  assert.match(cookies, new RegExp(`${SESSION_COOKIE}=[^;]+; HttpOnly`));
+  assert.equal(env.DB._rows.get(7).is_collaborator, 1);
+});
+
+test('a non-collaborator is refused and recorded as such', async () => {
+  const env = { ...(await APP_ENV()), DB: fakeUsersDb() };
+  _resetTokenCache();
+  const res = await runCallback(env, { verdictStatus: 404 });
+  assert.match(res.headers.get('Location'), /error=not_authorised/);
+  assert.equal(res.headers.getSetCookie().join('\n').includes(`${SESSION_COOKIE}=ey`), false);
+  assert.equal(env.DB._rows.get(7).is_collaborator, 0);
+});
+
+test('an indeterminate check is NOT cached as a refusal', async () => {
+  const env = { ...(await APP_ENV()), DB: fakeUsersDb() };
+  _resetTokenCache();
+  const res = await runCallback(env, { verdictStatus: 403 });
+  assert.match(res.headers.get('Location'), /error=check_unavailable/);
+  // The load-bearing assertion: a transient GitHub failure must not write a
+  // "not a collaborator" row that then locks a real admin out for the TTL.
+  assert.equal(env.DB._rows.size, 0, 'nothing may be recorded from an unanswered check');
+});
+
+// -------------------------------------------------------- session gating ---
+
+test('a fresh cached verdict is reused without calling GitHub', async () => {
+  const env = {
+    ...(await APP_ENV()),
+    DB: fakeUsersDb([{
+      id: 7, login: 'spuddeh', is_collaborator: 1,
+      checked_at: new Date().toISOString(), first_seen_at: '2026-01-01T00:00:00Z',
+    }]),
+  };
+  globalThis.fetch = async () => { throw new Error('must not call GitHub'); };
+  const token = await signSession(SECRET, { sub: 7, login: 'spuddeh', collaborator: true });
+  const req = new Request('https://api.nczoning.net/auth/me', {
+    headers: { Cookie: `${SESSION_COOKIE}=${token}` },
+  });
+  const s = await resolveSession(req, env);
+  assert.equal(s.collaborator, true);
+});
+
+test('a stale verdict is re-checked, so a removed admin loses access', async () => {
+  const env = {
+    ...(await APP_ENV()),
+    DB: fakeUsersDb([{
+      id: 7, login: 'spuddeh', is_collaborator: 1,
+      checked_at: '2026-01-01T00:00:00Z', // long stale
+      first_seen_at: '2026-01-01T00:00:00Z',
+    }]),
+  };
+  _resetTokenCache();
+  globalThis.fetch = ghFetch(404); // no longer a collaborator
+  const token = await signSession(SECRET, { sub: 7, login: 'spuddeh', collaborator: true });
+  const req = new Request('https://api.nczoning.net/auth/me', {
+    headers: { Cookie: `${SESSION_COOKIE}=${token}` },
+  });
+  const s = await resolveSession(req, env);
+  assert.equal(s.collaborator, false, 'the cookie says true; the repo says no. The repo wins.');
+});
+
+// ----------------------------------------------------------- route wiring ---
+
+test('POST /auth/logout survives the read-only method gate', async () => {
+  // Every non-auth route is GET/HEAD-only and 405s otherwise. Logout is a POST
+  // on purpose, so it has to be dispatched BEFORE that gate.
+  const res = await worker.fetch(
+    new Request('https://api.nczoning.net/auth/logout', { method: 'POST' }),
+    { SESSION_SECRET: SECRET },
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('Set-Cookie'), /ncz_session=; .*Max-Age=0/);
+});
+
+test('a POST to a non-auth route is still 405', async () => {
+  const res = await worker.fetch(
+    new Request('https://api.nczoning.net/v1/locations', { method: 'POST' }), {},
+  );
+  assert.equal(res.status, 405);
+});
+
+test('an unknown /auth/ path is 404, not a method error', async () => {
+  const res = await worker.fetch(new Request('https://api.nczoning.net/auth/nope'), {});
+  assert.equal(res.status, 404);
+});
+
+test('the /auth preflight is credentialed, and never wildcard', async () => {
+  const res = await worker.fetch(new Request('https://api.nczoning.net/auth/me', {
+    method: 'OPTIONS',
+    headers: { Origin: 'https://nczoning.net' },
+  }), {});
+  assert.equal(res.status, 204);
+  assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://nczoning.net');
+  assert.equal(res.headers.get('Access-Control-Allow-Credentials'), 'true');
+  assert.match(res.headers.get('Access-Control-Allow-Methods'), /POST/);
+});
+
+test('/v1 preflight keeps the public wildcard CORS', async () => {
+  const res = await worker.fetch(new Request('https://api.nczoning.net/v1/locations', {
+    method: 'OPTIONS',
+    headers: { Origin: 'https://anywhere.example' },
+  }), {});
+  assert.equal(res.headers.get('Access-Control-Allow-Origin'), '*');
+  assert.equal(res.headers.get('Access-Control-Allow-Credentials'), null);
+});
+
+test('/auth/login redirects to GitHub and sets a state cookie', async () => {
+  const res = await worker.fetch(
+    new Request('https://api.nczoning.net/auth/login?return_to=/admin/'),
+    { SESSION_SECRET: SECRET, GITHUB_OAUTH_CLIENT_ID: 'Iv1.test' },
+  );
+  assert.equal(res.status, 302);
+  const location = new URL(res.headers.get('Location'));
+  assert.equal(location.host, 'github.com');
+  assert.equal(location.searchParams.get('client_id'), 'Iv1.test');
+  assert.ok(location.searchParams.get('state'), 'state is required for CSRF');
+  assert.match(res.headers.get('Set-Cookie'), /ncz_oauth_state=/);
+});
+
+test('return_to cannot be turned into an open redirect', async () => {
+  for (const evil of ['https://evil.example/', '//evil.example/', 'http://evil.example']) {
+    const res = await worker.fetch(
+      new Request(`https://api.nczoning.net/auth/login?return_to=${encodeURIComponent(evil)}`),
+      { SESSION_SECRET: SECRET, GITHUB_OAUTH_CLIENT_ID: 'x' },
+    );
+    const state = res.headers.get('Set-Cookie').match(/ncz_oauth_state=([^;]+)/)[1];
+    const claims = await verifySession(SECRET, state);
+    assert.equal(claims.returnTo, '/admin/', `${evil} must be rejected`);
+  }
+});
+
+test('/auth/me is 401 with no cookie, 503 when the check is unavailable', async () => {
+  const env = { ...(await APP_ENV()), DB: fakeUsersDb() };
+  const anon = await me(new Request('https://api.nczoning.net/auth/me'), env);
+  assert.equal(anon.status, 401);
+  assert.equal((await anon.json()).authenticated, false);
+
+  _resetTokenCache();
+  globalThis.fetch = ghFetch(500);
+  const token = await signSession(SECRET, { sub: 7, login: 'spuddeh', collaborator: true });
+  const res = await me(new Request('https://api.nczoning.net/auth/me', {
+    headers: { Cookie: `${SESSION_COOKIE}=${token}` },
+  }), env);
+  // 503, not 403 — "we cannot tell" is not "you are not allowed".
+  assert.equal(res.status, 503);
+  assert.equal((await res.json()).error, 'check_unavailable');
+});

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -62,7 +62,17 @@
 		// Do not flip until parity-ab.mjs and parity-check.mjs are both green
 		// (worker/README.md). Tags and subdistricts still come from SITE_ORIGIN
 		// either way; they move to D1 at Phase 4.
-		"DATA_SOURCE": "mods"
+		"DATA_SOURCE": "mods",
+		// --- Admin auth (Phase 3) -------------------------------------------
+		// Not secrets: an App id and an OAuth client id are both public. The
+		// private key and client secret are Worker secrets — see README.
+		"GITHUB_APP_ID": "",
+		"GITHUB_OAUTH_CLIENT_ID": "",
+		// Repo whose collaborator list IS the admin list. Adding an admin is a
+		// repo-collaborator change; there is no separate allowlist to drift.
+		"GITHUB_REPO": "nczoning/nc-zoning-board",
+		// Where /auth/callback sends the browser back to.
+		"ADMIN_ORIGIN": "https://nczoning.net"
 	},
 	// Dataset store (dashboard title: nczoning-api-dataset). Recreate with:
 	//   npx wrangler kv namespace create nczoning-api-dataset
@@ -152,7 +162,16 @@
 				// archive cache and appear to stall.
 				// Seed its database first — an empty `locations` is refused, by
 				// design, rather than materialized as an empty map.
-				"DATA_SOURCE": "d1"
+				"DATA_SOURCE": "d1",
+				// Admin auth — see the production block. One App carries BOTH
+				// callback URLs (api.nczoning.net and api-dev.nczoning.net), so
+				// it serves both environments. SESSION_SECRET must DIFFER
+				// between them: a shared signing key means a staging session
+				// token is accepted as valid by production.
+				"GITHUB_APP_ID": "",
+				"GITHUB_OAUTH_CLIENT_ID": "",
+				"GITHUB_REPO": "nczoning/nc-zoning-board",
+				"ADMIN_ORIGIN": "https://dev.nczoning.net"
 			},
 			// dashboard title: nczoning-api-dataset-staging
 			"kv_namespaces": [

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -66,8 +66,8 @@
 		// --- Admin auth (Phase 3) -------------------------------------------
 		// Not secrets: an App id and an OAuth client id are both public. The
 		// private key and client secret are Worker secrets — see README.
-		"GITHUB_APP_ID": "",
-		"GITHUB_OAUTH_CLIENT_ID": "",
+		"GITHUB_APP_ID": "4397308",
+		"GITHUB_OAUTH_CLIENT_ID": "Iv23lixJitjZqJuIwhDW",
 		// Repo whose collaborator list IS the admin list. Adding an admin is a
 		// repo-collaborator change; there is no separate allowlist to drift.
 		"GITHUB_REPO": "nczoning/nc-zoning-board",
@@ -168,8 +168,8 @@
 				// it serves both environments. SESSION_SECRET must DIFFER
 				// between them: a shared signing key means a staging session
 				// token is accepted as valid by production.
-				"GITHUB_APP_ID": "",
-				"GITHUB_OAUTH_CLIENT_ID": "",
+				"GITHUB_APP_ID": "4397308",
+				"GITHUB_OAUTH_CLIENT_ID": "Iv23lixJitjZqJuIwhDW",
 				"GITHUB_REPO": "nczoning/nc-zoning-board",
 				"ADMIN_ORIGIN": "https://dev.nczoning.net"
 			},


### PR DESCRIPTION
Login only. There are no admin write routes yet — `/admin/` is a stub showing who
you are signed in as, and it becomes the shell Phase 4 fills in.

**Not live until the App exists.** Creating the GitHub App and setting its
secrets is a manual step; steps are in `worker/README.md`. Nothing in this PR
changes existing behaviour until then.

## 🔴 The collaborator check has three outcomes, not two

`GET /repos/{owner}/{repo}/collaborators/{login}` answers **204 = yes**,
**404 = no**. A broken or under-permissioned credential answers **401/403**.
Collapsing that third case is a security bug in *both* directions:

| Naive check | Behaviour on a dead credential |
| --- | --- |
| `not 404 → allow` | **everyone gets admin** |
| `not 204 → deny` | everyone locked out, silently |

So `checkCollaborator()` returns `'yes' | 'no' | 'error'`, and `'error'`:

- fails closed for the request
- is **never written to the `users` cache** — caching "no" from a transient blip
  would lock a real admin out for the full 10-minute TTL
- surfaces as **503 `check_unavailable`**, not 403. "We cannot tell" is not "you
  are not allowed", and the stub page words it that way rather than telling an
  admin they lack access because GitHub had a bad minute.

Useful consequence: **a wrong App permission shows up as `check_unavailable`**,
which is diagnosable, rather than as a lockout wearing a refusal's clothes.

## Why a GitHub App over a fine-grained PAT

A PAT expires within a year and belongs to one person. Admin access would break
on a date nobody remembers, presenting as "everyone is suddenly not a
collaborator" — the exact silent-scheduled-failure shape this project keeps
paying for. The installation token renews hourly in code; nothing sits on a
calendar.

Cost is ~50 lines of RS256 signing. GitHub issues **PKCS#1** keys and WebCrypto
only imports **PKCS#8**, which otherwise fails as an opaque `DataError` — so
that case is detected and reported with the exact `openssl` command instead.

## Other decisions

- **The user's OAuth token reads their login, then is discarded.** Collaborator
  status uses the App's installation token, so an admin never grants `repo`
  scope just to discover they are an admin.
- **`resolveSession` re-checks a verdict older than 10 minutes** rather than
  trusting the 8-hour session cookie's own `collaborator: true`. Removing
  someone from the repo has to take effect sooner than 8 hours.
- **`session.js` verifies only its own tokens and pins `alg` to `HS256`**, so
  `alg: "none"` is not a code path rather than a mitigated one.
- **`/auth/*` needs credentialed CORS** with the origin echoed back — the
  wildcard `/v1/*` uses is illegal with `Allow-Credentials`. `Vary: Origin` is
  set so one caller's permitted origin is never cached for another.
- **`SameSite=Lax` is correct** even though `nczoning.net` and
  `api.nczoning.net` are different origins: SameSite is judged on the
  registrable domain, so they are the same *site*. The cookie is host-only (no
  `Domain`), so only the API ever receives it.
- **Logout is `POST`**, dispatched before the read-only method gate, so a stray
  `<img>` or link cannot sign someone out.
- **`SESSION_SECRET` must differ between production and staging** — a shared
  signing key means a staging session token is accepted by production. Called
  out in both `wrangler.jsonc` and the README.

## Test plan

**139 pass (28 new).** The new ones are mostly failure modes, not the happy path:

- session: tampered payload, `alg:none`, wrong secret, expiry boundary, garbage
  input, and that the cookie is HttpOnly + Secure + SameSite=Lax + host-only
- gate: 204/404 map to yes/no; **401, 403, 500 and 502 all map to `error` and to
  neither yes nor no**; a token-mint failure is `error`; a PKCS#1 key is caught
- callback: CSRF state mismatch refused; collaborator gets a cookie;
  non-collaborator refused *and recorded*; **an indeterminate check records
  nothing at all**
- session gating: a fresh verdict is reused without calling GitHub; a stale one
  is re-checked, so a removed admin loses access even though their cookie still
  claims otherwise
- routing: `POST /auth/logout` survives the 405 gate while `POST /v1/locations`
  still 405s; `/auth` preflight is credentialed and `/v1` preflight stays
  wildcard; **`return_to` cannot be turned into an open redirect**

## Gate for this phase

Not met yet, and cannot be until the App is created: all three collaborators can
log in, and a non-collaborator is refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
