### PR TITLE
feat(admin): Phase 4a — admin CRUD, audit log, and the write-path validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A parity gate that rebuilds `/v1/locations` from D1 and diffs it byte-for-byte against the live API, with negative controls that prove the diff can fail.
 - The refresh cron can source the registry from D1 via `DATA_SOURCE=d1`. Production stays on `mods.json` until the cutover; unset never means D1.
 - A second harness that runs both source paths head-to-head across a swept clock, and fails if the swept field never varied.
-- GitHub sign-in for admins at `/admin/`, gated on repository collaborator status. Login only — there are no admin write routes yet.
+- GitHub sign-in for admins at `/admin/`, gated on repository collaborator status.
+- Admin CRUD over the location registry, with an append-only audit log: every mutation records who did it, and the record before and after. Nothing on the live map reads these writes yet.
 
 ## [1.7.2] - 2026-07-26
 

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "nczoning-api",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nczoning-api",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "devDependencies": {
+        "ajv": "^8.20.0",
         "wrangler": "^4.107.0"
       }
     },
@@ -1155,6 +1156,23 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
@@ -1238,6 +1256,30 @@
         "@esbuild/win32-x64": "0.28.1"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1252,6 +1294,13 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -1297,6 +1346,16 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.8.5",

--- a/worker/package.json
+++ b/worker/package.json
@@ -11,6 +11,7 @@
     "version:lock": "node scripts/api-version.mjs --write"
   },
   "devDependencies": {
+    "ajv": "^8.20.0",
     "wrangler": "^4.107.0"
   }
 }

