### PR TITLE
feat(tags): Phase 4b — tags move to D1, /v1/tags becomes an array (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GitHub sign-in for admins at `/admin/`, gated on repository collaborator status.
 - Admin CRUD over the location registry, with an append-only audit log: every mutation records who did it, and the record before and after. Nothing on the live map reads these writes yet.
 
+### Changed
+
+- **API `0.3.0` → `0.4.0`.** `/v1/tags` now returns an array of `{slug, name, description, sort_order}` instead of a `{tag: description}` map, matching `/v1/locations` and the shape the in-game parser maps most easily. `name` falls back to the slug, so nothing renders differently. Breaking, and taken now while the pre-1.0 window makes it free.
+- Tags are registry data in D1 rather than `data/tags.json`, so they can be edited in the dashboard instead of by pull request, and a mistyped tag is rejected on write rather than caught in CI afterwards. The site reads `/v1/tags`, falling back to the static file only if the API is unreachable.
+
 ## [1.7.2] - 2026-07-26
 
 ### Changed

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1814,15 +1814,29 @@ async function initMap() {
   try {
     // The server-built Data API (/v1) is the site's sole data source: it does
     // the manual + Nexus auto-discovery merge, district enrichment and thumbnail
-    // resolution server-side, so the browser makes no Nexus calls here. tags.json
-    // stays a local static fetch (same-origin, not the Nexus fragility this
-    // replaces). There is no client-side fallback — if the API is down the outer
-    // catch shows a loud "map data unavailable" state, keeping the site a real
-    // canary for the API (whose in-game consumer has no fallback either).
-    const [apiResult, tagsDict] = await Promise.all([
+    // resolution server-side, so the browser makes no Nexus calls here. Tags now
+    // come from /v1/tags too — one origin, one contract — since the D1 `tags`
+    // table replaced data/tags.json as the source of truth. There is no
+    // client-side fallback for LOCATIONS — if the API is down the outer catch
+    // shows a loud "map data unavailable" state, keeping the site a real canary
+    // for the API (whose in-game consumer has no fallback either).
+    //
+    // Tags are the one exception: they degrade to the static file rather than
+    // taking the map down, because a missing tag registry costs tooltips and
+    // filter labels, not pins.
+    const [apiResult, tagsPayload] = await Promise.all([
       NCZ.fetchLocationsFromApi(),
-      fetch(NCZ.DATA_TAGS_PATH).then((r) => r.json()),
+      fetch(`${NCZ.API_BASE}/v1/tags`)
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+        .then((body) => body.data)
+        .catch((err) => {
+          console.warn("/v1/tags unavailable, falling back to the static file:", err);
+          return fetch(NCZ.DATA_TAGS_PATH).then((r) => r.json());
+        }),
     ]);
+    // Accepts both the array-of-records shape and the legacy dictionary, so the
+    // site and the Worker can deploy in either order during the migration.
+    const tagsDict = NCZ.normaliseTags(tagsPayload);
     const { mods, nexusThumbs } = apiResult;
     // The API owns the recency window (it computes each mod's recently_updated
     // bool against it). Adopt it so the tooltip text matches; fall back to the

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -102,8 +102,13 @@ NCZ.API_BASE =
 // TTL-based cacheGet/cacheSet.
 NCZ.API_LOCATIONS_CACHE_KEY = "nc_api_locations_full";
 
-// Data paths. tags.json stays a local static fetch (same-origin) alongside the
-// /v1 dataset — the tag registry the sidebar and BBCode generator render from.
+// The tag registry now comes from /v1/tags alongside the locations: one origin,
+// one contract. It used to be a same-origin fetch of data/tags.json, which was
+// fine while the file was the source of truth — from Phase 4 the D1 `tags`
+// table is, edited in the dashboard rather than by pull request.
+//
+// Kept only as the fallback if /v1/tags cannot be reached, so a tag-registry
+// hiccup degrades tooltips rather than the map.
 NCZ.DATA_TAGS_PATH = "data/tags.json";
 
 // 3D scene GLB source folder. The committed runtime path is "assets/glb-meshopt"

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -248,6 +248,28 @@ NCZ.pointInPolygon = function (point, ring) {
 
 // Builds the full popup HTML string for a mod.
 // View-agnostic: both Leaflet (marker.bindPopup) and Three.js (CSS2DObject) call this.
+/**
+ * Normalise whatever /v1/tags returned into the { slug: description } map the
+ * renderers use.
+ *
+ * TRANSITIONAL: accepts BOTH the array-of-records shape (D1-backed, current)
+ * and the legacy { slug: description } dictionary. Not defensive coding for its
+ * own sake — the site and the Worker deploy independently, and the dev site
+ * reads the PRODUCTION API by default, so during the migration a new site can
+ * legitimately be talking to an API still serving the old shape. Tolerating
+ * both means the two can ship in either order with no flag day.
+ *
+ * Delete the dictionary branch once every environment serves the array.
+ */
+NCZ.normaliseTags = function (payload) {
+  if (Array.isArray(payload)) {
+    return Object.fromEntries(
+      payload.map((t) => [t.slug, t.description ?? ""])
+    );
+  }
+  return payload && typeof payload === "object" ? payload : {};
+};
+
 NCZ.buildPopupHtml = function (mod, catStyle, nexusThumbs, tagsDict) {
   const nexus_id_lower = String(mod.nexus_id).toLowerCase();
   let nexusUrl = `https://www.nexusmods.com/cyberpunk2077/mods/${mod.nexus_id}`;

--- a/data/locations/0f3d60d4-dc81-40cf-9fdb-44c0f82bffa4.json
+++ b/data/locations/0f3d60d4-dc81-40cf-9fdb-44c0f82bffa4.json
@@ -15,8 +15,8 @@
     "category": "location-overhaul",
     "tags": [
         "apartment",
-        "neomilitarism",
-        "corpo"
+        "corpo",
+        "neomilitarism"
     ],
     "yaw": 174.5
 }

--- a/worker/api-version.lock.json
+++ b/worker/api-version.lock.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.3.0",
-  "shape_hash": "sha256:799ed6247b85a33f3e167b57c3be48004275f1da2ae77458024d0e9c09873145"
+  "version": "0.4.0",
+  "shape_hash": "sha256:e8583171722ab16ec0670c245b0849736aafbc33760ca55bbe94f041410cb314"
 }

--- a/worker/migrations/0002_tags.sql
+++ b/worker/migrations/0002_tags.sql
@@ -1,0 +1,76 @@
+-- Phase 4b: tags become registry data in D1 instead of a JSON file in git.
+--
+-- Apply to BOTH databases (named environments inherit nothing):
+--   npx wrangler d1 migrations apply nczoning-data --remote
+--   npx wrangler d1 migrations apply nczoning-data-staging --env staging --remote
+--
+-- ADDITIVE ONLY. `locations.tags` is deliberately left in place: the
+-- materializer switches to the join, the parity gate proves it produces
+-- byte-identical output, and only then does a later migration drop the column.
+-- Dropping it here would make the join simultaneously the new source of truth
+-- and unverifiable.
+--
+-- The tag rows below are GENERATED from data/tags.json, not hand-transcribed,
+-- so the descriptions cannot drift during the transition.
+
+-- slug is the primary key rather than a surrogate integer, because it is
+-- already the identifier everywhere else: location records carry
+-- tags: ["entropism"]. An integer key would create a SECOND identifier for the
+-- same thing, which is the redundant-representation problem this work removes.
+CREATE TABLE tags (
+  slug TEXT PRIMARY KEY,
+  -- Display label. NULL falls back to the slug, which is exactly today's
+  -- behaviour: utils.js renders the raw tag string as the badge, so the
+  -- identifier and the label are currently the same string. Splitting them is
+  -- the point of the move -- "neomilitarism" can be shown as "Neo-Militarism"
+  -- without the identifier ever moving, which is what made renaming feel risky.
+  name TEXT,
+  description TEXT NOT NULL,
+  sort_order INTEGER,
+  created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+
+-- A join table rather than the JSON array, because referential integrity is the
+-- main reason for the move: a typo'd tag is currently caught by
+-- scripts/validate_tags.js in CI on a data PR, long after the edit.
+--
+-- ON UPDATE CASCADE covers the rare case where a slug genuinely must change (a
+-- typo): one update propagates. That is a link-breaking event done
+-- consciously; routine relabelling is what `name` is for.
+CREATE TABLE location_tags (
+  location_id TEXT NOT NULL REFERENCES locations(id) ON DELETE CASCADE,
+  tag_slug    TEXT NOT NULL REFERENCES tags(slug) ON UPDATE CASCADE,
+  PRIMARY KEY (location_id, tag_slug)
+);
+
+-- The materializer joins per location on every cron tick.
+CREATE INDEX idx_location_tags_tag ON location_tags (tag_slug);
+
+-- Seeded in data/tags.json order. `nczoning` is NOT here, deliberately: it is a
+-- marker auto-discovery adds to every Nexus-sourced record, not a registry
+-- entry an admin curates, and utils.js special-cases its description. Putting
+-- it here would make it editable and deletable, and deleting it would break
+-- every auto-discovered record's tag list.
+INSERT INTO tags (slug, name, description, sort_order, created_at, updated_at) VALUES
+  ('entropism', NULL, 'The look of poverty that derives from humans grappling with and struggling against technology and its unforgiving advance. It denotes a lack of design blending with a general poverty of means and ideas.', 1, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z'),
+  ('kitsch', NULL, 'The look of a long lost golden age on people entirely unwilling or unable to forget it. It''s flashy, bold and usually cheap - filled with gold-plated cyberware, implants encased in brightly colored plastic and larger-than-life makeup.', 2, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z'),
+  ('neomilitarism', NULL, 'The look of global conflict and corporations jockeying for power. Cold, sharp and modern. Making everyone look as if they are ready to drop out of an AV''s cargo door and head straight into combat.', 3, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z'),
+  ('neokitsch', NULL, 'The look of infinite wealth and vanity. Synonymous with luxury, it has been blossoming among Night City''s wealthiest elites - those who can afford to buy anything, who can afford to be anything they want to be.', 4, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z'),
+  ('shop', NULL, 'A retail location to purchase weapons, clothing, items, etc.', 5, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z'),
+  ('infrastructure', NULL, 'Roads, bridges, parking structures, and public works.', 6, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z'),
+  ('entertainment', NULL, 'Bars, clubs, casinos, and nightlife venues.', 7, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z'),
+  ('apartment', NULL, 'A player housing unit, usually a smaller dwelling within a megabuilding or high-rise.', 8, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z'),
+  ('house', NULL, 'A standalone player dwelling or safehouse structure.', 9, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z'),
+  ('quest', NULL, 'A location closely tied to custom gigs, missions, or storylines.', 10, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z'),
+  ('streetkid', NULL, 'Environments resonating with gang culture, neon lights, and urban survival.', 11, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z'),
+  ('corpo', NULL, 'High-end corporate architecture, slick aesthetics, and security-focused areas.', 12, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z'),
+  ('nomad', NULL, 'Off-the-grid, scrapyard, desert, or vehicular-based habitats.', 13, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z'),
+  ('photos', NULL, 'Scenic or atmospheric locations well-suited for virtual photography.', 14, '2026-07-26T00:00:00Z', '2026-07-26T00:00:00Z');
+
+-- Populate the join from the JSON column that is still present. json_each
+-- unpacks the array; the IN clause drops anything not in the registry, which is
+-- exactly how the synthetic 'nczoning' marker is excluded without naming it.
+INSERT INTO location_tags (location_id, tag_slug)
+SELECT l.id, je.value
+FROM locations l, json_each(l.tags) je
+WHERE je.value IN (SELECT slug FROM tags);

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "NC Zoning Data API",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "Read-only API serving the NC Zoning Board mod registry (Cyberpunk 2077 location mods) to in-game mods and the website. Every response is wrapped in a versioned envelope. Coordinates are raw CET world values [X, Y, Z], usable in-game with no transform. The JSON stays DTO-mappable for the in-game RedData parser: no arrays-of-arrays, property names are case-sensitive. See https://github.com/nczoning/nc-zoning-board for the project.",
     "contact": { "name": "NC Zoning Board", "url": "https://nczoning.net" }
   },
@@ -97,16 +97,21 @@
     },
     "/v1/tags": {
       "get": {
-        "summary": "Tag dictionary",
-        "description": "Map of tag id → human description. The allow-list a location's tags are drawn from.",
+        "summary": "Tag registry",
+        "description": "The tag registry. **Changed in 0.4.0**: this was a map of tag id → description; it is now an array of records, matching /v1/locations and the per-record shape the in-game RedData parser maps most easily. `slug` is the stable identifier a location's `tags` array carries; `name` is the display label and falls back to the slug when unset.",
         "parameters": [{ "$ref": "#/components/parameters/IfNoneMatch" }],
         "responses": {
           "200": {
-            "description": "Tag dictionary.",
+            "description": "Tag registry.",
             "headers": { "ETag": { "$ref": "#/components/headers/ETag" }, "Cache-Control": { "$ref": "#/components/headers/CacheControl" } },
             "content": { "application/json": { "schema": {
               "allOf": [{ "$ref": "#/components/schemas/Envelope" }, { "type": "object", "properties": {
-                "data": { "type": "object", "additionalProperties": { "type": "string" }, "example": { "apartment": "A residence you can enter", "corpo": "Corporate aesthetic" } } } }]
+                "data": { "type": "array", "items": { "type": "object", "required": ["slug", "name", "description"], "properties": {
+                  "slug": { "type": "string", "description": "Stable identifier; this is what a location record carries in its tags array." },
+                  "name": { "type": "string", "description": "Display label. Falls back to the slug when unset." },
+                  "description": { "type": "string" },
+                  "sort_order": { "type": "integer", "nullable": true }
+                } }, "example": [{ "slug": "apartment", "name": "apartment", "description": "A player housing unit, usually a smaller dwelling within a megabuilding or high-rise.", "sort_order": 8 }] } } }]
             } } }
           },
           "304": { "$ref": "#/components/responses/NotModified" },

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nczoning-api",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "NC Zoning Data API worker (api.nczoning.net)",
   "type": "module",

--- a/worker/scripts/parity-ab.mjs
+++ b/worker/scripts/parity-ab.mjs
@@ -116,6 +116,16 @@ async function main() {
   const rows = query(db, 'SELECT * FROM locations ORDER BY id');
   const dismissed = new Set(query(db, 'SELECT nexus_id FROM dismissed_candidates').map((r) => String(r.nexus_id)));
 
+  // The join, not the legacy locations.tags column. Passing this is what makes
+  // the comparison test the path production will actually take; without it
+  // materializeFromD1 silently falls back to the JSON column and the sweep
+  // proves nothing about the migration.
+  const locationTags = new Map();
+  for (const r of query(db, 'SELECT location_id, tag_slug FROM location_tags ORDER BY location_id, tag_slug')) {
+    if (!locationTags.has(r.location_id)) locationTags.set(r.location_id, []);
+    locationTags.get(r.location_id).push(r.tag_slug);
+  }
+
   // The tagged-mod nodes both paths consume. Reconstructed from the live auto
   // records so the two sides are fed byte-identical Nexus input; a real fetch
   // would introduce a second variable and could change mid-run.
@@ -163,7 +173,7 @@ async function main() {
   for (const days of offsets) {
     const nowMs = base + days * day;
     const a = buildDataset({ manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs, nowMs }).full;
-    const b = materializeFromD1({ rows, dismissed, tagsDict, nexusNodes, districts, manualThumbs, nowMs }).full;
+    const b = materializeFromD1({ rows, dismissed, tagsDict, nexusNodes, districts, manualThumbs, locationTags, nowMs }).full;
     const d = diff(a, b);
     const recent = Object.values(a).filter((r) => r.recently_updated).length;
     const label = `clock ${days >= 0 ? '+' : ''}${days}d`.padEnd(12);

--- a/worker/scripts/parity-check.mjs
+++ b/worker/scripts/parity-check.mjs
@@ -150,7 +150,7 @@ function withArchives(record, liveRecord) {
   return { ...record, archives: liveRecord.archives };
 }
 
-function buildFromRows(rows, dismissedIds, tagsDict, districts, liveRecords, nowMs) {
+function buildFromRows(rows, dismissedIds, tagsDict, districts, liveRecords, nowMs, locationTags) {
   const { full } = materializeFromD1({
     rows,
     dismissed: dismissedIds,
@@ -158,6 +158,10 @@ function buildFromRows(rows, dismissedIds, tagsDict, districts, liveRecords, now
     nexusNodes: [], // nothing auto-publishes; images arrive via manualThumbs
     districts,
     manualThumbs: thumbsFromLive(liveRecords),
+    // The join. Without it materializeFromD1 falls back to the legacy
+    // locations.tags column, so the gate would pass while testing the path
+    // production no longer takes.
+    locationTags,
     nowMs,
   });
   const byId = new Map(liveRecords.map((r) => [r.id, r]));
@@ -195,7 +199,14 @@ async function main() {
   console.log(`live: ${liveRecords.length} records, generated_at ${envelope.generated_at}\n`);
 
   const dismissedIds = new Set(dismissedRows.map((r) => String(r.nexus_id)));
-  const candidate = buildFromRows(rows, dismissedIds, tagsDict, subdistricts.districts, liveRecords, nowMs);
+
+  const locationTags = new Map();
+  for (const r of query(db, 'SELECT location_id, tag_slug FROM location_tags ORDER BY location_id, tag_slug')) {
+    if (!locationTags.has(r.location_id)) locationTags.set(r.location_id, []);
+    locationTags.get(r.location_id).push(r.tag_slug);
+  }
+
+  const candidate = buildFromRows(rows, dismissedIds, tagsDict, subdistricts.districts, liveRecords, nowMs, locationTags);
 
   // --- ID assertion (the deep-link contract) ----------------------------
   const liveIds = new Set(liveRecords.map((r) => r.id));
@@ -248,7 +259,7 @@ async function main() {
     const mutated = rows.map((r, i) => (i === 0 ? mutate(r) : r));
     let differs;
     try {
-      const out = buildFromRows(mutated, dismissedIds, tagsDict, subdistricts.districts, liveRecords, nowMs);
+      const out = buildFromRows(mutated, dismissedIds, tagsDict, subdistricts.districts, liveRecords, nowMs, locationTags);
       differs = !compare(out, liveRecords);
     } catch {
       differs = true; // a throw is also a detection

--- a/worker/src/d1.js
+++ b/worker/src/d1.js
@@ -40,6 +40,52 @@ export async function readDismissedIds(env) {
   return new Set((results ?? []).map((r) => String(r.nexus_id)));
 }
 
+/**
+ * The tag registry, in display order. This is the /v1/tags payload shape:
+ * an array of records, matching /v1/locations and the per-record philosophy,
+ * rather than the arbitrarily-keyed map it used to be (which is also awkward
+ * for the in-game RedData `FromJson`).
+ *
+ * `name` falls back to the slug when NULL, which is exactly today's rendering —
+ * the site shows the raw tag string as the badge. That fallback is what lets
+ * this ship without any visual change until labels are actually set.
+ */
+export async function readTags(env) {
+  const { results } = await env.DB.prepare(
+    'SELECT slug, name, description, sort_order FROM tags ORDER BY sort_order, slug',
+  ).all();
+  return (results ?? []).map((r) => ({
+    slug: r.slug,
+    name: r.name ?? r.slug,
+    description: r.description,
+    sort_order: r.sort_order,
+  }));
+}
+
+/**
+ * Per-location tag slugs, as a Map(location_id -> string[]).
+ *
+ * Ordered by slug, because tag order carries no meaning — it is a set rendered
+ * as badges. 286 of the 287 manual records were already alphabetical and the
+ * single outlier was normalised, so this reproduces the existing output rather
+ * than imposing a new order.
+ *
+ * `nczoning` is absent by construction (it is not a `tags` row), and is
+ * re-added by the materializer for auto-sourced records, exactly as merge.js
+ * prepends it.
+ */
+export async function readLocationTags(env) {
+  const { results } = await env.DB.prepare(
+    'SELECT location_id, tag_slug FROM location_tags ORDER BY location_id, tag_slug',
+  ).all();
+  const map = new Map();
+  for (const r of results ?? []) {
+    if (!map.has(r.location_id)) map.set(r.location_id, []);
+    map.get(r.location_id).push(r.tag_slug);
+  }
+  return map;
+}
+
 /** How long a collaborator verdict is trusted before it is re-checked. */
 export const COLLABORATOR_TTL_MS = 10 * 60 * 1000;
 

--- a/worker/src/materialize.js
+++ b/worker/src/materialize.js
@@ -37,7 +37,7 @@ import { RECENTLY_UPDATED_DAYS } from './config.js';
  * - NULL `yaw` / `credits` must OMIT the key rather than emit null, matching
  *   merge.js's conditional spreads.
  */
-export function rowToEntry(row) {
+export function rowToEntry(row, locationTags) {
   return {
     id: row.id,
     name: row.name,
@@ -47,12 +47,30 @@ export function rowToEntry(row) {
       : [row.x, row.y, row.z],
     yaw: row.yaw,
     category: row.category,
-    tags: JSON.parse(row.tags ?? '[]'),
+    tags: resolveTags(row, locationTags),
     authors: JSON.parse(row.authors ?? '[]'),
     source: row.source,
     description: row.description ?? '',
     credits: row.credits,
   };
+}
+
+/**
+ * Tags for one record.
+ *
+ * When `locationTags` is supplied it is authoritative — that is the join, and
+ * the production path. Without it the legacy `locations.tags` JSON column is
+ * used; migration 0002 keeps both in sync precisely so the switch can be
+ * proven byte-for-byte before the column is dropped.
+ *
+ * `nczoning` is re-added for auto-sourced records because it is not a registry
+ * row: it is a marker auto-discovery adds, and merge.js prepends it the same
+ * way. It goes first, matching every existing auto record.
+ */
+function resolveTags(row, locationTags) {
+  if (!locationTags) return JSON.parse(row.tags ?? '[]');
+  const slugs = locationTags.get(row.id) ?? [];
+  return row.source === 'auto' ? ['nczoning', ...slugs] : [...slugs];
 }
 
 /**
@@ -67,7 +85,8 @@ export function rowToEntry(row) {
  * @returns {{full: Object<string, object>, meta: object}}
  */
 export function materializeFromD1({
-  rows, dismissed, tagsDict, nexusNodes, districts, manualThumbs = {}, nowMs = Date.now(),
+  rows, dismissed, tagsDict, nexusNodes, districts, manualThumbs = {},
+  locationTags = null, nowMs = Date.now(),
 }) {
   const validTagNames = new Set(Object.keys(tagsDict));
   const dismissedIds = dismissed instanceof Set ? dismissed : new Set(dismissed || []);
@@ -105,7 +124,9 @@ export function materializeFromD1({
     if (!parsed) skipped.push({ nexus_id: nexusId, name: node.name || 'Unknown Mod' });
   }
 
-  const all = published.map(rowToEntry).sort((a, b) => a.name.localeCompare(b.name));
+  const all = published
+    .map((row) => rowToEntry(row, locationTags))
+    .sort((a, b) => a.name.localeCompare(b.name));
 
   const cutoffMs = nowMs - RECENTLY_UPDATED_DAYS * 86400000;
   const full = {};

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -16,7 +16,9 @@
 import { fetchTaggedModNodes, fetchModsByUidThumbs, fetchModArchiveNames } from './nexus.js';
 import { buildDataset } from './merge.js';
 import { materializeFromD1 } from './materialize.js';
-import { readLocationRows, readDismissedIds } from './d1.js';
+import {
+  readLocationRows, readDismissedIds, readTags, readLocationTags,
+} from './d1.js';
 import { districtsPayload } from './districts.js';
 import { HEARTBEAT_MIN_INTERVAL_MS } from './config.js';
 import {
@@ -191,17 +193,30 @@ async function attachArchives(env, fetchImpl, full) {
  * they move to D1 at Phase 4.
  */
 async function sourceAndBuild(env, fetchImpl, origin, nowMs) {
-  const [tagsDict, subdistricts] = await Promise.all([
-    fetchJson(fetchImpl, origin, '/data/tags.json'),
-    fetchJson(fetchImpl, origin, '/data/subdistricts.json'),
-  ]);
+  const useD1 = env.DATA_SOURCE === 'd1';
+  const subdistricts = await fetchJson(fetchImpl, origin, '/data/subdistricts.json');
   const districts = subdistricts.districts;
+
+  // The tag registry. From D1 once it owns tags, from the file otherwise — but
+  // EITHER WAY the served payload is the array shape. The public contract must
+  // not depend on an internal source flag, or /v1/tags would silently change
+  // shape when DATA_SOURCE flips. `tagsDict` stays a slug->description map for
+  // block validation, which is all the parsers need.
+  const tagsList = useD1
+    ? await readTags(env)
+    : Object.entries(await fetchJson(fetchImpl, origin, '/data/tags.json'))
+      .map(([slug, description], i) => ({
+        slug, name: slug, description, sort_order: i + 1,
+      }));
+  const tagsDict = Object.fromEntries(tagsList.map((t) => [t.slug, t.description]));
+
   const nexusNodes = await fetchTaggedModNodes(fetchImpl);
 
-  if (env.DATA_SOURCE === 'd1') {
-    const [rows, dismissed] = await Promise.all([
+  if (useD1) {
+    const [rows, dismissed, locationTags] = await Promise.all([
       readLocationRows(env),
       readDismissedIds(env),
+      readLocationTags(env),
     ]);
     // Thumbnail backfill covers every published record with a numeric id, not
     // just the "manual" ones: under D1 the auto-discovered records are rows too.
@@ -211,9 +226,9 @@ async function sourceAndBuild(env, fetchImpl, origin, nowMs) {
       .filter((id) => /^\d+$/.test(id));
     const manualThumbs = await fetchModsByUidThumbs(fetchImpl, numericIds);
     const built = materializeFromD1({
-      rows, dismissed, tagsDict, nexusNodes, districts, manualThumbs, nowMs,
+      rows, dismissed, tagsDict, nexusNodes, districts, manualThumbs, locationTags, nowMs,
     });
-    return { ...built, tagsDict, districts };
+    return { ...built, tagsList, districts };
   }
 
   const [manualMods, excluded] = await Promise.all([
@@ -227,7 +242,7 @@ async function sourceAndBuild(env, fetchImpl, origin, nowMs) {
   const built = buildDataset({
     manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs, nowMs,
   });
-  return { ...built, tagsDict, districts };
+  return { ...built, tagsList, districts };
 }
 
 /**
@@ -257,7 +272,7 @@ export async function runRefresh(env, fetchImpl = fetch) {
     // leaves some images null for a cycle, it never marks the dataset stale.
     // A D1 read failure, by contrast, throws and lands in the catch below --
     // last-known-good, discovery_stale, alert. Never an empty map.
-    const { full, meta, tagsDict, districts } = await sourceAndBuild(
+    const { full, meta, tagsList, districts } = await sourceAndBuild(
       env, fetchImpl, origin, Date.parse(generatedAt),
     );
     const districtsOut = districtsPayload(districts);
@@ -274,7 +289,7 @@ export async function runRefresh(env, fetchImpl = fetch) {
     // caches even though nothing on Nexus changed). This is why the cron
     // rebuilds every tick against a fresh clock, with no Nexus short-circuit.
     const version = await contentHash(
-      JSON.stringify({ full, districts: districtsOut, tags: tagsDict }),
+      JSON.stringify({ full, districts: districtsOut, tags: tagsList }),
     );
 
     const prev = await readMeta(env);
@@ -302,7 +317,7 @@ export async function runRefresh(env, fetchImpl = fetch) {
     await writeDataset(env, {
       full,
       districts: districtsOut,
-      tags: tagsDict,
+      tags: tagsList,
       meta: {
         schema: SCHEMA_VERSION,
         generated_at: generatedAt,

--- a/worker/test/refresh-d1.test.js
+++ b/worker/test/refresh-d1.test.js
@@ -112,13 +112,28 @@ function fakeFetch({ banModsJson = false } = {}) {
   };
 }
 
-function fakeD1({ rows = ROWS, dismissed = [{ nexus_id: '777' }], count, fail = false } = {}) {
+// The tag registry and the join, mirroring migration 0002. `nczoning` is
+// absent from both, exactly as in the real schema — the materializer re-adds it
+// for auto-sourced records.
+const TAG_ROWS = [
+  { slug: 'apartment', name: null, description: 'a place', sort_order: 1 },
+  { slug: 'corpo', name: null, description: 'suits', sort_order: 2 },
+];
+const LOCATION_TAG_ROWS = [{ location_id: 'm1', tag_slug: 'apartment' }];
+
+function fakeD1({
+  rows = ROWS, dismissed = [{ nexus_id: '777' }], count, fail = false,
+  tagRows = TAG_ROWS, locationTagRows = LOCATION_TAG_ROWS,
+} = {}) {
   return {
     prepare(sql) {
       return {
         async all() {
           if (fail) throw new Error('D1 unavailable');
           if (sql.includes('dismissed_candidates')) return { results: dismissed };
+          // Checked before `FROM locations`: "FROM location_tags" contains it.
+          if (sql.includes('FROM location_tags')) return { results: locationTagRows };
+          if (sql.includes('FROM tags')) return { results: tagRows };
           return { results: rows };
         },
         async first() {

--- a/worker/test/tags.test.js
+++ b/worker/test/tags.test.js
@@ -1,0 +1,104 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readTags, readLocationTags } from '../src/d1.js';
+import { materializeFromD1 } from '../src/materialize.js';
+
+const DISTRICTS = [{
+  id: 't', name: 'Testville',
+  polygon: [[0, 0], [1000, 0], [1000, 1000], [0, 1000]],
+  subdistricts: [],
+}];
+
+function fakeDb({ tags = [], links = [] } = {}) {
+  return {
+    prepare(sql) {
+      return {
+        async all() {
+          if (sql.includes('FROM location_tags')) return { results: links };
+          if (sql.includes('FROM tags')) return { results: tags };
+          throw new Error(`unexpected: ${sql}`);
+        },
+      };
+    },
+  };
+}
+
+const row = (over = {}) => ({
+  id: 'a', name: 'Alpha', nexus_id: '1', category: 'other',
+  x: 1, y: 2, z: 3, yaw: null, description: 'd', credits: null,
+  authors: '["Spud"]', tags: '["legacy-column-value"]',
+  source: 'manual', status: 'published',
+  created_at: 'x', updated_at: 'x', ...over,
+});
+
+const build = (rows, locationTags) => materializeFromD1({
+  rows, dismissed: [], tagsDict: {}, nexusNodes: [], districts: DISTRICTS,
+  locationTags, nowMs: 0,
+}).full;
+
+test('readTags falls back to the slug when no display name is set', async () => {
+  const env = {
+    DB: fakeDb({
+      tags: [
+        { slug: 'corpo', name: null, description: 'suits', sort_order: 2 },
+        { slug: 'apartment', name: 'Apartment', description: 'a place', sort_order: 1 },
+      ],
+    }),
+  };
+  const tags = await readTags(env);
+  // The fallback is what lets this ship with no visual change: the site renders
+  // the raw slug today, so name===slug reproduces it exactly.
+  assert.equal(tags[0].name, 'corpo');
+  assert.equal(tags[1].name, 'Apartment');
+  assert.deepEqual(Object.keys(tags[0]), ['slug', 'name', 'description', 'sort_order']);
+});
+
+test('readLocationTags groups slugs by location', async () => {
+  const env = {
+    DB: fakeDb({
+      links: [
+        { location_id: 'a', tag_slug: 'apartment' },
+        { location_id: 'a', tag_slug: 'corpo' },
+        { location_id: 'b', tag_slug: 'house' },
+      ],
+    }),
+  };
+  const map = await readLocationTags(env);
+  assert.deepEqual(map.get('a'), ['apartment', 'corpo']);
+  assert.deepEqual(map.get('b'), ['house']);
+  assert.equal(map.get('missing'), undefined);
+});
+
+test('the join is authoritative when supplied, not the legacy column', async () => {
+  const full = build([row()], new Map([['a', ['apartment', 'corpo']]]));
+  assert.deepEqual(full.a.tags, ['apartment', 'corpo']);
+  assert.equal(full.a.tags.includes('legacy-column-value'), false);
+});
+
+test('without the join it falls back to the legacy column', async () => {
+  // Migration 0002 keeps both in sync on purpose, so the fallback is a
+  // transitional path rather than a silent inconsistency.
+  const full = build([row()], null);
+  assert.deepEqual(full.a.tags, ['legacy-column-value']);
+});
+
+test('nczoning is re-added for auto records, and only for those', async () => {
+  const full = build(
+    [row({ id: 'm', source: 'manual' }), row({ id: 'x', name: 'Zeta', source: 'auto' })],
+    new Map([['m', ['apartment']], ['x', ['corpo']]]),
+  );
+  // It is not a registry row (not in the tags table), so the materializer
+  // prepends it exactly as merge.js does for auto entries.
+  assert.deepEqual(full.m.tags, ['apartment']);
+  assert.deepEqual(full.x.tags, ['nczoning', 'corpo']);
+});
+
+test('an auto record whose only tag was nczoning still gets it back', async () => {
+  const full = build([row({ id: 'x', source: 'auto' })], new Map()); // no links at all
+  assert.deepEqual(full.x.tags, ['nczoning']);
+});
+
+test('a location with no tags yields an empty array, not undefined', async () => {
+  const full = build([row()], new Map());
+  assert.deepEqual(full.a.tags, []);
+});

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -46,7 +46,7 @@
 		// package.json, then run `npm run version:lock` —
 		// test/api-version.test.js enforces all four. There is no monotonicity
 		// check, so a decrease passes provided all four move together.
-		"API_VERSION": "0.3.0",
+		"API_VERSION": "0.4.0",
 		// Origin the cron pulls source files from (mods.json, tags, subdistricts).
 		"SITE_ORIGIN": "https://nczoning.net",
 		// Where the LOCATION REGISTRY is read from: "mods" (the compiled
@@ -143,7 +143,7 @@
 			],
 			"vars": {
 				// Pre-1.0 window — see the production block above.
-				"API_VERSION": "0.3.0",
+				"API_VERSION": "0.4.0",
 				"SITE_ORIGIN": "https://dev.nczoning.net",
 				// STAGING IS THE D1 CANARY: it runs the D1 path while production
 				// stays on mods.json, so the binding, the reads and the whole


### PR DESCRIPTION
Tags become registry data edited in the dashboard, rather than a JSON file
edited by pull request — and a mistyped tag is rejected on write instead of
caught by CI afterwards.

Completes the Phase 4 gate: *the site reads `/v1/tags` and no longer fetches
`data/tags.json`.*

## Schema

`tags` (slug PK, `name`, `description`, `sort_order`) plus a `location_tags`
join, populated from the existing JSON column with `json_each`.

**`slug` is the primary key, not a surrogate integer**, because location records
already carry `tags: ["entropism"]` — an integer would create a *second*
identifier for the same thing.

**Splitting `name` from `slug` is the actual point.** Today `utils.js` renders
the raw tag string as the badge, so the identifier and the label are the same
string, which is exactly what makes renaming feel dangerous. A `name` column
lets the label become "Neo-Militarism" while the identifier never moves. `name`
falls back to the slug, so **nothing renders differently** until a label is set.

**`nczoning` is deliberately not a `tags` row.** It is a marker auto-discovery
adds to every Nexus-sourced record, not something an admin curates, and deleting
it would break every auto-discovered record's tag list. The materializer re-adds
it for `source='auto'`, exactly as `merge.js` prepends it.

The migration is **additive**: `locations.tags` stays, so the join is proven
byte-for-byte before a later migration drops the column.

## API `0.3.0` → `0.4.0`

```jsonc
// before: { "entropism": "description…" }
// after:  [ { "slug": "entropism", "name": "entropism", "description": "…", "sort_order": 1 } ]
```

Breaking, so MINOR while pre-1.0; the path stays `/v1`. An array also matches
`/v1/locations` and is the safer DTO shape — an arbitrarily-keyed map is awkward
for RedData's `FromJson`.

**The site tolerates both shapes on purpose.** It and the Worker deploy
independently, and the dev site reads the *production* API, so during the
migration a new site can legitimately be talking to an API still serving the old
map. Tolerating both means they can ship in either order with no flag day; the
dictionary branch is deleted at cleanup.

## One data change, and one known parity difference

A single record had tags in non-alphabetical order
(`["apartment","neomilitarism","corpo"]`). **286 of 287 were already sorted**,
and all 9 auto records are `nczoning`-then-alphabetical — so tag order is an
accident of hand-editing, not meaning. Sorting that one record lets the join be
a plain `ORDER BY` rather than carrying a `position` column to preserve a
mistake.

**Consequence, stated rather than hidden:** `parity-check` against production now
reports **exactly that one record differing**, because production still serves
the pre-fix order from `main`. It resolves when this reaches `main`. The gate has
**not** been weakened to hide it — a red gate you are told to ignore is the
thing this whole effort has been avoiding.

`parity-ab` (both code paths, local, swept clock) is green at all 10 clocks.

## The parity scripts were testing the wrong path

Both were calling `materializeFromD1` without `locationTags`, so they were
silently exercising the **legacy-column fallback** instead of the join — they
would have gone green while proving nothing about this change. Fixed in both.
That is what turned the sweep into a real test.

## Test plan

- **180 pass (7 new)**, covering: `name` falling back to the slug; the join
  being authoritative over the legacy column; `nczoning` re-added for auto
  records **and only** those; an auto record whose only tag was `nczoning`; a
  location with no tags yielding `[]`.
- Migration verified against an independently computed count: 547 manual + 23
  auto = **570 links**, matching D1 exactly, with **0** `nczoning` rows leaked.
- `build_mods.js`, `validate_tags.js` and the ajv schema check all still pass on
  the changed data file.
- Applied to both remote databases.

## Not in this PR

Admin CRUD for tags themselves — that arrives with the dashboard UI (4c), where
there is somewhere to edit them. `scripts/validate_tags.js` also stays for now:
locations remain in git until Phase 6, so it still guards that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
