### PR TITLE
feat(admin): Phase 4c — the admin dashboard, tag CRUD, and the 4a/4b tag fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A second harness that runs both source paths head-to-head across a swept clock, and fails if the swept field never varied.
 - GitHub sign-in for admins at `/admin/`, gated on repository collaborator status.
 - Admin CRUD over the location registry, with an append-only audit log: every mutation records who did it, and the record before and after. Nothing on the live map reads these writes yet.
+- The admin dashboard at `/admin/`: browse and filter every location, edit the full record, and read the audit log. Saves send only the fields that actually changed.
+- Tag management in the dashboard. A tag still attached to locations cannot be deleted — the refusal lists what is using it. Renaming a tag's identifier is locked behind an explicit unlock, because it re-points existing records and breaks `?tag=` links; the display name is the safe thing to edit.
+
+### Fixed
+
+- Admin tag edits reached the legacy column but not the join the map reads, so they returned success and changed nothing. Both are now written together.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The admin dashboard at `/admin/`: browse and filter every location, edit the full record, and read the audit log. Saves send only the fields that actually changed.
 - Tag management in the dashboard. A tag still attached to locations cannot be deleted — the refusal lists what is using it. Renaming a tag's identifier is locked behind an explicit unlock, because it re-points existing records and breaks `?tag=` links; the display name is the safe thing to edit.
 
+- The dashboard shows how old the served dataset is, and a Rebuild button that regenerates it on demand. Staging has no cron, so nothing there refreshed on its own and there was no way to see that.
+- `scripts/sync-locations.mjs` copies location records that exist in `data/locations/` but not yet in D1. Needed until submissions land in D1 directly: a mod merged to `main` reaches production but not the D1 registry.
+
 ### Fixed
 
 - Admin tag edits reached the legacy column but not the join the map reads, so they returned success and changed nothing. Both are now written together.
+- The new location added to `main` overnight reached production but not the D1 registry, so staging served one fewer mod than production.
 
 ### Changed
 

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -49,6 +49,23 @@ a { color: var(--secondary); }
 
 .who { color: var(--tertiary); font-weight: 600; }
 
+/* Dataset age. Three states rather than two, because "I have not asked yet" is
+   not the same as "it is current" — a blank indicator must never read as fresh. */
+.freshness {
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 2px var(--space-xs);
+    border: var(--ui-border-thin) solid var(--border-neutral);
+    border-radius: var(--ui-radius-xs);
+    color: var(--gray);
+    white-space: nowrap;
+}
+
+.freshness.fresh { border-color: var(--status-ok); color: var(--status-ok); }
+.freshness.stale { border-color: var(--tertiary); color: var(--tertiary); }
+.freshness.unknown { border-style: dashed; }
+
 nav.tabs { display: flex; gap: var(--space-2xs); }
 
 nav.tabs button {

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -1,0 +1,379 @@
+/*
+ * Admin dashboard layout.
+ *
+ * Colour, type and spacing come from ../assets/css/theme.css — the same custom
+ * properties the map uses, so switching theme switches this page too and there
+ * is no second palette to keep in sync. What is NOT shared is style.css: that
+ * is map layout (Leaflet panes, sidebar, marker clusters) and none of it
+ * applies here. The stub's self-contained hex values are gone.
+ */
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    background: var(--primary);
+    color: var(--white);
+    font-family: var(--font-body);
+    font-size: var(--text-md);
+    line-height: var(--lh-normal, 1.5);
+}
+
+a { color: var(--secondary); }
+
+/* ---------------------------------------------------------------- chrome -- */
+
+.topbar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-lg);
+    padding: var(--space-md) var(--space-lg);
+    background: var(--surface-nav-80);
+    border-bottom: var(--ui-border-thin) solid var(--secondary-30);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+
+.topbar h1 {
+    margin: 0;
+    font-family: var(--font-heading);
+    font-size: var(--text-lg);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--secondary);
+}
+
+.topbar .spacer { flex: 1; }
+
+.who { color: var(--tertiary); font-weight: 600; }
+
+nav.tabs { display: flex; gap: var(--space-2xs); }
+
+nav.tabs button {
+    background: transparent;
+    border: var(--ui-border-thin) solid transparent;
+    border-radius: var(--ui-radius-sm);
+    color: var(--gray);
+    font: inherit;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: var(--text-sm);
+    padding: var(--space-xs) var(--space-lg);
+    cursor: pointer;
+}
+
+nav.tabs button:hover { background: var(--surface-hover); color: var(--white); }
+
+nav.tabs button[aria-selected="true"] {
+    color: var(--secondary);
+    border-color: var(--secondary-30);
+    background: var(--secondary-05);
+}
+
+main { padding: var(--space-lg); }
+
+.panel {
+    background: var(--surface-panel);
+    border: var(--ui-border-thin) solid var(--secondary-20);
+    border-radius: var(--ui-radius-sm);
+    padding: var(--space-lg);
+}
+
+/* ------------------------------------------------------------- controls -- */
+
+button, input, select, textarea {
+    font: inherit;
+    font-family: var(--font-body);
+    color: var(--white);
+}
+
+input, select, textarea {
+    width: 100%;
+    background: var(--black-30);
+    border: var(--ui-border-thin) solid var(--border-neutral);
+    border-radius: var(--ui-radius-xs);
+    padding: var(--space-xs) var(--space-sm);
+}
+
+input:focus, select:focus, textarea:focus {
+    outline: none;
+    border-color: var(--secondary);
+}
+
+input:disabled, textarea:disabled {
+    color: var(--text-dim);
+    background: var(--black-10);
+    cursor: not-allowed;
+}
+
+textarea { resize: vertical; min-height: 5rem; }
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2xs);
+    width: auto;
+    cursor: pointer;
+    padding: var(--space-xs) var(--space-lg);
+    border-radius: var(--ui-radius-sm);
+    border: var(--ui-border-thin) solid var(--secondary);
+    background: transparent;
+    color: var(--secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: var(--text-sm);
+}
+
+.btn:hover:not(:disabled) { background: var(--secondary-10); }
+.btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.btn.secondary { border-color: var(--border-neutral); color: var(--gray); }
+.btn.secondary:hover:not(:disabled) { background: var(--surface-hover); color: var(--white); }
+
+.btn.danger { border-color: var(--status-critical); color: var(--status-critical); }
+.btn.danger:hover:not(:disabled) { background: rgb(255 0 0 / 0.1); }
+
+/* ------------------------------------------------------------- messages -- */
+
+.notice {
+    border-left: 3px solid var(--secondary);
+    background: var(--secondary-05);
+    padding: var(--space-sm) var(--space-lg);
+    margin-bottom: var(--space-lg);
+    font-size: var(--text-md);
+}
+
+/* 🔴 Three states, three colours, and they are NOT interchangeable.
+   `.warn` is "we could not tell" (503). `.error` is "no" (403, 422, 409).
+   Rendering an indeterminate check in the refusal colour tells an admin they
+   lack access when the truth is that GitHub was unreachable. */
+.notice.error { border-left-color: var(--status-critical); background: rgb(255 0 0 / 0.08); }
+.notice.warn { border-left-color: var(--tertiary); background: var(--tertiary-05); }
+.notice.ok { border-left-color: var(--status-ok); background: rgb(0 255 0 / 0.06); }
+
+.notice ul { margin: var(--space-xs) 0 0; padding-left: 1.1rem; }
+
+.muted { color: var(--gray); font-size: var(--text-sm); }
+
+/* --------------------------------------------------------------- tables -- */
+
+.toolbar {
+    display: flex;
+    gap: var(--space-sm);
+    align-items: center;
+    margin-bottom: var(--space-lg);
+    flex-wrap: wrap;
+}
+
+.toolbar input[type="search"] { width: 18rem; }
+.toolbar select { width: auto; }
+
+.table-wrap { overflow-x: auto; }
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--text-sm);
+}
+
+th, td {
+    text-align: left;
+    padding: var(--space-xs) var(--space-sm);
+    border-bottom: var(--ui-border-thin) solid var(--border-subtle);
+    vertical-align: top;
+}
+
+th {
+    color: var(--gray);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: var(--text-xs);
+    font-weight: 600;
+    position: sticky;
+    top: 0;
+    background: var(--surface-panel-90);
+}
+
+tbody tr:hover { background: var(--surface-hover); }
+tbody tr[aria-selected="true"] { background: var(--secondary-10); }
+
+td.num { text-align: right; font-variant-numeric: tabular-nums; }
+
+/* ---------------------------------------------------------------- badges -- */
+
+.badge {
+    display: inline-block;
+    padding: 1px var(--space-xs);
+    margin: 1px var(--space-2xs) 1px 0;
+    border-radius: var(--ui-radius-xs);
+    font-size: var(--text-2xs);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    border: var(--ui-border-thin) solid var(--border-neutral);
+    color: var(--text-subtle);
+    white-space: nowrap;
+}
+
+.badge.status-published { border-color: var(--status-ok); color: var(--status-ok); }
+.badge.status-hidden { border-color: var(--tertiary); color: var(--tertiary); }
+.badge.status-draft { border-color: var(--gray); color: var(--gray); }
+.badge.source-auto { border-color: var(--secondary); color: var(--secondary); }
+
+/* The synthetic marker, shown so it is not mistaken for a missing tag. */
+.badge.synthetic { border-style: dashed; color: var(--text-dim); }
+
+/* ---------------------------------------------------------------- editor -- */
+
+.split {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 26rem);
+    gap: var(--space-lg);
+    align-items: start;
+}
+
+@media (max-width: 60rem) {
+    .split { grid-template-columns: minmax(0, 1fr); }
+}
+
+.field { margin-bottom: var(--space-md); }
+
+.field label {
+    display: block;
+    color: var(--gray);
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: var(--space-2xs);
+}
+
+.field.row { display: flex; gap: var(--space-sm); }
+.field.row > * { flex: 1; }
+
+/* A field the server rejected. The message sits with the input, not in a
+   summary box: a validation error the admin has to scroll to find is one they
+   will read as "the save just did not work". */
+.field.invalid input,
+.field.invalid select,
+.field.invalid textarea { border-color: var(--status-critical); }
+
+.field .msg { color: var(--status-critical); font-size: var(--text-xs); margin-top: 2px; }
+
+.tag-picker {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2xs);
+    padding: var(--space-xs);
+    border: var(--ui-border-thin) solid var(--border-neutral);
+    border-radius: var(--ui-radius-xs);
+    background: var(--black-30);
+    max-height: 11rem;
+    overflow-y: auto;
+}
+
+.tag-picker label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2xs);
+    padding: 2px var(--space-xs);
+    border: var(--ui-border-thin) solid var(--border-neutral);
+    border-radius: var(--ui-radius-xs);
+    font-size: var(--text-xs);
+    cursor: pointer;
+    text-transform: none;
+    letter-spacing: 0;
+    color: var(--text-subtle);
+    margin: 0;
+}
+
+.tag-picker label:has(input:checked) {
+    border-color: var(--secondary);
+    color: var(--secondary);
+    background: var(--secondary-10);
+}
+
+.tag-picker input { width: auto; }
+
+.editor-actions {
+    display: flex;
+    gap: var(--space-sm);
+    align-items: center;
+    margin-top: var(--space-lg);
+    padding-top: var(--space-lg);
+    border-top: var(--ui-border-thin) solid var(--border-subtle);
+}
+
+.editor-actions .spacer { flex: 1; }
+
+/* Which fields will actually be sent. The PATCH carries only what changed, so
+   showing the diff is the difference between "save" and "save something". */
+.dirty-summary { font-size: var(--text-xs); color: var(--tertiary); }
+
+/* ------------------------------------------------------------ slug lock -- */
+
+.slug-lock {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    margin-top: var(--space-2xs);
+}
+
+.slug-lock .btn { padding: 2px var(--space-sm); font-size: var(--text-2xs); }
+
+.slug-warning {
+    border-left: 3px solid var(--tertiary);
+    background: var(--tertiary-05);
+    padding: var(--space-xs) var(--space-sm);
+    margin-top: var(--space-xs);
+    font-size: var(--text-xs);
+    color: var(--text-subtle);
+}
+
+/* ----------------------------------------------------------------- audit -- */
+
+.audit-entry {
+    border-bottom: var(--ui-border-thin) solid var(--border-subtle);
+    padding: var(--space-sm) 0;
+}
+
+.audit-head {
+    display: flex;
+    gap: var(--space-sm);
+    align-items: baseline;
+    flex-wrap: wrap;
+    font-size: var(--text-sm);
+}
+
+.audit-head time { color: var(--gray); font-variant-numeric: tabular-nums; }
+.audit-head .action { color: var(--secondary); font-weight: 600; }
+.audit-head .target { color: var(--text-dim); font-family: ui-monospace, monospace; font-size: var(--text-xs); }
+
+.audit-entry details { margin-top: var(--space-2xs); }
+.audit-entry summary { cursor: pointer; color: var(--gray); font-size: var(--text-xs); }
+
+.diff { margin: var(--space-xs) 0 0; font-size: var(--text-xs); }
+.diff div { padding: 1px 0; font-family: ui-monospace, monospace; }
+.diff .k { color: var(--gray); }
+.diff .from { color: var(--status-critical); }
+.diff .to { color: var(--status-ok); }
+
+/* ---------------------------------------------------------------- gate -- */
+
+/* The signed-out / refused screen, which is the whole page rather than a tab. */
+body.gate { display: grid; place-items: center; padding: var(--space-lg); }
+body.gate .topbar, body.gate main { display: none; }
+
+#gate { width: 100%; max-width: 30rem; }
+#gate h1 {
+    margin: 0 0 var(--space-lg);
+    font-family: var(--font-heading);
+    font-size: var(--text-lg);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--secondary);
+}
+
+body:not(.gate) #gate { display: none; }
+
+.spinner { color: var(--gray); }

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -320,10 +320,14 @@
     const val = (name) => form.elements[name]?.value ?? '';
     const trimmed = (name) => val(name).trim();
 
+    // A blank X or Y becomes null, NOT 0. `Number('')` is 0, which would place
+    // a new record at the world origin and look like a deliberate coordinate;
+    // null fails the server's finite-number check and says so against the field.
+    const num = (raw) => (raw === '' ? null : Number(raw));
     const nums = ['x', 'y', 'z'].map((k) => trimmed(`coord_${k}`));
     const coordinates = nums[2] === ''
-      ? [Number(nums[0]), Number(nums[1])]
-      : [Number(nums[0]), Number(nums[1]), Number(nums[2])];
+      ? [num(nums[0]), num(nums[1])]
+      : [num(nums[0]), num(nums[1]), num(nums[2])];
 
     const yawRaw = trimmed('yaw');
     const creditsRaw = trimmed('credits');
@@ -460,8 +464,17 @@
     if (isNew) saveBtn.disabled = false;
   }
 