--- a/worker/src/admin.js
+++ b/worker/src/admin.js
@@ -1,0 +1,238 @@
+/**
+ * Admin CRUD over the location registry. Phase 4: direct writes, no submission
+ * queue yet (that is Phase 5).
+ *
+ * Every route is gated on repository collaborator status, and every mutation
+ * writes an audit row in the same request. The audit row is not optional
+ * bookkeeping — once edits stop arriving as pull requests, it is the only
+ * record of who changed what.
+ */
+
+import { resolveSession } from './auth.js';
+import { adminCors } from './auth.js';
+import { validateLocationInput } from './validate.js';
+import { writeAudit, readAudit } from './audit.js';
+import { KEYS } from './store.js';
+import { runRefresh } from './refresh.js';
+
+const json = (request, body, status = 200) => new Response(JSON.stringify(body), {
+  status,
+  headers: {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+    ...adminCors(request),
+  },
+});
+
+/**
+ * Gate. Returns the session, or a Response to return immediately.
+ *
+ * 503 for an indeterminate check, never 403: "we cannot tell" is not "you are
+ * not allowed", and an admin locked out by a transient GitHub blip should be
+ * told which of those happened. See github-app.js.
+ */
+async function requireCollaborator(request, env) {
+  const session = await resolveSession(request, env);
+  if (!session) return { error: json(request, { error: 'unauthenticated' }, 401) };
+  if (session.indeterminate) {
+    return { error: json(request, { error: 'check_unavailable' }, 503) };
+  }
+  if (!session.collaborator) return { error: json(request, { error: 'forbidden' }, 403) };
+  return { session };
+}
+
+/** Row -> the admin representation (everything, including admin-only fields). */
+function rowToAdmin(row) {
+  return {
+    id: row.id,
+    name: row.name,
+    nexus_id: row.nexus_id,
+    category: row.category,
+    coordinates: row.z === null || row.z === undefined ? [row.x, row.y] : [row.x, row.y, row.z],
+    yaw: row.yaw,
+    description: row.description ?? '',
+    credits: row.credits,
+    authors: JSON.parse(row.authors ?? '[]'),
+    tags: JSON.parse(row.tags ?? '[]'),
+    source: row.source,
+    status: row.status,
+    admin_notes: row.admin_notes,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+/** Known tag ids, from the KV dataset the cron already maintains. */
+async function tagNames(env) {
+  const tags = await env.DATASET.get(KEYS.tags, 'json');
+  return new Set(Object.keys(tags || {}));
+}
+
+/**
+ * Rebuild the KV read path from D1 after a write, so an approved change appears
+ * in seconds rather than at the next cron tick.
+ *
+ * 🔴 GATED ON DATA_SOURCE. If the cron is still sourcing from mods.json, a
+ * write-through materialize would overwrite KV with D1-derived content and
+ * silently perform the Phase 2 cutover as a side effect of an admin edit. So
+ * when DATA_SOURCE is not 'd1' the write lands in D1 and the map keeps showing
+ * mods.json — which is correct, and is what "nothing reads D1 yet" means.
+ */
+function materializeAfterWrite(env, ctx) {
+  if (env.DATA_SOURCE !== 'd1') return;
+  // Fire-and-forget: the admin gets their response immediately, and a failed
+  // rebuild leaves last-known-good in place exactly as a failed cron does.
+  ctx?.waitUntil?.(runRefresh(env).catch((err) => {
+    console.error('write-through materialize failed:', String(err).slice(0, 200));
+  }));
+}
+
+const COLUMN_FOR = {
+  name: 'name', nexus_id: 'nexus_id', category: 'category', description: 'description',
+  credits: 'credits', source: 'source', status: 'status', admin_notes: 'admin_notes',
+  yaw: 'yaw',
+};
+
+/** Build the SET clause for a validated patch. */
+function buildUpdate(payload) {
+  const sets = [];
+  const binds = [];
+  for (const [field, column] of Object.entries(COLUMN_FOR)) {
+    if (Object.prototype.hasOwnProperty.call(payload, field)) {
+      sets.push(`${column} = ?`);
+      binds.push(payload[field] === undefined ? null : payload[field]);
+    }
+  }
+  if (Object.prototype.hasOwnProperty.call(payload, 'authors')) {
+    sets.push('authors = ?'); binds.push(JSON.stringify(payload.authors));
+  }
+  if (Object.prototype.hasOwnProperty.call(payload, 'tags')) {
+    sets.push('tags = ?'); binds.push(JSON.stringify(payload.tags));
+  }
+  if (Object.prototype.hasOwnProperty.call(payload, 'coordinates')) {
+    const [x, y, z] = payload.coordinates;
+    sets.push('x = ?', 'y = ?', 'z = ?');
+    binds.push(x, y, z === undefined ? null : z);
+  }
+  return { sets, binds };
+}
+
+async function getRow(env, id) {
+  return env.DB.prepare('SELECT * FROM locations WHERE id = ?').bind(id).first();
+}
+
+/**
+ * Route the /admin/* surface.
+ * @returns {Promise<Response|null>} null when the path is not an admin route.
+ */
+export async function handleAdmin(request, env, ctx) {
+  const url = new URL(request.url);
+  if (!url.pathname.startsWith('/admin/')) return null;
+
+  const gate = await requireCollaborator(request, env);
+  if (gate.error) return gate.error;
+  const actor = gate.session.login;
+
+  const method = request.method;
+  const listMatch = url.pathname === '/admin/locations';
+  const oneMatch = url.pathname.match(/^\/admin\/locations\/([^/]+)$/);
+
+  // ---- audit -------------------------------------------------------------
+  if (url.pathname === '/admin/audit' && method === 'GET') {
+    return json(request, { entries: await readAudit(env, url.searchParams.get('limit')) });
+  }
+
+  // ---- list --------------------------------------------------------------
+  if (listMatch && method === 'GET') {
+    const { results } = await env.DB.prepare('SELECT * FROM locations ORDER BY name').all();
+    return json(request, { locations: (results ?? []).map(rowToAdmin) });
+  }
+
+  // ---- create ------------------------------------------------------------
+  if (listMatch && method === 'POST') {
+    let payload;
+    try { payload = await request.json(); } catch { return json(request, { error: 'invalid_json' }, 400); }
+
+    const v = validateLocationInput(payload, { tagNames: await tagNames(env) });
+    if (!v.ok) return json(request, { error: 'validation_failed', errors: v.errors }, 422);
+
+    // Server-generated, never client-supplied: a caller-chosen id is how a deep
+    // link gets silently repointed at a different mod.
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const [x, y, z] = payload.coordinates;
+
+    await env.DB.prepare(`
+      INSERT INTO locations (id, name, nexus_id, category, x, y, z, yaw, description,
+        credits, authors, tags, source, status, admin_notes, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).bind(
+      id, payload.name, payload.nexus_id, payload.category,
+      x, y, z === undefined ? null : z,
+      payload.yaw ?? null,
+      payload.description ?? '',
+      payload.credits || null,
+      JSON.stringify(payload.authors), JSON.stringify(payload.tags),
+      payload.source ?? 'manual', payload.status ?? 'published',
+      payload.admin_notes ?? null, now, now,
+    ).run();
+
+    const after = rowToAdmin(await getRow(env, id));
+    await writeAudit(env, { actor, action: 'location.create', target: id, after });
+    materializeAfterWrite(env, ctx);
+    return json(request, { location: after }, 201);
+  }
+
+  // ---- read one ----------------------------------------------------------
+  if (oneMatch && method === 'GET') {
+    const row = await getRow(env, decodeURIComponent(oneMatch[1]));
+    if (!row) return json(request, { error: 'not_found' }, 404);
+    return json(request, { location: rowToAdmin(row) });
+  }
+
+  // ---- update ------------------------------------------------------------
+  if (oneMatch && method === 'PATCH') {
+    const id = decodeURIComponent(oneMatch[1]);
+    const before = await getRow(env, id);
+    if (!before) return json(request, { error: 'not_found' }, 404);
+
+    let payload;
+    try { payload = await request.json(); } catch { return json(request, { error: 'invalid_json' }, 400); }
+
+    const v = validateLocationInput(payload, { tagNames: await tagNames(env), partial: true });
+    if (!v.ok) return json(request, { error: 'validation_failed', errors: v.errors }, 422);
+
+    const { sets, binds } = buildUpdate(payload);
+    if (!sets.length) return json(request, { error: 'empty_patch' }, 400);
+
+    sets.push('updated_at = ?');
+    binds.push(new Date().toISOString(), id);
+    await env.DB.prepare(`UPDATE locations SET ${sets.join(', ')} WHERE id = ?`).bind(...binds).run();
+
+    const after = rowToAdmin(await getRow(env, id));
+    await writeAudit(env, {
+      actor, action: 'location.update', target: id, before: rowToAdmin(before), after,
+    });
+    materializeAfterWrite(env, ctx);
+    return json(request, { location: after });
+  }
+
+  // ---- delete ------------------------------------------------------------
+  if (oneMatch && method === 'DELETE') {
+    const id = decodeURIComponent(oneMatch[1]);
+    const before = await getRow(env, id);
+    if (!before) return json(request, { error: 'not_found' }, 404);
+
+    await env.DB.prepare('DELETE FROM locations WHERE id = ?').bind(id).run();
+    // The full record goes into `before`, so a delete is recoverable from the
+    // audit log. `status: 'hidden'` remains the right move for a mod pulled
+    // from the map; this is for records that should never have existed.
+    await writeAudit(env, {
+      actor, action: 'location.delete', target: id, before: rowToAdmin(before),
+    });
+    materializeAfterWrite(env, ctx);
+    return json(request, { deleted: id });
+  }
+
+  return json(request, { error: 'not_found' }, 404);
+}

--- a/worker/src/audit.js
+++ b/worker/src/audit.js
@@ -1,0 +1,47 @@
+/**
+ * The append-only audit log. This is what replaces `git log` for data changes:
+ * once locations are edited through the API rather than through pull requests,
+ * the commit history stops recording who changed what, and nothing else does.
+ *
+ * Never updated, never deleted. A correction is another row.
+ *
+ * `before`/`after` are stored verbatim, INCLUDING `admin_notes`. That is right
+ * for the live table and wrong for the export: Part C mirrors the audit log to
+ * a public branch, and must redact those fields there rather than here. Storing
+ * a redacted copy would lose the actual history for the sake of a future export.
+ */
+
+/**
+ * @param {object} env
+ * @param {object} entry
+ * @param {string} entry.actor   github login, or 'system' for the cron
+ * @param {string} entry.action  e.g. location.create | location.update | location.delete
+ * @param {string} [entry.target]
+ * @param {object|null} [entry.before]
+ * @param {object|null} [entry.after]
+ */
+export async function writeAudit(env, { actor, action, target = null, before = null, after = null }, nowMs = Date.now()) {
+  await env.DB.prepare(
+    'INSERT INTO audit_log (at, actor, action, target, before, after) VALUES (?, ?, ?, ?, ?, ?)',
+  ).bind(
+    new Date(nowMs).toISOString(),
+    actor,
+    action,
+    target,
+    before === null ? null : JSON.stringify(before),
+    after === null ? null : JSON.stringify(after),
+  ).run();
+}
+
+/** Most recent entries first. */
+export async function readAudit(env, limit = 100) {
+  const capped = Math.min(Math.max(Number(limit) || 100, 1), 500);
+  const { results } = await env.DB.prepare(
+    'SELECT id, at, actor, action, target, before, after FROM audit_log ORDER BY id DESC LIMIT ?',
+  ).bind(capped).all();
+  return (results ?? []).map((r) => ({
+    ...r,
+    before: r.before ? JSON.parse(r.before) : null,
+    after: r.after ? JSON.parse(r.after) : null,
+  }));
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -19,6 +19,7 @@ import { KEYS } from './store.js';
 import { docsPage, spec } from './docs.js';
 import { RECENTLY_UPDATED_DAYS } from './config.js';
 import { login, callback, me, logout, adminCors } from './auth.js';
+import { handleAdmin } from './admin.js';
 
 const SCHEMA_VERSION = 1;
 
@@ -171,9 +172,10 @@ export default {
     ctx.waitUntil(runRefresh(env));
   },
 
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     const url = new URL(request.url);
     const isAuth = url.pathname.startsWith('/auth/');
+    const isAdmin = url.pathname.startsWith('/admin/');
 
     if (request.method === 'OPTIONS') {
       // Auth routes are credentialed, so they need the caller's exact origin
@@ -181,14 +183,22 @@ export default {
       // Allow-Credentials and would fail the preflight.
       return new Response(null, {
         status: 204,
-        headers: isAuth
+        headers: isAuth || isAdmin
           ? {
             ...adminCors(request),
-            'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+            'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
             'Access-Control-Allow-Headers': 'Content-Type',
           }
           : CORS_HEADERS,
       });
+    }
+
+    // Admin CRUD, before the read-only method gate: these are the write routes.
+    // handleAdmin gates every one of them on collaborator status itself, so
+    // there is no path through here that reaches a mutation ungated.
+    if (isAdmin) {
+      const res = await handleAdmin(request, env, ctx);
+      if (res) return res;
     }
 
     // Auth routes, before the read-only method gate below: logout is a POST

--- a/worker/src/validate.js
+++ b/worker/src/validate.js
@@ -1,0 +1,145 @@
+/**
+ * Write-path validation for admin location mutations.
+ *
+ * `mods.schema.json` was the CI gate on `data/locations/*.json`. Once writes
+ * arrive through the API instead of through pull requests, that gate has to
+ * move here or it simply disappears — the validation does not leave with the
+ * workflow.
+ *
+ * Hand-rolled rather than ajv-in-the-Worker: ajv is heavy and its default mode
+ * compiles with `new Function`, which Workers refuses. The link back to the
+ * real schema is therefore a TEST, not an import — test/validate.test.js runs
+ * ajv over `mods.schema.json` and asserts it agrees with this file across all
+ * 287 live records plus crafted invalid ones. If the schema changes and this
+ * does not, that test fails. That is the whole mechanism, and it is the reason
+ * the duplication is safe rather than a slow drift.
+ *
+ * Differences from the file schema, deliberately:
+ * - `id` is NOT accepted from input. It is server-generated on create and
+ *   immutable afterwards; letting a payload set it is how a deep link gets
+ *   silently repointed at a different mod.
+ * - `status` and `admin_notes` are admin-only fields that never existed in the
+ *   file format.
+ */
+
+export const CATEGORIES = ['location-overhaul', 'new-location', 'other'];
+export const STATUSES = ['published', 'hidden', 'draft'];
+export const DESCRIPTION_MAX = 500;
+const NEXUS_ID_RE = /^(\d+|WIP|Dummy)$/;
+
+/** Fields an admin may set. Anything else in the payload is rejected outright. */
+const WRITABLE = new Set([
+  'name', 'authors', 'credits', 'coordinates', 'yaw', 'nexus_id',
+  'description', 'category', 'tags', 'status', 'admin_notes', 'source',
+]);
+
+const isPlainObject = (v) => typeof v === 'object' && v !== null && !Array.isArray(v);
+
+/**
+ * @param {object} payload
+ * @param {object} opts
+ * @param {Set<string>} opts.tagNames  known tag ids; unknown tags are an error
+ *   here rather than silently dropped as they are in auto-discovery. An admin
+ *   typing a tag that does not exist has made a mistake worth surfacing; a
+ *   third-party Nexus description has not.
+ * @param {boolean} [opts.partial]  PATCH semantics: only validate present keys,
+ *   and do not require the mandatory set.
+ * @returns {{ok: boolean, errors: string[]}}
+ */
+export function validateLocationInput(payload, { tagNames, partial = false } = {}) {
+  const errors = [];
+  const err = (m) => errors.push(m);
+
+  if (!isPlainObject(payload)) return { ok: false, errors: ['body must be a JSON object'] };
+
+  // Unknown keys are rejected rather than ignored. A typo'd field name that is
+  // silently discarded looks exactly like a successful save.
+  for (const key of Object.keys(payload)) {
+    if (!WRITABLE.has(key)) {
+      err(key === 'id'
+        ? 'id cannot be set: it is server-generated and immutable'
+        : `unknown field: ${key}`);
+    }
+  }
+
+  const has = (k) => Object.prototype.hasOwnProperty.call(payload, k);
+  const required = ['name', 'authors', 'coordinates', 'nexus_id', 'description', 'category', 'tags'];
+  if (!partial) {
+    for (const k of required) if (!has(k)) err(`missing required field: ${k}`);
+  }
+
+  if (has('name')) {
+    if (typeof payload.name !== 'string' || payload.name.length < 3) {
+      err('name must be a string of at least 3 characters');
+    }
+  }
+
+  if (has('authors')) {
+    const a = payload.authors;
+    if (!Array.isArray(a) || a.length < 1 || !a.every((x) => typeof x === 'string')) {
+      err('authors must be a non-empty array of strings');
+    }
+  }
+
+  if (has('credits') && payload.credits !== null && typeof payload.credits !== 'string') {
+    err('credits must be a string or null');
+  }
+
+  if (has('coordinates')) {
+    const c = payload.coordinates;
+    if (!Array.isArray(c) || c.length < 2 || c.length > 3) {
+      err('coordinates must be [X, Y] or [X, Y, Z]');
+    } else if (!c.every((n) => typeof n === 'number' && Number.isFinite(n))) {
+      // Number.isFinite matters: JSON.parse yields NaN/Infinity for neither,
+      // but a client can still send them as strings that coerce badly later.
+      err('coordinates must all be finite numbers');
+    }
+  }
+
+  if (has('yaw') && payload.yaw !== null) {
+    if (typeof payload.yaw !== 'number' || !Number.isFinite(payload.yaw)) {
+      err('yaw must be a finite number or null');
+    }
+  }
+
+  if (has('nexus_id')) {
+    if (typeof payload.nexus_id !== 'string' || !NEXUS_ID_RE.test(payload.nexus_id)) {
+      err('nexus_id must be a numeric string, or "WIP" / "Dummy"');
+    }
+  }
+
+  if (has('description')) {
+    if (typeof payload.description !== 'string') err('description must be a string');
+    else if (payload.description.length > DESCRIPTION_MAX) {
+      err(`description must be at most ${DESCRIPTION_MAX} characters`);
+    }
+  }
+
+  if (has('category') && !CATEGORIES.includes(payload.category)) {
+    err(`category must be one of: ${CATEGORIES.join(', ')}`);
+  }
+
+  if (has('tags')) {
+    const t = payload.tags;
+    if (!Array.isArray(t) || !t.every((x) => typeof x === 'string')) {
+      err('tags must be an array of strings');
+    } else if (tagNames) {
+      const unknown = t.filter((x) => !tagNames.has(x));
+      if (unknown.length) err(`unknown tag(s): ${unknown.join(', ')}`);
+    }
+  }
+
+  if (has('status') && !STATUSES.includes(payload.status)) {
+    err(`status must be one of: ${STATUSES.join(', ')}`);
+  }
+
+  if (has('admin_notes') && payload.admin_notes !== null && typeof payload.admin_notes !== 'string') {
+    err('admin_notes must be a string or null');
+  }
+
+  if (has('source') && !['manual', 'auto'].includes(payload.source)) {
+    err('source must be "manual" or "auto"');
+  }
+
+  return { ok: errors.length === 0, errors };
+}

--- a/worker/test/admin.test.js
+++ b/worker/test/admin.test.js
@@ -1,0 +1,288 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { signSession, SESSION_COOKIE } from '../src/session.js';
+import { _resetTokenCache } from '../src/github-app.js';
+import worker from '../src/index.js';
+
+const SECRET = 'admin-test-secret';
+
+// Minimal in-memory D1 covering the statements admin.js issues. Rows are kept
+// as objects; SQL is matched by shape, which is enough because this file owns
+// every statement it has to answer.
+function fakeDb({ locations = [], users = [] } = {}) {
+  const locs = new Map(locations.map((r) => [r.id, { ...r }]));
+  const usersById = new Map(users.map((u) => [u.id, u]));
+  const audit = [];
+  let auditId = 0;
+
+  return {
+    _locations: locs,
+    _audit: audit,
+    prepare(sql) {
+      const stmt = {
+        _args: [],
+        bind(...args) { stmt._args = args; return stmt; },
+        async first() {
+          if (sql.includes('FROM users')) return usersById.get(stmt._args[0]) ?? null;
+          if (sql.includes('FROM locations WHERE id')) return locs.get(stmt._args[0]) ?? null;
+          if (sql.includes('COUNT(*)')) return { n: locs.size };
+          throw new Error(`unexpected first(): ${sql}`);
+        },
+        async all() {
+          if (sql.includes('FROM audit_log')) {
+            return { results: [...audit].reverse().slice(0, stmt._args[0] ?? 100) };
+          }
+          if (sql.includes('FROM locations')) return { results: [...locs.values()] };
+          if (sql.includes('dismissed_candidates')) return { results: [] };
+          throw new Error(`unexpected all(): ${sql}`);
+        },
+        async run() {
+          if (sql.includes('INSERT INTO users')) return;
+          if (sql.includes('INSERT INTO audit_log')) {
+            const [at, actor, action, target, before, after] = stmt._args;
+            auditId += 1;
+            audit.push({ id: auditId, at, actor, action, target, before, after });
+            return;
+          }
+          if (sql.includes('INSERT INTO locations')) {
+            const c = ['id', 'name', 'nexus_id', 'category', 'x', 'y', 'z', 'yaw', 'description',
+              'credits', 'authors', 'tags', 'source', 'status', 'admin_notes', 'created_at', 'updated_at'];
+            const row = {};
+            c.forEach((k, i) => { row[k] = stmt._args[i]; });
+            locs.set(row.id, row);
+            return;
+          }
+          if (sql.startsWith('UPDATE locations')) {
+            const id = stmt._args[stmt._args.length - 1];
+            const row = locs.get(id);
+            const cols = [...sql.matchAll(/(\w+) = \?/g)].map((m) => m[1]);
+            cols.forEach((col, i) => { row[col] = stmt._args[i]; });
+            return;
+          }
+          if (sql.startsWith('DELETE FROM locations')) { locs.delete(stmt._args[0]); return; }
+          throw new Error(`unexpected run(): ${sql}`);
+        },
+      };
+      return stmt;
+    },
+  };
+}
+
+const fakeKv = (tags = { apartment: 'a place', corpo: 'suits' }) => ({
+  async get(key, type) {
+    if (key.endsWith(':tags')) return type === 'json' ? tags : JSON.stringify(tags);
+    return null;
+  },
+  async put() {},
+});
+
+const ROW = {
+  id: 'loc-1', name: 'Existing Loft', nexus_id: '12345', category: 'new-location',
+  x: 1, y: 2, z: 3, yaw: 90, description: 'a place', credits: null,
+  authors: '["Spud"]', tags: '["apartment"]', source: 'manual', status: 'published',
+  admin_notes: null, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+};
+
+const FRESH_USER = (collab = 1) => ({
+  id: 7, login: 'spuddeh', is_collaborator: collab,
+  checked_at: new Date().toISOString(), first_seen_at: '2026-01-01T00:00:00Z',
+});
+
+async function envFor({ collab = 1, dataSource = 'mods', locations = [ROW] } = {}) {
+  return {
+    SESSION_SECRET: SECRET,
+    DATA_SOURCE: dataSource,
+    DATASET: fakeKv(),
+    DB: fakeDb({ locations, users: [FRESH_USER(collab)] }),
+  };
+}
+
+async function authed(url, init = {}) {
+  const token = await signSession(SECRET, { sub: 7, login: 'spuddeh', collaborator: true });
+  return new Request(url, {
+    ...init,
+    headers: { Cookie: `${SESSION_COOKIE}=${token}`, 'Content-Type': 'application/json', ...(init.headers || {}) },
+  });
+}
+
+const VALID = {
+  name: 'A New Location', authors: ['Spud'], coordinates: [10, 20, 30],
+  nexus_id: '99999', description: 'Brand new.', category: 'other', tags: ['apartment'],
+};
+
+// ------------------------------------------------------------------ gate ---
+
+test('every admin route is refused without a session', async () => {
+  const env = await envFor();
+  for (const [method, path] of [
+    ['GET', '/admin/locations'], ['POST', '/admin/locations'],
+    ['GET', '/admin/locations/loc-1'], ['PATCH', '/admin/locations/loc-1'],
+    ['DELETE', '/admin/locations/loc-1'], ['GET', '/admin/audit'],
+  ]) {
+    const res = await worker.fetch(
+      new Request(`https://api.nczoning.net${path}`, { method }), env, {},
+    );
+    assert.equal(res.status, 401, `${method} ${path}`);
+  }
+});
+
+test('a signed-in NON-collaborator is refused, and writes nothing', async () => {
+  const env = await envFor({ collab: 0 });
+  const res = await worker.fetch(
+    await authed('https://api.nczoning.net/admin/locations', {
+      method: 'POST', body: JSON.stringify(VALID),
+    }), env, {},
+  );
+  assert.equal(res.status, 403);
+  assert.equal(env.DB._locations.size, 1, 'no row may be created');
+  assert.equal(env.DB._audit.length, 0, 'no audit row either');
+});
+
+test('an indeterminate collaborator check is 503, not 403, and writes nothing', async () => {
+  const env = await envFor();
+  // Stale verdict forces a re-check; make GitHub unreachable.
+  env.DB = fakeDb({
+    locations: [ROW],
+    users: [{ ...FRESH_USER(), checked_at: '2020-01-01T00:00:00Z' }],
+  });
+  _resetTokenCache();
+  globalThis.fetch = async () => ({ ok: false, status: 500 });
+  const res = await worker.fetch(
+    await authed('https://api.nczoning.net/admin/locations', {
+      method: 'POST', body: JSON.stringify(VALID),
+    }), env, {},
+  );
+  assert.equal(res.status, 503);
+  assert.equal(env.DB._audit.length, 0);
+});
+
+// ----------------------------------------------------------------- CRUD ---
+
+test('create: server generates the id and refuses a client-supplied one', async () => {
+  const env = await envFor();
+  const ok = await worker.fetch(
+    await authed('https://api.nczoning.net/admin/locations', {
+      method: 'POST', body: JSON.stringify(VALID),
+    }), env, {},
+  );
+  assert.equal(ok.status, 201);
+  const body = await ok.json();
+  assert.match(body.location.id, /^[0-9a-f-]{36}$/);
+
+  const refused = await worker.fetch(
+    await authed('https://api.nczoning.net/admin/locations', {
+      method: 'POST', body: JSON.stringify({ ...VALID, id: 'attacker-chosen' }),
+    }), env, {},
+  );
+  assert.equal(refused.status, 422);
+});
+
+test('create: invalid input is 422 and writes nothing', async () => {
+  const env = await envFor();
+  const res = await worker.fetch(
+    await authed('https://api.nczoning.net/admin/locations', {
+      method: 'POST', body: JSON.stringify({ ...VALID, category: 'nope' }),
+    }), env, {},
+  );
+  assert.equal(res.status, 422);
+  assert.equal(env.DB._locations.size, 1);
+  assert.equal(env.DB._audit.length, 0, 'a rejected write must not be audited');
+});
+
+test('update: patches only what was sent', async () => {
+  const env = await envFor();
+  const res = await worker.fetch(
+    await authed('https://api.nczoning.net/admin/locations/loc-1', {
+      method: 'PATCH', body: JSON.stringify({ name: 'Renamed Loft' }),
+    }), env, {},
+  );
+  assert.equal(res.status, 200);
+  const row = env.DB._locations.get('loc-1');
+  assert.equal(row.name, 'Renamed Loft');
+  assert.equal(row.category, 'new-location', 'untouched fields must survive');
+  assert.notEqual(row.updated_at, '2026-01-01T00:00:00Z', 'updated_at must move');
+});
+
+test('update: an unknown id is 404, not a silent no-op', async () => {
+  const env = await envFor();
+  const res = await worker.fetch(
+    await authed('https://api.nczoning.net/admin/locations/nope', {
+      method: 'PATCH', body: JSON.stringify({ name: 'Whatever' }),
+    }), env, {},
+  );
+  assert.equal(res.status, 404);
+});
+
+test('delete: removes the row and keeps the whole record in the audit entry', async () => {
+  const env = await envFor();
+  const res = await worker.fetch(
+    await authed('https://api.nczoning.net/admin/locations/loc-1', { method: 'DELETE' }), env, {},
+  );
+  assert.equal(res.status, 200);
+  assert.equal(env.DB._locations.size, 0);
+  const entry = env.DB._audit.at(-1);
+  assert.equal(entry.action, 'location.delete');
+  // Recoverable: the deleted record survives in `before`.
+  assert.equal(JSON.parse(entry.before).name, 'Existing Loft');
+});
+
+// ---------------------------------------------------------------- audit ---
+
+test('EVERY successful mutation produces exactly one audit row', async () => {
+  // This is the Phase 4 gate, asserted directly.
+  const env = await envFor();
+  const calls = [
+    ['POST', '/admin/locations', VALID, 'location.create'],
+    ['PATCH', '/admin/locations/loc-1', { name: 'Renamed' }, 'location.update'],
+    ['DELETE', '/admin/locations/loc-1', null, 'location.delete'],
+  ];
+  for (const [method, path, body, action] of calls) {
+    const before = env.DB._audit.length;
+    const res = await worker.fetch(
+      await authed(`https://api.nczoning.net${path}`, {
+        method, ...(body ? { body: JSON.stringify(body) } : {}),
+      }), env, {},
+    );
+    assert.ok(res.status < 300, `${method} ${path} -> ${res.status}`);
+    assert.equal(env.DB._audit.length, before + 1, `${action} must add exactly one row`);
+    assert.equal(env.DB._audit.at(-1).action, action);
+    assert.equal(env.DB._audit.at(-1).actor, 'spuddeh');
+  }
+});
+
+test('the audit row records the actor, not a generic "admin"', async () => {
+  const env = await envFor();
+  await worker.fetch(
+    await authed('https://api.nczoning.net/admin/locations', {
+      method: 'POST', body: JSON.stringify(VALID),
+    }), env, {},
+  );
+  assert.equal(env.DB._audit.at(-1).actor, 'spuddeh');
+});
+
+// ------------------------------------------------- write-through gating ---
+
+test('a write does NOT materialize while DATA_SOURCE is mods', async () => {
+  // Otherwise an admin edit would silently overwrite KV with D1-derived data
+  // and perform the Phase 2 cutover as a side effect.
+  const env = await envFor({ dataSource: 'mods' });
+  const waited = [];
+  await worker.fetch(
+    await authed('https://api.nczoning.net/admin/locations', {
+      method: 'POST', body: JSON.stringify(VALID),
+    }), env, { waitUntil: (p) => waited.push(p) },
+  );
+  assert.equal(waited.length, 0, 'must not rebuild KV while mods.json is the source');
+});
+
+test('a write DOES materialize once DATA_SOURCE is d1', async () => {
+  const env = await envFor({ dataSource: 'd1' });
+  const waited = [];
+  await worker.fetch(
+    await authed('https://api.nczoning.net/admin/locations', {
+      method: 'POST', body: JSON.stringify(VALID),
+    }), env, { waitUntil: (p) => waited.push(p) },
+  );
+  assert.equal(waited.length, 1, 'the read path must be rebuilt write-through');
+  await waited[0]; // must not reject
+});

--- a/worker/test/validate.test.js
+++ b/worker/test/validate.test.js
@@ -1,0 +1,130 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+import { validateLocationInput, CATEGORIES } from '../src/validate.js';
+
+const require = createRequire(import.meta.url);
+const Ajv = require('ajv');
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const schema = JSON.parse(fs.readFileSync(path.join(REPO, 'mods.schema.json'), 'utf8'));
+const tagsDict = JSON.parse(fs.readFileSync(path.join(REPO, 'data', 'tags.json'), 'utf8'));
+const TAG_NAMES = new Set(Object.keys(tagsDict));
+
+// The file schema describes an ARRAY of locations; the write path validates one.
+const ajv = new Ajv({ allErrors: true });
+const ajvValidateOne = ajv.compile(schema.items);
+
+const RECORDS = fs.readdirSync(path.join(REPO, 'data', 'locations'))
+  .filter((f) => f.endsWith('.json'))
+  .map((f) => JSON.parse(fs.readFileSync(path.join(REPO, 'data', 'locations', f), 'utf8')));
+
+/** The write path never accepts `id`; strip it before comparing. */
+const asInput = (rec) => { const { id, ...rest } = rec; return rest; };
+
+// ---------------------------------------------------------------------------
+// This is the link between validate.js and mods.schema.json. validate.js is
+// hand-rolled because ajv cannot run in a Worker, so nothing *imports* the
+// schema at runtime. These tests are what stop the two drifting apart: change
+// the schema without changing validate.js and they fail.
+// ---------------------------------------------------------------------------
+
+test('every live record is accepted by BOTH ajv and validate.js', () => {
+  assert.ok(RECORDS.length > 200, `expected the real corpus, got ${RECORDS.length}`);
+  for (const rec of RECORDS) {
+    assert.equal(ajvValidateOne(rec), true, `ajv rejected ${rec.id}: ${ajv.errorsText(ajvValidateOne.errors)}`);
+    const mine = validateLocationInput(asInput(rec), { tagNames: TAG_NAMES });
+    assert.equal(mine.ok, true, `validate.js rejected ${rec.id}: ${mine.errors.join('; ')}`);
+  }
+});
+
+// Each mutation must be rejected by both. If ajv accepts one, the mutation is
+// not actually invalid and the case is wrong — asserted explicitly so a
+// mis-written test cannot pass by accident.
+const MUTATIONS = [
+  ['name too short', (r) => ({ ...r, name: 'ab' })],
+  ['name not a string', (r) => ({ ...r, name: 42 })],
+  ['authors empty', (r) => ({ ...r, authors: [] })],
+  ['authors not strings', (r) => ({ ...r, authors: [1, 2] })],
+  ['category unknown', (r) => ({ ...r, category: 'not-a-category' })],
+  ['coordinates too long', (r) => ({ ...r, coordinates: [1, 2, 3, 4] })],
+  ['coordinates too short', (r) => ({ ...r, coordinates: [1] })],
+  ['coordinates not numbers', (r) => ({ ...r, coordinates: ['1', '2', '3'] })],
+  ['nexus_id malformed', (r) => ({ ...r, nexus_id: 'not-an-id' })],
+  ['description over 500', (r) => ({ ...r, description: 'x'.repeat(501) })],
+  ['tags not an array', (r) => ({ ...r, tags: 'apartment' })],
+  ['missing category', (r) => { const { category, ...rest } = r; return rest; }],
+  ['missing name', (r) => { const { name, ...rest } = r; return rest; }],
+];
+
+for (const [label, mutate] of MUTATIONS) {
+  test(`both reject: ${label}`, () => {
+    const bad = mutate(RECORDS[0]);
+    assert.equal(ajvValidateOne(bad), false, `ajv ACCEPTED "${label}" — the case is not actually invalid`);
+    const mine = validateLocationInput(asInput(bad), { tagNames: TAG_NAMES });
+    assert.equal(mine.ok, false, `validate.js accepted "${label}"`);
+    assert.ok(mine.errors.length > 0);
+  });
+}
+
+test('the category list matches the schema exactly', () => {
+  // Catches a category added to one and not the other, which the corpus above
+  // would not notice until a record actually used it.
+  assert.deepEqual(CATEGORIES, schema.items.properties.category.enum);
+});
+
+test('the required field list matches the schema, minus the server-generated id', () => {
+  const schemaRequired = schema.items.required.filter((f) => f !== 'id');
+  for (const field of schemaRequired) {
+    const { [field]: _, ...without } = asInput(RECORDS[0]);
+    const mine = validateLocationInput(without, { tagNames: TAG_NAMES });
+    assert.equal(mine.ok, false, `validate.js allowed a record with no ${field}`);
+  }
+});
+
+// ------------------------------------------- write-path-only rules (no ajv) ---
+
+test('id is refused rather than ignored', () => {
+  const r = validateLocationInput({ ...asInput(RECORDS[0]), id: 'attacker-chosen' }, { tagNames: TAG_NAMES });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join(' '), /id cannot be set/);
+});
+
+test('an unknown field is an error, not silently dropped', () => {
+  // A typo'd field name that is discarded looks exactly like a successful save.
+  const r = validateLocationInput({ ...asInput(RECORDS[0]), coordinats: [1, 2, 3] }, { tagNames: TAG_NAMES });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join(' '), /unknown field: coordinats/);
+});
+
+test('unknown tags are rejected for an admin, unlike auto-discovery', () => {
+  const r = validateLocationInput(
+    { ...asInput(RECORDS[0]), tags: ['apartment', 'not-a-real-tag'] },
+    { tagNames: TAG_NAMES },
+  );
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join(' '), /unknown tag\(s\): not-a-real-tag/);
+});
+
+test('admin-only fields are accepted, and validated', () => {
+  const base = asInput(RECORDS[0]);
+  assert.equal(validateLocationInput({ ...base, status: 'hidden', admin_notes: 'note' }, { tagNames: TAG_NAMES }).ok, true);
+  assert.equal(validateLocationInput({ ...base, status: 'deleted' }, { tagNames: TAG_NAMES }).ok, false);
+});
+
+test('partial mode skips the required set but still validates what is present', () => {
+  assert.equal(validateLocationInput({ name: 'A new name' }, { tagNames: TAG_NAMES, partial: true }).ok, true);
+  assert.equal(validateLocationInput({ name: 'ab' }, { tagNames: TAG_NAMES, partial: true }).ok, false);
+  // ...and an empty patch is not an error, just a no-op the route rejects.
+  assert.equal(validateLocationInput({}, { tagNames: TAG_NAMES, partial: true }).ok, true);
+});
+
+test('non-finite coordinates are rejected', () => {
+  for (const bad of [[1, 2, NaN], [Infinity, 2, 3]]) {
+    const r = validateLocationInput({ ...asInput(RECORDS[0]), coordinates: bad }, { tagNames: TAG_NAMES });
+    assert.equal(r.ok, false, JSON.stringify(bad));
+  }
+});


### PR DESCRIPTION
First slice of Phase 4: the write path. Direct writes, no submission queue yet
(that is Phase 5), and no dashboard UI yet (4c).

**Nothing on the live map reads any of this.** Production still sources from
`mods.json`.

## The validator, and why it is duplicated on purpose

`mods.schema.json` has been the CI gate on `data/locations/*.json`. Once writes
arrive through the API instead of through pull requests, **that gate has to move
into the Worker or it silently disappears along with the workflow**.

It could not simply be imported: ajv compiles with `new Function`, which Workers
refuses. So `validate.js` is hand-rolled, and the link back to the schema is a
**test** rather than an import — `validate.test.js` compiles the real
`mods.schema.json` with ajv and asserts the two agree over:

- **all 287 live records** — both must accept every one
- **13 crafted invalid records** — both must reject every one, and the test also
  asserts *ajv rejects them*, so a mis-written case cannot pass by accident
- the category enum and the required-field list, compared against the schema
  directly

Change the schema without changing `validate.js` and it fails. That is the whole
mechanism, and it is why the duplication is safe rather than a slow drift.

## Two things worth reviewing closely

**Write-through materialization is gated on `DATA_SOURCE`.** After a write, the
read path is rebuilt so a change appears in seconds rather than at the next cron
tick — *but only when the cron is already sourcing from D1*. If it is still on
`mods.json`, rebuilding KV from D1 would overwrite the served dataset with
D1-derived content and **perform the Phase 2 cutover as a side effect of someone
saving a form**. Tested in both directions.

**Input is refused, not ignored.**

- `id` is server-generated and rejected if supplied. A caller-chosen id is how a
  `?mod=` deep link gets silently repointed at a different mod.
- Unknown fields are a 422, not dropped. A typo'd field name that is silently
  discarded looks exactly like a successful save.
- Unknown *tags* are an error here, unlike auto-discovery where they are dropped.
  An admin typing a tag that does not exist has made a mistake worth surfacing;
  a third-party Nexus description has not.

## Audit log

Append-only, never updated or deleted — a correction is another row. This is
what replaces `git log` for data changes: once edits stop being commits, nothing
else records who changed what.

`before`/`after` are stored **verbatim, including `admin_notes`**. Redaction
belongs to Part C's public export, not here — storing a redacted copy would lose
the real history for the sake of a future consumer.

A `DELETE` keeps the entire record in `before`, so it is recoverable.
`status: 'hidden'` remains the right move for a mod pulled from the map; delete
is for records that should never have existed.

## Test plan

**173 pass (34 new).**

The Phase 4 gate — *every mutation produces an audit row* — is asserted
directly, walking create → update → delete and checking the count increments by
exactly one each time, with the correct action and the real actor login.

Also covered: every route 401s with no session; a signed-in **non**-collaborator
gets 403 and writes **neither a row nor an audit entry**; an indeterminate
collaborator check is 503 and also writes nothing; invalid input is 422 and
audits nothing; `PATCH` touches only what was sent and moves `updated_at`; an
unknown id is 404 rather than a silent no-op.

## Next in Phase 4

- **4b:** tags move to D1, `/v1/tags` reshape (breaking → `0.4.0`), site stops
  fetching `data/tags.json`
- **4c:** the dashboard UI on top of these routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
