### PR TITLE
fix(map): share links collide when one mod supplies two locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Share links pointed at the mod rather than the pin, so when one Nexus mod supplied two locations both pins produced the same link and it always opened the first. Links now use the location's own id. Links shared before this keep working.
 - Admin tag edits reached the legacy column but not the join the map reads, so they returned success and changed nothing. Both are now written together.
 - The API never told browsers they could read the `ETag` header, so the site's own conditional-request cache had never stored anything and its `304` handling was unreachable code. The browser's built-in cache masked it, which is why nothing looked wrong.
 - The new location added to `main` overnight reached production but not the D1 registry, so staging served one fewer mod than production.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1132,10 +1132,8 @@ async function initMap() {
   // opened synchronously and were unaffected).
   function setModUrlParam(mod) {
     if (!mod) return;
-    const isNum = /^\d+$/.test(String(mod.nexus_id));
-    const lid = isNum ? String(mod.nexus_id) : mod.id;
     const url = new URL(window.location.href);
-    url.searchParams.set(NCZ.URL_PARAM_MOD, lid);
+    url.searchParams.set(NCZ.URL_PARAM_MOD, NCZ.modLinkId(mod));
     history.replaceState(null, "", url.toString());
   }
   function clearModUrlParam() {
@@ -1932,12 +1930,7 @@ async function initMap() {
         // silently send a dev tab back to production.
         const url = new URL(window.location.href);
         if (focusTarget) {
-          // Same id rule as the copy-link button (utils.js modLinkId): the
-          // numeric Nexus id when there is one, the UUID otherwise.
-          const linkId = /^\d+$/.test(String(focusTarget.nexus_id))
-            ? String(focusTarget.nexus_id)
-            : focusTarget.id;
-          url.searchParams.set(NCZ.URL_PARAM_MOD, linkId);
+          url.searchParams.set(NCZ.URL_PARAM_MOD, NCZ.modLinkId(focusTarget));
         }
         window.location.href = url.toString();
       });

--- a/assets/js/three-markers.js
+++ b/assets/js/three-markers.js
@@ -673,10 +673,8 @@ const ThreeMarkers = (() => {
   // URL deep-link sync: matches the Leaflet popupopen/popupclose handlers
   // so refreshing or switching views re-opens the same pin.
   function syncUrlForMod(mod) {
-    const isNum = /^\d+$/.test(String(mod.nexus_id));
-    const lid = isNum ? String(mod.nexus_id) : mod.id;
     const url = new URL(window.location.href);
-    url.searchParams.set(NCZ.URL_PARAM_MOD, lid);
+    url.searchParams.set(NCZ.URL_PARAM_MOD, NCZ.modLinkId(mod));
     history.replaceState(null, '', url.toString());
   }
   function clearUrlMod() {

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -270,6 +270,17 @@ NCZ.normaliseTags = function (payload) {
   return payload && typeof payload === "object" ? payload : {};
 };
 
+/**
+ * The id a shared ?mod= link addresses. Always the location id: a Nexus id
+ * identifies a mod, and one mod can supply several locations (#889).
+ *
+ * The resolver must keep accepting a Nexus id too. Every link shared before
+ * this uses one.
+ */
+NCZ.modLinkId = function (mod) {
+  return mod.id;
+};
+
 NCZ.buildPopupHtml = function (mod, catStyle, nexusThumbs, tagsDict) {
   const nexus_id_lower = String(mod.nexus_id).toLowerCase();
   let nexusUrl = `https://www.nexusmods.com/cyberpunk2077/mods/${mod.nexus_id}`;
@@ -282,9 +293,7 @@ NCZ.buildPopupHtml = function (mod, catStyle, nexusThumbs, tagsDict) {
     nexusLabel = "Status: Dummy/Test";
   }
 
-  const isNumericNexusId = /^\d+$/.test(String(mod.nexus_id));
-  const modLinkId = isNumericNexusId ? String(mod.nexus_id) : mod.id;
-  const copyLinkUrl = `${NCZ.SITE_URL}?${NCZ.URL_PARAM_MOD}=${encodeURIComponent(modLinkId)}`;
+  const copyLinkUrl = `${NCZ.SITE_URL}?${NCZ.URL_PARAM_MOD}=${encodeURIComponent(NCZ.modLinkId(mod))}`;
 
   const [cX, cY, cZ] = mod.coordinates;
   const yawParam = mod.yaw != null ? `&yaw=${mod.yaw}` : "";


### PR DESCRIPTION
Closes #889.

## The bug

A Nexus id identifies a mod, not a place, and one mod can supply several
locations. Mod 23896 ships two tattoo shops 911 metres apart, so both pins built
`?mod=23896` and the resolver took the first match. **The Copy link button on
Northside Tattoo & Body Mods handed out a link that opened Little China Pink
Ink.** Live on production.

The narrow fix, using the location id only when a Nexus id is shared, is worse
than it looks: it makes a location's public address depend on other records. Had
the second shop been registered a year later, the first one's already-shared
links would have become ambiguous without that location changing at all.

There was also an existing inconsistency. `GET /v1/locations/{id}` keys straight
into the record map by location id, so `/v1/locations/23896` is a 404 while
`?mod=23896` worked. The share link was the only thing addressing a location by
Nexus id.

## The change

Share links always use the location id, via one `NCZ.modLinkId`.

The rule was written out **four** times, which is why it could drift:

- `utils.js` `buildPopupHtml`, the Copy link button
- `app.js` `setModUrlParam`, the URL while browsing
- `app.js`, the update notice focus target
- `three-markers.js` `syncUrlForMod`, the 3D marker URL sync

**Old links keep working.** The resolver already accepts a Nexus id as well as a
location id and must keep doing so, because every link shared before this uses
one. Only what gets generated changes.

## Verified in a browser, in both views

`?forcewebgl` to reach the Leaflet view, welcome modal dismissed before asserting
anything.

| | 3D SCHEMA | 2D SAT |
| --- | --- | --- |
| Northside link opens Northside | yes | yes |
| Legacy `?mod=23896` still resolves | yes | yes |
| Legacy URL rewrites itself to the canonical id | yes | yes |
| Copy link button emits the location id | yes | yes |

The self-upgrade is a property of the existing `setModUrlParam`, not something
added here: opening a pin rewrites the URL, so a legacy link becomes a canonical
one as soon as it is followed.

One earlier run looked like it passed and proved nothing: the view is not
persisted, so navigating with a `?mod=` param always lands in SCHEMA and the
Leaflet branch never ran. The table above is from runs that confirmed
`#map` was visible first.

## Not doing

- **A slug** such as `?mod=watson-tattoo-little-china`. 34 of 295 location names
  have already been re-curated away from their Nexus title, so slugs would change
  and break links at the same rate names get tidied.
- **Deduplicating the two records.** The data is correct: the Nexus page ships
  two separately installable location mods, and the mod's own author registered
  both.

## Cost

Links get longer: `?mod=6575bd5a-8672-4ed6-b2ac-1fb8afe6326f` rather than
`?mod=23896`. The 9 auto-discovered records keep their readable `nexus-16445`
ids. Accepted deliberately, since an immutable address beats a derived one for a
permanent public link.