-  /** Paint server-side field errors next to the inputs they belong to. */
-  function applyFieldErrors(form, errors) {
+  const TAG_FIELDS = ['slug', 'name', 'description', 'sort_order'];
+
+  /**
+   * Paint server-side field errors next to the inputs they belong to.
+   *
+   * `fields` is the form's own writable set — the location list for the record
+   * editor, the tag list for the tag editor. Using one shared list would leave
+   * "slug must be lowercase…" with nowhere to land, and an error the admin has
+   * to hunt for reads as "the save just did not work".
+   */
+  function applyFieldErrors(form, errors, fields = WRITABLE) {
     form.querySelectorAll('.field.invalid').forEach((el) => {
       el.classList.remove('invalid');
       el.querySelector('.msg')?.remove();
@@ -472,7 +485,7 @@
       // unmatched shows in the banner, so nothing is swallowed.
       const key = message.startsWith('unknown tag(s)') ? 'tags'
         : message.startsWith('id cannot be set') ? null
-          : WRITABLE.find((k) => message.startsWith(k) || message.startsWith(`unknown field: ${k}`));
+          : fields.find((k) => message.startsWith(k) || message.startsWith(`unknown field: ${k}`));
       const target = key && form.querySelector(`.field[data-field="${key}"]`);
       if (!target) continue;
       target.classList.add('invalid');
@@ -675,7 +688,7 @@
     if (!res.ok) {
       const [kind, message] = describeFailure(res);
       banner(kind, message);
-      if (res.status === 422) applyFieldErrors(form, res.body.errors || []);
+      if (res.status === 422) applyFieldErrors(form, res.body.errors || [], TAG_FIELDS);
       return;
     }
 

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -751,6 +751,72 @@
     if (tag) renderTagEditor(tag);
   }
 
+  // ----------------------------------------------------------- freshness --
+
+  // Matches the external health monitor's threshold. The cron runs every 5
+  // minutes, so anything past this is either a failing cron or, on staging,
+  // no cron at all.
+  const STALE_AFTER_S = 45 * 60;
+
+  function describeAge(seconds) {
+    if (seconds < 90) return `${Math.round(seconds)}s ago`;
+    if (seconds < 5400) return `${Math.round(seconds / 60)}m ago`;
+    if (seconds < 172800) return `${Math.round(seconds / 3600)}h ago`;
+    return `${Math.round(seconds / 86400)}d ago`;
+  }
+
+  /**
+   * Read dataset age off /v1/health — public and uncached, so no extra route.
+   *
+   * 🔴 An unreadable health check renders as `unknown`, never as fresh. A blank
+   * or green indicator that actually means "I could not tell" is the same class
+   * of lie as reporting an unrecognised status as a successful login.
+   */
+  async function refreshFreshness() {
+    const el = $('#freshness');
+    let age = null;
+    try {
+      const res = await fetch(`${API}/v1/health`);
+      if (res.ok) age = (await res.json())?.data?.refresh_age_seconds ?? null;
+    } catch { /* falls through to unknown */ }
+
+    if (typeof age !== 'number') {
+      el.className = 'freshness unknown';
+      el.textContent = 'dataset age unknown';
+      return;
+    }
+    const stale = age > STALE_AFTER_S;
+    el.className = `freshness ${stale ? 'stale' : 'fresh'}`;
+    el.textContent = `dataset ${describeAge(age)}`;
+    el.title = stale
+      ? 'The served dataset is older than the cron interval. Staging has no cron, so this is expected there until you rebuild.'
+      : 'The served dataset is current.';
+  }
+
+  /** Rebuild the served dataset from whatever DATA_SOURCE says. */
+  async function rebuildDataset(button) {
+    button.disabled = true;
+    button.textContent = 'Rebuilding…';
+    const res = await api('/admin/refresh', { method: 'POST' });
+    button.disabled = false;
+    button.textContent = 'Rebuild';
+
+    if (!res.ok) {
+      const [kind, message] = res.status === 500 && res.body?.error === 'refresh_failed'
+        ? ['error', `The rebuild failed, so the previous dataset is still being served: ${res.body.detail}`]
+        : describeFailure(res);
+      await refreshFreshness();
+      return banner(kind, message);
+    }
+    // "Nothing changed" is a real outcome, not a nicer way of saying "done".
+    // If the admin just edited a record and the rebuild reports no change,
+    // that is worth knowing rather than smoothing over.
+    banner('ok', res.body.changed
+      ? `Rebuilt from ${res.body.source}. New dataset version ${res.body.dataset_version}.`
+      : `Rebuilt from ${res.body.source}. The content hash was unchanged, so nothing was rewritten.`);
+    await refreshFreshness();
+  }
+
   // --------------------------------------------------------------- audit --
 
   /** Field-level diff between two audit snapshots. */
@@ -836,10 +902,12 @@
     $('#tag-new').onclick = () => selectTag('');
     $('#audit-refresh').onclick = loadAudit;
     $('#audit-limit').onchange = loadAudit;
+    $('#rebuild').onclick = (e) => rebuildDataset(e.currentTarget);
 
     // Tags first: the location editor's picker is built from them.
     await loadTags();
     await loadLocations();
+    await refreshFreshness();
   }
 
   main();

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,0 +1,833 @@
+/*
+ * NC Zoning Board — admin dashboard.
+ *
+ * Phase 4c. The server side already exists (worker/src/admin.js); this is the
+ * surface for it. No framework and no build step, matching the rest of the
+ * site: a few hundred lines of DOM against a JSON API does not need one.
+ *
+ * Three rules run through the whole file, and all three exist because the
+ * opposite already shipped once:
+ *
+ * 1. A response is a success only when it says so. `res.ok` is checked
+ *    explicitly and an unrecognised status is an error, never a fall-through to
+ *    the happy path. The stub once rendered "Signed in as undefined —
+ *    collaborator access confirmed" against a 404 by doing the reverse.
+ * 2. 403 and 503 are different things. 403 is "you are not a collaborator".
+ *    503 `check_unavailable` is "GitHub could not be reached", which is not a
+ *    refusal and is never worded as one.
+ * 3. Writes send only fields that actually changed. The API rejects unknown
+ *    keys with a 422 rather than ignoring them, so a typo is loud — but only if
+ *    the client does not paper over it by resending everything.
+ */
+
+(() => {
+  'use strict';
+
+  // ------------------------------------------------------------- config --
+
+  // Resolve by hostname, NOT "always production" the way the map does.
+  //
+  // The map reads the production API from every origin because there has never
+  // been a deliberate dev dataset. Auth is the opposite case: the auth routes
+  // reach dev before they reach main, so a dev page pointed at production would
+  // call routes that do not exist there yet. dev talks to dev.
+  const API = (() => {
+    const override = new URLSearchParams(location.search).get('api');
+    if (override === 'dev') return 'https://api-dev.nczoning.net';
+    if (override === 'prod') return 'https://api.nczoning.net';
+    return location.hostname === 'dev.nczoning.net'
+      ? 'https://api-dev.nczoning.net'
+      : 'https://api.nczoning.net';
+  })();
+
+  const CATEGORIES = ['location-overhaul', 'new-location', 'other'];
+  const STATUSES = ['published', 'hidden', 'draft'];
+  const SOURCES = ['manual', 'auto'];
+
+  /** Exactly the fields the API will accept. Anything else is a 422. */
+  const WRITABLE = [
+    'name', 'authors', 'credits', 'coordinates', 'yaw', 'nexus_id',
+    'description', 'category', 'tags', 'status', 'admin_notes', 'source',
+  ];
+
+  // Reasons the OAuth callback can bounce back with. `check_unavailable` is
+  // deliberately worded as "cannot tell", not "denied" — GitHub being
+  // unreachable is not a statement about who you are, and telling an admin they
+  // lack access because of a transient blip is a lie the UI should not tell.
+  const CALLBACK_ERRORS = {
+    bad_state: ['error', 'Login could not be verified. Start again from this page.'],
+    oauth_failed: ['error', 'GitHub sign-in failed. Try again.'],
+    not_authorised: ['error', 'That account is not a collaborator on the repository.'],
+    check_unavailable: ['warn', 'Could not reach GitHub to confirm access. This is not a refusal — try again shortly.'],
+  };
+
+  // --------------------------------------------------------------- state --
+
+  const state = {
+    login: null,
+    locations: [],
+    tags: [],
+    selectedLocation: null,   // id, or '' for a new record
+    selectedTag: null,        // slug, or '' for a new tag
+  };
+
+  // ----------------------------------------------------------- DOM utils --
+
+  const $ = (sel) => document.querySelector(sel);
+
+  /**
+   * Element builder. Text goes in via textContent, never innerHTML, so mod
+   * names and admin notes cannot inject markup — this page renders strings
+   * written by third parties on Nexus.
+   */
+  function h(tag, attrs = {}, ...children) {
+    const el = document.createElement(tag);
+    for (const [k, v] of Object.entries(attrs)) {
+      if (v === null || v === undefined || v === false) continue;
+      if (k === 'class') el.className = v;
+      else if (k === 'text') el.textContent = v;
+      else if (k.startsWith('on') && typeof v === 'function') el.addEventListener(k.slice(2), v);
+      else if (v === true) el.setAttribute(k, '');
+      else el.setAttribute(k, v);
+    }
+    for (const child of children.flat()) {
+      if (child === null || child === undefined || child === false) continue;
+      el.append(child instanceof Node ? child : document.createTextNode(String(child)));
+    }
+    return el;
+  }
+
+  const clear = (el) => { while (el.firstChild) el.removeChild(el.firstChild); return el; };
+  const replace = (el, ...nodes) => { clear(el).append(...nodes.flat().filter(Boolean)); return el; };
+
+  // ------------------------------------------------------------ requests --
+
+  /**
+   * One JSON call. Always credentialed — the session is an HttpOnly cookie, and
+   * the origin has to be in ADMIN_ORIGINS (worker/src/auth.js) for the browser
+   * to send it. `*.pages.dev` preview URLs are NOT on that list, so a PR
+   * preview cannot exercise auth; test on dev.nczoning.net.
+   *
+   * Never throws on an HTTP error: the status IS the information here, and
+   * callers have to branch on 403 vs 503 vs 409 rather than on "it failed".
+   */
+  async function api(path, { method = 'GET', body } = {}) {
+    let res;
+    try {
+      res = await fetch(`${API}${path}`, {
+        method,
+        credentials: 'include',
+        ...(body === undefined ? {} : {
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }),
+      });
+    } catch (err) {
+      // Network-level: no status at all. Distinct from every HTTP status, and
+      // in particular NOT reported as a refusal.
+      return { ok: false, status: 0, body: {}, offline: true, error: String(err) };
+    }
+    const parsed = await res.json().catch(() => ({}));
+    return { ok: res.ok, status: res.status, body: parsed };
+  }
+
+  /**
+   * Turn any non-2xx into a message, keeping the distinctions that matter.
+   * Returns `[kind, message]` where kind is 'error' or 'warn'.
+   */
+  function describeFailure(res) {
+    if (res.offline) return ['error', `Could not reach ${API}. Check your connection and retry.`];
+    switch (res.status) {
+      case 401:
+        return ['error', 'Your session has expired. Reload the page and sign in again.'];
+      case 403:
+        return ['error', 'Refused: your account is not a collaborator on the repository.'];
+      case 503:
+        // Not a refusal. See rule 2 at the top of this file.
+        return ['warn', 'GitHub could not be reached to confirm your access. This is not a refusal — try again shortly.'];
+      case 404:
+        return ['error', 'Not found. It may have been deleted in another tab.'];
+      case 409:
+        return ['error', res.body?.error === 'tag_exists'
+          ? `A tag with the slug "${res.body.slug}" already exists.`
+          : 'Conflict — nothing was changed.'];
+      case 422:
+        return ['error', 'The server rejected this: ' + (res.body?.errors || ['validation failed']).join('; ')];
+      case 400:
+        return ['error', res.body?.error === 'empty_patch'
+          ? 'Nothing changed, so nothing was sent.'
+          : 'The request was malformed.'];
+      case 500:
+        // cascade_failed is the one 500 with something useful to say: the tag
+        // was renamed but its links did not follow, which needs a person.
+        return ['error', res.body?.error === 'cascade_failed'
+          ? `The rename did not propagate — ${res.body.detail}. The registry and the location links are now out of step; do not retry, check the database.`
+          : 'The server failed on this request. Nothing is guaranteed to have been written.'];
+      default:
+        // Anything unrecognised is an error, never a silent success.
+        return ['error', `Unexpected response from ${API} (HTTP ${res.status}).`];
+    }
+  }
+
+  function banner(kind, message, extra) {
+    const box = h('div', { class: `notice ${kind}` }, message, extra || null);
+    replace($('#banner'), box);
+    box.scrollIntoView({ block: 'nearest' });
+    return box;
+  }
+
+  const clearBanner = () => clear($('#banner'));
+
+  // ---------------------------------------------------------------- gate --
+
+  function renderGate(nodes) {
+    document.body.classList.add('gate');
+    replace($('#gate-body'), nodes);
+  }
+
+  const signInButton = (label = 'Sign in with GitHub') => h('button', {
+    class: 'btn',
+    type: 'button',
+    text: label,
+    onclick: () => {
+      location.href = `${API}/auth/login?return_to=${encodeURIComponent(location.pathname)}`;
+    },
+  });
+
+  async function signOut() {
+    await api('/auth/logout', { method: 'POST' });
+    location.replace(location.pathname);
+  }
+
+  /**
+   * Decide whether this browser gets a dashboard.
+   *
+   * 🔴 Success requires an explicit 200 AND collaborator === true. Everything
+   * else falls to the final branch, including statuses this page has never
+   * seen. Treating "not one of the failures I listed" as success is how the
+   * stub once greeted a 404 with "Signed in as undefined".
+   */
+  async function checkSession(callbackBanner) {
+    const res = await api('/auth/me');
+
+    if (res.offline) {
+      return renderGate([
+        h('div', { class: 'notice error', text: `Could not reach ${API}.` }),
+        signInButton('Retry'),
+      ]);
+    }
+
+    if (res.status === 401) {
+      return renderGate([
+        callbackBanner,
+        h('p', { class: 'muted', text: 'Sign in with a GitHub account that is a collaborator on the repository.' }),
+        signInButton(),
+      ]);
+    }
+
+    if (res.status === 503) {
+      // Distinct from 403 on purpose.
+      return renderGate([
+        callbackBanner,
+        h('div', { class: 'notice warn' },
+          'Signed in as ', h('span', { class: 'who', text: res.body.login ?? 'unknown' }),
+          ', but GitHub could not be reached to confirm access. This is not a refusal.'),
+        signInButton('Retry'),
+      ]);
+    }
+
+    if (res.status === 403) {
+      return renderGate([
+        callbackBanner,
+        h('div', { class: 'notice error' },
+          'Signed in as ', h('span', { class: 'who', text: res.body.login ?? 'unknown' }),
+          ', which is not a collaborator on the repository.'),
+        h('button', { class: 'btn secondary', type: 'button', text: 'Sign out', onclick: signOut }),
+      ]);
+    }
+
+    if (res.status === 200 && res.body.collaborator === true) {
+      state.login = res.body.login;
+      return true;
+    }
+
+    return renderGate([
+      callbackBanner,
+      h('div', { class: 'notice error' },
+        `Unexpected response from ${API} (HTTP ${res.status}). The auth routes may not be deployed there.`),
+      signInButton('Retry'),
+    ]);
+  }
+
+  // ----------------------------------------------------------- locations --
+
+  const tagsOf = (loc) => (loc.source === 'auto' ? ['nczoning', ...loc.tags] : loc.tags);
+
+  function locationMatches(loc, { q, status, category }) {
+    if (status && loc.status !== status) return false;
+    if (category && loc.category !== category) return false;
+    if (!q) return true;
+    const hay = [loc.name, loc.nexus_id, ...(loc.authors || []), ...(loc.tags || [])]
+      .join(' ').toLowerCase();
+    return hay.includes(q.toLowerCase());
+  }
+
+  function renderLocations() {
+    const filters = {
+      q: $('#loc-search').value.trim(),
+      status: $('#loc-status').value,
+      category: $('#loc-category').value,
+    };
+    const shown = state.locations.filter((l) => locationMatches(l, filters));
+
+    replace($('#loc-rows'), shown.map((loc) => h('tr', {
+      'aria-selected': loc.id === state.selectedLocation ? 'true' : 'false',
+      onclick: () => selectLocation(loc.id),
+      style: 'cursor:pointer',
+    },
+    h('td', {}, loc.name),
+    h('td', {}, loc.category.replace(/-/g, ' ')),
+    h('td', {}, tagsOf(loc).map((t) => h('span', {
+      class: `badge${t === 'nczoning' ? ' synthetic' : ''}`,
+      title: t === 'nczoning' ? 'Synthetic marker, added to auto-discovered records. Not editable.' : null,
+      text: t,
+    }))),
+    h('td', {},
+      h('span', { class: `badge status-${loc.status}`, text: loc.status }),
+      loc.source === 'auto' ? h('span', { class: 'badge source-auto', text: 'auto' }) : null),
+    h('td', {}, loc.nexus_id))));
+
+    $('#loc-count').textContent = shown.length === state.locations.length
+      ? `${shown.length} locations`
+      : `${shown.length} of ${state.locations.length} locations`;
+  }
+
+  async function loadLocations() {
+    const res = await api('/admin/locations');
+    if (!res.ok) {
+      const [kind, message] = describeFailure(res);
+      banner(kind, message);
+      return;
+    }
+    state.locations = res.body.locations || [];
+    renderLocations();
+  }
+
+  // -------------------------------------------------------- record editor --
+
+  /** Read the editor form into a payload of writable fields only. */
+  function readLocationForm(form) {
+    const val = (name) => form.elements[name]?.value ?? '';
+    const trimmed = (name) => val(name).trim();
+
+    const nums = ['x', 'y', 'z'].map((k) => trimmed(`coord_${k}`));
+    const coordinates = nums[2] === ''
+      ? [Number(nums[0]), Number(nums[1])]
+      : [Number(nums[0]), Number(nums[1]), Number(nums[2])];
+
+    const yawRaw = trimmed('yaw');
+    const creditsRaw = trimmed('credits');
+    const notesRaw = trimmed('admin_notes');
+
+    return {
+      name: trimmed('name'),
+      nexus_id: trimmed('nexus_id'),
+      category: val('category'),
+      status: val('status'),
+      source: val('source'),
+      coordinates,
+      // Blank means "no value", which the API models as null, not as 0 or "".
+      yaw: yawRaw === '' ? null : Number(yawRaw),
+      credits: creditsRaw === '' ? null : creditsRaw,
+      admin_notes: notesRaw === '' ? null : notesRaw,
+      description: val('description'),
+      authors: trimmed('authors').split(',').map((a) => a.trim()).filter(Boolean),
+      tags: [...form.querySelectorAll('input[name="tag"]:checked')].map((i) => i.value),
+    };
+  }
+
+  const sameValue = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+
+  /**
+   * Only what changed.
+   *
+   * This is why the API's reject-unknown-keys behaviour stays useful: if the
+   * client resent the whole record every time, a field the server does not
+   * know about would come back on every save and the 422 would be noise rather
+   * than a signal. It also makes `updated_at` mean something.
+   */
+  function diffPayload(current, original) {
+    const patch = {};
+    for (const key of WRITABLE) {
+      if (!sameValue(current[key], original[key])) patch[key] = current[key];
+    }
+    return patch;
+  }
+
+  const field = (label, control, hint) => h('div', { class: 'field', 'data-field': control.name || control.dataset?.field },
+    h('label', { text: label }), control, hint ? h('p', { class: 'muted', text: hint }) : null);
+
+  const input = (name, value, attrs = {}) => h('input', { name, value: value ?? '', ...attrs });
+
+  const select = (name, options, value) => h('select', { name },
+    options.map((o) => {
+      const opt = h('option', { value: o, text: typeof o === 'string' ? o.replace(/-/g, ' ') : o });
+      if (o === value) opt.selected = true;
+      return opt;
+    }));
+
+  function tagPicker(selected) {
+    return h('div', { class: 'tag-picker', 'data-field': 'tags' },
+      state.tags.map((t) => {
+        const box = h('input', { type: 'checkbox', name: 'tag', value: t.slug });
+        box.checked = selected.includes(t.slug);
+        return h('label', { title: t.description || '' }, box, t.name || t.slug);
+      }));
+  }
+
+  const BLANK_LOCATION = {
+    id: '', name: '', nexus_id: '', category: 'new-location', status: 'draft',
+    source: 'manual', coordinates: ['', '', ''], yaw: null, credits: null,
+    admin_notes: null, description: '', authors: [], tags: [],
+  };
+
+  function renderLocationEditor(loc) {
+    const isNew = !loc.id;
+    const [x, y, z] = loc.coordinates ?? ['', '', ''];
+
+    const form = h('form', { autocomplete: 'off', onsubmit: (e) => e.preventDefault() },
+      field('Name', input('name', loc.name, { required: true, minlength: '3' })),
+      h('div', { class: 'field row' },
+        field('Category', select('category', CATEGORIES, loc.category)),
+        field('Status', select('status', STATUSES, loc.status))),
+      h('div', { class: 'field row' },
+        field('Nexus ID', input('nexus_id', loc.nexus_id, { placeholder: '12345, WIP or Dummy' })),
+        field('Source', select('source', SOURCES, loc.source))),
+      // One data-field for all three, because the validator reports on
+      // `coordinates` as a unit ("coordinates must all be finite numbers") and
+      // an error that cannot find its input is an error nobody sees.
+      h('div', { class: 'field row', 'data-field': 'coordinates' },
+        field('X', input('coord_x', x, { type: 'number', step: 'any' })),
+        field('Y', input('coord_y', y, { type: 'number', step: 'any' })),
+        field('Z', input('coord_z', z ?? '', { type: 'number', step: 'any' }))),
+      field('Yaw', input('yaw', loc.yaw ?? '', { type: 'number', step: 'any', placeholder: 'blank for none' })),
+      field('Authors', input('authors', (loc.authors || []).join(', '), { placeholder: 'comma separated' })),
+      field('Credits', input('credits', loc.credits ?? '', { placeholder: 'blank for none' })),
+      field('Description', h('textarea', { name: 'description', maxlength: '500' }, loc.description || '')),
+      field('Tags', tagPicker(loc.tags || []),
+        loc.source === 'auto'
+          ? 'nczoning is added automatically for auto-sourced records and is not listed here.'
+          : null),
+      field('Admin notes', h('textarea', { name: 'admin_notes', placeholder: 'internal, never served on /v1' },
+        loc.admin_notes || '')),
+    );
+
+    const dirtyLabel = h('span', { class: 'dirty-summary' });
+    const saveBtn = h('button', { class: 'btn', type: 'button', text: isNew ? 'Create' : 'Save changes' });
+
+    const refreshDirty = () => {
+      if (isNew) { dirtyLabel.textContent = ''; return; }
+      const patch = diffPayload(readLocationForm(form), loc);
+      const keys = Object.keys(patch);
+      dirtyLabel.textContent = keys.length ? `will send: ${keys.join(', ')}` : 'no changes';
+      saveBtn.disabled = keys.length === 0;
+    };
+    form.addEventListener('input', refreshDirty);
+    form.addEventListener('change', refreshDirty);
+
+    saveBtn.onclick = () => saveLocation(loc, form, saveBtn);
+
+    const actions = h('div', { class: 'editor-actions' },
+      saveBtn,
+      h('button', {
+        class: 'btn secondary', type: 'button', text: 'Cancel',
+        onclick: () => selectLocation(null),
+      }),
+      dirtyLabel,
+      h('span', { class: 'spacer' }),
+      isNew ? null : h('button', {
+        class: 'btn danger', type: 'button', text: 'Delete',
+        onclick: () => deleteLocation(loc),
+      }),
+    );
+
+    replace($('#loc-editor'),
+      h('h2', { style: 'margin-top:0;font-size:var(--text-md)', text: isNew ? 'New location' : loc.name }),
+      isNew ? null : h('p', { class: 'muted', text: `id ${loc.id} · updated ${loc.updated_at}` }),
+      form, actions);
+
+    refreshDirty();
+    if (isNew) saveBtn.disabled = false;
+  }
+
+  /** Paint server-side field errors next to the inputs they belong to. */
+  function applyFieldErrors(form, errors) {
+    form.querySelectorAll('.field.invalid').forEach((el) => {
+      el.classList.remove('invalid');
+      el.querySelector('.msg')?.remove();
+    });
+    for (const message of errors) {
+      // The validator's messages lead with the field name where there is one
+      // ("name must be…"), with two shapes that do not. Anything still
+      // unmatched shows in the banner, so nothing is swallowed.
+      const key = message.startsWith('unknown tag(s)') ? 'tags'
+        : message.startsWith('id cannot be set') ? null
+          : WRITABLE.find((k) => message.startsWith(k) || message.startsWith(`unknown field: ${k}`));
+      const target = key && form.querySelector(`.field[data-field="${key}"]`);
+      if (!target) continue;
+      target.classList.add('invalid');
+      target.append(h('p', { class: 'msg', text: message }));
+    }
+  }
+
+  async function saveLocation(loc, form, button) {
+    const isNew = !loc.id;
+    const current = readLocationForm(form);
+    const payload = isNew ? current : diffPayload(current, loc);
+
+    if (!isNew && Object.keys(payload).length === 0) {
+      banner('warn', 'Nothing changed, so nothing was sent.');
+      return;
+    }
+
+    button.disabled = true;
+    const res = isNew
+      ? await api('/admin/locations', { method: 'POST', body: payload })
+      : await api(`/admin/locations/${encodeURIComponent(loc.id)}`, { method: 'PATCH', body: payload });
+    button.disabled = false;
+
+    if (!res.ok) {
+      const [kind, message] = describeFailure(res);
+      banner(kind, message);
+      if (res.status === 422) applyFieldErrors(form, res.body.errors || []);
+      return;
+    }
+
+    banner('ok', isNew
+      ? `Created "${res.body.location.name}".`
+      : `Saved ${Object.keys(payload).join(', ')} on "${res.body.location.name}".`);
+    await loadLocations();
+    selectLocation(res.body.location.id);
+  }
+
+  async function deleteLocation(loc) {
+    // `hidden` keeps the row and pulls the pin; delete is for records that
+    // should never have existed. Say so, rather than asking "are you sure?".
+    const ok = confirm(
+      `Delete "${loc.name}" outright?\n\n`
+      + 'The full record is preserved in the audit log, so this is recoverable — but if you '
+      + 'only want it off the map, set the status to "hidden" instead.',
+    );
+    if (!ok) return;
+
+    const res = await api(`/admin/locations/${encodeURIComponent(loc.id)}`, { method: 'DELETE' });
+    if (!res.ok) {
+      const [kind, message] = describeFailure(res);
+      return banner(kind, message);
+    }
+    banner('ok', `Deleted "${loc.name}". The record is in the audit log if you need it back.`);
+    state.selectedLocation = null;
+    await loadLocations();
+    replace($('#loc-editor'), h('p', { class: 'muted', text: 'Select a location to edit it, or create a new one.' }));
+  }
+
+  function selectLocation(id) {
+    state.selectedLocation = id;
+    clearBanner();
+    if (id === null) {
+      renderLocations();
+      return replace($('#loc-editor'),
+        h('p', { class: 'muted', text: 'Select a location to edit it, or create a new one.' }));
+    }
+    renderLocations();
+    const loc = id === '' ? { ...BLANK_LOCATION } : state.locations.find((l) => l.id === id);
+    if (loc) renderLocationEditor(loc);
+  }
+
+  // ---------------------------------------------------------------- tags --
+
+  function renderTags() {
+    replace($('#tag-rows'), state.tags.map((tag) => h('tr', {
+      'aria-selected': tag.slug === state.selectedTag ? 'true' : 'false',
+      onclick: () => selectTag(tag.slug),
+      style: 'cursor:pointer',
+    },
+    h('td', {}, h('code', { text: tag.slug })),
+    h('td', {}, tag.name || h('span', { class: 'muted', text: '— (falls back to the slug)' })),
+    h('td', {}, tag.description),
+    h('td', { class: 'num' }, String(tag.usage_count)))));
+  }
+
+  async function loadTags() {
+    const res = await api('/admin/tags');
+    if (!res.ok) {
+      const [kind, message] = describeFailure(res);
+      banner(kind, message);
+      return;
+    }
+    state.tags = res.body.tags || [];
+    renderTags();
+  }
+
+  const BLANK_TAG = { slug: '', name: null, description: '', sort_order: null, usage_count: 0 };
+
+  function renderTagEditor(tag) {
+    const isNew = !tag.slug;
+
+    const slugInput = input('slug', tag.slug, isNew ? {} : { disabled: true });
+    const nameInput = input('name', tag.name ?? '', { placeholder: 'blank falls back to the slug' });
+    const descInput = h('textarea', { name: 'description', maxlength: '500' }, tag.description || '');
+    const orderInput = input('sort_order', tag.sort_order ?? '', { type: 'number', step: '1' });
+
+    const slugField = field('Slug', slugInput);
+    let slugUnlocked = isNew;
+
+    if (!isNew) {
+      // 🔴 Renaming a slug is an ON UPDATE CASCADE through location_tags and a
+      // link-breaking event: anything pointing at ?tag=<slug> stops resolving.
+      // Routine relabelling is what `name` is for, so the identifier is
+      // read-only until it is deliberately unlocked.
+      const warning = h('div', { class: 'slug-warning', hidden: true },
+        'Renaming the identifier re-points every location that uses it '
+        + `(${tag.usage_count} right now) and breaks any existing ?tag=${tag.slug} link. `
+        + 'To relabel this tag without breaking anything, edit its Name instead.');
+      const unlock = h('button', {
+        class: 'btn secondary', type: 'button', text: 'Edit identifier',
+        onclick: () => {
+          slugUnlocked = !slugUnlocked;
+          slugInput.disabled = !slugUnlocked;
+          warning.hidden = !slugUnlocked;
+          unlock.textContent = slugUnlocked ? 'Keep identifier' : 'Edit identifier';
+          if (!slugUnlocked) slugInput.value = tag.slug;
+          else slugInput.focus();
+        },
+      });
+      slugField.append(h('div', { class: 'slug-lock' },
+        h('span', { class: 'muted', text: 'Locked. Editing it re-points existing records.' }), unlock));
+      slugField.append(warning);
+    }
+
+    const form = h('form', { autocomplete: 'off', onsubmit: (e) => e.preventDefault() },
+      slugField,
+      field('Name', nameInput, 'The display label. Safe to change at any time.'),
+      field('Description', descInput),
+      field('Sort order', orderInput, 'Controls the order tags appear in on the site. Blank sorts last.'),
+    );
+
+    const saveBtn = h('button', { class: 'btn', type: 'button', text: isNew ? 'Create tag' : 'Save changes' });
+    saveBtn.onclick = () => saveTag(tag, form, saveBtn, () => slugUnlocked);
+
+    const actions = h('div', { class: 'editor-actions' },
+      saveBtn,
+      h('button', { class: 'btn secondary', type: 'button', text: 'Cancel', onclick: () => selectTag(null) }),
+      h('span', { class: 'spacer' }),
+      isNew ? null : h('button', {
+        class: 'btn danger', type: 'button', text: 'Delete', onclick: () => deleteTag(tag),
+      }),
+    );
+
+    replace($('#tag-editor'),
+      h('h2', { style: 'margin-top:0;font-size:var(--text-md)', text: isNew ? 'New tag' : tag.slug }),
+      isNew ? null : h('p', { class: 'muted', text: `used by ${tag.usage_count} location(s)` }),
+      form, actions);
+  }
+
+  async function saveTag(tag, form, button, slugUnlocked) {
+    const isNew = !tag.slug;
+    const name = form.elements.name.value.trim();
+    const order = form.elements.sort_order.value.trim();
+
+    const current = {
+      slug: form.elements.slug.value.trim(),
+      name: name === '' ? null : name,
+      description: form.elements.description.value.trim(),
+      sort_order: order === '' ? null : Number(order),
+    };
+
+    let payload;
+    if (isNew) {
+      payload = current;
+    } else {
+      payload = {};
+      for (const key of ['name', 'description', 'sort_order']) {
+        if (!sameValue(current[key], tag[key])) payload[key] = current[key];
+      }
+      // The slug only travels when it was deliberately unlocked AND changed.
+      if (slugUnlocked() && current.slug !== tag.slug) payload.slug = current.slug;
+      if (Object.keys(payload).length === 0) return banner('warn', 'Nothing changed, so nothing was sent.');
+    }
+
+    if (payload.slug && payload.slug !== tag.slug && !isNew) {
+      const ok = confirm(
+        `Rename "${tag.slug}" to "${payload.slug}"?\n\n`
+        + `${tag.usage_count} location(s) will be re-pointed, and any existing `
+        + `?tag=${tag.slug} link will stop working.`,
+      );
+      if (!ok) return;
+    }
+
+    button.disabled = true;
+    const res = isNew
+      ? await api('/admin/tags', { method: 'POST', body: payload })
+      : await api(`/admin/tags/${encodeURIComponent(tag.slug)}`, { method: 'PATCH', body: payload });
+    button.disabled = false;
+
+    if (!res.ok) {
+      const [kind, message] = describeFailure(res);
+      banner(kind, message);
+      if (res.status === 422) applyFieldErrors(form, res.body.errors || []);
+      return;
+    }
+
+    banner('ok', isNew ? `Created tag "${res.body.tag.slug}".` : `Saved tag "${res.body.tag.slug}".`);
+    await Promise.all([loadTags(), loadLocations()]);
+    selectTag(res.body.tag.slug);
+  }
+
+  /**
+   * Delete, or explain why not.
+   *
+   * The API refuses a tag that is still attached (409 `tag_in_use`) rather than
+   * cascading, so the answer here is a list of what is in the way, not a
+   * failure message. Detaching is the admin's decision to make, one record at a
+   * time or in bulk, and this is what turns that into a next step.
+   */
+  async function deleteTag(tag) {
+    const res = await api(`/admin/tags/${encodeURIComponent(tag.slug)}`, { method: 'DELETE' });
+
+    if (res.status === 409 && res.body.error === 'tag_in_use') {
+      const jump = h('button', {
+        class: 'btn secondary', type: 'button', text: `Show the ${res.body.usage_count} location(s)`,
+        onclick: () => {
+          switchTab('locations');
+          $('#loc-search').value = tag.slug;
+          $('#loc-status').value = '';
+          $('#loc-category').value = '';
+          renderLocations();
+        },
+      });
+      return banner('error',
+        `"${tag.slug}" is still attached to ${res.body.usage_count} location(s), so it was not deleted. `
+        + 'Remove it from those records first — nothing was changed.',
+        h('div', { style: 'margin-top:var(--space-sm)' },
+          h('ul', {}, res.body.locations.map((l) => h('li', { text: l.name }))),
+          jump));
+    }
+
+    if (!res.ok) {
+      const [kind, message] = describeFailure(res);
+      return banner(kind, message);
+    }
+
+    banner('ok', `Deleted tag "${tag.slug}".`);
+    state.selectedTag = null;
+    await loadTags();
+    replace($('#tag-editor'), h('p', { class: 'muted', text: 'Select a tag to edit it, or create a new one.' }));
+  }
+
+  function selectTag(slug) {
+    state.selectedTag = slug;
+    clearBanner();
+    if (slug === null) {
+      renderTags();
+      return replace($('#tag-editor'),
+        h('p', { class: 'muted', text: 'Select a tag to edit it, or create a new one.' }));
+    }
+    renderTags();
+    const tag = slug === '' ? { ...BLANK_TAG } : state.tags.find((t) => t.slug === slug);
+    if (tag) renderTagEditor(tag);
+  }
+
+  // --------------------------------------------------------------- audit --
+
+  /** Field-level diff between two audit snapshots. */
+  function renderDiff(before, after) {
+    const keys = [...new Set([...Object.keys(before || {}), ...Object.keys(after || {})])].sort();
+    const rows = [];
+    for (const key of keys) {
+      const from = before ? before[key] : undefined;
+      const to = after ? after[key] : undefined;
+      // updated_at moves on every write; showing it as a change is noise that
+      // makes the real change harder to find.
+      if (key === 'updated_at') continue;
+      if (sameValue(from, to)) continue;
+      rows.push(h('div', {},
+        h('span', { class: 'k', text: `${key}: ` }),
+        before ? h('span', { class: 'from', text: JSON.stringify(from) }) : null,
+        before && after ? ' → ' : null,
+        after ? h('span', { class: 'to', text: JSON.stringify(to) }) : null));
+    }
+    return rows.length ? h('div', { class: 'diff' }, rows) : h('p', { class: 'muted', text: 'No field changes recorded.' });
+  }
+
+  async function loadAudit() {
+    const limit = $('#audit-limit').value;
+    const res = await api(`/admin/audit?limit=${encodeURIComponent(limit)}`);
+    if (!res.ok) {
+      const [kind, message] = describeFailure(res);
+      return banner(kind, message);
+    }
+    const entries = res.body.entries || [];
+    replace($('#audit-list'), entries.length
+      ? entries.map((e) => h('div', { class: 'audit-entry' },
+        h('div', { class: 'audit-head' },
+          h('time', { datetime: e.at, text: new Date(e.at).toLocaleString() }),
+          h('span', { class: 'action', text: e.action }),
+          h('span', { class: 'who', text: e.actor }),
+          h('span', { class: 'target', text: e.target || '' })),
+        h('details', {}, h('summary', { text: 'What changed' }), renderDiff(e.before, e.after))))
+      : h('p', { class: 'muted', text: 'No entries yet.' }));
+  }
+
+  // ---------------------------------------------------------------- tabs --
+
+  function switchTab(name) {
+    for (const btn of document.querySelectorAll('nav.tabs button')) {
+      btn.setAttribute('aria-selected', String(btn.dataset.tab === name));
+    }
+    for (const id of ['locations', 'tags', 'audit']) {
+      $(`#tab-${id}`).hidden = id !== name;
+    }
+    if (name === 'audit') loadAudit();
+  }
+
+  // ---------------------------------------------------------------- boot --
+
+  async function main() {
+    // Surface a callback error, then strip it so a refresh does not re-show it.
+    const params = new URLSearchParams(location.search);
+    const err = params.get('error');
+    let callbackBanner = null;
+    if (err) {
+      const [kind, message] = CALLBACK_ERRORS[err] || ['error', `Sign-in failed (${err}).`];
+      callbackBanner = h('div', { class: `notice ${kind}`, text: message });
+      params.delete('error');
+      history.replaceState({}, '', location.pathname + (params.toString() ? `?${params}` : ''));
+    }
+
+    const allowed = await checkSession(callbackBanner);
+    if (allowed !== true) return;
+
+    document.body.classList.remove('gate');
+    $('#whoami').textContent = state.login;
+    $('#api-label').textContent = API.replace('https://', '');
+    $('#signout').onclick = signOut;
+
+    for (const btn of document.querySelectorAll('nav.tabs button')) {
+      btn.onclick = () => switchTab(btn.dataset.tab);
+    }
+    for (const id of ['#loc-search', '#loc-status', '#loc-category']) {
+      $(id).addEventListener('input', renderLocations);
+    }
+    $('#loc-new').onclick = () => selectLocation('');
+    $('#tag-new').onclick = () => selectTag('');
+    $('#audit-refresh').onclick = loadAudit;
+    $('#audit-limit').onchange = loadAudit;
+
+    // Tags first: the location editor's picker is built from them.
+    await loadTags();
+    await loadLocations();
+  }
+
+  main();
+})();

--- a/admin/index.html
+++ b/admin/index.html
@@ -1,176 +1,132 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="theme-night-corp">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex, nofollow">
 <title>NC Zoning Board — Admin</title>
-<!--
-  Phase 3 stub. This exists so the collaborator gate can be tested by clicking
-  rather than by curl, and it is the shell the Phase 4 dashboard fills in.
+<link rel="icon" type="image/svg+xml" href="../assets/img/favicon/favicon-map-cyan.svg">
 
-  Self-contained styling on purpose: pulling in theme.css/style.css would drag
-  the whole map layout in for one status line. It adopts the shared theme at
-  Phase 4, when there is actually a UI to theme.
--->
-<style>
-  :root {
-    --navy: #0a192f;
-    --navy-light: #112240;
-    --cyan: #00f0ff;
-    --amber: #ffb300;
-    --text: #ccd6f6;
-    --muted: #8892b0;
-    --error: #ff5370;
-  }
-  * { box-sizing: border-box; }
-  body {
-    margin: 0;
-    min-height: 100vh;
-    display: grid;
-    place-items: center;
-    background: var(--navy);
-    color: var(--text);
-    font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-    padding: 1.5rem;
-  }
-  main {
-    width: 100%;
-    max-width: 26rem;
-    background: var(--navy-light);
-    border: 1px solid rgb(0 240 255 / 0.15);
-    border-radius: 6px;
-    padding: 2rem;
-  }
-  h1 {
-    margin: 0 0 1.5rem;
-    font-size: 1.1rem;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--cyan);
-  }
-  button {
-    font: inherit;
-    cursor: pointer;
-    padding: 0.6rem 1.2rem;
-    border-radius: 4px;
-    border: 1px solid var(--cyan);
-    background: transparent;
-    color: var(--cyan);
-  }
-  button:hover { background: rgb(0 240 255 / 0.1); }
-  button.secondary { border-color: var(--muted); color: var(--muted); }
-  .muted { color: var(--muted); font-size: 0.9rem; }
-  .who { color: var(--amber); font-weight: 600; }
-  .error {
-    border-left: 3px solid var(--error);
-    padding: 0.5rem 0.9rem;
-    margin-bottom: 1.25rem;
-    background: rgb(255 83 112 / 0.08);
-    font-size: 0.9rem;
-  }
-  .warn { border-left-color: var(--amber); background: rgb(255 179 0 / 0.08); }
-</style>
+<!-- Fonts, as the map loads them. -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Rajdhani:wght@400;500;700&display=swap">
+
+<!-- theme.css only: the custom properties, shared with the map. style.css is
+     map layout (Leaflet panes, sidebar, clusters) and has nothing for this page. -->
+<link rel="stylesheet" href="../assets/css/theme.css">
+<link rel="stylesheet" href="admin.css">
 </head>
-<body>
-<main>
+
+<body class="gate">
+
+<!-- The signed-out / refused screen. Shown until /auth/me answers 200 AND says
+     collaborator; see admin.js. -->
+<main id="gate" class="panel">
   <h1>NC Zoning Board — Admin</h1>
-  <div id="status" class="muted">Checking session…</div>
+  <div id="gate-body" class="spinner">Checking session…</div>
 </main>
 
-<script>
-// Resolve by hostname, NOT "always production" the way the map does.
-//
-// The map reads the production API from every origin because there has never
-// been a deliberate dev dataset. Auth is the opposite case: the auth routes
-// reach dev before they reach main, so a dev page pointed at production would
-// call routes that do not exist there yet. dev talks to dev.
-const API = (() => {
-  const override = new URLSearchParams(location.search).get('api');
-  if (override === 'dev') return 'https://api-dev.nczoning.net';
-  if (override === 'prod') return 'https://api.nczoning.net';
-  return location.hostname === 'dev.nczoning.net'
-    ? 'https://api-dev.nczoning.net'
-    : 'https://api.nczoning.net';
-})();
+<header class="topbar">
+  <h1>NC Zoning Board</h1>
+  <nav class="tabs" role="tablist">
+    <button type="button" role="tab" data-tab="locations" aria-selected="true">Locations</button>
+    <button type="button" role="tab" data-tab="tags" aria-selected="false">Tags</button>
+    <button type="button" role="tab" data-tab="audit" aria-selected="false">Audit</button>
+  </nav>
+  <span class="spacer"></span>
+  <span class="muted">Signed in as <span class="who" id="whoami"></span></span>
+  <span class="muted" id="api-label"></span>
+  <button type="button" class="btn secondary" id="signout">Sign out</button>
+</header>
 
-const el = document.getElementById('status');
+<main>
+  <div id="banner"></div>
 
-// Reasons the callback can bounce back with. `check_unavailable` is
-// deliberately worded as "cannot tell", not "denied" — GitHub being unreachable
-// is not a statement about who you are, and telling an admin they lack access
-// because of a transient blip is a lie the UI should not tell.
-const ERRORS = {
-  bad_state:         ['error', 'Login could not be verified. Start again from this page.'],
-  oauth_failed:      ['error', 'GitHub sign-in failed. Try again.'],
-  not_authorised:    ['error', 'That account is not a collaborator on the repository.'],
-  check_unavailable: ['warn',  'Could not reach GitHub to confirm access. This is not a refusal — try again shortly.'],
-};
+  <!-- ------------------------------------------------------ locations -- -->
+  <section id="tab-locations" class="split">
+    <div class="panel">
+      <div class="toolbar">
+        <input type="search" id="loc-search" placeholder="Search name, author, nexus id…" aria-label="Search locations">
+        <select id="loc-status" aria-label="Filter by status">
+          <option value="">All statuses</option>
+          <option value="published">Published</option>
+          <option value="hidden">Hidden</option>
+          <option value="draft">Draft</option>
+        </select>
+        <select id="loc-category" aria-label="Filter by category">
+          <option value="">All categories</option>
+          <option value="location-overhaul">Location overhaul</option>
+          <option value="new-location">New location</option>
+          <option value="other">Other</option>
+        </select>
+        <span class="spacer" style="flex:1"></span>
+        <button type="button" class="btn" id="loc-new">New location</button>
+      </div>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th><th>Category</th><th>Tags</th><th>Status</th><th>Nexus</th>
+            </tr>
+          </thead>
+          <tbody id="loc-rows"></tbody>
+        </table>
+      </div>
+      <p class="muted" id="loc-count"></p>
+    </div>
 
-function render(html) { el.innerHTML = html; }
+    <div class="panel" id="loc-editor">
+      <p class="muted">Select a location to edit it, or create a new one.</p>
+    </div>
+  </section>
 
-function signInButton(label = 'Sign in with GitHub') {
-  return `<button id="signin">${label}</button>`;
-}
+  <!-- ----------------------------------------------------------- tags -- -->
+  <section id="tab-tags" class="split" hidden>
+    <div class="panel">
+      <div class="toolbar">
+        <span class="muted">The tag registry. Counts are live.</span>
+        <span class="spacer" style="flex:1"></span>
+        <button type="button" class="btn" id="tag-new">New tag</button>
+      </div>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr><th>Slug</th><th>Name</th><th>Description</th><th class="num">Used by</th></tr>
+          </thead>
+          <tbody id="tag-rows"></tbody>
+        </table>
+      </div>
+      <p class="muted">
+        <code>nczoning</code> is not listed: it is a marker auto-discovery adds to every
+        Nexus-sourced record, not a registry entry, and it cannot be created or deleted here.
+      </p>
+    </div>
 
-function wire() {
-  const signin = document.getElementById('signin');
-  if (signin) {
-    signin.onclick = () => {
-      location.href = `${API}/auth/login?return_to=${encodeURIComponent(location.pathname)}`;
-    };
-  }
-  const out = document.getElementById('signout');
-  if (out) {
-    out.onclick = async () => {
-      await fetch(`${API}/auth/logout`, { method: 'POST', credentials: 'include' });
-      location.replace(location.pathname);
-    };
-  }
-}
+    <div class="panel" id="tag-editor">
+      <p class="muted">Select a tag to edit it, or create a new one.</p>
+    </div>
+  </section>
 
-async function main() {
-  // Surface a callback error, then strip it so a refresh does not re-show it.
-  const params = new URLSearchParams(location.search);
-  const err = params.get('error');
-  let banner = '';
-  if (err) {
-    const [kind, message] = ERRORS[err] || ['error', `Sign-in failed (${err}).`];
-    banner = `<div class="error ${kind === 'warn' ? 'warn' : ''}">${message}</div>`;
-    params.delete('error');
-    history.replaceState({}, '', location.pathname + (params.toString() ? `?${params}` : ''));
-  }
+  <!-- ---------------------------------------------------------- audit -- -->
+  <section id="tab-audit" hidden>
+    <div class="panel">
+      <div class="toolbar">
+        <span class="muted">Append-only. A correction is another row, never an edit.</span>
+        <span class="spacer" style="flex:1"></span>
+        <select id="audit-limit" aria-label="How many entries">
+          <option value="50">Last 50</option>
+          <option value="100" selected>Last 100</option>
+          <option value="500">Last 500</option>
+        </select>
+        <button type="button" class="btn secondary" id="audit-refresh">Refresh</button>
+      </div>
+      <div id="audit-list"></div>
+    </div>
+  </section>
+</main>
 
-  let res;
-  try {
-    res = await fetch(`${API}/auth/me`, { credentials: 'include' });
-  } catch {
-    render(`${banner}<div class="error">Could not reach the API.</div>${signInButton('Retry')}`);
-    return wire();
-  }
-
-  const body = await res.json().catch(() => ({}));
-
-  if (res.status === 401) {
-    render(`${banner}<p class="muted">Sign in with a GitHub account that is a collaborator on the repository.</p>${signInButton()}`);
-  } else if (res.status === 503) {
-    // Distinct from 403 on purpose — see ERRORS above.
-    render(`${banner}<div class="error warn">Signed in as <span class="who">${body.login}</span>, but GitHub could not be reached to confirm access. Not a refusal.</div>${signInButton('Retry')}`);
-  } else if (res.status === 403) {
-    render(`${banner}<div class="error">Signed in as <span class="who">${body.login}</span>, which is not a collaborator on the repository.</div><button id="signout" class="secondary">Sign out</button>`);
-  } else if (res.status === 200 && body.collaborator === true) {
-    render(`${banner}<p>Signed in as <span class="who">${body.login}</span> — collaborator access confirmed.</p><p class="muted">The dashboard itself arrives at Phase 4.</p><button id="signout" class="secondary">Sign out</button>`);
-  } else {
-    // Anything else is unexpected — most likely this page is pointed at an API
-    // that has no /auth routes yet (a 404). Treating an unrecognised status as
-    // success would render "Signed in as undefined - access confirmed", which
-    // is the worst possible thing for an auth screen to say.
-    render(`${banner}<div class="error">Unexpected response from <code>${API}</code> (HTTP ${res.status}). The auth routes may not be deployed there.</div>${signInButton('Retry')}`);
-  }
-  wire();
-}
-
-main();
-</script>
+<script src="admin.js"></script>
 </body>
 </html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -36,6 +36,11 @@
     <button type="button" role="tab" data-tab="audit" aria-selected="false">Audit</button>
   </nav>
   <span class="spacer"></span>
+  <!-- What the map is actually serving right now, and how old it is. Staging
+       has no cron, so without this the read path can sit hours stale with
+       nothing to show for it. -->
+  <span class="freshness" id="freshness" title="Age of the dataset the public API is serving"></span>
+  <button type="button" class="btn secondary" id="rebuild" title="Rebuild the served dataset from the current source">Rebuild</button>
   <span class="muted">Signed in as <span class="who" id="whoami"></span></span>
   <span class="muted" id="api-label"></span>
   <button type="button" class="btn secondary" id="signout">Sign out</button>

--- a/worker/README.md
+++ b/worker/README.md
@@ -206,8 +206,9 @@ scripts green.
 
 ## Admin auth (Phase 3)
 
-Login only — there are no write routes yet. `/admin/` in the site repo is a stub
-that shows who you are signed in as.
+Sign-in and the collaborator gate. The write routes it gates are in
+[Admin API](#admin-api-phase-4) below; `/admin/` in the site repo is the
+dashboard that drives them.
 
 | Route | Method | Does |
 | --- | --- | --- |
@@ -290,6 +291,65 @@ npm run dev
 curl "http://127.0.0.1:8787/__scheduled"                 # trigger one refresh
 npx wrangler kv key get "dataset:v1:meta" --binding DATASET --local
 ```
+
+## Admin API (Phase 4)
+
+Every route below is gated on collaborator status, answers `no-store`, and needs
+`credentials: 'include'` from an origin in `ADMIN_ORIGINS` (`src/auth.js`).
+**`*.pages.dev` preview URLs are not on that list**, so a PR preview cannot
+exercise auth — test on `dev.nczoning.net`. These are deliberately absent from
+`openapi.json`, which documents the public read surface only.
+
+| Route | Method | Does |
+| --- | --- | --- |
+| `/admin/locations` | GET | every location, all statuses, including `admin_notes` |
+| `/admin/locations` | POST | 201; `id` is server-generated and refused from input |
+| `/admin/locations/{id}` | GET / PATCH / DELETE | PATCH is partial; DELETE keeps the full record in the audit row |
+| `/admin/tags` | GET | the registry, each row with `usage_count` |
+| `/admin/tags` | POST | 201; 409 `tag_exists` on a duplicate slug |
+| `/admin/tags/{slug}` | GET / PATCH / DELETE | see the two rules below |
+| `/admin/audit` | GET | newest first, `?limit=` capped at 500 |
+
+**Unknown payload keys are a 422, not an ignore**, and `id` is refused outright.
+A silently dropped typo looks exactly like a successful save.
+
+### 🔴 Tags live in the join, and writes must go through it
+
+`locations.tags` is still present (migration 0002 is additive so parity can be
+proven before the column drops), but `materializeFromD1` reads
+**`location_tags`**. A write that touched only the column returned `200` and
+changed nothing on the map. `syncLocationTags()` in `src/tag-registry.js` owns
+both representations and is the only thing that may write either; it batches so
+the join is never briefly empty, and it keeps the synthetic `nczoning` marker in
+the legacy column for `source='auto'` rows so the stored shape does not drift.
+
+Tag validation reads the **`tags` table**, not the KV snapshot. Reading KV was
+correct while tags came from a file in git and became wrong the moment they were
+editable: a tag created through the API would have 422'd on first use.
+
+### 🔴 Two tag rules the schema implies but does not enforce
+
+- **`slug` is the primary key**, so renaming one is an `ON UPDATE CASCADE`
+  through `location_tags` and a link-breaking event. The cascade only fires with
+  foreign keys enforced — D1 has them on, SQLite does not by default — so the
+  handler re-counts the links after a rename and returns **500 `cascade_failed`**
+  rather than reporting a success that silently orphaned every record. The
+  dashboard keeps the slug read-only behind an explicit unlock; routine
+  relabelling is what `name` is for.
+- **Deleting a tag still in use is refused** — 409 `tag_in_use`, with the count
+  and the affected records in the body. `location_tags` has no `ON DELETE` for
+  `tag_slug`, so a bare delete fails on the foreign key with an opaque error, and
+  a cascade would strip the tag from every record as a side effect of one click.
+  Detach first, then delete.
+- **`nczoning` can never be created or renamed into.** It is not a registry row;
+  it is a marker the materializer prepends to auto-sourced records. A row with
+  that slug would collide with it, and deleting that row would strip the tag from
+  every auto-discovered record at once.
+
+Tests run against **real SQLite with the real migrations**
+(`test-support/d1-sqlite.mjs`), not a SQL-shape-matching mock: the two rules
+above are claims about constraints, and a mock can only restate the belief it was
+written from.
 
 ## Routes
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -309,9 +309,53 @@ exercise auth — test on `dev.nczoning.net`. These are deliberately absent from
 | `/admin/tags` | POST | 201; 409 `tag_exists` on a duplicate slug |
 | `/admin/tags/{slug}` | GET / PATCH / DELETE | see the two rules below |
 | `/admin/audit` | GET | newest first, `?limit=` capped at 500 |
+| `/admin/refresh` | POST | rebuild the served dataset now; see below |
 
 **Unknown payload keys are a 422, not an ignore**, and `id` is refused outright.
 A silently dropped typo looks exactly like a successful save.
+
+### Rebuilding the read path by hand
+
+**Staging has no cron.** It was removed to stay inside the 1,000 KV writes/day
+free-tier cap, which means nothing there re-materializes on its own: staging's
+KV was found 14 hours stale, still serving the pre-4b `/v1/tags` map shape, with
+nothing to notice it. `POST /admin/refresh` is the fix, and the dashboard shows
+dataset age in the top bar so the state is visible rather than assumed.
+
+Unlike the write-through materialize, it is **not** gated on `DATA_SOURCE`. That
+gate exists so an admin write does not spend a KV write rebuilding from a source
+the write did not touch; this route is someone explicitly asking, and
+`runRefresh` honours `DATA_SOURCE` either way — from `mods.json` in production,
+from D1 on staging. It cannot flip the cutover.
+
+🔴 **`runRefresh` does not throw on failure.** It catches, keeps last-known-good,
+flags `discovery_stale` and *returns* `{stale: true}`. So the route branches on
+that return value, not on whether the call threw — treating "it did not throw" as
+success would report every failed rebuild as a win. `changed: false` is a
+success, meaning the content hash matched and nothing needed rewriting.
+
+### Keeping D1 in step with `data/locations/` before the cutover
+
+Submissions still arrive the old way: issue → PR → `main` → a new
+`data/locations/<uuid>.json`. `mods.json` is rebuilt from those files so
+production picks the record up, and **D1 hears nothing** — so staging, which
+reads D1, silently serves a smaller map than production. A mod merged overnight
+did exactly that.
+
+```bash
+node scripts/sync-locations.mjs --db nczoning-data-staging --env staging --out .import/sync.sql
+npx wrangler d1 execute nczoning-data-staging --env staging --remote --file .import/sync.sql
+```
+
+Emits SQL rather than running it, INSERT-only, and writes **both**
+`locations` and `location_tags` — a record inserted without the join rows
+renders with no tags at all. It never deletes: rows in D1 with no file are not
+drift, since the nine auto-discovered records have never existed as files. It
+also reports records that exist in both and disagree, without rewriting them.
+
+Run it against **both** databases, and delete the script at cleanup — keeping it
+after submissions land in D1 directly would preserve git as a second source of
+truth.
 
 ### 🔴 Tags live in the join, and writes must go through it
 

--- a/worker/scripts/sync-locations.mjs
+++ b/worker/scripts/sync-locations.mjs
@@ -1,0 +1,232 @@
+/**
+ * Delta sync: `data/locations/*.json` -> D1, for records D1 does not have yet.
+ *
+ * WHY THIS EXISTS, and why it is temporary.
+ *
+ * Until the cutover, submissions still arrive the old way: an issue becomes a
+ * PR, the PR merges to `main`, and a new `data/locations/<uuid>.json` appears.
+ * `mods.json` is rebuilt from those files, so production picks the record up on
+ * the next cron tick. **D1 hears nothing.** A mod merged overnight is live on
+ * `nczoning.net` and absent from both D1 databases, so staging — which reads D1
+ * — silently serves a smaller map than production.
+ *
+ * That is the same failure the whole migration exists to remove, just pointing
+ * the other way: after the cutover a submission that merges into git and never
+ * reaches D1 would never reach the map at all. Before then, this closes the gap
+ * by hand. **Delete this script at cleanup**, once submissions land in D1
+ * directly; keeping it afterwards would preserve git as a second source of
+ * truth, which is the redundant-representation problem the migration removes.
+ *
+ * Usage — emits SQL, never executes it, so the delta is reviewable first:
+ *
+ *   node worker/scripts/sync-locations.mjs --db nczoning-data-staging --env staging --out .import/sync.sql
+ *   npx wrangler d1 execute nczoning-data-staging --env staging --remote --file .import/sync.sql
+ *
+ * INSERT-only, no upsert and no DELETE. Two consequences, both deliberate:
+ *
+ * - Running it twice fails on the primary key instead of quietly duplicating.
+ * - It never removes anything. Rows in D1 with no file are NOT drift: the nine
+ *   auto-discovered records have never existed as files, and a script that
+ *   "reconciled" by deleting the unmatched would wipe them. Only `source =
+ *   'manual'` rows are compared at all.
+ *
+ * It also reports records that exist in BOTH but disagree, without changing
+ * them. Once D1 is authoritative an edit belongs in the dashboard, and having
+ * this script quietly overwrite a D1 row from a git file would make the file
+ * authoritative again — the exact inversion the migration is undoing. Reporting
+ * is the point: nothing else currently notices that drift at all.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const LOCATIONS_DIR = path.join(REPO_ROOT, 'data', 'locations');
+const WRANGLER = path.join(REPO_ROOT, 'worker', 'node_modules', 'wrangler', 'bin', 'wrangler.js');
+
+/** SQLite string literal. Same escaping rules as import-locations.mjs. */
+function sql(value) {
+  if (value === null || value === undefined) return 'NULL';
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error(`non-finite number: ${value}`);
+    return String(value);
+  }
+  const str = String(value);
+  if (str.includes('\0')) throw new Error(`NUL byte in value: ${str.slice(0, 60)}`);
+  return `'${str.replace(/'/g, "''")}'`;
+}
+
+const COLUMNS = [
+  'id', 'name', 'nexus_id', 'category', 'x', 'y', 'z', 'yaw',
+  'description', 'credits', 'authors', 'tags', 'source', 'status',
+  'created_at', 'updated_at',
+];
+
+/** Map a location JSON record onto a `locations` row. Mirrors import-locations.mjs. */
+function toRow(rec, stamp) {
+  const [x, y, z] = rec.coordinates;
+  if (typeof x !== 'number' || typeof y !== 'number') {
+    throw new Error(`${rec.id}: coordinates must be numeric, got ${JSON.stringify(rec.coordinates)}`);
+  }
+  return {
+    id: rec.id,
+    name: rec.name,
+    nexus_id: String(rec.nexus_id),
+    category: rec.category,
+    x,
+    y,
+    z: z === undefined ? null : z,
+    yaw: rec.yaw === undefined ? null : rec.yaw,
+    description: rec.description ?? '',
+    // '' means "none" in the JSON files, the same as a missing key. NULL in D1.
+    credits: rec.credits ? rec.credits : null,
+    authors: JSON.stringify(rec.authors ?? []),
+    // The legacy column, kept in step with the join below until it is dropped.
+    tags: JSON.stringify(rec.tags ?? []),
+    source: 'manual',
+    status: 'published',
+    created_at: stamp,
+    updated_at: stamp,
+  };
+}
+
+function readManual(stamp) {
+  return fs.readdirSync(LOCATIONS_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => toRow(JSON.parse(fs.readFileSync(path.join(LOCATIONS_DIR, f), 'utf8')), stamp));
+}
+
+/**
+ * Ask the target database what it already has.
+ *
+ * 🔴 `--remote` is not optional. Without it wrangler answers from a local
+ * SQLite file that is usually empty, so the delta would be "every record is
+ * missing" and the script would cheerfully emit 288 INSERTs against a full
+ * table. Every one would fail on the primary key, which is the safe outcome —
+ * but the same mistake on a query that is not INSERT-only would not be.
+ */
+function readD1(db, envName) {
+  const args = [WRANGLER, 'd1', 'execute', db];
+  if (envName) args.push('--env', envName);
+  args.push('--remote', '--json', '--command',
+    'SELECT id, name, nexus_id, category, x, y, z, yaw, tags, source FROM locations');
+
+  const out = execFileSync(process.execPath, args, {
+    cwd: path.join(REPO_ROOT, 'worker'),
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+    env: { ...process.env },
+  });
+
+  // wrangler prefixes the JSON with human-readable lines; take from the first [.
+  const start = out.indexOf('[');
+  if (start === -1) throw new Error(`no JSON in wrangler output:\n${out.slice(0, 500)}`);
+  const parsed = JSON.parse(out.slice(start));
+  const results = parsed[0]?.results;
+  if (!Array.isArray(results)) throw new Error('unexpected wrangler --json shape');
+  return results;
+}
+
+/** Fields worth comparing on a record that exists in both places. */
+const COMPARED = ['name', 'nexus_id', 'category', 'x', 'y', 'z', 'yaw'];
+
+function main() {
+  const arg = (flag) => {
+    const i = process.argv.indexOf(flag);
+    return i === -1 ? null : process.argv[i + 1] ?? null;
+  };
+  const db = arg('--db');
+  const envName = arg('--env');
+  const outPath = arg('--out');
+  if (!db || !outPath) {
+    console.error('usage: sync-locations.mjs --db <name> [--env staging] --out <file.sql>');
+    process.exit(1);
+  }
+
+  const stamp = new Date().toISOString();
+  const files = readManual(stamp);
+  const existing = readD1(db, envName);
+
+  const byId = new Map(existing.map((r) => [r.id, r]));
+  const autoCount = existing.filter((r) => r.source === 'auto').length;
+  const manualInD1 = existing.filter((r) => r.source === 'manual');
+
+  const missing = files.filter((r) => !byId.has(r.id));
+
+  // Present in both, but disagreeing. Reported, never rewritten.
+  const drifted = [];
+  for (const file of files) {
+    const row = byId.get(file.id);
+    if (!row) continue;
+    const diffs = COMPARED.filter((k) => {
+      const a = row[k] === undefined ? null : row[k];
+      const b = file[k] === undefined ? null : file[k];
+      return JSON.stringify(a) !== JSON.stringify(b);
+    });
+    // Tag comparison uses the file's array against the legacy column, sorted:
+    // order carries no meaning and 4b normalised it.
+    const fileTags = JSON.parse(file.tags).slice().sort();
+    const rowTags = JSON.parse(row.tags ?? '[]').filter((t) => t !== 'nczoning').slice().sort();
+    if (JSON.stringify(fileTags) !== JSON.stringify(rowTags)) diffs.push('tags');
+    if (diffs.length) drifted.push({ id: file.id, name: file.name, diffs });
+  }
+
+  // Manual rows in D1 with no file. Not deleted, but worth saying out loud:
+  // this is either a record created in the dashboard (expected, and the first
+  // sign the cutover is really happening) or a file deleted in git.
+  const orphans = manualInD1.filter((r) => !files.some((f) => f.id === r.id));
+
+  console.log(`database:        ${db}${envName ? ` (--env ${envName})` : ''}`);
+  console.log(`files:           ${files.length} manual records`);
+  console.log(`D1:              ${existing.length} rows (${manualInD1.length} manual, ${autoCount} auto)`);
+  console.log(`to insert:       ${missing.length}`);
+  console.log(`already present: ${files.length - missing.length}`);
+  console.log(`drifted:         ${drifted.length}`);
+  console.log(`manual-only-in-D1: ${orphans.length}`);
+
+  for (const m of missing) console.log(`  + ${m.id}  ${m.name}`);
+  for (const d of drifted) console.log(`  ~ ${d.id}  ${d.name}  [${d.diffs.join(', ')}]`);
+  for (const o of orphans) console.log(`  ? ${o.id}  ${o.name}  (in D1, no file)`);
+
+  // The count identity, asserted rather than assumed: every file is either
+  // going in or already there, and nothing else.
+  if (missing.length + (files.length - missing.length) !== files.length) {
+    throw new Error('delta accounting does not add up');
+  }
+
+  if (!missing.length) {
+    console.log('\nNothing to insert. No file written.');
+    return;
+  }
+
+  const statements = [];
+  for (const row of missing) {
+    const values = COLUMNS.map((c) => sql(row[c])).join(', ');
+    statements.push(`INSERT INTO locations (${COLUMNS.join(', ')}) VALUES (${values});`);
+    // 🔴 The join, not just the column. The materializer reads location_tags;
+    // a record inserted without these rows renders on the map with no tags at
+    // all. `nczoning` is excluded because it is not a registry row -- the
+    // materializer re-adds it for auto records, and these are all manual.
+    for (const tag of JSON.parse(row.tags).filter((t) => t !== 'nczoning')) {
+      statements.push(
+        `INSERT INTO location_tags (location_id, tag_slug) VALUES (${sql(row.id)}, ${sql(tag)});`,
+      );
+    }
+  }
+
+  const header = [
+    `-- Generated by sync-locations.mjs at ${stamp}`,
+    `-- Target: ${db}${envName ? ` (--env ${envName})` : ''}`,
+    `-- ${missing.length} location(s), ${statements.length - missing.length} tag link(s).`,
+    '-- INSERT-only: re-running this file must fail on the primary key.',
+    '',
+  ].join('\n');
+
+  fs.mkdirSync(path.dirname(path.resolve(outPath)), { recursive: true });
+  fs.writeFileSync(path.resolve(outPath), `${header}${statements.join('\n')}\n`);
+  console.log(`\nWrote ${statements.length} statement(s) to ${outPath}`);
+}
+
+main();

--- a/worker/src/admin.js
+++ b/worker/src/admin.js
@@ -161,6 +161,53 @@ export async function handleAdmin(request, env, ctx) {
     return json(request, { entries: await readAudit(env, url.searchParams.get('limit')) });
   }
 
+  // ---- rebuild the read path ---------------------------------------------
+  //
+  // Deliberately NOT gated on DATA_SOURCE, unlike materializeAfterWrite. That
+  // gate exists so an admin write does not spend a KV write rebuilding from a
+  // source the write did not touch; this route is someone explicitly asking for
+  // a rebuild, and runRefresh honours DATA_SOURCE either way — from mods.json in
+  // production, from D1 on staging. It cannot flip the cutover.
+  //
+  // It exists because staging has NO CRON (removed to stay inside the 1,000
+  // KV writes/day free-tier cap), so nothing there re-materializes on its own.
+  // Staging's KV sat 14 hours stale and served the pre-4b /v1/tags shape, and
+  // there was no way to notice or fix it short of an admin write.
+  //
+  // Awaited rather than fire-and-forget: the caller asked for a rebuild, so the
+  // response has to say whether they got one.
+  if (url.pathname === '/admin/refresh' && method === 'POST') {
+    const source = env.DATA_SOURCE ?? 'mods';
+    let result;
+    try {
+      result = await runRefresh(env);
+    } catch (err) {
+      // 🔴 runRefresh does NOT throw on a failed rebuild -- it catches, keeps
+      // last-known-good, flags discovery_stale and RETURNS {stale: true}. So
+      // this catch is only for a failure of its own error path, and branching
+      // on `stale` below is what actually detects a failed rebuild. Reporting
+      // success off "it did not throw" would have called every failure a win.
+      return json(request, { error: 'refresh_failed', detail: String(err).slice(0, 300) }, 500);
+    }
+
+    if (result?.stale) {
+      return json(request, {
+        error: 'refresh_failed',
+        detail: String(result.error ?? 'unknown').slice(0, 300),
+      }, 500);
+    }
+
+    await writeAudit(env, { actor, action: 'dataset.refresh', target: source });
+    // `changed: false` is a success: the content hash matched, so there was
+    // nothing to write. Distinct from a failure, and the caller is told which.
+    return json(request, {
+      refreshed: true,
+      source,
+      changed: result?.changed === true,
+      dataset_version: result?.version ?? null,
+    });
+  }
+
   // ---- tags --------------------------------------------------------------
   const tagResponse = await handleTags(
     { request, env, ctx, actor, method, tagListMatch, tagOneMatch },

--- a/worker/src/admin.js
+++ b/worker/src/admin.js
@@ -12,8 +12,11 @@ import { resolveSession } from './auth.js';
 import { adminCors } from './auth.js';
 import { validateLocationInput } from './validate.js';
 import { writeAudit, readAudit } from './audit.js';
-import { KEYS } from './store.js';
 import { runRefresh } from './refresh.js';
+import {
+  validateTagInput, readTagSlugs, readTagsWithUsage, readTagUsers, readTag,
+  readTagsForLocations, syncLocationTags,
+} from './tag-registry.js';
 
 const json = (request, body, status = 200) => new Response(JSON.stringify(body), {
   status,
@@ -41,8 +44,19 @@ async function requireCollaborator(request, env) {
   return { session };
 }
 
-/** Row -> the admin representation (everything, including admin-only fields). */
-function rowToAdmin(row) {
+/**
+ * Row -> the admin representation (everything, including admin-only fields).
+ *
+ * `tags` comes from the `location_tags` join, passed in by the caller, NOT from
+ * the legacy `locations.tags` column. The join is what the materializer reads,
+ * so it is what the dashboard must show — rendering the column would let an
+ * edit that never reached the join look like it had landed.
+ *
+ * The synthetic `nczoning` marker is absent here by construction (it is not a
+ * registry row, so it has no join rows). That is correct for an editor: it is
+ * not a tag an admin owns, and the materializer re-adds it for auto records.
+ */
+function rowToAdmin(row, tags = []) {
   return {
     id: row.id,
     name: row.name,
@@ -53,7 +67,7 @@ function rowToAdmin(row) {
     description: row.description ?? '',
     credits: row.credits,
     authors: JSON.parse(row.authors ?? '[]'),
-    tags: JSON.parse(row.tags ?? '[]'),
+    tags,
     source: row.source,
     status: row.status,
     admin_notes: row.admin_notes,
@@ -62,10 +76,10 @@ function rowToAdmin(row) {
   };
 }
 
-/** Known tag ids, from the KV dataset the cron already maintains. */
-async function tagNames(env) {
-  const tags = await env.DATASET.get(KEYS.tags, 'json');
-  return new Set(Object.keys(tags || {}));
+/** One location, joined to its tags. */
+async function loadAdminRecord(env, row) {
+  const map = await readTagsForLocations(env, [row.id]);
+  return rowToAdmin(row, map.get(row.id) ?? []);
 }
 
 /**
@@ -93,7 +107,13 @@ const COLUMN_FOR = {
   yaw: 'yaw',
 };
 
-/** Build the SET clause for a validated patch. */
+/**
+ * Build the SET clause for a validated patch.
+ *
+ * `tags` is deliberately NOT here: it lives in the join now, and
+ * syncLocationTags owns both representations. Setting the column here as well
+ * would write it twice with two different normalisations.
+ */
 function buildUpdate(payload) {
   const sets = [];
   const binds = [];
@@ -105,9 +125,6 @@ function buildUpdate(payload) {
   }
   if (Object.prototype.hasOwnProperty.call(payload, 'authors')) {
     sets.push('authors = ?'); binds.push(JSON.stringify(payload.authors));
-  }
-  if (Object.prototype.hasOwnProperty.call(payload, 'tags')) {
-    sets.push('tags = ?'); binds.push(JSON.stringify(payload.tags));
   }
   if (Object.prototype.hasOwnProperty.call(payload, 'coordinates')) {
     const [x, y, z] = payload.coordinates;
@@ -136,16 +153,26 @@ export async function handleAdmin(request, env, ctx) {
   const method = request.method;
   const listMatch = url.pathname === '/admin/locations';
   const oneMatch = url.pathname.match(/^\/admin\/locations\/([^/]+)$/);
+  const tagListMatch = url.pathname === '/admin/tags';
+  const tagOneMatch = url.pathname.match(/^\/admin\/tags\/([^/]+)$/);
 
   // ---- audit -------------------------------------------------------------
   if (url.pathname === '/admin/audit' && method === 'GET') {
     return json(request, { entries: await readAudit(env, url.searchParams.get('limit')) });
   }
 
+  // ---- tags --------------------------------------------------------------
+  const tagResponse = await handleTags(
+    { request, env, ctx, actor, method, tagListMatch, tagOneMatch },
+  );
+  if (tagResponse) return tagResponse;
+
   // ---- list --------------------------------------------------------------
   if (listMatch && method === 'GET') {
     const { results } = await env.DB.prepare('SELECT * FROM locations ORDER BY name').all();
-    return json(request, { locations: (results ?? []).map(rowToAdmin) });
+    const rows = results ?? [];
+    const tagMap = await readTagsForLocations(env, rows.map((r) => r.id));
+    return json(request, { locations: rows.map((r) => rowToAdmin(r, tagMap.get(r.id) ?? [])) });
   }
 
   // ---- create ------------------------------------------------------------
@@ -153,7 +180,7 @@ export async function handleAdmin(request, env, ctx) {
     let payload;
     try { payload = await request.json(); } catch { return json(request, { error: 'invalid_json' }, 400); }
 
-    const v = validateLocationInput(payload, { tagNames: await tagNames(env) });
+    const v = validateLocationInput(payload, { tagNames: await readTagSlugs(env) });
     if (!v.ok) return json(request, { error: 'validation_failed', errors: v.errors }, 422);
 
     // Server-generated, never client-supplied: a caller-chosen id is how a deep
@@ -177,7 +204,11 @@ export async function handleAdmin(request, env, ctx) {
       payload.admin_notes ?? null, now, now,
     ).run();
 
-    const after = rowToAdmin(await getRow(env, id));
+    // The join, not just the column. Without this the record materializes with
+    // no tags at all, because resolveTags treats the join as authoritative.
+    await syncLocationTags(env, id, payload.tags, payload.source ?? 'manual');
+
+    const after = await loadAdminRecord(env, await getRow(env, id));
     await writeAudit(env, { actor, action: 'location.create', target: id, after });
     materializeAfterWrite(env, ctx);
     return json(request, { location: after }, 201);
@@ -187,32 +218,42 @@ export async function handleAdmin(request, env, ctx) {
   if (oneMatch && method === 'GET') {
     const row = await getRow(env, decodeURIComponent(oneMatch[1]));
     if (!row) return json(request, { error: 'not_found' }, 404);
-    return json(request, { location: rowToAdmin(row) });
+    return json(request, { location: await loadAdminRecord(env, row) });
   }
 
   // ---- update ------------------------------------------------------------
   if (oneMatch && method === 'PATCH') {
     const id = decodeURIComponent(oneMatch[1]);
-    const before = await getRow(env, id);
-    if (!before) return json(request, { error: 'not_found' }, 404);
+    const beforeRow = await getRow(env, id);
+    if (!beforeRow) return json(request, { error: 'not_found' }, 404);
+    const before = await loadAdminRecord(env, beforeRow);
 
     let payload;
     try { payload = await request.json(); } catch { return json(request, { error: 'invalid_json' }, 400); }
 
-    const v = validateLocationInput(payload, { tagNames: await tagNames(env), partial: true });
+    const v = validateLocationInput(payload, { tagNames: await readTagSlugs(env), partial: true });
     if (!v.ok) return json(request, { error: 'validation_failed', errors: v.errors }, 422);
 
+    const patchesTags = Object.prototype.hasOwnProperty.call(payload, 'tags');
     const { sets, binds } = buildUpdate(payload);
-    if (!sets.length) return json(request, { error: 'empty_patch' }, 400);
+    if (!sets.length && !patchesTags) return json(request, { error: 'empty_patch' }, 400);
 
+    // A tags-only patch still has to move updated_at, so the column write is
+    // unconditional rather than gated on `sets`.
     sets.push('updated_at = ?');
     binds.push(new Date().toISOString(), id);
     await env.DB.prepare(`UPDATE locations SET ${sets.join(', ')} WHERE id = ?`).bind(...binds).run();
 
-    const after = rowToAdmin(await getRow(env, id));
-    await writeAudit(env, {
-      actor, action: 'location.update', target: id, before: rowToAdmin(before), after,
-    });
+    if (patchesTags) {
+      // Re-read rather than reusing `beforeRow`: the same PATCH may have just
+      // changed `source`, which decides whether the legacy column keeps the
+      // nczoning marker.
+      const { source } = await getRow(env, id);
+      await syncLocationTags(env, id, payload.tags, source);
+    }
+
+    const after = await loadAdminRecord(env, await getRow(env, id));
+    await writeAudit(env, { actor, action: 'location.update', target: id, before, after });
     materializeAfterWrite(env, ctx);
     return json(request, { location: after });
   }
@@ -220,19 +261,170 @@ export async function handleAdmin(request, env, ctx) {
   // ---- delete ------------------------------------------------------------
   if (oneMatch && method === 'DELETE') {
     const id = decodeURIComponent(oneMatch[1]);
-    const before = await getRow(env, id);
-    if (!before) return json(request, { error: 'not_found' }, 404);
+    const beforeRow = await getRow(env, id);
+    if (!beforeRow) return json(request, { error: 'not_found' }, 404);
+    // Snapshot the tags BEFORE the delete: location_tags cascades on
+    // location_id, so reading them afterwards returns an empty list and the
+    // audit row would claim the record had no tags.
+    const before = await loadAdminRecord(env, beforeRow);
 
     await env.DB.prepare('DELETE FROM locations WHERE id = ?').bind(id).run();
     // The full record goes into `before`, so a delete is recoverable from the
     // audit log. `status: 'hidden'` remains the right move for a mod pulled
     // from the map; this is for records that should never have existed.
-    await writeAudit(env, {
-      actor, action: 'location.delete', target: id, before: rowToAdmin(before),
-    });
+    await writeAudit(env, { actor, action: 'location.delete', target: id, before });
     materializeAfterWrite(env, ctx);
     return json(request, { deleted: id });
   }
 
   return json(request, { error: 'not_found' }, 404);
+}
+
+/**
+ * The /admin/tags surface. Split out so handleAdmin stays readable; returns
+ * null when the path is not a tag route, exactly as handleAdmin does for
+ * non-admin paths.
+ *
+ * Every mutation writes an audit row and rebuilds the read path, same as
+ * locations — a tag's name and description are served on /v1/tags, so an edit
+ * that skipped the materialize would sit invisible until the next cron tick.
+ */
+async function handleTags({ request, env, ctx, actor, method, tagListMatch, tagOneMatch }) {
+  // ---- list --------------------------------------------------------------
+  if (tagListMatch && method === 'GET') {
+    return json(request, { tags: await readTagsWithUsage(env) });
+  }
+
+  // ---- create ------------------------------------------------------------
+  if (tagListMatch && method === 'POST') {
+    let payload;
+    try { payload = await request.json(); } catch { return json(request, { error: 'invalid_json' }, 400); }
+
+    const v = validateTagInput(payload);
+    if (!v.ok) return json(request, { error: 'validation_failed', errors: v.errors }, 422);
+
+    if (await readTag(env, payload.slug)) {
+      return json(request, { error: 'tag_exists', slug: payload.slug }, 409);
+    }
+
+    const now = new Date().toISOString();
+    await env.DB.prepare(`
+      INSERT INTO tags (slug, name, description, sort_order, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).bind(
+      payload.slug, payload.name ?? null, payload.description,
+      payload.sort_order ?? null, now, now,
+    ).run();
+
+    const after = await readTag(env, payload.slug);
+    await writeAudit(env, { actor, action: 'tag.create', target: payload.slug, after });
+    materializeAfterWrite(env, ctx);
+    return json(request, { tag: { ...after, usage_count: 0 } }, 201);
+  }
+
+  if (!tagOneMatch) return null;
+  const slug = decodeURIComponent(tagOneMatch[1]);
+
+  // ---- read one ----------------------------------------------------------
+  if (method === 'GET') {
+    const tag = await readTag(env, slug);
+    if (!tag) return json(request, { error: 'not_found' }, 404);
+    return json(request, { tag, locations: await readTagUsers(env, slug) });
+  }
+
+  // ---- update ------------------------------------------------------------
+  if (method === 'PATCH') {
+    const before = await readTag(env, slug);
+    if (!before) return json(request, { error: 'not_found' }, 404);
+
+    let payload;
+    try { payload = await request.json(); } catch { return json(request, { error: 'invalid_json' }, 400); }
+
+    const v = validateTagInput(payload, { partial: true });
+    if (!v.ok) return json(request, { error: 'validation_failed', errors: v.errors }, 422);
+
+    const renaming = Object.prototype.hasOwnProperty.call(payload, 'slug')
+      && payload.slug !== slug;
+    if (renaming && await readTag(env, payload.slug)) {
+      return json(request, { error: 'tag_exists', slug: payload.slug }, 409);
+    }
+
+    const sets = [];
+    const binds = [];
+    for (const field of ['slug', 'name', 'description', 'sort_order']) {
+      if (Object.prototype.hasOwnProperty.call(payload, field)) {
+        sets.push(`${field} = ?`);
+        binds.push(payload[field] ?? null);
+      }
+    }
+    if (!sets.length) return json(request, { error: 'empty_patch' }, 400);
+
+    sets.push('updated_at = ?');
+    binds.push(new Date().toISOString(), slug);
+
+    // 🔴 A slug change propagates to location_tags through ON UPDATE CASCADE,
+    // which only fires with foreign keys enforced. D1 enforces them by default;
+    // if that ever stops being true the rename silently orphans every link,
+    // which is why the count is re-read below and compared.
+    const usedBefore = (await env.DB.prepare(
+      'SELECT COUNT(*) AS n FROM location_tags WHERE tag_slug = ?',
+    ).bind(slug).first())?.n ?? 0;
+
+    await env.DB.prepare(`UPDATE tags SET ${sets.join(', ')} WHERE slug = ?`).bind(...binds).run();
+
+    const newSlug = renaming ? payload.slug : slug;
+    if (renaming) {
+      const usedAfter = (await env.DB.prepare(
+        'SELECT COUNT(*) AS n FROM location_tags WHERE tag_slug = ?',
+      ).bind(newSlug).first())?.n ?? 0;
+      if (usedAfter !== usedBefore) {
+        // Loud, not silent: the tag now exists under the new slug but the
+        // locations no longer point at it. Reporting 200 here would hand back a
+        // renamed tag and quietly untag every location that carried it.
+        return json(request, {
+          error: 'cascade_failed',
+          detail: `rename left ${usedAfter} of ${usedBefore} location links intact`,
+        }, 500);
+      }
+    }
+
+    const after = await readTag(env, newSlug);
+    await writeAudit(env, {
+      actor,
+      action: renaming ? 'tag.rename' : 'tag.update',
+      target: newSlug,
+      before,
+      after,
+    });
+    materializeAfterWrite(env, ctx);
+    return json(request, { tag: { ...after, usage_count: usedBefore } });
+  }
+
+  // ---- delete ------------------------------------------------------------
+  if (method === 'DELETE') {
+    const before = await readTag(env, slug);
+    if (!before) return json(request, { error: 'not_found' }, 404);
+
+    // Refuse rather than cascade. location_tags has no ON DELETE for tag_slug,
+    // so a bare delete would fail on the foreign key with an opaque error; and
+    // a cascade would strip the tag from every record as a side effect of one
+    // click, with a single audit row to show for it. The count and the affected
+    // records come back so the caller can decide, which is the whole point.
+    const users = await readTagUsers(env, slug);
+    if (users.length) {
+      const total = (await env.DB.prepare(
+        'SELECT COUNT(*) AS n FROM location_tags WHERE tag_slug = ?',
+      ).bind(slug).first())?.n ?? users.length;
+      return json(request, {
+        error: 'tag_in_use', slug, usage_count: total, locations: users,
+      }, 409);
+    }
+
+    await env.DB.prepare('DELETE FROM tags WHERE slug = ?').bind(slug).run();
+    await writeAudit(env, { actor, action: 'tag.delete', target: slug, before });
+    materializeAfterWrite(env, ctx);
+    return json(request, { deleted: slug });
+  }
+
+  return null;
 }

--- a/worker/src/tag-registry.js
+++ b/worker/src/tag-registry.js
@@ -1,0 +1,204 @@
+/**
+ * Write layer for the tag registry. The read side lives in d1.js (`readTags`,
+ * `readLocationTags`); this is everything that mutates `tags` and the
+ * `location_tags` join.
+ *
+ * Phase 4b moved tags into D1 but only wired up the read path. Phase 4a's admin
+ * writes predate it and still set the legacy `locations.tags` JSON column, which
+ * the materializer stopped reading the moment the join became authoritative. An
+ * admin editing tags therefore got a 200 and no change on the map. That is the
+ * gap this module closes, and it is why every location write now goes through
+ * `syncLocationTags` rather than a bare column update.
+ *
+ * DUAL WRITE, on purpose. `locations.tags` is kept byte-compatible with the join
+ * until a later migration drops the column. Migration 0002 is additive
+ * specifically so the switch can be proven byte-for-byte first; writing to only
+ * one of the two would make the parity gate compare a live column against a
+ * frozen one and call the difference a regression.
+ */
+
+/** Never a registry row: a marker auto-discovery prepends, not a curated tag. */
+export const RESERVED_SLUGS = new Set(['nczoning']);
+
+/**
+ * Lowercase, hyphen-separated, no leading/trailing/doubled hyphens.
+ *
+ * Every existing slug is a bare lowercase word, so this is stricter than the
+ * corpus requires. That is deliberate: the slug is a URL parameter and a
+ * primary key, and the cost of tightening it later (after someone has deep
+ * linked `?tag=Mixed_Case`) is much higher than the cost of tightening it now.
+ */
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const SLUG_MAX = 40;
+export const TAG_NAME_MAX = 60;
+export const TAG_DESCRIPTION_MAX = 500;
+
+/** Fields an admin may set on a tag. Anything else is rejected, as for locations. */
+const WRITABLE = new Set(['slug', 'name', 'description', 'sort_order']);
+
+const isPlainObject = (v) => typeof v === 'object' && v !== null && !Array.isArray(v);
+
+/**
+ * @param {object} payload
+ * @param {object} [opts]
+ * @param {boolean} [opts.partial]  PATCH semantics: validate only present keys.
+ * @returns {{ok: boolean, errors: string[]}}
+ */
+export function validateTagInput(payload, { partial = false } = {}) {
+  const errors = [];
+  const err = (m) => errors.push(m);
+
+  if (!isPlainObject(payload)) return { ok: false, errors: ['body must be a JSON object'] };
+
+  for (const key of Object.keys(payload)) {
+    if (!WRITABLE.has(key)) err(`unknown field: ${key}`);
+  }
+
+  const has = (k) => Object.prototype.hasOwnProperty.call(payload, k);
+
+  if (!partial) {
+    for (const k of ['slug', 'description']) if (!has(k)) err(`missing required field: ${k}`);
+  }
+
+  if (has('slug')) {
+    if (typeof payload.slug !== 'string' || !SLUG_RE.test(payload.slug)) {
+      err('slug must be lowercase letters, digits and single hyphens');
+    } else if (payload.slug.length > SLUG_MAX) {
+      err(`slug must be at most ${SLUG_MAX} characters`);
+    } else if (RESERVED_SLUGS.has(payload.slug)) {
+      // `nczoning` is prepended by the materializer for every auto-sourced
+      // record. A registry row with that slug would collide with the marker and
+      // make it editable and deletable, and deleting it would strip the tag from
+      // every auto-discovered location at once.
+      err(`slug "${payload.slug}" is reserved and cannot be used`);
+    }
+  }
+
+  if (has('name') && payload.name !== null) {
+    if (typeof payload.name !== 'string' || payload.name.length < 1) {
+      err('name must be a non-empty string or null');
+    } else if (payload.name.length > TAG_NAME_MAX) {
+      err(`name must be at most ${TAG_NAME_MAX} characters`);
+    }
+  }
+
+  if (has('description')) {
+    if (typeof payload.description !== 'string' || payload.description.length < 1) {
+      err('description must be a non-empty string');
+    } else if (payload.description.length > TAG_DESCRIPTION_MAX) {
+      err(`description must be at most ${TAG_DESCRIPTION_MAX} characters`);
+    }
+  }
+
+  if (has('sort_order') && payload.sort_order !== null) {
+    if (!Number.isInteger(payload.sort_order)) err('sort_order must be an integer or null');
+  }
+
+  return { ok: errors.length === 0, errors };
+}
+
+/**
+ * Known slugs, for validating a location's `tags`.
+ *
+ * Reads the `tags` TABLE, not the KV snapshot the cron maintains. Phase 4a read
+ * KV, which was correct when tags came from a file in git and wrong the moment
+ * tags became editable: a tag created through this API would not be valid on a
+ * location until the next materialize, so the create would succeed and the very
+ * next use of it would 422.
+ */
+export async function readTagSlugs(env) {
+  const { results } = await env.DB.prepare('SELECT slug FROM tags').all();
+  return new Set((results ?? []).map((r) => r.slug));
+}
+
+/**
+ * Every tag with the number of locations carrying it.
+ *
+ * The count is the whole point of the admin view: it is what turns "delete this
+ * tag" from a guess into a decision, and it is what the 409 on delete reports.
+ */
+export async function readTagsWithUsage(env) {
+  const { results } = await env.DB.prepare(`
+    SELECT t.slug, t.name, t.description, t.sort_order, t.created_at, t.updated_at,
+           COUNT(lt.location_id) AS usage_count
+    FROM tags t
+    LEFT JOIN location_tags lt ON lt.tag_slug = t.slug
+    GROUP BY t.slug
+    ORDER BY t.sort_order, t.slug
+  `).all();
+  return (results ?? []).map((r) => ({
+    slug: r.slug,
+    name: r.name,
+    description: r.description,
+    sort_order: r.sort_order,
+    usage_count: Number(r.usage_count) || 0,
+    created_at: r.created_at,
+    updated_at: r.updated_at,
+  }));
+}
+
+/** The locations carrying a tag: `{id, name}`, name-ordered. Used by the 409 body. */
+export async function readTagUsers(env, slug, limit = 50) {
+  const { results } = await env.DB.prepare(`
+    SELECT l.id, l.name FROM location_tags lt
+    JOIN locations l ON l.id = lt.location_id
+    WHERE lt.tag_slug = ?
+    ORDER BY l.name
+    LIMIT ?
+  `).bind(slug, limit).all();
+  return results ?? [];
+}
+
+/** One tag row, or null. */
+export async function readTag(env, slug) {
+  return env.DB.prepare(
+    'SELECT slug, name, description, sort_order, created_at, updated_at FROM tags WHERE slug = ?',
+  ).bind(slug).first();
+}
+
+/** Slugs attached to each of `ids`, as Map(location_id -> string[]). */
+export async function readTagsForLocations(env, ids) {
+  const map = new Map(ids.map((id) => [id, []]));
+  if (!ids.length) return map;
+  const placeholders = ids.map(() => '?').join(', ');
+  const { results } = await env.DB.prepare(
+    `SELECT location_id, tag_slug FROM location_tags
+     WHERE location_id IN (${placeholders}) ORDER BY location_id, tag_slug`,
+  ).bind(...ids).all();
+  for (const r of results ?? []) map.get(r.location_id)?.push(r.tag_slug);
+  return map;
+}
+
+/**
+ * Point a location at exactly `slugs`, in both representations.
+ *
+ * Replace rather than diff: the join row carries no payload beyond its own
+ * existence, so a delete-then-insert is the same end state as a computed diff
+ * and has no partial-update case to get wrong.
+ *
+ * `source` decides whether the legacy column keeps the synthetic `nczoning`
+ * marker at the front, which is how the existing auto rows are stored. Without
+ * it, editing an auto record's tags would rewrite the column into a shape no
+ * existing row has, and the parity gate would report a difference that is an
+ * artefact of the write rather than a real one.
+ */
+export async function syncLocationTags(env, locationId, slugs, source) {
+  const clean = [...new Set(slugs.filter((s) => !RESERVED_SLUGS.has(s)))].sort();
+  const legacy = source === 'auto' ? ['nczoning', ...clean] : clean;
+
+  const statements = [
+    env.DB.prepare('DELETE FROM location_tags WHERE location_id = ?').bind(locationId),
+    ...clean.map((slug) => env.DB.prepare(
+      'INSERT INTO location_tags (location_id, tag_slug) VALUES (?, ?)',
+    ).bind(locationId, slug)),
+    env.DB.prepare('UPDATE locations SET tags = ? WHERE id = ?')
+      .bind(JSON.stringify(legacy), locationId),
+  ];
+
+  // Batched so the join is never briefly empty for a location that has tags.
+  // A cron tick landing between the DELETE and the INSERTs would otherwise
+  // materialize that record with no tags at all.
+  await env.DB.batch(statements);
+  return clean;
+}

--- a/worker/test-support/d1-sqlite.mjs
+++ b/worker/test-support/d1-sqlite.mjs
@@ -1,0 +1,114 @@
+/**
+ * A D1 binding backed by real SQLite, running the real migrations.
+ *
+ * The admin tests used to run against a hand-rolled fake that matched SQL by
+ * substring. That was adequate while every statement was a plain single-table
+ * read or write, and it stopped being adequate the moment tag behaviour became
+ * a question about CONSTRAINTS: "deleting a tag in use is refused" and "renaming
+ * a slug cascades to location_tags" are claims about SQLite, and a mock can only
+ * ever restate the author's belief about them. Proving them needs an engine.
+ *
+ * node:sqlite is experimental, and it is a test-only dependency — nothing here
+ * ships to the Worker, which talks to D1.
+ *
+ * Two behaviours matter and are asserted by the tests that use this:
+ * - `PRAGMA foreign_keys = ON`. SQLite defaults it OFF, D1 defaults it ON. With
+ *   it off, ON UPDATE CASCADE silently does nothing and every rename orphans
+ *   its links — which is why admin.js re-counts after a rename rather than
+ *   trusting the cascade.
+ * - `batch()` runs inside a transaction, as D1's does.
+ */
+
+import { DatabaseSync } from 'node:sqlite';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Outside test/ on purpose: `node --test` treats every .js/.mjs under a test/
+// directory as a test file, and a helper with no tests in it would be reported
+// as a passing suite.
+const MIGRATIONS = join(dirname(fileURLToPath(import.meta.url)), '..', 'migrations');
+
+/** D1 returns `{results, meta}` from all(), a bare row (or null) from first(). */
+function statement(db, sql, args = []) {
+  return {
+    bind(...next) { return statement(db, sql, next); },
+    async first(column) {
+      const row = db.prepare(sql).get(...args) ?? null;
+      if (row === null || column === undefined) return row;
+      return row[column];
+    },
+    async all() {
+      return { results: db.prepare(sql).all(...args), success: true };
+    },
+    async run() {
+      const info = db.prepare(sql).run(...args);
+      return { success: true, meta: { changes: Number(info.changes) } };
+    },
+    // Internal: batch() needs the pieces, not the promise.
+    _sql: sql,
+    _args: args,
+  };
+}
+
+/**
+ * @param {object} [seed]
+ * @param {Array}  [seed.locations]      raw `locations` rows
+ * @param {Array}  [seed.locationTags]   `[location_id, tag_slug]` pairs
+ * @param {Array}  [seed.users]          raw `users` rows
+ * @param {Array}  [seed.tags]           extra tag rows beyond migration 0002's seed
+ */
+export function sqliteD1(seed = {}) {
+  const db = new DatabaseSync(':memory:');
+  db.exec('PRAGMA foreign_keys = ON');
+
+  // The real migrations, in order. If a migration stops being valid SQLite this
+  // throws here rather than producing a subtly different schema to test against.
+  for (const file of readdirSync(MIGRATIONS).filter((f) => f.endsWith('.sql')).sort()) {
+    db.exec(readFileSync(join(MIGRATIONS, file), 'utf8'));
+  }
+
+  for (const row of seed.locations ?? []) {
+    const cols = Object.keys(row);
+    db.prepare(
+      `INSERT INTO locations (${cols.join(', ')}) VALUES (${cols.map(() => '?').join(', ')})`,
+    ).run(...cols.map((c) => row[c]));
+  }
+  for (const [locationId, tagSlug] of seed.locationTags ?? []) {
+    db.prepare('INSERT INTO location_tags (location_id, tag_slug) VALUES (?, ?)')
+      .run(locationId, tagSlug);
+  }
+  for (const row of seed.users ?? []) {
+    db.prepare(
+      'INSERT INTO users (id, login, is_collaborator, checked_at, first_seen_at) VALUES (?, ?, ?, ?, ?)',
+    ).run(row.id, row.login, row.is_collaborator, row.checked_at, row.first_seen_at);
+  }
+  for (const row of seed.tags ?? []) {
+    db.prepare(
+      'INSERT INTO tags (slug, name, description, sort_order, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+    ).run(row.slug, row.name ?? null, row.description, row.sort_order ?? null,
+      row.created_at ?? 'seed', row.updated_at ?? 'seed');
+  }
+
+  return {
+    _db: db,
+    prepare: (sql) => statement(db, sql),
+    async batch(statements) {
+      db.exec('BEGIN');
+      try {
+        const out = statements.map((s) => {
+          const info = db.prepare(s._sql).run(...s._args);
+          return { success: true, meta: { changes: Number(info.changes) } };
+        });
+        db.exec('COMMIT');
+        return out;
+      } catch (err) {
+        db.exec('ROLLBACK');
+        throw err;
+      }
+    },
+    /** Test conveniences — reads, never writes. */
+    rows: (sql, ...args) => db.prepare(sql).all(...args),
+    one: (sql, ...args) => db.prepare(sql).get(...args) ?? null,
+  };
+}

--- a/worker/test/admin.test.js
+++ b/worker/test/admin.test.js
@@ -14,6 +14,66 @@ const SECRET = 'admin-test-secret';
 
 const fakeKv = () => ({ async get() { return null; }, async put() {} });
 
+/**
+ * A KV that actually stores, for the tests that run a real refresh through.
+ *
+ * The discarding KV above is fine for the CRUD tests, which never read back.
+ * It is NOT fine for a refresh: runRefresh compares the new content hash
+ * against the stored meta, so with a KV that forgets, every rebuild looks like
+ * a first one.
+ */
+function storingKv(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    _store: store,
+    async get(key, type) {
+      const v = store.get(key);
+      if (v === undefined) return null;
+      return type === 'json' ? JSON.parse(v) : v;
+    },
+    async put(key, value) { store.set(key, value); },
+  };
+}
+
+const SUBDISTRICTS = {
+  districts: [{
+    id: 'testville',
+    name: 'Testville',
+    polygon: [[-9000, -9000], [9000, -9000], [9000, 9000], [-9000, 9000]],
+    subdistricts: [],
+  }],
+};
+
+/**
+ * Everything runRefresh reaches for. Mirrors the stub in refresh-d1.test.js.
+ *
+ * 🔴 Installed as globalThis.fetch, because admin.js calls `runRefresh(env)`
+ * without a fetchImpl. An earlier test in this file replaces globalThis.fetch
+ * with a hard failure and does not restore it, so a refresh test that does not
+ * set this inherits that and rebuilds "successfully" against nothing.
+ */
+function refreshFetch() {
+  return async (url, init) => {
+    const u = String(url);
+    if (u.includes('/mods.json')) return { ok: true, json: async () => [] };
+    if (u.includes('/tags.json')) return { ok: true, json: async () => ({ apartment: 'a place' }) };
+    if (u.includes('/excluded_mods.json')) return { ok: true, json: async () => ({}) };
+    if (u.includes('/subdistricts.json')) return { ok: true, json: async () => SUBDISTRICTS };
+    // Non-fatal by construction in refresh.js: a miss leaves images null.
+    if (u.includes('api-router.nexusmods.com')) return { ok: false, status: 503 };
+    if (u.includes('file-metadata.nexusmods.com')) return { ok: false, status: 503 };
+    if (u.includes('api.nexusmods.com')) {
+      const query = init?.body ? JSON.parse(init.body).query : '';
+      if (query.includes('modsByUid')) {
+        return { ok: true, json: async () => ({ data: { modsByUid: { nodes: [] } } }) };
+      }
+      return { ok: true, json: async () => ({ data: { mods: { nodes: [], totalCount: 0 } } }) };
+    }
+    if (u.includes('discord')) return { ok: true };
+    throw new Error(`unexpected fetch: ${u}`);
+  };
+}
+
 const ROW = {
   id: 'loc-1', name: 'Existing Loft', nexus_id: '12345', category: 'new-location',
   x: 1, y: 2, z: 3, yaw: 90, description: 'a place', credits: null,
@@ -81,7 +141,7 @@ test('every admin route is refused without a session', async () => {
     ['DELETE', '/admin/locations/loc-1'], ['GET', '/admin/audit'],
     ['GET', '/admin/tags'], ['POST', '/admin/tags'],
     ['GET', '/admin/tags/corpo'], ['PATCH', '/admin/tags/corpo'],
-    ['DELETE', '/admin/tags/corpo'],
+    ['DELETE', '/admin/tags/corpo'], ['POST', '/admin/refresh'],
   ]) {
     const res = await worker.fetch(
       new Request(`https://api.nczoning.net${path}`, { method }), env, {},
@@ -435,11 +495,72 @@ test('a tag write does NOT materialize while DATA_SOURCE is mods either', async 
 });
 
 test('a write DOES materialize once DATA_SOURCE is d1', async () => {
-  const env = envFor({ dataSource: 'd1' });
+  // 🔴 Asserts KV actually gained the dataset, not merely that waitUntil was
+  // handed a promise. materializeAfterWrite catches its own errors, so the
+  // previous `await waited[0]; // must not reject` could not fail: a rebuild
+  // that blew up on every record passed it as happily as one that worked.
+  const env = refreshableEnv({ dataSource: 'd1' });
   const waited = [];
   await hit(env, 'POST', '/admin/locations', VALID, { waitUntil: (p) => waited.push(p) });
   assert.equal(waited.length, 1, 'the read path must be rebuilt write-through');
-  await waited[0]; // must not reject
+  await waited[0];
+  assert.ok(env.DATASET._store.size > 0, 'the rebuild must reach KV, not just be scheduled');
+});
+
+// ------------------------------------------------------ manual rebuild ---
+
+/** An env whose refresh can actually succeed: storing KV, working fetch. */
+function refreshableEnv(opts = {}) {
+  const env = envFor(opts);
+  env.DATASET = storingKv();
+  globalThis.fetch = refreshFetch();
+  return env;
+}
+
+test('POST /admin/refresh rebuilds and says which source it used', async () => {
+  const env = refreshableEnv({ dataSource: 'd1' });
+  const res = await hit(env, 'POST', '/admin/refresh');
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.refreshed, true);
+  assert.equal(body.source, 'd1');
+  assert.equal(body.changed, true, 'a first rebuild into an empty KV must write');
+  assert.ok(env.DATASET._store.size > 0, 'and the dataset must actually be in KV');
+  assert.equal(auditRows(env).at(-1).action, 'dataset.refresh');
+});
+
+test('🔴 a manual refresh runs even while DATA_SOURCE is mods', async () => {
+  // Unlike the write-through materialize, which is skipped there. The gate on
+  // that one avoids spending a KV write rebuilding from a source the write did
+  // not touch; this route is someone explicitly asking, and runRefresh honours
+  // DATA_SOURCE either way, so it cannot flip the cutover.
+  const env = refreshableEnv({ dataSource: 'mods' });
+  const res = await hit(env, 'POST', '/admin/refresh');
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).source, 'mods');
+});
+
+test('an unchanged rebuild reports changed:false, which is still a success', async () => {
+  const env = refreshableEnv({ dataSource: 'd1' });
+  assert.equal((await (await hit(env, 'POST', '/admin/refresh')).json()).changed, true);
+  const second = await (await hit(env, 'POST', '/admin/refresh')).json();
+  assert.equal(second.refreshed, true);
+  assert.equal(second.changed, false, 'the content hash matched, so nothing was rewritten');
+});
+
+test('🔴 a failed rebuild is a 500 that says so, not a reported success', async () => {
+  // runRefresh does NOT throw on failure -- it catches, keeps last-known-good
+  // and returns {stale: true}. Reporting success off "it did not throw" would
+  // have called every failed rebuild a win. An empty registry is the trigger
+  // here (readLocationRows refuses to materialize an empty map); the shape of
+  // the failure is what matters, not its cause.
+  const env = refreshableEnv({ dataSource: 'd1', locations: [], locationTags: [] });
+  const res = await hit(env, 'POST', '/admin/refresh');
+  assert.equal(res.status, 500);
+  const body = await res.json();
+  assert.equal(body.error, 'refresh_failed');
+  assert.match(body.detail, /empty/);
+  assert.equal(auditRows(env).length, 0, 'a rebuild that did not happen is not audited');
 });
 
 test('a tag write rebuilds the read path too, since /v1/tags serves it', async () => {

--- a/worker/test/admin.test.js
+++ b/worker/test/admin.test.js
@@ -2,79 +2,17 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { signSession, SESSION_COOKIE } from '../src/session.js';
 import { _resetTokenCache } from '../src/github-app.js';
+import { sqliteD1 } from '../test-support/d1-sqlite.mjs';
 import worker from '../src/index.js';
 
 const SECRET = 'admin-test-secret';
 
-// Minimal in-memory D1 covering the statements admin.js issues. Rows are kept
-// as objects; SQL is matched by shape, which is enough because this file owns
-// every statement it has to answer.
-function fakeDb({ locations = [], users = [] } = {}) {
-  const locs = new Map(locations.map((r) => [r.id, { ...r }]));
-  const usersById = new Map(users.map((u) => [u.id, u]));
-  const audit = [];
-  let auditId = 0;
+// Backed by real SQLite running the real migrations, not a SQL-shape-matching
+// mock. The tag routes are mostly claims about CONSTRAINTS -- "delete in use is
+// refused", "rename cascades" -- and a mock can only restate the belief it was
+// written from. See test-support/d1-sqlite.mjs.
 
-  return {
-    _locations: locs,
-    _audit: audit,
-    prepare(sql) {
-      const stmt = {
-        _args: [],
-        bind(...args) { stmt._args = args; return stmt; },
-        async first() {
-          if (sql.includes('FROM users')) return usersById.get(stmt._args[0]) ?? null;
-          if (sql.includes('FROM locations WHERE id')) return locs.get(stmt._args[0]) ?? null;
-          if (sql.includes('COUNT(*)')) return { n: locs.size };
-          throw new Error(`unexpected first(): ${sql}`);
-        },
-        async all() {
-          if (sql.includes('FROM audit_log')) {
-            return { results: [...audit].reverse().slice(0, stmt._args[0] ?? 100) };
-          }
-          if (sql.includes('FROM locations')) return { results: [...locs.values()] };
-          if (sql.includes('dismissed_candidates')) return { results: [] };
-          throw new Error(`unexpected all(): ${sql}`);
-        },
-        async run() {
-          if (sql.includes('INSERT INTO users')) return;
-          if (sql.includes('INSERT INTO audit_log')) {
-            const [at, actor, action, target, before, after] = stmt._args;
-            auditId += 1;
-            audit.push({ id: auditId, at, actor, action, target, before, after });
-            return;
-          }
-          if (sql.includes('INSERT INTO locations')) {
-            const c = ['id', 'name', 'nexus_id', 'category', 'x', 'y', 'z', 'yaw', 'description',
-              'credits', 'authors', 'tags', 'source', 'status', 'admin_notes', 'created_at', 'updated_at'];
-            const row = {};
-            c.forEach((k, i) => { row[k] = stmt._args[i]; });
-            locs.set(row.id, row);
-            return;
-          }
-          if (sql.startsWith('UPDATE locations')) {
-            const id = stmt._args[stmt._args.length - 1];
-            const row = locs.get(id);
-            const cols = [...sql.matchAll(/(\w+) = \?/g)].map((m) => m[1]);
-            cols.forEach((col, i) => { row[col] = stmt._args[i]; });
-            return;
-          }
-          if (sql.startsWith('DELETE FROM locations')) { locs.delete(stmt._args[0]); return; }
-          throw new Error(`unexpected run(): ${sql}`);
-        },
-      };
-      return stmt;
-    },
-  };
-}
-
-const fakeKv = (tags = { apartment: 'a place', corpo: 'suits' }) => ({
-  async get(key, type) {
-    if (key.endsWith(':tags')) return type === 'json' ? tags : JSON.stringify(tags);
-    return null;
-  },
-  async put() {},
-});
+const fakeKv = () => ({ async get() { return null; }, async put() {} });
 
 const ROW = {
   id: 'loc-1', name: 'Existing Loft', nexus_id: '12345', category: 'new-location',
@@ -88,14 +26,25 @@ const FRESH_USER = (collab = 1) => ({
   checked_at: new Date().toISOString(), first_seen_at: '2026-01-01T00:00:00Z',
 });
 
-async function envFor({ collab = 1, dataSource = 'mods', locations = [ROW] } = {}) {
+function envFor({
+  collab = 1, dataSource = 'mods', locations = [ROW],
+  locationTags = [['loc-1', 'apartment']], checkedAt,
+} = {}) {
+  const user = FRESH_USER(collab);
+  if (checkedAt) user.checked_at = checkedAt;
   return {
     SESSION_SECRET: SECRET,
     DATA_SOURCE: dataSource,
     DATASET: fakeKv(),
-    DB: fakeDb({ locations, users: [FRESH_USER(collab)] }),
+    DB: sqliteD1({ locations, locationTags, users: [user] }),
   };
 }
+
+const locCount = (env) => env.DB.one('SELECT COUNT(*) AS n FROM locations').n;
+const auditRows = (env) => env.DB.rows('SELECT * FROM audit_log ORDER BY id');
+const tagsOf = (env, id) => env.DB
+  .rows('SELECT tag_slug FROM location_tags WHERE location_id = ? ORDER BY tag_slug', id)
+  .map((r) => r.tag_slug);
 
 async function authed(url, init = {}) {
   const token = await signSession(SECRET, { sub: 7, login: 'spuddeh', collaborator: true });
@@ -105,6 +54,18 @@ async function authed(url, init = {}) {
   });
 }
 
+/** Authenticated request helper: `await hit(env, 'POST', '/admin/tags', {...})`. */
+async function hit(env, method, path, body, ctx = {}) {
+  return worker.fetch(
+    await authed(`https://api.nczoning.net${path}`, {
+      method, ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    }),
+    env,
+    ctx,
+  );
+}
+
+// `apartment` and `corpo` are real rows from migration 0002's seed.
 const VALID = {
   name: 'A New Location', authors: ['Spud'], coordinates: [10, 20, 30],
   nexus_id: '99999', description: 'Brand new.', category: 'other', tags: ['apartment'],
@@ -113,11 +74,14 @@ const VALID = {
 // ------------------------------------------------------------------ gate ---
 
 test('every admin route is refused without a session', async () => {
-  const env = await envFor();
+  const env = envFor();
   for (const [method, path] of [
     ['GET', '/admin/locations'], ['POST', '/admin/locations'],
     ['GET', '/admin/locations/loc-1'], ['PATCH', '/admin/locations/loc-1'],
     ['DELETE', '/admin/locations/loc-1'], ['GET', '/admin/audit'],
+    ['GET', '/admin/tags'], ['POST', '/admin/tags'],
+    ['GET', '/admin/tags/corpo'], ['PATCH', '/admin/tags/corpo'],
+    ['DELETE', '/admin/tags/corpo'],
   ]) {
     const res = await worker.fetch(
       new Request(`https://api.nczoning.net${path}`, { method }), env, {},
@@ -127,137 +91,328 @@ test('every admin route is refused without a session', async () => {
 });
 
 test('a signed-in NON-collaborator is refused, and writes nothing', async () => {
-  const env = await envFor({ collab: 0 });
-  const res = await worker.fetch(
-    await authed('https://api.nczoning.net/admin/locations', {
-      method: 'POST', body: JSON.stringify(VALID),
-    }), env, {},
-  );
+  const env = envFor({ collab: 0 });
+  const res = await hit(env, 'POST', '/admin/locations', VALID);
   assert.equal(res.status, 403);
-  assert.equal(env.DB._locations.size, 1, 'no row may be created');
-  assert.equal(env.DB._audit.length, 0, 'no audit row either');
+  assert.equal(locCount(env), 1, 'no row may be created');
+  assert.equal(auditRows(env).length, 0, 'no audit row either');
+});
+
+test('a non-collaborator cannot mutate tags either', async () => {
+  const env = envFor({ collab: 0 });
+  const res = await hit(env, 'DELETE', '/admin/tags/photos');
+  assert.equal(res.status, 403);
+  assert.ok(env.DB.one('SELECT slug FROM tags WHERE slug = ?', 'photos'));
 });
 
 test('an indeterminate collaborator check is 503, not 403, and writes nothing', async () => {
-  const env = await envFor();
   // Stale verdict forces a re-check; make GitHub unreachable.
-  env.DB = fakeDb({
-    locations: [ROW],
-    users: [{ ...FRESH_USER(), checked_at: '2020-01-01T00:00:00Z' }],
-  });
+  const env = envFor({ checkedAt: '2020-01-01T00:00:00Z' });
   _resetTokenCache();
   globalThis.fetch = async () => ({ ok: false, status: 500 });
-  const res = await worker.fetch(
-    await authed('https://api.nczoning.net/admin/locations', {
-      method: 'POST', body: JSON.stringify(VALID),
-    }), env, {},
-  );
+  const res = await hit(env, 'POST', '/admin/locations', VALID);
   assert.equal(res.status, 503);
-  assert.equal(env.DB._audit.length, 0);
+  assert.equal(auditRows(env).length, 0);
 });
 
 // ----------------------------------------------------------------- CRUD ---
 
 test('create: server generates the id and refuses a client-supplied one', async () => {
-  const env = await envFor();
-  const ok = await worker.fetch(
-    await authed('https://api.nczoning.net/admin/locations', {
-      method: 'POST', body: JSON.stringify(VALID),
-    }), env, {},
-  );
+  const env = envFor();
+  const ok = await hit(env, 'POST', '/admin/locations', VALID);
   assert.equal(ok.status, 201);
   const body = await ok.json();
   assert.match(body.location.id, /^[0-9a-f-]{36}$/);
 
-  const refused = await worker.fetch(
-    await authed('https://api.nczoning.net/admin/locations', {
-      method: 'POST', body: JSON.stringify({ ...VALID, id: 'attacker-chosen' }),
-    }), env, {},
-  );
+  const refused = await hit(env, 'POST', '/admin/locations', { ...VALID, id: 'attacker-chosen' });
   assert.equal(refused.status, 422);
 });
 
 test('create: invalid input is 422 and writes nothing', async () => {
-  const env = await envFor();
-  const res = await worker.fetch(
-    await authed('https://api.nczoning.net/admin/locations', {
-      method: 'POST', body: JSON.stringify({ ...VALID, category: 'nope' }),
-    }), env, {},
-  );
+  const env = envFor();
+  const res = await hit(env, 'POST', '/admin/locations', { ...VALID, category: 'nope' });
   assert.equal(res.status, 422);
-  assert.equal(env.DB._locations.size, 1);
-  assert.equal(env.DB._audit.length, 0, 'a rejected write must not be audited');
+  assert.equal(locCount(env), 1);
+  assert.equal(auditRows(env).length, 0, 'a rejected write must not be audited');
 });
 
 test('update: patches only what was sent', async () => {
-  const env = await envFor();
-  const res = await worker.fetch(
-    await authed('https://api.nczoning.net/admin/locations/loc-1', {
-      method: 'PATCH', body: JSON.stringify({ name: 'Renamed Loft' }),
-    }), env, {},
-  );
+  const env = envFor();
+  const res = await hit(env, 'PATCH', '/admin/locations/loc-1', { name: 'Renamed Loft' });
   assert.equal(res.status, 200);
-  const row = env.DB._locations.get('loc-1');
+  const row = env.DB.one('SELECT * FROM locations WHERE id = ?', 'loc-1');
   assert.equal(row.name, 'Renamed Loft');
   assert.equal(row.category, 'new-location', 'untouched fields must survive');
   assert.notEqual(row.updated_at, '2026-01-01T00:00:00Z', 'updated_at must move');
+  assert.deepEqual(tagsOf(env, 'loc-1'), ['apartment'], 'a patch that omits tags must not clear them');
 });
 
 test('update: an unknown id is 404, not a silent no-op', async () => {
-  const env = await envFor();
-  const res = await worker.fetch(
-    await authed('https://api.nczoning.net/admin/locations/nope', {
-      method: 'PATCH', body: JSON.stringify({ name: 'Whatever' }),
-    }), env, {},
-  );
+  const env = envFor();
+  const res = await hit(env, 'PATCH', '/admin/locations/nope', { name: 'Whatever' });
   assert.equal(res.status, 404);
 });
 
 test('delete: removes the row and keeps the whole record in the audit entry', async () => {
-  const env = await envFor();
-  const res = await worker.fetch(
-    await authed('https://api.nczoning.net/admin/locations/loc-1', { method: 'DELETE' }), env, {},
-  );
+  const env = envFor();
+  const res = await hit(env, 'DELETE', '/admin/locations/loc-1');
   assert.equal(res.status, 200);
-  assert.equal(env.DB._locations.size, 0);
-  const entry = env.DB._audit.at(-1);
+  assert.equal(locCount(env), 0);
+  const entry = auditRows(env).at(-1);
   assert.equal(entry.action, 'location.delete');
-  // Recoverable: the deleted record survives in `before`.
-  assert.equal(JSON.parse(entry.before).name, 'Existing Loft');
+  const before = JSON.parse(entry.before);
+  assert.equal(before.name, 'Existing Loft');
+  // Snapshotted before the cascade, or the audit row would claim it had none.
+  assert.deepEqual(before.tags, ['apartment']);
+});
+
+test('delete: the join rows cascade away with the location', async () => {
+  const env = envFor();
+  await hit(env, 'DELETE', '/admin/locations/loc-1');
+  assert.deepEqual(tagsOf(env, 'loc-1'), [], 'ON DELETE CASCADE must clear the join');
+});
+
+// ------------------------------------------------- tags on the write path ---
+
+test('🔴 a tag edit reaches location_tags, not just the legacy column', async () => {
+  // The 4a/4b gap: admin writes set locations.tags, the materializer reads the
+  // join. A PATCH that only moved the column returned 200 and changed nothing
+  // on the map.
+  const env = envFor();
+  const res = await hit(env, 'PATCH', '/admin/locations/loc-1', { tags: ['corpo', 'photos'] });
+  assert.equal(res.status, 200);
+  assert.deepEqual(tagsOf(env, 'loc-1'), ['corpo', 'photos']);
+  assert.deepEqual((await res.json()).location.tags, ['corpo', 'photos']);
+});
+
+test('the legacy column is kept byte-compatible with the join', async () => {
+  // Migration 0002 is additive so parity can be proven before the column drops.
+  // Writing only one of the two would make the gate compare a live column
+  // against a frozen one and call the difference a regression.
+  const env = envFor();
+  await hit(env, 'PATCH', '/admin/locations/loc-1', { tags: ['photos', 'corpo'] });
+  const row = env.DB.one('SELECT tags FROM locations WHERE id = ?', 'loc-1');
+  assert.deepEqual(JSON.parse(row.tags), ['corpo', 'photos'], 'sorted, matching the join');
+});
+
+test('an auto-sourced record keeps the nczoning marker in the legacy column only', async () => {
+  const env = envFor({
+    locations: [{ ...ROW, id: 'auto-1', source: 'auto', tags: '["nczoning","apartment"]' }],
+    locationTags: [['auto-1', 'apartment']],
+  });
+  await hit(env, 'PATCH', '/admin/locations/auto-1', { tags: ['corpo'] });
+  assert.deepEqual(tagsOf(env, 'auto-1'), ['corpo'], 'the marker is not a registry row');
+  assert.deepEqual(
+    JSON.parse(env.DB.one('SELECT tags FROM locations WHERE id = ?', 'auto-1').tags),
+    ['nczoning', 'corpo'],
+    'the stored column keeps the shape existing auto rows have',
+  );
+});
+
+test('a tags-only patch still moves updated_at', async () => {
+  const env = envFor();
+  const res = await hit(env, 'PATCH', '/admin/locations/loc-1', { tags: ['corpo'] });
+  assert.equal(res.status, 200);
+  assert.notEqual(
+    env.DB.one('SELECT updated_at FROM locations WHERE id = ?', 'loc-1').updated_at,
+    '2026-01-01T00:00:00Z',
+  );
+});
+
+test('an empty patch is 400, and an empty tag list is not an empty patch', async () => {
+  const env = envFor();
+  assert.equal((await hit(env, 'PATCH', '/admin/locations/loc-1', {})).status, 400);
+  assert.equal((await hit(env, 'PATCH', '/admin/locations/loc-1', { tags: [] })).status, 200);
+  assert.deepEqual(tagsOf(env, 'loc-1'), []);
+});
+
+test('create attaches the join rows too', async () => {
+  const env = envFor();
+  const res = await hit(env, 'POST', '/admin/locations', { ...VALID, tags: ['corpo', 'apartment'] });
+  const { location } = await res.json();
+  assert.deepEqual(tagsOf(env, location.id), ['apartment', 'corpo']);
+});
+
+test('tag validation reads the tags TABLE, so a just-created tag is usable at once', async () => {
+  // Phase 4a validated against the KV snapshot the cron maintains. Once tags
+  // became editable that was wrong: creating a tag then using it would 422
+  // until the next materialize.
+  const env = envFor();
+  const created = await hit(env, 'POST', '/admin/tags', {
+    slug: 'rooftop', description: 'Up top.',
+  });
+  assert.equal(created.status, 201);
+  const used = await hit(env, 'PATCH', '/admin/locations/loc-1', { tags: ['rooftop'] });
+  assert.equal(used.status, 200, 'a tag created a moment ago must be valid immediately');
+  assert.deepEqual(tagsOf(env, 'loc-1'), ['rooftop']);
+});
+
+test('an unknown tag is 422 and leaves the existing tags alone', async () => {
+  const env = envFor();
+  const res = await hit(env, 'PATCH', '/admin/locations/loc-1', { tags: ['not-a-real-tag'] });
+  assert.equal(res.status, 422);
+  assert.deepEqual(tagsOf(env, 'loc-1'), ['apartment']);
+});
+
+// ------------------------------------------------------------- tag CRUD ---
+
+test('list: every tag comes back with its usage count', async () => {
+  const env = envFor();
+  const res = await hit(env, 'GET', '/admin/tags');
+  assert.equal(res.status, 200);
+  const { tags } = await res.json();
+  assert.equal(tags.length, 14, 'migration 0002 seeds 14');
+  assert.equal(tags.find((t) => t.slug === 'apartment').usage_count, 1);
+  assert.equal(tags.find((t) => t.slug === 'corpo').usage_count, 0);
+});
+
+test('nczoning is not a tag row and cannot be created', async () => {
+  const env = envFor();
+  assert.equal(env.DB.one('SELECT slug FROM tags WHERE slug = ?', 'nczoning'), null);
+  const res = await hit(env, 'POST', '/admin/tags', {
+    slug: 'nczoning', description: 'Trying it on.',
+  });
+  assert.equal(res.status, 422);
+  assert.match((await res.json()).errors.join(' '), /reserved/);
+  assert.equal(env.DB.one('SELECT slug FROM tags WHERE slug = ?', 'nczoning'), null);
+});
+
+test('a tag cannot be renamed INTO the reserved slug either', async () => {
+  const env = envFor();
+  const res = await hit(env, 'PATCH', '/admin/tags/corpo', { slug: 'nczoning' });
+  assert.equal(res.status, 422);
+  assert.ok(env.DB.one('SELECT slug FROM tags WHERE slug = ?', 'corpo'));
+});
+
+test('create: a duplicate slug is 409, not a silent overwrite', async () => {
+  const env = envFor();
+  const res = await hit(env, 'POST', '/admin/tags', {
+    slug: 'corpo', description: 'A second one.',
+  });
+  assert.equal(res.status, 409);
+  assert.equal((await res.json()).error, 'tag_exists');
+  assert.match(env.DB.one('SELECT description FROM tags WHERE slug = ?', 'corpo').description, /corporate/);
+});
+
+test('create: malformed slugs are refused', async () => {
+  const env = envFor();
+  for (const slug of ['Mixed Case', 'trailing-', '-leading', 'double--hyphen', 'under_score', '']) {
+    const res = await hit(env, 'POST', '/admin/tags', { slug, description: 'x' });
+    assert.equal(res.status, 422, `slug ${JSON.stringify(slug)} must be refused`);
+  }
+});
+
+test('update: editing name and description leaves the slug and the links alone', async () => {
+  const env = envFor();
+  const res = await hit(env, 'PATCH', '/admin/tags/apartment', {
+    name: 'Apartment', description: 'A player housing unit.',
+  });
+  assert.equal(res.status, 200);
+  const tag = env.DB.one('SELECT * FROM tags WHERE slug = ?', 'apartment');
+  assert.equal(tag.name, 'Apartment');
+  assert.deepEqual(tagsOf(env, 'loc-1'), ['apartment']);
+  assert.equal(auditRows(env).at(-1).action, 'tag.update');
+});
+
+test('🔴 renaming a slug cascades to location_tags', async () => {
+  // Proven against SQLite with foreign keys on, which is D1's default. With
+  // them off the UPDATE succeeds and every link silently orphans -- the exact
+  // failure the cascade_failed guard in admin.js exists to catch.
+  const env = envFor();
+  const res = await hit(env, 'PATCH', '/admin/tags/apartment', { slug: 'flat' });
+  assert.equal(res.status, 200);
+  assert.equal(env.DB.one('SELECT slug FROM tags WHERE slug = ?', 'apartment'), null);
+  assert.deepEqual(tagsOf(env, 'loc-1'), ['flat'], 'the link must follow the rename');
+  assert.equal(auditRows(env).at(-1).action, 'tag.rename', 'a rename is audited as its own action');
+});
+
+test('renaming onto an existing slug is 409, not a merge', async () => {
+  const env = envFor();
+  const res = await hit(env, 'PATCH', '/admin/tags/apartment', { slug: 'corpo' });
+  assert.equal(res.status, 409);
+  assert.deepEqual(tagsOf(env, 'loc-1'), ['apartment']);
+});
+
+test('🔴 deleting a tag that is in use is refused, with the count and the records', async () => {
+  const env = envFor();
+  const res = await hit(env, 'DELETE', '/admin/tags/apartment');
+  assert.equal(res.status, 409);
+  const body = await res.json();
+  assert.equal(body.error, 'tag_in_use');
+  assert.equal(body.usage_count, 1);
+  assert.deepEqual(body.locations, [{ id: 'loc-1', name: 'Existing Loft' }]);
+  assert.ok(env.DB.one('SELECT slug FROM tags WHERE slug = ?', 'apartment'), 'still there');
+  assert.deepEqual(tagsOf(env, 'loc-1'), ['apartment'], 'and still attached');
+});
+
+test('deleting an unused tag succeeds and is audited', async () => {
+  const env = envFor();
+  const res = await hit(env, 'DELETE', '/admin/tags/photos');
+  assert.equal(res.status, 200);
+  assert.equal(env.DB.one('SELECT slug FROM tags WHERE slug = ?', 'photos'), null);
+  const entry = auditRows(env).at(-1);
+  assert.equal(entry.action, 'tag.delete');
+  assert.equal(JSON.parse(entry.before).slug, 'photos');
+});
+
+test('detaching then deleting is the two-step path out', async () => {
+  const env = envFor();
+  assert.equal((await hit(env, 'DELETE', '/admin/tags/apartment')).status, 409);
+  assert.equal((await hit(env, 'PATCH', '/admin/locations/loc-1', { tags: [] })).status, 200);
+  assert.equal((await hit(env, 'DELETE', '/admin/tags/apartment')).status, 200);
+});
+
+test('an unknown tag slug is 404 on read, update and delete', async () => {
+  const env = envFor();
+  for (const method of ['GET', 'PATCH', 'DELETE']) {
+    const res = await hit(env, method, '/admin/tags/nope', method === 'PATCH' ? { name: 'x' } : undefined);
+    assert.equal(res.status, 404, method);
+  }
 });
 
 // ---------------------------------------------------------------- audit ---
 
 test('EVERY successful mutation produces exactly one audit row', async () => {
-  // This is the Phase 4 gate, asserted directly.
-  const env = await envFor();
+  // This is the Phase 4 gate, asserted directly -- now including tags.
+  const env = envFor();
   const calls = [
     ['POST', '/admin/locations', VALID, 'location.create'],
     ['PATCH', '/admin/locations/loc-1', { name: 'Renamed' }, 'location.update'],
-    ['DELETE', '/admin/locations/loc-1', null, 'location.delete'],
+    ['POST', '/admin/tags', { slug: 'rooftop', description: 'Up top.' }, 'tag.create'],
+    ['PATCH', '/admin/tags/rooftop', { name: 'Rooftop' }, 'tag.update'],
+    ['PATCH', '/admin/tags/rooftop', { slug: 'roofs' }, 'tag.rename'],
+    ['DELETE', '/admin/tags/roofs', undefined, 'tag.delete'],
+    ['DELETE', '/admin/locations/loc-1', undefined, 'location.delete'],
   ];
   for (const [method, path, body, action] of calls) {
-    const before = env.DB._audit.length;
-    const res = await worker.fetch(
-      await authed(`https://api.nczoning.net${path}`, {
-        method, ...(body ? { body: JSON.stringify(body) } : {}),
-      }), env, {},
-    );
+    const before = auditRows(env).length;
+    const res = await hit(env, method, path, body);
     assert.ok(res.status < 300, `${method} ${path} -> ${res.status}`);
-    assert.equal(env.DB._audit.length, before + 1, `${action} must add exactly one row`);
-    assert.equal(env.DB._audit.at(-1).action, action);
-    assert.equal(env.DB._audit.at(-1).actor, 'spuddeh');
+    const rows = auditRows(env);
+    assert.equal(rows.length, before + 1, `${action} must add exactly one row`);
+    assert.equal(rows.at(-1).action, action);
+    assert.equal(rows.at(-1).actor, 'spuddeh');
   }
 });
 
+test('a refused tag delete is NOT audited', async () => {
+  const env = envFor();
+  await hit(env, 'DELETE', '/admin/tags/apartment');
+  assert.equal(auditRows(env).length, 0);
+});
+
 test('the audit row records the actor, not a generic "admin"', async () => {
-  const env = await envFor();
-  await worker.fetch(
-    await authed('https://api.nczoning.net/admin/locations', {
-      method: 'POST', body: JSON.stringify(VALID),
-    }), env, {},
-  );
-  assert.equal(env.DB._audit.at(-1).actor, 'spuddeh');
+  const env = envFor();
+  await hit(env, 'POST', '/admin/locations', VALID);
+  assert.equal(auditRows(env).at(-1).actor, 'spuddeh');
+});
+
+test('the audit feed comes back newest first', async () => {
+  const env = envFor();
+  await hit(env, 'POST', '/admin/tags', { slug: 'first-one', description: 'a' });
+  await hit(env, 'POST', '/admin/tags', { slug: 'second-one', description: 'b' });
+  const { entries } = await (await hit(env, 'GET', '/admin/audit')).json();
+  assert.equal(entries[0].target, 'second-one');
 });
 
 // ------------------------------------------------- write-through gating ---
@@ -265,24 +420,33 @@ test('the audit row records the actor, not a generic "admin"', async () => {
 test('a write does NOT materialize while DATA_SOURCE is mods', async () => {
   // Otherwise an admin edit would silently overwrite KV with D1-derived data
   // and perform the Phase 2 cutover as a side effect.
-  const env = await envFor({ dataSource: 'mods' });
+  const env = envFor({ dataSource: 'mods' });
   const waited = [];
-  await worker.fetch(
-    await authed('https://api.nczoning.net/admin/locations', {
-      method: 'POST', body: JSON.stringify(VALID),
-    }), env, { waitUntil: (p) => waited.push(p) },
-  );
+  await hit(env, 'POST', '/admin/locations', VALID, { waitUntil: (p) => waited.push(p) });
   assert.equal(waited.length, 0, 'must not rebuild KV while mods.json is the source');
 });
 
-test('a write DOES materialize once DATA_SOURCE is d1', async () => {
-  const env = await envFor({ dataSource: 'd1' });
+test('a tag write does NOT materialize while DATA_SOURCE is mods either', async () => {
+  const env = envFor({ dataSource: 'mods' });
   const waited = [];
-  await worker.fetch(
-    await authed('https://api.nczoning.net/admin/locations', {
-      method: 'POST', body: JSON.stringify(VALID),
-    }), env, { waitUntil: (p) => waited.push(p) },
-  );
+  await hit(env, 'POST', '/admin/tags', { slug: 'rooftop', description: 'Up top.' },
+    { waitUntil: (p) => waited.push(p) });
+  assert.equal(waited.length, 0);
+});
+
+test('a write DOES materialize once DATA_SOURCE is d1', async () => {
+  const env = envFor({ dataSource: 'd1' });
+  const waited = [];
+  await hit(env, 'POST', '/admin/locations', VALID, { waitUntil: (p) => waited.push(p) });
   assert.equal(waited.length, 1, 'the read path must be rebuilt write-through');
   await waited[0]; // must not reject
+});
+
+test('a tag write rebuilds the read path too, since /v1/tags serves it', async () => {
+  const env = envFor({ dataSource: 'd1' });
+  const waited = [];
+  await hit(env, 'PATCH', '/admin/tags/corpo', { name: 'Corpo' },
+    { waitUntil: (p) => waited.push(p) });
+  assert.equal(waited.length, 1);
+  await waited[0];
 });


### PR DESCRIPTION
Fills in the Phase 3 stub. Everything server-side already existed except tag CRUD, which is new here.

## The bug this found

Phase 4b moved tags into `location_tags` and pointed the materializer at the join. Phase 4a's admin writes predate that and only ever set the legacy `locations.tags` column. Under `DATA_SOURCE=d1` (staging today, production at release), editing a location's tags returned `200`, echoed the new tags back, and changed nothing on the map.

Latent rather than already damaging: the two representations were still in sync when I measured (570 join rows, 570 legacy entries, 296 locations, 14 tags), because no admin tag edit had happened yet.

`syncLocationTags()` in `worker/src/tag-registry.js` now owns both representations. It batches, so the join is never briefly empty for a record that has tags, and it keeps the synthetic `nczoning` marker in the legacy column for `source='auto'` rows so the stored shape does not drift from what the existing rows have.

Tag validation also moves from the KV snapshot to the `tags` table. Reading KV was right while tags came from a file in git and wrong the moment they became editable: a tag created through the API would have 422'd on first use.

## Tag CRUD

`/admin/tags` GET/POST, `/admin/tags/{slug}` GET/PATCH/DELETE. Every mutation writes an audit row and rebuilds the read path, same as locations.

Two behaviours decided rather than left to the foreign key:

- **Delete of a tag in use is refused**: `409 tag_in_use` with the count and the affected records. `location_tags` has no `ON DELETE` for `tag_slug`, so a bare delete fails on the constraint with an opaque error; a cascade would strip the tag from every record as a side effect of one click. The dashboard turns the 409 into a list plus a "show me those locations" jump. Detach, then delete.
- **Renaming a slug is locked behind an explicit unlock.** It is an `ON UPDATE CASCADE` and a link-breaking event, so any `?tag=<slug>` deep link stops resolving. The display `name` is the safe field and the UI says so.

`nczoning` cannot be created, nor renamed into. It is not a registry row.

## The cascade has a guard

`ON UPDATE CASCADE` only fires with foreign keys enforced. Measured, not assumed:

- real D1 staging: `PRAGMA foreign_keys` → `1`
- SQLite with them off: the `UPDATE` succeeds and every link silently orphans

So the handler re-counts links after a rename and returns `500 cascade_failed` rather than reporting a success that quietly untagged every record.

## Tests: real SQLite, real migrations

The admin tests ran against a hand-rolled fake that matched SQL by substring. That was fine while every statement was a single-table read or write; it stopped being fine when the questions became "is delete-in-use refused" and "does rename cascade", which are claims about SQLite that a mock can only restate.

`worker/test-support/d1-sqlite.mjs` is a D1 binding over `node:sqlite` that runs `migrations/*.sql` verbatim. 180 → 206 tests.

Negative controls, because a green run proves nothing:

| Sabotage | Result |
| --- | --- |
| disable the `location_tags` write, keep the legacy column write (i.e. reintroduce the 4a bug) | 4 fail, and exactly the 4 that assert it |
| `PRAGMA foreign_keys = OFF` in the harness | 2 fail, both cascade tests, including the one whose guard then fires |

## UI

`admin/index.html` + `admin.css` + `admin.js`, no framework, no build step.

- Colour, type and spacing come from `assets/css/theme.css`, the map's tokens, so a theme switch carries. `style.css` is not linked: it is Leaflet panes, sidebar and clusters, none of which applies. The stub's self-contained hex values are gone.
- The 403/503 distinction is preserved verbatim from the stub, and extended to every route: `403` is a refusal, `503 check_unavailable` is "GitHub could not be reached" and is never worded as one. `500 cascade_failed` gets its own message telling you not to retry.
- Success requires an explicit `200` **and** `collaborator === true`. Every unrecognised status falls to the error branch. This bug shipped once already.
- Text is written with `textContent`, never `innerHTML`, because the page renders mod names and descriptions written by third parties on Nexus.
- The editor shows which fields will actually be sent (`will send: name, tags`) and disables save when nothing changed.

## Verified

- `npm test`: 206 pass
- staging deploy live; `/admin/*` all `401` unauthenticated, including `/admin/nonsense`, so the gate runs before routing and does not leak which routes exist
- production untouched: `/v1/health` still `0.3.0`, `/auth/me` still `404`

## Not verified yet, and why

The dashboard cannot be exercised from a PR preview: `*.pages.dev` is not in `ADMIN_ORIGINS`, so the session cookie is never sent. That needs `dev.nczoning.net`, i.e. after this merges.

**Browser check to run after merge.** A predicate that fails on the old state rather than one that cannot fail: staging has no cron, so its KV was last materialized before 4b and `/v1/tags` there still serves the **old map shape**. Signing in on `dev.nczoning.net` and editing any tag triggers the write-through materialize. `/v1/tags` flipping from map to array is proof the whole path ran.

## Not touched

`openapi.json` documents the public read surface only, as it did before this. API version stays `0.4.0`: no `/v1` shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

