### PR TITLE
feat(api): nexus_cache becomes the Nexus mod index, and the parity gate covers every served field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The map notices when locations change while a tab is open and offers to refresh, instead of showing its load-time snapshot indefinitely. The check is served from the browser's own cache almost every time, so it costs roughly one request per tab per five minutes.
 
+- The cron keeps a Nexus mod index in D1, covering every tagged mod and every mod the map serves. It backs the submissions candidate list without a live Nexus call, and it is where the four Nexus-derived fields on each location now come from.
+- The parity gate covers all 18 served fields, including the thumbnails, pictures, update times and archive listings it could not rebuild before.
+
 ### Fixed
 
 - Admin tag edits reached the legacy column but not the join the map reads, so they returned success and changed nothing. Both are now written together.

--- a/worker/README.md
+++ b/worker/README.md
@@ -165,16 +165,53 @@ node scripts/parity-check.mjs                                   # the gate
 ```
 
 `parity-check.mjs` rebuilds `/v1/locations` from D1 via `src/materialize.js` and
-diffs it **byte-for-byte** against what the live API is serving. It rebuilds the
-14 fields D1 owns (including `district`/`subdistrict`, recomputed from D1's own
-coordinates) and feeds in the 4 Nexus-derived ones it does not own until Phase 2
-— and it **fails on any served field that falls into neither set**, so a new
-`/v1` field cannot slip past as "not compared".
+diffs it **byte-for-byte** against what the live API is serving. All 18 served
+fields are rebuilt: 11 from `locations`, 4 from `nexus_cache`, and
+`district`/`subdistrict`/`recently_updated` recomputed from D1's own data. It
+**fails on any served field it neither rebuilds nor feeds in**, so a new `/v1`
+field cannot slip past as "not compared".
 
-It then mutates a row five ways and asserts the diff catches each one. A green
-run that did not also prove it can go red exits non-zero: the header comment
-explains what the check does and does not cover, and is worth reading before
-trusting a pass.
+It then mutates the input nine ways (five location columns and the four
+Nexus-derived fields) and asserts the diff catches each one. A green run that
+did not also prove it can go red exits non-zero: the header comment explains
+what the check does and does not cover, and is worth reading before trusting a
+pass.
+
+**It needs a swept `nexus_cache`.** Against a database the sweep has never run
+on, every image rebuilds as null; the script says so and stops rather than
+reporting ~300 mismatches.
+
+### `nexus_cache`: the Nexus mod index
+
+One row per mod, swept from the cron: every NCZoning-tagged mod (the candidate
+pool for submissions) plus every mod the map serves a pin for. It supplies the
+four Nexus-derived fields on each location through a join on `nexus_id`, and it
+lets the candidates list be a SQL query instead of a live Nexus call on a public
+route.
+
+Three properties worth knowing before changing anything here:
+
+- **The sweep writes only what changed.** ~300 rows on 288 daily ticks would be
+  86k row-writes against a 100k/day free-tier cap, so an unchanged tick must
+  cost zero writes. Measured against the live corpus: a first sweep writes 296
+  rows, the next writes 0.
+- **`nexus_id` is not unique across locations.** 296 locations use 295 distinct
+  ids: mod 23896 supplies two tattoo shops. The join is one-to-many by design.
+- **`name` is stored for comparison, never for display.** 34 location names
+  differ from their Nexus title by curation, not staleness. Serving this column
+  would undo that; diffing it detects a rename.
+
+Archive listings (the `.archive` file names behind installed-mod detection) live
+here too, in `archives`, with `archives_at` recording the mod `updated_at` they
+were read against. `updated_at` alone cannot carry that, because the sweep
+overwrites it the moment Nexus reports a re-upload, so the two columns are
+compared to decide a refetch.
+
+The KV key `dataset:v1:archives` is now a carry-over source, read once by the
+sweep and never written. **Do not delete it until the sweep has run against both
+databases**: it holds the hand-built listings from `scripts/archive-seeds.json`
+for mods whose Nexus file preview is broken, and a refetch replaces those with
+nothing.
 
 ### Switching the source (`DATA_SOURCE`)
 

--- a/worker/migrations/0003_nexus_cache_index.sql
+++ b/worker/migrations/0003_nexus_cache_index.sql
@@ -19,5 +19,14 @@ ALTER TABLE nexus_cache ADD COLUMN name TEXT;
 -- a record first arrived and is being retired.
 ALTER TABLE nexus_cache ADD COLUMN nczoning_tagged INTEGER NOT NULL DEFAULT 0;
 
+-- The mod updated_at that the stored `archives` listing was fetched against.
+--
+-- `updated_at` alone cannot carry this. The sweep overwrites it as soon as
+-- Nexus reports a re-upload, while the previous version's file list is still in
+-- the row, so the two columns must be compared to decide a refetch. Without it,
+-- a mod deferred past the per-tick budget would be written with the new
+-- updated_at and never refetched.
+ALTER TABLE nexus_cache ADD COLUMN archives_at TEXT;
+
 -- Only the candidates query selects by this.
 CREATE INDEX idx_nexus_cache_tagged ON nexus_cache (nczoning_tagged);

--- a/worker/migrations/0003_nexus_cache_index.sql
+++ b/worker/migrations/0003_nexus_cache_index.sql
@@ -1,0 +1,33 @@
+-- nexus_cache becomes the Nexus mod INDEX, not just an image cache.
+--
+-- The table was declared at Phase 1 and never populated: 0 rows in both
+-- databases, and nothing in the codebase wrote to it. Phase 1 deliberately left
+-- the four Nexus-derived served fields (thumbnail_url, picture_url, updated_at,
+-- archives) out of the parity gate and fed them in from the live record,
+-- recording it as a blind spot to close once this table held something. This is
+-- that change.
+--
+-- Adding `name` and `nczoning_tagged` is what lets the candidates list be a
+-- query rather than a live Nexus call on a public unauthenticated route:
+--
+--   tagged, minus locations, minus dismissed_candidates
+--
+-- and lets the served Nexus fields come from a join on locations.nexus_id
+-- instead of the two-path resolution in materialize.js, where auto-sourced
+-- records carried their own images and manual ones were backfilled separately.
+
+-- Mod title as Nexus reports it. Needed for the candidates list, which has to
+-- name a mod that is not a location yet and therefore has no row to name it.
+ALTER TABLE nexus_cache ADD COLUMN name TEXT;
+
+-- Whether the mod currently carries the NCZoning tag. Recomputed every sweep
+-- from the full tagged set, so untagging a mod removes it from candidates
+-- rather than leaving it there forever.
+--
+-- NOT the same question as `source='auto'` on locations, which records how a
+-- record first arrived and is being retired. This is a live property of the
+-- Nexus page.
+ALTER TABLE nexus_cache ADD COLUMN nczoning_tagged INTEGER NOT NULL DEFAULT 0;
+
+-- The candidates query filters on this and nothing else selects by it.
+CREATE INDEX idx_nexus_cache_tagged ON nexus_cache (nczoning_tagged);

--- a/worker/migrations/0003_nexus_cache_index.sql
+++ b/worker/migrations/0003_nexus_cache_index.sql
@@ -1,33 +1,23 @@
--- nexus_cache becomes the Nexus mod INDEX, not just an image cache.
+-- Makes nexus_cache the Nexus mod index rather than only an image cache, so
+-- the candidates list can be a query (tagged, minus locations, minus
+-- dismissed_candidates) and the four Nexus-derived /v1 fields can come from a
+-- join on locations.nexus_id.
 --
--- The table was declared at Phase 1 and never populated: 0 rows in both
--- databases, and nothing in the codebase wrote to it. Phase 1 deliberately left
--- the four Nexus-derived served fields (thumbnail_url, picture_url, updated_at,
--- archives) out of the parity gate and fed them in from the live record,
--- recording it as a blind spot to close once this table held something. This is
--- that change.
---
--- Adding `name` and `nczoning_tagged` is what lets the candidates list be a
--- query rather than a live Nexus call on a public unauthenticated route:
---
---   tagged, minus locations, minus dismissed_candidates
---
--- and lets the served Nexus fields come from a join on locations.nexus_id
--- instead of the two-path resolution in materialize.js, where auto-sourced
--- records carried their own images and manual ones were backfilled separately.
+-- Safe to ALTER in place: the table held 0 rows in both databases and nothing
+-- read or wrote it.
 
--- Mod title as Nexus reports it. Needed for the candidates list, which has to
--- name a mod that is not a location yet and therefore has no row to name it.
+-- Mod title as Nexus reports it. The candidates list has to name a mod that is
+-- not a location yet, so no locations row can supply the name.
+--
+-- Stored for comparison, not display. See the header note in src/nexus-cache.js.
 ALTER TABLE nexus_cache ADD COLUMN name TEXT;
 
--- Whether the mod currently carries the NCZoning tag. Recomputed every sweep
--- from the full tagged set, so untagging a mod removes it from candidates
--- rather than leaving it there forever.
+-- Whether the mod currently carries the NCZoning tag, recomputed each sweep
+-- from the full tagged set so an untagged mod leaves the candidate pool.
 --
--- NOT the same question as `source='auto'` on locations, which records how a
--- record first arrived and is being retired. This is a live property of the
--- Nexus page.
+-- A live property of the Nexus page, unlike locations.source, which records how
+-- a record first arrived and is being retired.
 ALTER TABLE nexus_cache ADD COLUMN nczoning_tagged INTEGER NOT NULL DEFAULT 0;
 
--- The candidates query filters on this and nothing else selects by it.
+-- Only the candidates query selects by this.
 CREATE INDEX idx_nexus_cache_tagged ON nexus_cache (nczoning_tagged);

--- a/worker/scripts/parity-ab.mjs
+++ b/worker/scripts/parity-ab.mjs
@@ -112,6 +112,16 @@ async function main() {
   const live = envelope.data;
   const districts = subdistricts.districts;
   const manualThumbs = thumbsFromLive(live);
+  // The D1 builder reads images from the nexus_cache index rather than the
+  // modsByUid channel. Deriving it from the same thumbs keeps this an A/B of
+  // the two BUILDERS: feeding them different image data would make every
+  // difference ambiguous between "the builders disagree" and "the inputs did".
+  const nexusIndex = new Map(Object.entries(manualThumbs).map(([id, t]) => [id, {
+    thumbnailUrl: t.thumbnailUrl ?? null,
+    pictureUrl: t.pictureUrl ?? null,
+    updatedAt: t.updatedAt ?? null,
+    archives: [],
+  }]));
   const manualMods = readManualMods();
   const rows = query(db, 'SELECT * FROM locations ORDER BY id');
   const dismissed = new Set(query(db, 'SELECT nexus_id FROM dismissed_candidates').map((r) => String(r.nexus_id)));
@@ -173,7 +183,7 @@ async function main() {
   for (const days of offsets) {
     const nowMs = base + days * day;
     const a = buildDataset({ manualMods, tagsDict, excluded, nexusNodes, districts, manualThumbs, nowMs }).full;
-    const b = materializeFromD1({ rows, dismissed, tagsDict, nexusNodes, districts, manualThumbs, locationTags, nowMs }).full;
+    const b = materializeFromD1({ rows, dismissed, tagsDict, nexusNodes, districts, nexusIndex, locationTags, nowMs }).full;
     const d = diff(a, b);
     const recent = Object.values(a).filter((r) => r.recently_updated).length;
     const label = `clock ${days >= 0 ? '+' : ''}${days}d`.padEnd(12);

--- a/worker/scripts/parity-check.mjs
+++ b/worker/scripts/parity-check.mjs
@@ -11,43 +11,34 @@
  * ---------------------------------------------------------------------------
  * WHAT THIS CHECK CAN AND CANNOT CATCH -- read before trusting a green run.
  *
- * The live API is the still-running reference system. 13 of the 18 served
- * fields are rebuilt from D1 and compared; the other 5 are Nexus-derived and
- * are NOT D1's job until Phase 2, so they are fed in from the live record:
+ * The live API is the still-running reference system. EVERY served field is now
+ * rebuilt from D1 and compared; nothing is fed in from the live record:
  *
- *   REBUILT FROM D1   id, name, nexus_id, coordinates, yaw, category, tags,
- *                     authors, source, description, credits  (D1 columns)
- *                     district, subdistrict                  (recomputed from
- *                                                             D1's OWN x/y/z,
- *                                                             which is what
- *                                                             catches a mangled
- *                                                             coordinate)
- *                     recently_updated                       (recomputed from
- *                                                             updated_at against
- *                                                             the envelope's
- *                                                             generated_at clock)
- *   FED IN FROM LIVE  thumbnail_url, picture_url, updated_at  (Nexus images,
- *                                                             via the same
- *                                                             manualThumbs
- *                                                             channel the cron
- *                                                             uses)
- *                     archives                                (KV-cached Nexus
- *                                                             file listing)
+ *   FROM `locations`     id, name, nexus_id, coordinates, yaw, category, tags,
+ *                        authors, source, description, credits
+ *   FROM `nexus_cache`   thumbnail_url, picture_url, updated_at, archives
+ *   RECOMPUTED           district, subdistrict   (from D1's OWN x/y/z, which is
+ *                                                 what catches a mangled
+ *                                                 coordinate)
+ *                        recently_updated        (from nexus_cache.updated_at
+ *                                                 against the envelope's
+ *                                                 generated_at clock)
  *
  * A field in NEITHER set fails the run (see assertKeyCoverage). That is what
  * stops a newly added /v1 field from silently slipping past the gate as
  * "not compared".
  *
- * The 5 fed-in fields are therefore unverified BY THIS CHECK, by construction
- * and on purpose -- Phase 2 moves them into `nexus_cache` and they become
- * D1's problem then.
+ * Feeding a field in from the live record makes the gate agree with itself for
+ * that field: an image the cron resolves wrongly still matches, because both
+ * sides came from the same place. So a field belongs in FED_IN_KEYS only while
+ * D1 genuinely cannot answer for it, and the set is empty.
  * ---------------------------------------------------------------------------
  */
 
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { materializeFromD1 } from '../src/materialize.js';
+import { materializeFromD1, attachArchives } from '../src/materialize.js';
 
 const WORKER_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 // Wrangler's JS entrypoint, not `npx`: node >=20 refuses to spawn a .cmd shim
@@ -61,8 +52,11 @@ const ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID || 'b9937d8d595fad7de8d1549
 const REBUILT_KEYS = new Set([
   'id', 'name', 'nexus_id', 'coordinates', 'yaw', 'category', 'tags', 'authors',
   'source', 'description', 'credits', 'district', 'subdistrict', 'recently_updated',
+  'thumbnail_url', 'picture_url', 'updated_at', 'archives',
 ]);
-const FED_IN_KEYS = new Set(['thumbnail_url', 'picture_url', 'updated_at', 'archives']);
+// Empty on purpose, and kept rather than deleted: it is the list of fields this
+// gate does not actually check, and it should stay visible and stay at zero.
+const FED_IN_KEYS = new Set();
 
 const fail = (msg) => { console.error(`\n❌ ${msg}`); process.exit(1); };
 
@@ -107,26 +101,29 @@ async function getJson(url) {
 }
 
 /**
- * Rebuild the manualThumbs channel from the live records. Keyed by nexus_id,
- * which WIP/Dummy entries share -- so assert that colliding keys agree rather
- * than letting the last one win silently.
+ * readNexusIndex()'s output, built from a `nexus_cache` dump rather than a live
+ * binding. Deliberately a separate implementation of the same shape: importing
+ * the Worker's version would need a D1 binding, and this script talks to
+ * wrangler.
  */
-function thumbsFromLive(records) {
-  const thumbs = {};
-  for (const r of records) {
-    const key = String(r.nexus_id);
-    const value = {
-      thumbnailUrl: r.thumbnail_url,
-      pictureUrl: r.picture_url,
-      updatedAt: r.updated_at,
-    };
-    const prev = thumbs[key];
-    if (prev && JSON.stringify(prev) !== JSON.stringify(value)) {
-      throw new Error(`nexus_id ${key} appears twice with different images -- cannot key thumbs by it`);
+function indexFromRows(rows) {
+  const index = new Map();
+  for (const r of rows) {
+    let archives = [];
+    if (typeof r.archives === 'string') {
+      try {
+        const parsed = JSON.parse(r.archives);
+        if (Array.isArray(parsed)) archives = parsed;
+      } catch { /* a malformed cell reads as no listing, exactly as the Worker does */ }
     }
-    thumbs[key] = value;
+    index.set(String(r.nexus_id), {
+      thumbnailUrl: r.thumbnail_url ?? null,
+      pictureUrl: r.picture_url ?? null,
+      updatedAt: r.updated_at ?? null,
+      archives,
+    });
   }
-  return thumbs;
+  return index;
 }
 
 /** Every served key must be classified, or the gate has a blind spot. */
@@ -145,27 +142,23 @@ function assertKeyCoverage(records) {
   }
 }
 
-/** Attach the fed-in Nexus fields, in the position refresh.js appends them. */
-function withArchives(record, liveRecord) {
-  return { ...record, archives: liveRecord.archives };
-}
-
-function buildFromRows(rows, dismissedIds, tagsDict, districts, liveRecords, nowMs, locationTags) {
+function buildFromRows(rows, dismissedIds, tagsDict, districts, nexusIndex, nowMs, locationTags) {
   const { full } = materializeFromD1({
     rows,
     dismissed: dismissedIds,
     tagsDict,
-    nexusNodes: [], // nothing auto-publishes; images arrive via manualThumbs
+    nexusNodes: [], // nothing auto-publishes; images arrive via nexusIndex
     districts,
-    manualThumbs: thumbsFromLive(liveRecords),
+    nexusIndex,
     // The join. Without it materializeFromD1 falls back to the legacy
     // locations.tags column, so the gate would pass while testing the path
     // production no longer takes.
     locationTags,
     nowMs,
   });
-  const byId = new Map(liveRecords.map((r) => [r.id, r]));
-  return Object.values(full).map((rec) => withArchives(rec, byId.get(rec.id) ?? {}));
+  // Appended last, in the position the cron appends it, because the comparison
+  // below is on bytes and JSON.stringify emits insertion order.
+  return Object.values(attachArchives(full, nexusIndex));
 }
 
 async function main() {
@@ -188,6 +181,10 @@ async function main() {
 
   const rows = query(db, 'SELECT * FROM locations ORDER BY id');
   const dismissedRows = query(db, 'SELECT nexus_id FROM dismissed_candidates');
+  const nexusRows = query(
+    db,
+    'SELECT nexus_id, updated_at, thumbnail_url, picture_url, archives FROM nexus_cache',
+  );
 
   // A truncated result set is the failure mode that looks like success, so
   // compare the rows returned against a count the database computed itself.
@@ -196,7 +193,16 @@ async function main() {
     fail(`D1 returned ${rows.length} rows but COUNT(*) is ${n} -- the result set was truncated`);
   }
   console.log(`D1: ${rows.length} locations (COUNT(*) agrees), ${dismissedRows.length} dismissed`);
-  console.log(`live: ${liveRecords.length} records, generated_at ${envelope.generated_at}\n`);
+  console.log(`live: ${liveRecords.length} records, generated_at ${envelope.generated_at}`);
+
+  // An unswept nexus_cache would rebuild every image as null and every listing
+  // as [], which is a difference in ~300 records reported as ~300 mismatches.
+  // Say what it is instead: this database has not been swept yet.
+  const withArchivesCount = nexusRows.filter((r) => r.archives != null).length;
+  console.log(`nexus_cache: ${nexusRows.length} mods, ${withArchivesCount} with a file listing\n`);
+  if (nexusRows.length === 0) {
+    fail('nexus_cache is empty -- deploy the sweep and let one cron tick run before comparing.');
+  }
 
   const dismissedIds = new Set(dismissedRows.map((r) => String(r.nexus_id)));
 
@@ -206,7 +212,8 @@ async function main() {
     locationTags.get(r.location_id).push(r.tag_slug);
   }
 
-  const candidate = buildFromRows(rows, dismissedIds, tagsDict, subdistricts.districts, liveRecords, nowMs, locationTags);
+  const nexusIndex = indexFromRows(nexusRows);
+  const candidate = buildFromRows(rows, dismissedIds, tagsDict, subdistricts.districts, nexusIndex, nowMs, locationTags);
 
   // --- ID assertion (the deep-link contract) ----------------------------
   const liveIds = new Set(liveRecords.map((r) => r.id));
@@ -247,19 +254,36 @@ async function main() {
   // A green result above is worthless unless this comparison can go red. Prove
   // it on the same run, against the same code path, with the same data.
   console.log('\nnegative control (the check must FAIL on each of these):');
+  // Two families: the location columns, and the Nexus-derived fields. The
+  // second family only detects anything while those fields are rebuilt rather
+  // than fed in, so these four controls are what keeps FED_IN_KEYS empty.
   const controls = [
-    ['id changed', (r) => ({ ...r, id: `${r.id}-x` })],
-    ['name changed', (r) => ({ ...r, name: `${r.name} ` })],
-    ['coordinate nudged', (r) => ({ ...r, x: r.x + 0.0001 })],
-    ['z dropped to NULL', (r) => ({ ...r, z: null })],
-    ['tag removed', (r) => ({ ...r, tags: JSON.stringify(JSON.parse(r.tags).slice(1)) })],
+    ['id changed', (r) => ({ ...r, id: `${r.id}-x` }), null],
+    ['name changed', (r) => ({ ...r, name: `${r.name} ` }), null],
+    ['coordinate nudged', (r) => ({ ...r, x: r.x + 0.0001 }), null],
+    ['z dropped to NULL', (r) => ({ ...r, z: null }), null],
+    ['tag removed', (r) => ({ ...r, tags: JSON.stringify(JSON.parse(r.tags).slice(1)) }), null],
+    ['thumbnail_url changed', null, (e) => ({ ...e, thumbnailUrl: `${e.thumbnailUrl}?x` })],
+    ['picture_url dropped', null, (e) => ({ ...e, pictureUrl: null })],
+    ['updated_at moved', null, (e) => ({ ...e, updatedAt: '2020-01-01T00:00:00.000Z' })],
+    ['archive name changed', null, (e) => ({ ...e, archives: [...e.archives, 'ghost.archive'] })],
   ];
   let controlsPassed = 0;
-  for (const [label, mutate] of controls) {
-    const mutated = rows.map((r, i) => (i === 0 ? mutate(r) : r));
+  for (const [label, mutateRow, mutateIndex] of controls) {
+    const mutatedRows = mutateRow ? rows.map((r, i) => (i === 0 ? mutateRow(r) : r)) : rows;
+    let mutatedIndex = nexusIndex;
+    if (mutateIndex) {
+      // The first record's mod, so a one-record mutation stays a one-record
+      // difference even though the index is keyed by mod rather than location.
+      const key = String(rows[0].nexus_id);
+      mutatedIndex = new Map(nexusIndex);
+      const entry = mutatedIndex.get(key);
+      if (!entry) fail(`negative control cannot run: no nexus_cache row for ${key}`);
+      mutatedIndex.set(key, mutateIndex(entry));
+    }
     let differs;
     try {
-      const out = buildFromRows(mutated, dismissedIds, tagsDict, subdistricts.districts, liveRecords, nowMs, locationTags);
+      const out = buildFromRows(mutatedRows, dismissedIds, tagsDict, subdistricts.districts, mutatedIndex, nowMs, locationTags);
       differs = !compare(out, liveRecords);
     } catch {
       differs = true; // a throw is also a detection

--- a/worker/src/materialize.js
+++ b/worker/src/materialize.js
@@ -18,8 +18,8 @@
  * The record key ORDER below is load-bearing: /v1 responses are compared
  * byte-for-byte at the Phase 1 gate, and JSON.stringify emits insertion order.
  * It mirrors merge.js:141-157 deliberately, and the parity diff is what proves
- * the mirror is faithful. `archives` is appended by the caller (as refresh.js
- * does today), so it is absent here by design, not by omission.
+ * the mirror is faithful. `archives` is appended afterwards by attachArchives
+ * below, so it is absent from the literal by design, not by omission.
  */
 
 import { parseNcZoningBlock } from './parse.js';
@@ -80,12 +80,15 @@ function resolveTags(row, locationTags) {
  * @param {object} input.tagsDict      data/tags.json, for block validation
  * @param {Array}  input.nexusNodes    raw nodes from the NCZoning GraphQL query
  * @param {Array}  input.districts     data/subdistricts.json `districts[]`
- * @param {object} [input.manualThumbs] modsByUid image/updatedAt, keyed by nexus_id
+ * @param {Map}    [input.nexusIndex]  readNexusIndex(): the Nexus-derived fields
+ *   keyed by nexus_id. One lookup, not two: under D1 the tagged nodes and the
+ *   modsByUid backfill have both already been folded into `nexus_cache` by the
+ *   sweep, so a second in-memory channel would only be a way for them to disagree.
  * @param {number} [input.nowMs]       clock the recently_updated bool is computed against
  * @returns {{full: Object<string, object>, meta: object}}
  */
 export function materializeFromD1({
-  rows, dismissed, tagsDict, nexusNodes, districts, manualThumbs = {},
+  rows, dismissed, tagsDict, nexusNodes, districts, nexusIndex = new Map(),
   locationTags = null, nowMs = Date.now(),
 }) {
   const validTagNames = new Set(Object.keys(tagsDict));
@@ -103,20 +106,14 @@ export function materializeFromD1({
       .filter((id) => id && !['wip', 'dummy'].includes(id.toLowerCase())),
   );
 
-  const nexusThumbs = {};
   const skipped = [];
 
   for (const node of nexusNodes || []) {
     const nexusId = String(node.modId);
     if (dismissedIds.has(nexusId)) continue;
-    if (existingNexusIds.has(nexusId)) {
-      nexusThumbs[nexusId] = {
-        pictureUrl: node.pictureUrl || null,
-        thumbnailUrl: node.thumbnailUrl || null,
-        updatedAt: node.updatedAt || null,
-      };
-      continue;
-    }
+    // Already on the map. Its images come from the index like every other
+    // record's, so the node has nothing left to contribute here.
+    if (existingNexusIds.has(nexusId)) continue;
     // Not a location and not dismissed: a candidate. Surfaced on /v1/meta as
     // `skipped` exactly as before when it has no valid block. A mod WITH a
     // valid block is also not published here -- see the header note.
@@ -133,7 +130,7 @@ export function materializeFromD1({
 
   for (const entry of all) {
     const { district, subdistrict } = assignDistrict(entry.coordinates, districts);
-    const t = manualThumbs[String(entry.nexus_id)] || nexusThumbs[String(entry.nexus_id)] || null;
+    const t = nexusIndex.get(String(entry.nexus_id)) || null;
     const thumbs = {
       thumbnail_url: t?.thumbnailUrl ?? null,
       picture_url: t?.pictureUrl ?? null,
@@ -162,5 +159,21 @@ export function materializeFromD1({
     };
   }
 
-  return { full, meta: { skipped, nexus_thumbs: nexusThumbs } };
+  return { full, meta: { skipped } };
+}
+
+/**
+ * Attach each record's `.archive` file names, in place and last, matching the
+ * position refresh.js has always appended them in. Always an array: `[]` means
+ * unknown or not yet swept, never "ships no archives", and the in-game consumer
+ * reads it that way.
+ *
+ * Pure, and shared by the cron and the parity gate so the gate cannot pass
+ * against a channel the cron does not use.
+ */
+export function attachArchives(full, nexusIndex = new Map()) {
+  for (const rec of Object.values(full)) {
+    rec.archives = nexusIndex.get(String(rec.nexus_id))?.archives ?? [];
+  }
+  return full;
 }

--- a/worker/src/nexus-cache.js
+++ b/worker/src/nexus-cache.js
@@ -38,6 +38,21 @@
  * "Cliffside Abode Player Home". Serving this column would undo that. It exists
  * so a rename can be detected by diffing it against locations.name.
  *
+ * ## Archives live here too, and cost the most to fetch
+ *
+ * The `.archive` file names a mod ships (installed-mod detection) are a
+ * per-mod, multi-subrequest fetch, so they are budgeted per tick and refetched
+ * only when a mod re-uploads. `archives_at` records the `updated_at` they were
+ * read against, because `updated_at` itself moves the instant Nexus reports the
+ * re-upload.
+ *
+ * refreshArchives() is a SEPARATE pass from the sweep, driven by the records
+ * the dataset actually serves rather than by the `locations` table. While
+ * production still builds from mods.json those two sets can differ -- a mod
+ * merged to main reaches mods.json and does not reach D1 until someone runs
+ * sync-locations.mjs -- and driving archives off the table would silently ship
+ * no file list for exactly those mods.
+ *
  * ## D1 bound parameters
  *
  * The ceiling is 100 per query, measured
@@ -47,10 +62,23 @@
  * surfaces in a browser as a CORS error rather than a SQL one.
  */
 
-import { fetchTaggedModNodes, fetchModsByUidThumbs } from './nexus.js';
+import { fetchTaggedModNodes, fetchModsByUidThumbs, fetchModArchiveNames } from './nexus.js';
+import { readArchives } from './store.js';
 
 /** Columns compared to decide whether a row needs writing. */
-const TRACKED = ['name', 'updated_at', 'thumbnail_url', 'picture_url', 'archives', 'nczoning_tagged'];
+const TRACKED = [
+  'name', 'updated_at', 'thumbnail_url', 'picture_url', 'archives', 'archives_at',
+  'nczoning_tagged',
+];
+
+// Per-tick archive budgets, carried over from refresh.js unchanged. Archives are
+// near-static, so steady state fetches nothing; these cap the cold fill and any
+// re-upload burst so archive work can never breach the Worker's 50-subrequest
+// limit alongside the tagged query and the thumbnail batches. A cold cache fills
+// over roughly ceil(records / ARCHIVE_MOD_BUDGET) ticks, which the one-time
+// carry-over below is there to avoid paying at all.
+const ARCHIVE_MOD_BUDGET = 15;
+const ARCHIVE_SUBREQUEST_BUDGET = 25;
 
 /** Nexus ids that are placeholders rather than real mods. */
 const isRealNexusId = (id) => Boolean(id) && /^\d+$/.test(String(id));
@@ -77,12 +105,63 @@ function nodeToRow(node, tagged) {
 export async function readNexusCache(env) {
   const { results } = await env.DB.prepare(
     `SELECT nexus_id, name, updated_at, thumbnail_url, picture_url, archives,
-            nczoning_tagged, fetched_at
+            archives_at, nczoning_tagged, fetched_at
        FROM nexus_cache`,
   ).all();
   const map = new Map();
   for (const r of results ?? []) map.set(String(r.nexus_id), r);
   return map;
+}
+
+/**
+ * A stored `archives` value as an array. Never throws: a malformed cell is a
+ * cosmetic loss for one mod, and letting it propagate would take the whole
+ * refresh into last-known-good over a file listing.
+ */
+function parseArchives(value) {
+  if (typeof value !== 'string') return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The four Nexus-derived /v1 fields, keyed by nexus_id, for the materializer to
+ * join on. One-to-many: two locations sharing a mod read the same entry.
+ *
+ * Callers must treat an empty index as a failure rather than as "no images" --
+ * see the guard in refresh.js. Serving 297 records with every image stripped is
+ * a valid-looking dataset that would sail through the content hash and replace
+ * a good one.
+ */
+export async function readNexusIndex(env) {
+  const { results } = await env.DB.prepare(
+    `SELECT nexus_id, updated_at, thumbnail_url, picture_url, archives, archives_at,
+            nczoning_tagged
+       FROM nexus_cache`,
+  ).all();
+  const index = new Map();
+  for (const r of results ?? []) {
+    index.set(String(r.nexus_id), {
+      thumbnailUrl: r.thumbnail_url ?? null,
+      pictureUrl: r.picture_url ?? null,
+      updatedAt: r.updated_at ?? null,
+      archives: parseArchives(r.archives),
+      // Carried so an archives-only write can preserve it: writeRows sets the
+      // flag unconditionally, and a candidate that lost it here would quietly
+      // drop out of the candidates list.
+      nczoning_tagged: r.nczoning_tagged ?? 0,
+      // `archives: []` is a real answer -- plenty of mods ship no .archive at
+      // all -- so the array cannot say whether the listing has ever been read.
+      // These two carry that, and only refreshArchives looks at them.
+      archivesKnown: r.archives != null,
+      archivesAt: r.archives_at ?? null,
+    });
+  }
+  return index;
 }
 
 /**
@@ -148,14 +227,15 @@ async function writeRows(env, rows, nowIso) {
   const stmt = env.DB.prepare(
     `INSERT INTO nexus_cache
        (nexus_id, name, updated_at, thumbnail_url, picture_url, archives,
-        nczoning_tagged, fetched_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        archives_at, nczoning_tagged, fetched_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(nexus_id) DO UPDATE SET
        name            = COALESCE(excluded.name, nexus_cache.name),
        updated_at      = COALESCE(excluded.updated_at, nexus_cache.updated_at),
        thumbnail_url   = COALESCE(excluded.thumbnail_url, nexus_cache.thumbnail_url),
        picture_url     = COALESCE(excluded.picture_url, nexus_cache.picture_url),
        archives        = COALESCE(excluded.archives, nexus_cache.archives),
+       archives_at     = COALESCE(excluded.archives_at, nexus_cache.archives_at),
        nczoning_tagged = excluded.nczoning_tagged,
        fetched_at      = excluded.fetched_at`,
   );
@@ -166,10 +246,105 @@ async function writeRows(env, rows, nowIso) {
     r.thumbnail_url ?? null,
     r.picture_url ?? null,
     r.archives ?? null,
+    r.archives_at ?? null,
     r.nczoning_tagged ?? 0,
     nowIso,
   )));
   return rows.length;
+}
+
+/**
+ * Resolve `archives` for the records this cycle is about to serve, budgeted.
+ *
+ * Driven by `records` (the built dataset), not by the `locations` table -- see
+ * the header note. Updates `index` in place so the caller can attach the result
+ * without re-reading, and writes only the rows whose listing actually changed.
+ *
+ * A mod is due when its listing has never been read, or when the `updated_at`
+ * it was read against no longer matches the record's -- the exact re-upload
+ * signal for its file contents. Newest first, so a re-upload beats the cold
+ * fill for the budget. A transient failure (`ok:false`) is skipped rather than
+ * stored, so the next tick retries instead of recording a partial listing as
+ * final.
+ *
+ * @param {object} env
+ * @param {typeof fetch} fetchImpl
+ * @param {object} opts
+ * @param {Array}  opts.records  served records, each `{nexus_id, updated_at}`
+ * @param {Map}    opts.index    readNexusIndex(), mutated in place
+ * @param {string} opts.nowIso
+ */
+export async function refreshArchives(env, fetchImpl, { records, index, nowIso }) {
+  const summary = { seeded: 0, fetched: 0, pending: 0, written: 0 };
+  const stamp = nowIso ?? new Date().toISOString();
+
+  const due = new Map();
+  for (const rec of records) {
+    const id = String(rec.nexus_id);
+    if (!isRealNexusId(id) || due.has(id)) continue;
+    const updatedAt = rec.updated_at ?? null;
+    const entry = index.get(id);
+    if (entry?.archivesKnown && entry.archivesAt === updatedAt) continue;
+    due.set(id, updatedAt);
+  }
+  if (!due.size) return summary;
+
+  // One-time carry-over from the KV blob this table replaces. Worth the read
+  // twice over: it skips a ~20 tick cold fill, and archive-seeds.json holds
+  // hand-built listings for mods whose Nexus "Preview file contents" is broken,
+  // which a refetch would silently replace with nothing. The read stops
+  // happening once every served mod has a listing, because `due` is then empty.
+  let seeds = {};
+  try {
+    seeds = await readArchives(env);
+  } catch {
+    // The blob is an optimisation, not a source. Fetching covers its absence.
+  }
+
+  const resolved = new Map();
+  const take = (id, updatedAt, archives) => {
+    resolved.set(id, { archives, updatedAt });
+    index.set(id, {
+      ...(index.get(id) ?? { thumbnailUrl: null, pictureUrl: null, updatedAt }),
+      archives,
+      archivesKnown: true,
+      archivesAt: updatedAt,
+    });
+    due.delete(id);
+  };
+
+  for (const [id, updatedAt] of [...due]) {
+    const seed = seeds[id];
+    if (!seed || (seed.updatedAt ?? null) !== updatedAt || !Array.isArray(seed.archives)) continue;
+    take(id, updatedAt, seed.archives);
+    summary.seeded += 1;
+  }
+
+  const ordered = [...due].sort((a, b) => String(b[1] ?? '').localeCompare(String(a[1] ?? '')));
+  let mods = 0;
+  let subrequests = 0;
+  for (const [id, updatedAt] of ordered) {
+    if (mods >= ARCHIVE_MOD_BUDGET || subrequests >= ARCHIVE_SUBREQUEST_BUDGET) break;
+    const res = await fetchModArchiveNames(fetchImpl, id);
+    mods += 1;
+    subrequests += res.subrequests;
+    if (!res.ok) continue;
+    take(id, updatedAt, res.archives);
+    summary.fetched += 1;
+  }
+  summary.pending = due.size;
+
+  // A row per mod, same batching and the same 100-bound-parameter ceiling as
+  // the sweep. Nothing resolved means nothing written, which is the steady
+  // state: archives only move when a mod re-uploads.
+  const rows = [...resolved].map(([nexusId, r]) => ({
+    nexus_id: nexusId,
+    nczoning_tagged: index.get(nexusId)?.nczoning_tagged ?? 0,
+    archives: JSON.stringify(r.archives),
+    archives_at: r.updatedAt,
+  }));
+  summary.written = await writeRows(env, rows, stamp);
+  return summary;
 }
 
 /**
@@ -181,19 +356,24 @@ async function writeRows(env, rows, nowIso) {
  * @param {object} [opts]
  * @param {Function} [opts.fetchImpl]  injected for tests
  * @param {string}   [opts.nowIso]     injected for tests
+ * @param {Array}    [opts.taggedNodes] the tagged set, when the caller has
+ *   already fetched it. The cron does: one GraphQL call serves both this sweep
+ *   and the dataset build, and a second would double the cost of the tick.
  */
-export async function refreshNexusCache(env, { fetchImpl = fetch, nowIso } = {}) {
+export async function refreshNexusCache(env, { fetchImpl = fetch, nowIso, taggedNodes: given } = {}) {
   const stamp = nowIso ?? new Date().toISOString();
   const summary = { tagged: 0, backfilled: 0, written: 0, untagged: 0, stale: false };
 
-  let taggedNodes;
-  try {
-    taggedNodes = await fetchTaggedModNodes(fetchImpl);
-  } catch (err) {
-    // Last known good stays. Reported, not thrown: see the header note.
-    summary.stale = true;
-    summary.error = String(err).slice(0, 200);
-    return summary;
+  let taggedNodes = given;
+  if (!taggedNodes) {
+    try {
+      taggedNodes = await fetchTaggedModNodes(fetchImpl);
+    } catch (err) {
+      // Last known good stays. Reported, not thrown: see the header note.
+      summary.stale = true;
+      summary.error = String(err).slice(0, 200);
+      return summary;
+    }
   }
 
   const existing = await readNexusCache(env);
@@ -206,8 +386,8 @@ export async function refreshNexusCache(env, { fetchImpl = fetch, nowIso } = {})
   }
   summary.tagged = incoming.size;
 
-  // Locations whose images we serve but which are not tagged, so the tagged
-  // query said nothing about them.
+  // Mods with a pin but no NCZoning tag, which the tagged query says nothing
+  // about. DISTINCT, because one mod can supply two locations.
   const { results: locRows } = await env.DB.prepare(
     'SELECT DISTINCT nexus_id FROM locations WHERE nexus_id IS NOT NULL',
   ).all();

--- a/worker/src/nexus-cache.js
+++ b/worker/src/nexus-cache.js
@@ -37,6 +37,26 @@
  * precisely the 86k writes being avoided. Sweep freshness is a dataset-level
  * value, not a per-row one.
  *
+ * nexus_id IS NOT UNIQUE ACROSS LOCATIONS
+ *
+ * Measured 2026-07-27: 296 locations carry a numeric nexus_id and they use 295
+ * distinct values. Mod 23896 ("Watson Tattoo Shops") supplies two locations,
+ * Little China Pink Ink and Northside Tattoo & Body Mods, which is legitimate:
+ * one mod can add two separate places, each deserving its own pin.
+ *
+ * So the join from here to `locations` is ONE-TO-MANY. Both locations read the
+ * same images and the same upstream title, which is correct. Do not add a
+ * UNIQUE constraint on locations.nexus_id, and do not key a location lookup by
+ * it.
+ *
+ * NAME IS NOT DERIVED FROM THIS TABLE, deliberately. 34 of 295 location names
+ * differ from the Nexus title, and the differences are curation rather than
+ * staleness: stripped version prefixes ("CP2.31 Cliffside Abode Player Home"),
+ * stripped tool suffixes ("(World Builder)", "Worldbuilder"), stripped
+ * marketing tails ("- REVOLUTION"), tidied whitespace. Serving `name` from
+ * here would undo all of it. The stored title is for DETECTING a rename, by
+ * comparing it against locations.name, not for replacing one.
+ *
  * D1 BOUND PARAMETER LIMIT
  *
  * D1 allows exactly 100 bound parameters PER QUERY, measured, not documented

--- a/worker/src/nexus-cache.js
+++ b/worker/src/nexus-cache.js
@@ -1,0 +1,258 @@
+/**
+ * nexus_cache: the Nexus mod index, refreshed from the cron.
+ *
+ * Holds one row per mod we care about, which is the union of
+ *   - every mod currently carrying the NCZoning tag (candidates), and
+ *   - every location's numeric nexus_id (served images and update times).
+ *
+ * WHY THIS TABLE EARNS ITS KEEP
+ *
+ * Before it, the four Nexus-derived served fields were fetched live on every
+ * cron tick and resolved two different ways depending on `source`: auto records
+ * carried their own images from the tagged query, manual ones came from a
+ * separate modsByUid backfill (materialize.js:136, merge.js resolveThumbs).
+ * One table collapses that to a single lookup, and it is what lets the
+ * candidates list be a query instead of a live Nexus call on a public
+ * unauthenticated route.
+ *
+ * THE WRITE BUDGET IS THE WHOLE DESIGN
+ *
+ * D1's free tier allows 100k row-writes/day. The cron fires every 5 minutes,
+ * so 288 times a day. Writing ~300 rows on every tick is 86,400 writes/day,
+ * 86% of the cap, before locations writes and audit rows. That does not fit.
+ *
+ * So: FETCH every tick (cheap: one GraphQL call for the whole tagged set, plus
+ * batched modsByUid for the rest), but WRITE only rows whose content actually
+ * changed. A tick where nothing changed on Nexus costs zero writes, and a mod's
+ * name, images or file list change rarely.
+ *
+ * This is the same content-hash gate refresh.js already applies to KV, and the
+ * reason to be strict about it is on the record: issue #849 added a liveness
+ * heartbeat that deliberately bypassed that gate and reinstated the exact
+ * per-tick write cost the gate existed to remove. HEARTBEAT_MIN_INTERVAL_MS in
+ * config.js is the scar. This is the same mistake available at 86x the scale.
+ *
+ * Consequence, deliberately accepted: `fetched_at` means "when this row last
+ * CHANGED", not "when we last checked". Storing a per-row checked-timestamp is
+ * precisely the 86k writes being avoided. Sweep freshness is a dataset-level
+ * value, not a per-row one.
+ *
+ * D1 BOUND PARAMETER LIMIT
+ *
+ * D1 allows exactly 100 bound parameters PER QUERY, measured, not documented
+ * (learnings/d1-refuses-more-than-100-bound-parameters). Every write here goes
+ * through DB.batch() as one statement per row, so each statement binds about
+ * eight. Never assemble a single multi-row statement with one placeholder per
+ * mod: at ~300 mods that throws on every call, and the browser reports it as a
+ * CORS error rather than as the SQL error it is.
+ */
+
+import { fetchTaggedModNodes, fetchModsByUidThumbs } from './nexus.js';
+
+/** Columns compared to decide whether a row needs writing. */
+const TRACKED = ['name', 'updated_at', 'thumbnail_url', 'picture_url', 'archives', 'nczoning_tagged'];
+
+/** Nexus ids that are placeholders rather than real mods. */
+const isRealNexusId = (id) => Boolean(id) && /^\d+$/.test(String(id));
+
+/**
+ * Normalise a tagged-query node into the row shape.
+ *
+ * `archives` stays whatever the caller already resolved (it is fetched
+ * separately and expensively); null means "not known this sweep", which is
+ * distinct from "known to be empty" and must not overwrite a stored value.
+ */
+function nodeToRow(node, tagged) {
+  return {
+    nexus_id: String(node.modId),
+    name: node.name ?? null,
+    updated_at: node.updatedAt ?? null,
+    thumbnail_url: node.thumbnailUrl ?? null,
+    picture_url: node.pictureUrl ?? null,
+    nczoning_tagged: tagged ? 1 : 0,
+  };
+}
+
+/** Existing rows, keyed by nexus_id. One query, no bound parameters. */
+export async function readNexusCache(env) {
+  const { results } = await env.DB.prepare(
+    `SELECT nexus_id, name, updated_at, thumbnail_url, picture_url, archives,
+            nczoning_tagged, fetched_at
+       FROM nexus_cache`,
+  ).all();
+  const map = new Map();
+  for (const r of results ?? []) map.set(String(r.nexus_id), r);
+  return map;
+}
+
+/**
+ * Candidates: NCZoning-tagged mods that are neither a location nor dismissed.
+ *
+ * Pure SQL and no bound parameters, which is the point of the table. The
+ * anti-joins are NOT IN subqueries rather than an id list from the caller,
+ * precisely so this does not grow a placeholder per location and hit the 100
+ * bound parameter ceiling at 297 records.
+ */
+export async function readCandidates(env) {
+  const { results } = await env.DB.prepare(
+    `SELECT nexus_id, name, thumbnail_url, picture_url, updated_at
+       FROM nexus_cache
+      WHERE nczoning_tagged = 1
+        AND nexus_id NOT IN (SELECT nexus_id FROM locations WHERE nexus_id IS NOT NULL)
+        AND nexus_id NOT IN (SELECT nexus_id FROM dismissed_candidates)
+      ORDER BY name`,
+  ).all();
+  return (results ?? []).map((r) => ({
+    nexus_id: String(r.nexus_id),
+    name: r.name ?? 'Unknown Mod',
+    thumbnail_url: r.thumbnail_url ?? null,
+    picture_url: r.picture_url ?? null,
+    updated_at: r.updated_at ?? null,
+  }));
+}
+
+/**
+ * Decide which rows differ from what is stored.
+ *
+ * Exported for the tests: the write gate is the load-bearing part of this
+ * module, so it is tested directly rather than only through a live sweep.
+ *
+ * A field that is `undefined` in the incoming row means "not resolved this
+ * sweep" and never counts as a change. A field that is explicitly `null` does:
+ * a mod whose image was removed should lose it.
+ */
+export function diffRows(incoming, existing) {
+  const writes = [];
+  for (const row of incoming) {
+    const prev = existing.get(String(row.nexus_id));
+    if (!prev) { writes.push(row); continue; }
+    const changed = TRACKED.some((k) => {
+      if (row[k] === undefined) return false;
+      return (row[k] ?? null) !== (prev[k] ?? null);
+    });
+    if (changed) writes.push({ ...row });
+  }
+  return writes;
+}
+
+/**
+ * Upsert the changed rows. One statement per row, batched.
+ *
+ * COALESCE on the expensive/optional columns so a sweep that did not resolve
+ * them leaves the stored value alone rather than nulling it. Passing undefined
+ * as a bind is an error in D1, so undefined is normalised to null first and the
+ * COALESCE is what makes null mean "keep".
+ */
+async function writeRows(env, rows, nowIso) {
+  if (!rows.length) return 0;
+  const stmt = env.DB.prepare(
+    `INSERT INTO nexus_cache
+       (nexus_id, name, updated_at, thumbnail_url, picture_url, archives,
+        nczoning_tagged, fetched_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(nexus_id) DO UPDATE SET
+       name            = COALESCE(excluded.name, nexus_cache.name),
+       updated_at      = COALESCE(excluded.updated_at, nexus_cache.updated_at),
+       thumbnail_url   = COALESCE(excluded.thumbnail_url, nexus_cache.thumbnail_url),
+       picture_url     = COALESCE(excluded.picture_url, nexus_cache.picture_url),
+       archives        = COALESCE(excluded.archives, nexus_cache.archives),
+       nczoning_tagged = excluded.nczoning_tagged,
+       fetched_at      = excluded.fetched_at`,
+  );
+  await env.DB.batch(rows.map((r) => stmt.bind(
+    String(r.nexus_id),
+    r.name ?? null,
+    r.updated_at ?? null,
+    r.thumbnail_url ?? null,
+    r.picture_url ?? null,
+    r.archives ?? null,
+    r.nczoning_tagged ?? 0,
+    nowIso,
+  )));
+  return rows.length;
+}
+
+/**
+ * One sweep. Returns a summary rather than throwing, matching runRefresh's
+ * posture: a Nexus outage must leave the last known good cache in place and be
+ * visible, not take the cron down with it.
+ *
+ * @param {object} env
+ * @param {object} [opts]
+ * @param {Function} [opts.fetchImpl]  injected for tests
+ * @param {string}   [opts.nowIso]     injected for tests
+ */
+export async function refreshNexusCache(env, { fetchImpl = fetch, nowIso } = {}) {
+  const stamp = nowIso ?? new Date().toISOString();
+  const summary = { tagged: 0, backfilled: 0, written: 0, untagged: 0, stale: false };
+
+  let taggedNodes;
+  try {
+    taggedNodes = await fetchTaggedModNodes(fetchImpl);
+  } catch (err) {
+    // Last known good stays. Reported, not thrown: see the header note.
+    summary.stale = true;
+    summary.error = String(err).slice(0, 200);
+    return summary;
+  }
+
+  const existing = await readNexusCache(env);
+  const incoming = new Map();
+
+  for (const node of taggedNodes ?? []) {
+    if (!isRealNexusId(node.modId)) continue;
+    const row = nodeToRow(node, true);
+    incoming.set(row.nexus_id, row);
+  }
+  summary.tagged = incoming.size;
+
+  // Locations whose images we serve but which are not tagged, so the tagged
+  // query said nothing about them.
+  const { results: locRows } = await env.DB.prepare(
+    'SELECT DISTINCT nexus_id FROM locations WHERE nexus_id IS NOT NULL',
+  ).all();
+  const needBackfill = (locRows ?? [])
+    .map((r) => String(r.nexus_id))
+    .filter((id) => isRealNexusId(id) && !incoming.has(id));
+
+  if (needBackfill.length) {
+    // fetchModsByUidThumbs NEVER throws: thumbnails are cosmetic, so it swallows
+    // and returns {} on any failure. A try/catch here would be dead code, and
+    // the empty object it returns on total failure is indistinguishable from a
+    // successful call that found nothing. So the check is on the COUNT against
+    // what was asked for, not on an exception that cannot arrive.
+    const thumbs = await fetchModsByUidThumbs(fetchImpl, needBackfill);
+    for (const [id, t] of Object.entries(thumbs ?? {})) {
+      incoming.set(String(id), {
+        nexus_id: String(id),
+        name: t.name ?? null,
+        updated_at: t.updatedAt ?? null,
+        thumbnail_url: t.thumbnailUrl ?? null,
+        picture_url: t.pictureUrl ?? null,
+        nczoning_tagged: 0,
+      });
+    }
+    summary.backfilled = Object.keys(thumbs ?? {}).length;
+    summary.backfill_requested = needBackfill.length;
+    if (summary.backfilled === 0) {
+      // Asked for some, got none. Either Nexus is down or every id is unknown
+      // to it; both are worth surfacing rather than reporting a clean sweep.
+      summary.stale = true;
+      summary.error = `backfill returned nothing for ${needBackfill.length} ids`;
+    }
+  }
+
+  // A mod that was tagged and no longer is must lose the flag, or it stays in
+  // the candidates list forever. Set difference against what is stored, so this
+  // costs a write only for mods that actually changed state.
+  for (const [id, prev] of existing) {
+    if (prev.nczoning_tagged === 1 && !incoming.has(id)) {
+      incoming.set(id, { nexus_id: id, nczoning_tagged: 0 });
+      summary.untagged += 1;
+    }
+  }
+
+  const writes = diffRows([...incoming.values()], existing);
+  summary.written = await writeRows(env, writes, stamp);
+  return summary;
+}

--- a/worker/src/nexus-cache.js
+++ b/worker/src/nexus-cache.js
@@ -1,70 +1,50 @@
 /**
- * nexus_cache: the Nexus mod index, refreshed from the cron.
+ * nexus_cache: the Nexus mod index, swept from the cron.
  *
- * Holds one row per mod we care about, which is the union of
- *   - every mod currently carrying the NCZoning tag (candidates), and
- *   - every location's numeric nexus_id (served images and update times).
+ * One row per mod, being the union of every NCZoning-tagged mod (the candidate
+ * pool) and every location's numeric nexus_id (served images and update times).
+ * Serves the four Nexus-derived `/v1` fields via a join on nexus_id, and backs
+ * the candidates list as a query rather than a live Nexus call on a public
+ * route.
  *
- * WHY THIS TABLE EARNS ITS KEEP
+ * ## Fetch every tick, write only what changed
  *
- * Before it, the four Nexus-derived served fields were fetched live on every
- * cron tick and resolved two different ways depending on `source`: auto records
- * carried their own images from the tagged query, manual ones came from a
- * separate modsByUid backfill (materialize.js:136, merge.js resolveThumbs).
- * One table collapses that to a single lookup, and it is what lets the
- * candidates list be a query instead of a live Nexus call on a public
- * unauthenticated route.
+ * D1's free tier allows 100k row-writes/day and the cron fires 288 times.
+ * Writing ~300 rows per tick is 86,400 writes/day, 86% of the cap before
+ * locations and audit rows. So a sweep writes only rows whose content differs
+ * from what is stored, and an unchanged tick costs nothing. Fetching is cheap
+ * either way: one GraphQL call for the whole tagged set plus batched modsByUid.
  *
- * THE WRITE BUDGET IS THE WHOLE DESIGN
+ * Same gate refresh.js applies to KV, and worth holding: the #849 heartbeat
+ * bypassed that gate and reinstated the per-tick cost it existed to remove
+ * (HEARTBEAT_MIN_INTERVAL_MS in config.js).
  *
- * D1's free tier allows 100k row-writes/day. The cron fires every 5 minutes,
- * so 288 times a day. Writing ~300 rows on every tick is 86,400 writes/day,
- * 86% of the cap, before locations writes and audit rows. That does not fit.
+ * Follows from the gate: **`fetched_at` is when the row last CHANGED**, not
+ * when it was last checked. A per-row checked-timestamp is the 86k writes being
+ * avoided. Sweep freshness is a dataset-level value.
  *
- * So: FETCH every tick (cheap: one GraphQL call for the whole tagged set, plus
- * batched modsByUid for the rest), but WRITE only rows whose content actually
- * changed. A tick where nothing changed on Nexus costs zero writes, and a mod's
- * name, images or file list change rarely.
+ * ## nexus_id is not unique across locations
  *
- * This is the same content-hash gate refresh.js already applies to KV, and the
- * reason to be strict about it is on the record: issue #849 added a liveness
- * heartbeat that deliberately bypassed that gate and reinstated the exact
- * per-tick write cost the gate existed to remove. HEARTBEAT_MIN_INTERVAL_MS in
- * config.js is the scar. This is the same mistake available at 86x the scale.
- *
- * Consequence, deliberately accepted: `fetched_at` means "when this row last
- * CHANGED", not "when we last checked". Storing a per-row checked-timestamp is
- * precisely the 86k writes being avoided. Sweep freshness is a dataset-level
- * value, not a per-row one.
- *
- * nexus_id IS NOT UNIQUE ACROSS LOCATIONS
- *
- * Measured 2026-07-27: 296 locations carry a numeric nexus_id and they use 295
- * distinct values. Mod 23896 ("Watson Tattoo Shops") supplies two locations,
- * Little China Pink Ink and Northside Tattoo & Body Mods, which is legitimate:
- * one mod can add two separate places, each deserving its own pin.
- *
- * So the join from here to `locations` is ONE-TO-MANY. Both locations read the
- * same images and the same upstream title, which is correct. Do not add a
+ * 296 locations carry a numeric nexus_id and use 295 distinct values: mod 23896
+ * supplies two separate tattoo shops. The join to `locations` is therefore
+ * ONE-TO-MANY, and both rows correctly read the same images. Do not add a
  * UNIQUE constraint on locations.nexus_id, and do not key a location lookup by
- * it.
+ * it (see #889).
  *
- * NAME IS NOT DERIVED FROM THIS TABLE, deliberately. 34 of 295 location names
- * differ from the Nexus title, and the differences are curation rather than
- * staleness: stripped version prefixes ("CP2.31 Cliffside Abode Player Home"),
- * stripped tool suffixes ("(World Builder)", "Worldbuilder"), stripped
- * marketing tails ("- REVOLUTION"), tidied whitespace. Serving `name` from
- * here would undo all of it. The stored title is for DETECTING a rename, by
- * comparing it against locations.name, not for replacing one.
+ * ## `name` is stored for comparison, never for display
  *
- * D1 BOUND PARAMETER LIMIT
+ * 34 of 295 location names differ from their Nexus title by curation rather
+ * than staleness, for example "CP2.31 Cliffside Abode Player Home" served as
+ * "Cliffside Abode Player Home". Serving this column would undo that. It exists
+ * so a rename can be detected by diffing it against locations.name.
  *
- * D1 allows exactly 100 bound parameters PER QUERY, measured, not documented
- * (learnings/d1-refuses-more-than-100-bound-parameters). Every write here goes
- * through DB.batch() as one statement per row, so each statement binds about
- * eight. Never assemble a single multi-row statement with one placeholder per
- * mod: at ~300 mods that throws on every call, and the browser reports it as a
- * CORS error rather than as the SQL error it is.
+ * ## D1 bound parameters
+ *
+ * The ceiling is 100 per query, measured
+ * (learnings/d1-refuses-more-than-100-bound-parameters). Writes go through
+ * DB.batch() as one statement per row, binding eight each. A single multi-row
+ * statement with a placeholder per mod throws on every call at this size, and
+ * surfaces in a browser as a CORS error rather than a SQL one.
  */
 
 import { fetchTaggedModNodes, fetchModsByUidThumbs } from './nexus.js';
@@ -236,11 +216,10 @@ export async function refreshNexusCache(env, { fetchImpl = fetch, nowIso } = {})
     .filter((id) => isRealNexusId(id) && !incoming.has(id));
 
   if (needBackfill.length) {
-    // fetchModsByUidThumbs NEVER throws: thumbnails are cosmetic, so it swallows
-    // and returns {} on any failure. A try/catch here would be dead code, and
-    // the empty object it returns on total failure is indistinguishable from a
-    // successful call that found nothing. So the check is on the COUNT against
-    // what was asked for, not on an exception that cannot arrive.
+    // Do not wrap this in a try/catch: fetchModsByUidThumbs never throws, it
+    // returns {} on failure because images are cosmetic. That empty object is
+    // indistinguishable from a successful call that found nothing, so the only
+    // usable signal is the count against what was requested.
     const thumbs = await fetchModsByUidThumbs(fetchImpl, needBackfill);
     for (const [id, t] of Object.entries(thumbs ?? {})) {
       incoming.set(String(id), {

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -106,6 +106,7 @@ const THUMBS_QUERY = `query modsByUid($uids: [ID!]!, $count: Int!) {
   modsByUid(uids: $uids, count: $count) {
     nodes {
       modId
+      name
       pictureUrl
       thumbnailUrl
       updatedAt
@@ -147,6 +148,7 @@ export async function fetchModsByUidThumbs(fetchImpl = fetch, numericIds = []) {
       const map = {};
       for (const node of nodes) {
         map[String(node.modId)] = {
+          name: node.name || null,
           pictureUrl: node.pictureUrl || null,
           thumbnailUrl: node.thumbnailUrl || null,
           updatedAt: node.updatedAt || null,

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -13,28 +13,20 @@
  * unit-testable with a fake KV + fake fetch.
  */
 
-import { fetchTaggedModNodes, fetchModsByUidThumbs, fetchModArchiveNames } from './nexus.js';
+import { fetchTaggedModNodes, fetchModsByUidThumbs } from './nexus.js';
 import { buildDataset } from './merge.js';
-import { materializeFromD1 } from './materialize.js';
+import { materializeFromD1, attachArchives } from './materialize.js';
+import { refreshNexusCache, refreshArchives, readNexusIndex } from './nexus-cache.js';
 import {
   readLocationRows, readDismissedIds, readTags, readLocationTags,
 } from './d1.js';
 import { districtsPayload } from './districts.js';
 import { HEARTBEAT_MIN_INTERVAL_MS } from './config.js';
 import {
-  KEYS, contentHash, readMeta, writeDataset, writeMeta, readArchives, writeArchives,
+  KEYS, contentHash, readMeta, writeDataset, writeMeta,
 } from './store.js';
 
 const SCHEMA_VERSION = 1;
-
-// Per-run limits on archive-name fetching. Archives are near-static (a mod's
-// .archive filenames only change on a re-upload, which bumps its updatedAt), so
-// steady state fetches nothing. These budgets cap the cold-start fill and any
-// re-upload burst so archive work can never breach the Worker's 50-subrequest
-// cap alongside the existing discovery + thumbnail calls. A cold cache fills
-// over ~ceil(mods / ARCHIVE_MOD_BUDGET) cron ticks.
-const ARCHIVE_MOD_BUDGET = 15; // max mods refreshed per run
-const ARCHIVE_SUBREQUEST_BUDGET = 25; // max archive subrequests per run
 
 /** Fetch a JSON file from the site origin; throws on non-200. */
 async function fetchJson(fetchImpl, origin, path) {
@@ -98,80 +90,58 @@ async function alertDiscordRecovered(env, fetchImpl) {
 }
 
 /**
- * Refresh the archive-name cache in place, budgeted. Mutates `cache`
- * ({ [nexus_id]: { updatedAt, archives } }) and returns { changed } so the
- * caller knows whether to persist it.
+ * Sweep `nexus_cache` and return the index the dataset is built against.
  *
- * A mod is refetched only when it's absent from the cache or its updatedAt moved
- * (the exact re-upload signal for its archive contents). Newest-updated mods are
- * refreshed first so a re-upload beats cold-fill for the budget. A transient
- * failure (ok:false) is left uncached so the next run retries, rather than
- * caching an empty/partial listing as final.
+ * The sweep never throws (a Nexus outage must leave last-known-good in place),
+ * so the only signal that it produced nothing usable is the index itself. What
+ * an empty one means depends on the source, so the caller judges it: see the
+ * guard in sourceAndBuild.
  */
-async function refreshArchives(fetchImpl, full, cache) {
-  const records = Object.values(full).filter((r) => /^\d+$/.test(r.nexus_id));
-
-  const stale = records
-    .filter((r) => {
-      const c = cache[r.nexus_id];
-      return !c || c.updatedAt !== (r.updated_at ?? null);
-    })
-    .sort((a, b) => String(b.updated_at ?? '').localeCompare(String(a.updated_at ?? '')));
-
-  let changed = false;
-  let refreshed = 0;
-  let okCount = 0;
-  let subrequests = 0;
-  for (const r of stale) {
-    if (refreshed >= ARCHIVE_MOD_BUDGET || subrequests >= ARCHIVE_SUBREQUEST_BUDGET) break;
-    const res = await fetchModArchiveNames(fetchImpl, r.nexus_id);
-    refreshed += 1;
-    subrequests += res.subrequests;
-    if (!res.ok) continue; // transient failure: leave stale, retry next run
-    okCount += 1;
-    cache[r.nexus_id] = { updatedAt: r.updated_at ?? null, archives: res.archives };
-    changed = true;
-  }
-  if (refreshed > 0) {
-    // Ops visibility for the cold-fill / re-upload catch-up (cf. the thumbnail
-    // warnings). Silent in steady state, when nothing is stale.
-    console.log(
-      `archives: refreshed ${okCount}/${refreshed} mods (${stale.length} stale, ${subrequests} subrequests), cache=${Object.keys(cache).length}`,
-    );
-  }
-
-  // Evict entries for mods no longer in the dataset (deleted/hidden on Nexus) so
-  // the cache can't grow without bound. No fetching, just set membership.
-  const live = new Set(records.map((r) => r.nexus_id));
-  for (const id of Object.keys(cache)) {
-    if (!live.has(id)) {
-      delete cache[id];
-      changed = true;
+async function sweepNexusCache(env, fetchImpl, nexusNodes, nowIso) {
+  try {
+    const sweep = await refreshNexusCache(env, { fetchImpl, taggedNodes: nexusNodes, nowIso });
+    if (sweep.written) {
+      console.log(
+        `nexus_cache: ${sweep.written} rows written (${sweep.tagged} tagged, `
+        + `${sweep.backfilled} backfilled, ${sweep.untagged} untagged)`,
+      );
     }
+    return await readNexusIndex(env);
+  } catch (err) {
+    // While production still builds from mods.json, D1 is not on its critical
+    // path and must not become so ahead of the cutover: a database problem may
+    // cost that environment its archives, never its freshness. Under
+    // DATA_SOURCE=d1 the registry read throws on its own account anyway.
+    if (env.DATA_SOURCE === 'd1') throw err;
+    console.warn('nexus_cache sweep failed (non-fatal on mods.json):', String(err).slice(0, 200));
+    return new Map();
   }
-
-  return { changed };
 }
 
 /**
- * Attach an `archives` string array to every full record (always present, `[]`
- * when unknown or not yet filled), refreshing the KV-backed cache first. Wrapped
- * so archive work can NEVER fail the refresh: on any error every record still
- * gets at least `[]`. Mutates `full` in place; run it before the content hash so
- * archive changes propagate to the ETag.
+ * Resolve and attach every record's `.archive` file names.
+ *
+ * Wrapped so archive work can NEVER fail the refresh, which is the posture the
+ * KV-backed version had: on any error every record still gets at least `[]`.
+ * Runs after the build because the served record set is what decides which mods
+ * need a listing, and before the content hash so a re-upload that changes only
+ * the file list still moves the ETag.
  */
-async function attachArchives(env, fetchImpl, full) {
-  let cache = {};
+async function fillArchives(env, fetchImpl, full, index, nowIso) {
   try {
-    cache = await readArchives(env);
-    const { changed } = await refreshArchives(fetchImpl, full, cache);
-    if (changed) await writeArchives(env, cache);
+    const r = await refreshArchives(env, fetchImpl, {
+      records: Object.values(full), index, nowIso,
+    });
+    if (r.fetched || r.seeded || r.pending) {
+      console.log(
+        `archives: +${r.fetched} fetched, +${r.seeded} carried over from KV, `
+        + `${r.pending} still due, ${r.written} rows written`,
+      );
+    }
   } catch (err) {
     console.warn('archive refresh failed (non-fatal):', String(err).slice(0, 200));
   }
-  for (const rec of Object.values(full)) {
-    rec.archives = cache[rec.nexus_id]?.archives ?? [];
-  }
+  attachArchives(full, index);
 }
 
 /**
@@ -191,8 +161,12 @@ async function attachArchives(env, fetchImpl, full) {
  * same `{ full, meta }` shape, which is what lets parity-ab.mjs diff them
  * head-to-head. tags/subdistricts still come from the site origin in both —
  * they move to D1 at Phase 4.
+ *
+ * `nexusNodes` and `nexusIndex` are passed in rather than fetched here: the
+ * sweep needs both before this runs, and the tagged query is one of the two
+ * expensive calls in the tick.
  */
-async function sourceAndBuild(env, fetchImpl, origin, nowMs) {
+async function sourceAndBuild(env, fetchImpl, origin, nowMs, { nexusNodes, nexusIndex }) {
   const useD1 = env.DATA_SOURCE === 'd1';
   const subdistricts = await fetchJson(fetchImpl, origin, '/data/subdistricts.json');
   const districts = subdistricts.districts;
@@ -210,23 +184,27 @@ async function sourceAndBuild(env, fetchImpl, origin, nowMs) {
       }));
   const tagsDict = Object.fromEntries(tagsList.map((t) => [t.slug, t.description]));
 
-  const nexusNodes = await fetchTaggedModNodes(fetchImpl);
-
   if (useD1) {
     const [rows, dismissed, locationTags] = await Promise.all([
       readLocationRows(env),
       readDismissedIds(env),
       readLocationTags(env),
     ]);
-    // Thumbnail backfill covers every published record with a numeric id, not
-    // just the "manual" ones: under D1 the auto-discovered records are rows too.
-    const numericIds = rows
-      .filter((r) => r.status === 'published')
-      .map((r) => String(r.nexus_id))
-      .filter((id) => /^\d+$/.test(id));
-    const manualThumbs = await fetchModsByUidThumbs(fetchImpl, numericIds);
+    // Checked here rather than at the sweep, so an empty registry reports
+    // itself first and this reads as what it is: there are records to serve and
+    // no images for any of them. Serving them anyway would pass the content
+    // hash and replace a good dataset with a stripped one. On the mods.json
+    // path this cannot arise, because merge.js images from its own modsByUid
+    // channel and an empty index costs only archives, which have always been
+    // allowed to degrade to `[]`.
+    if (nexusIndex.size === 0) {
+      throw new Error('nexus_cache is empty -- refusing to serve a dataset with no images');
+    }
+    // No modsByUid call here any more: the sweep has already resolved every
+    // published record's images into nexus_cache, including the auto-discovered
+    // ones, which are rows like any other under D1.
     const built = materializeFromD1({
-      rows, dismissed, tagsDict, nexusNodes, districts, manualThumbs, locationTags, nowMs,
+      rows, dismissed, tagsDict, nexusNodes, districts, nexusIndex, locationTags, nowMs,
     });
     return { ...built, tagsList, districts };
   }
@@ -268,19 +246,23 @@ export async function runRefresh(env, fetchImpl = fetch) {
   const generatedAt = new Date().toISOString();
 
   try {
+    // One tagged query per tick, shared by the sweep and the build. It throws
+    // on failure, which is the existing posture: the catch below keeps
+    // last-known-good, flags discovery_stale and alerts.
+    const nexusNodes = await fetchTaggedModNodes(fetchImpl);
+    const nexusIndex = await sweepNexusCache(env, fetchImpl, nexusNodes, generatedAt);
+
     // Thumbnails are cosmetic and non-throwing inside this: a failure there
     // leaves some images null for a cycle, it never marks the dataset stale.
     // A D1 read failure, by contrast, throws and lands in the catch below --
     // last-known-good, discovery_stale, alert. Never an empty map.
     const { full, meta, tagsList, districts } = await sourceAndBuild(
-      env, fetchImpl, origin, Date.parse(generatedAt),
+      env, fetchImpl, origin, Date.parse(generatedAt), { nexusNodes, nexusIndex },
     );
     const districtsOut = districtsPayload(districts);
 
-    // Enrich every record with its shipped .archive file names (installed-mod
-    // detection). Budgeted + updatedAt-gated, and non-fatal by construction, so
-    // it slots in before the hash without touching the failure posture below.
-    await attachArchives(env, fetchImpl, full);
+    // Each record's shipped .archive file names (installed-mod detection).
+    await fillArchives(env, fetchImpl, full, nexusIndex, generatedAt);
 
     // Hash the content that actually varies (not generated_at). Tags are
     // included so a tags.json edit propagates through the ETag. `full` carries

--- a/worker/src/store.js
+++ b/worker/src/store.js
@@ -13,10 +13,12 @@
  *                          which only moves on content change); /v1/health serves
  *                          it so a wedged cron can be detected (issue #849).
  * - dataset:v1:archives  { [nexus_id]: { updatedAt, archives: [name, ...] } }:
- *                        a persistent cache, NOT part of the served envelope.
- *                        The cron refetches a mod's archive names only when its
- *                        updatedAt moves (a re-upload), so this survives across
- *                        runs; see refresh.js for the budgeted fill.
+ *                        RETIRED. `nexus_cache.archives` in D1 holds this now.
+ *                        Read once more, by the sweep, to carry the existing
+ *                        entries across (including the hand-built listings from
+ *                        scripts/archive-seeds.json, which a refetch cannot
+ *                        reproduce for mods whose Nexus file preview is broken).
+ *                        Nothing writes it. Delete the key at cutover.
  *
  * dataset_version is a content hash: the cron writes only when it changes,
  * and it doubles as the ETag for the read path.
@@ -63,14 +65,10 @@ export async function writeMeta(env, meta) {
 }
 
 /**
- * Read the archive-name cache ({ [nexus_id]: { updatedAt, archives } }), or {}
- * before the first fill. This is a cross-run cache, not a served payload.
+ * Read the retired archive-name cache ({ [nexus_id]: { updatedAt, archives } }),
+ * or {} once it is gone. Carry-over only: see the key note above.
  */
 export async function readArchives(env) {
+  if (!env.DATASET) return {};
   return (await env.DATASET.get(KEYS.archives, 'json')) || {};
-}
-
-/** Persist the archive-name cache. The caller writes only when it changed. */
-export async function writeArchives(env, cache) {
-  await env.DATASET.put(KEYS.archives, JSON.stringify(cache));
 }

--- a/worker/test/admin.test.js
+++ b/worker/test/admin.test.js
@@ -65,7 +65,12 @@ function refreshFetch() {
     if (u.includes('api.nexusmods.com')) {
       const query = init?.body ? JSON.parse(init.body).query : '';
       if (query.includes('modsByUid')) {
-        return { ok: true, json: async () => ({ data: { modsByUid: { nodes: [] } } }) };
+        // Answers for the fixture's own mod. An empty answer here would leave
+        // nexus_cache with no rows at all, which the D1 build refuses rather
+        // than serving every record image-less.
+        return { ok: true, json: async () => ({ data: { modsByUid: { nodes: [
+          { modId: 12345, name: 'Existing Loft', pictureUrl: 'p', thumbnailUrl: 't', updatedAt: '2026-01-02T00:00:00Z' },
+        ] } } }) };
       }
       return { ok: true, json: async () => ({ data: { mods: { nodes: [], totalCount: 0 } } }) };
     }

--- a/worker/test/materialize.test.js
+++ b/worker/test/materialize.test.js
@@ -36,6 +36,11 @@ const build = (rows, over = {}) => materializeFromD1({
   nowMs: Date.parse('2026-01-10T00:00:00Z'), ...over,
 });
 
+/** readNexusIndex()'s shape, for the four Nexus-derived fields. */
+const index = (entries) => new Map(Object.entries(entries).map(([id, e]) => [id, {
+  thumbnailUrl: null, pictureUrl: null, updatedAt: null, archives: [], ...e,
+}]));
+
 test('a NULL z rebuilds the legacy 2-element coordinate pair, not [x, y, null]', () => {
   const { full } = build([row({ z: null })]);
   assert.deepEqual(full['aaaa-1111'].coordinates, [250, 250]);
@@ -107,14 +112,21 @@ test('a dismissed candidate is not even reported as skipped', () => {
   assert.deepEqual(meta.skipped, []);
 });
 
-test('an existing record suppresses its own re-creation and contributes thumbs', () => {
+test('an existing record suppresses its own re-creation, and is imaged from the index', () => {
+  // The tagged node still names a mod already on the map, and must not create a
+  // second record. What it no longer does is supply the images: those come from
+  // nexus_cache for every record, tagged or not, so there is one channel and no
+  // way for the two to disagree.
   const nexusNodes = [{
     modId: 12345, name: 'Alpha (Nexus page)', summary: 'dup',
     description: 'NCZoning:\ncoords=1,1\ncategory=other',
-    pictureUrl: 'pic', thumbnailUrl: 'thumb', updatedAt: '2026-01-08T00:00:00Z',
+    pictureUrl: 'node-pic', thumbnailUrl: 'node-thumb', updatedAt: '2026-01-08T00:00:00Z',
     uploader: { name: 'Spud' },
   }];
-  const { full } = build([row()], { nexusNodes });
+  const nexusIndex = index({
+    12345: { thumbnailUrl: 'thumb', pictureUrl: 'pic', updatedAt: '2026-01-08T00:00:00Z' },
+  });
+  const { full } = build([row()], { nexusNodes, nexusIndex });
   assert.equal(Object.keys(full).length, 1);
   assert.equal(full['aaaa-1111'].thumbnail_url, 'thumb');
   assert.equal(full['aaaa-1111'].picture_url, 'pic');
@@ -122,22 +134,36 @@ test('an existing record suppresses its own re-creation and contributes thumbs',
   assert.equal(full['aaaa-1111'].recently_updated, true);
 });
 
-test('recently_updated is false outside the window and for an unknown date', () => {
-  const stale = [{
-    modId: 12345, name: 'x', summary: '', description: '',
-    updatedAt: '2025-01-01T00:00:00Z', uploader: { name: 'Spud' },
+test('a tagged node cannot image a record on its own', () => {
+  // Negative control for the test above: the same node, no index entry. If the
+  // node channel were still wired up this would leak 'node-thumb'.
+  const nexusNodes = [{
+    modId: 12345, name: 'Alpha (Nexus page)', summary: '', description: '',
+    pictureUrl: 'node-pic', thumbnailUrl: 'node-thumb', uploader: { name: 'Spud' },
   }];
-  assert.equal(build([row()], { nexusNodes: stale }).full['aaaa-1111'].recently_updated, false);
-  // No node at all: updated_at null, so the bool is false rather than NaN-ish.
+  const { full } = build([row()], { nexusNodes });
+  assert.equal(full['aaaa-1111'].thumbnail_url, null);
+});
+
+test('recently_updated is false outside the window and for an unknown date', () => {
+  const stale = index({ 12345: { updatedAt: '2025-01-01T00:00:00Z' } });
+  assert.equal(build([row()], { nexusIndex: stale }).full['aaaa-1111'].recently_updated, false);
+  // No index entry at all: updated_at null, so the bool is false rather than
+  // NaN-ish.
   assert.equal(build([row()]).full['aaaa-1111'].recently_updated, false);
 });
 
-test('WIP and Dummy nexus ids never match a Nexus node', () => {
+test('a WIP record stays image-less rather than borrowing another mod images', () => {
+  // The index is keyed by real mod id and never carries a placeholder (the
+  // sweep refuses to write one -- asserted in nexus-cache.test.js), so a WIP
+  // record simply misses. The populated 12345 entry is here so a miss is
+  // distinguishable from a lookup that finds nothing for anyone.
+  const nexusIndex = index({ 12345: { thumbnailUrl: 'thumb' } });
   const nexusNodes = [{
     modId: 'WIP', name: 'nope', summary: '', description: '',
     thumbnailUrl: 'leaked', uploader: { name: 'x' },
   }];
-  const { full } = build([row({ nexus_id: 'WIP' })], { nexusNodes });
+  const { full } = build([row({ nexus_id: 'WIP' })], { nexusNodes, nexusIndex });
   assert.equal(full['aaaa-1111'].thumbnail_url, null);
 });
 

--- a/worker/test/nexus-cache.test.js
+++ b/worker/test/nexus-cache.test.js
@@ -1,0 +1,177 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sqliteD1 } from '../test-support/d1-sqlite.mjs';
+import { refreshNexusCache, readNexusCache, readCandidates, diffRows } from '../src/nexus-cache.js';
+
+// Real SQLite running the real migrations, so 0003 is exercised here rather
+// than asserted about. The harness also enforces D1's 100 bound parameter
+// ceiling inside batch(), which is what makes the large-sweep test below a real
+// check and not a restatement of the belief it was written from.
+// See learnings/d1-refuses-more-than-100-bound-parameters.
+
+const NOW = '2026-07-27T00:00:00.000Z';
+
+/** A fetch that answers the tagged query, then modsByUid, from fixtures. */
+function fakeNexus({ tagged = [], byUid = {}, taggedFails = false, byUidFails = false } = {}) {
+  let calls = 0;
+  const impl = async (_url, init) => {
+    calls += 1;
+    const body = JSON.parse(init.body);
+    const isTagged = body.query.includes('NCZoningMods');
+    if (isTagged) {
+      if (taggedFails) return { ok: false, status: 503, async json() { return {}; } };
+      return {
+        ok: true,
+        async json() {
+          return { data: { mods: { nodes: tagged, totalCount: tagged.length } } };
+        },
+      };
+    }
+    if (byUidFails) return { ok: false, status: 503, async json() { return {}; } };
+    const wanted = body.variables.uids.length;
+    const nodes = Object.entries(byUid).map(([modId, v]) => ({ modId, ...v })).slice(0, wanted);
+    return { ok: true, async json() { return { data: { modsByUid: { nodes } } }; } };
+  };
+  impl.calls = () => calls;
+  return impl;
+}
+
+const node = (modId, over = {}) => ({
+  modId,
+  name: `Mod ${modId}`,
+  description: '',
+  pictureUrl: `https://img/${modId}-p.jpg`,
+  thumbnailUrl: `https://img/${modId}-t.jpg`,
+  updatedAt: '2026-07-01T00:00:00.000Z',
+  ...over,
+});
+
+const location = (id, nexusId) => ({
+  id, name: `Loc ${id}`, nexus_id: nexusId, category: 'new-location',
+  x: 0, y: 0, z: 0, authors: '["a"]', description: '', source: 'manual',
+  status: 'published', created_at: NOW, updated_at: NOW,
+});
+
+// --------------------------------------------------------------- write gate ---
+// The whole design rests on this: ~300 mods on 288 daily ticks is 86,400
+// row-writes against a 100k/day free-tier cap, so a sweep that finds nothing
+// changed must cost zero writes.
+
+test('a second identical sweep writes nothing', async () => {
+  const env = { DB: sqliteD1({ locations: [location('l1', '100')] }) };
+  const fetchImpl = fakeNexus({ tagged: [node('100'), node('200')] });
+
+  const first = await refreshNexusCache(env, { fetchImpl, nowIso: NOW });
+  assert.equal(first.written, 2, 'first sweep should write both rows');
+
+  const second = await refreshNexusCache(env, { fetchImpl, nowIso: '2026-07-27T00:05:00.000Z' });
+  assert.equal(second.written, 0, 'an unchanged sweep must not write, or the cron burns the D1 budget');
+});
+
+test('a changed field is written, an unchanged one is not', async () => {
+  const env = { DB: sqliteD1() };
+  await refreshNexusCache(env, { fetchImpl: fakeNexus({ tagged: [node('100'), node('200')] }), nowIso: NOW });
+
+  const renamed = fakeNexus({ tagged: [node('100', { name: 'Renamed' }), node('200')] });
+  const r = await refreshNexusCache(env, { fetchImpl: renamed, nowIso: NOW });
+  assert.equal(r.written, 1, 'only the renamed mod should be written');
+
+  const cache = await readNexusCache(env);
+  assert.equal(cache.get('100').name, 'Renamed');
+  assert.equal(cache.get('200').name, 'Mod 200');
+});
+
+test('diffRows treats undefined as "not resolved" and null as "cleared"', () => {
+  const existing = new Map([['1', { nexus_id: '1', name: 'A', thumbnail_url: 'x', nczoning_tagged: 1 }]]);
+  assert.equal(diffRows([{ nexus_id: '1', name: undefined }], existing).length, 0,
+    'an unresolved field must not count as a change, or every sweep writes everything');
+  assert.equal(diffRows([{ nexus_id: '1', thumbnail_url: null }], existing).length, 1,
+    'an image removed on Nexus must clear here');
+  assert.equal(diffRows([{ nexus_id: '2', name: 'New' }], existing).length, 1,
+    'an unseen mod is always a write');
+});
+
+// ------------------------------------------------------------------ tagging ---
+
+test('a mod that loses the NCZoning tag stops being a candidate', async () => {
+  const env = { DB: sqliteD1() };
+  await refreshNexusCache(env, { fetchImpl: fakeNexus({ tagged: [node('100'), node('200')] }), nowIso: NOW });
+  assert.deepEqual((await readCandidates(env)).map((c) => c.nexus_id), ['100', '200']);
+
+  const r = await refreshNexusCache(env, { fetchImpl: fakeNexus({ tagged: [node('100')] }), nowIso: NOW });
+  assert.equal(r.untagged, 1);
+  assert.deepEqual((await readCandidates(env)).map((c) => c.nexus_id), ['100'],
+    'an untagged mod left in candidates would sit there forever');
+
+  // The row survives, so a location built from it keeps its images.
+  assert.ok((await readNexusCache(env)).has('200'));
+});
+
+test('candidates exclude locations and dismissed mods', async () => {
+  const env = { DB: sqliteD1({ locations: [location('l1', '100')] }) };
+  env.DB._db.prepare(
+    'INSERT INTO dismissed_candidates (nexus_id, reason, dismissed_by, dismissed_at) VALUES (?, ?, ?, ?)',
+  ).run('200', 'not a location', 'tester', NOW);
+
+  await refreshNexusCache(env, {
+    fetchImpl: fakeNexus({ tagged: [node('100'), node('200'), node('300')] }), nowIso: NOW,
+  });
+
+  assert.deepEqual((await readCandidates(env)).map((c) => c.nexus_id), ['300'],
+    '100 is already a location, 200 was dismissed');
+});
+
+// ------------------------------------------------------------------- limits ---
+
+test('a sweep of 300 mods stays inside D1 bound parameter limits', async () => {
+  // The harness throws D1_ERROR above 100 binds per statement, exactly as D1
+  // does. A single multi-row INSERT would fail here, which is the point.
+  const env = { DB: sqliteD1() };
+  const many = Array.from({ length: 300 }, (_, i) => node(String(1000 + i)));
+  const r = await refreshNexusCache(env, { fetchImpl: fakeNexus({ tagged: many }), nowIso: NOW });
+  assert.equal(r.written, 300);
+  assert.equal((await readNexusCache(env)).size, 300);
+});
+
+// ----------------------------------------------------------------- failures ---
+
+test('a tagged-query failure leaves the cache untouched and reports stale', async () => {
+  const env = { DB: sqliteD1() };
+  await refreshNexusCache(env, { fetchImpl: fakeNexus({ tagged: [node('100')] }), nowIso: NOW });
+
+  const r = await refreshNexusCache(env, { fetchImpl: fakeNexus({ taggedFails: true }), nowIso: NOW });
+  assert.equal(r.stale, true);
+  assert.equal(r.written, 0);
+  assert.equal((await readNexusCache(env)).get('100').name, 'Mod 100',
+    'last known good must survive a Nexus outage');
+});
+
+test('a backfill that returns nothing is reported, not read as a clean sweep', async () => {
+  // fetchModsByUidThumbs never throws: it swallows and returns {}. So a total
+  // failure is byte-identical to "found nothing", and only the count against
+  // what was requested can tell them apart.
+  const env = { DB: sqliteD1({ locations: [location('l1', '900')] }) };
+  const r = await refreshNexusCache(env, {
+    fetchImpl: fakeNexus({ tagged: [node('100')], byUidFails: true }), nowIso: NOW,
+  });
+  assert.equal(r.backfill_requested, 1);
+  assert.equal(r.backfilled, 0);
+  assert.equal(r.stale, true, 'a silent empty backfill must not report success');
+});
+
+test('a location that is not tagged still gets its images backfilled', async () => {
+  const env = { DB: sqliteD1({ locations: [location('l1', '900')] }) };
+  const r = await refreshNexusCache(env, {
+    fetchImpl: fakeNexus({
+      tagged: [node('100')],
+      byUid: { 900: { name: 'Manual Mod', pictureUrl: 'p', thumbnailUrl: 't', updatedAt: NOW } },
+    }),
+    nowIso: NOW,
+  });
+  assert.equal(r.backfilled, 1);
+  assert.equal(r.stale, false);
+
+  const row = (await readNexusCache(env)).get('900');
+  assert.equal(row.name, 'Manual Mod');
+  assert.equal(row.nczoning_tagged, 0, 'backfilled locations are not candidates');
+});

--- a/worker/test/nexus-cache.test.js
+++ b/worker/test/nexus-cache.test.js
@@ -1,7 +1,10 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { sqliteD1 } from '../test-support/d1-sqlite.mjs';
-import { refreshNexusCache, readNexusCache, readCandidates, diffRows } from '../src/nexus-cache.js';
+import {
+  refreshNexusCache, refreshArchives, readNexusCache, readNexusIndex,
+  readCandidates, diffRows,
+} from '../src/nexus-cache.js';
 
 // Real SQLite running the real migrations, so 0003 is exercised here rather
 // than asserted about. The harness also enforces D1's 100 bound parameter
@@ -169,6 +172,218 @@ test('a backfill that returns nothing is reported, not read as a clean sweep', a
   assert.equal(r.backfill_requested, 1);
   assert.equal(r.backfilled, 0);
   assert.equal(r.stale, true, 'a silent empty backfill must not report success');
+});
+
+// ------------------------------------------------------------- archives ---
+// The file listing behind installed-mod detection. Its own pass, because the
+// mods that need one are the records the dataset serves, which is not the
+// `locations` table while production still builds from mods.json.
+
+/** A fetch answering the two archive endpoints for any mod. */
+function fakeArchiveFetch({ fail = false, files = 1, calls = [] } = {}) {
+  const impl = async (url, init) => {
+    if (String(url).includes('api-router.nexusmods.com')) {
+      calls.push(`router:${JSON.parse(init.body).variables.modId}`);
+      if (fail) return { ok: false, status: 503 };
+      return {
+        ok: true,
+        async json() {
+          return { data: { modFiles: Array.from({ length: files }, (_, i) => ({ uri: `f${i}.7z`, category: 'MAIN' })) } };
+        },
+      };
+    }
+    if (String(url).includes('file-metadata.nexusmods.com')) {
+      // Deliberately not restricted to numeric ids: if this only answered for
+      // real mods, a test that a placeholder id is refused would pass because
+      // the stub declined it rather than because the code did.
+      const modId = String(url).match(/\/3333\/([^/]+)\//)[1];
+      calls.push(`file:${modId}`);
+      return {
+        ok: true,
+        async json() {
+          return { children: [{ name: 'archive', type: 'directory', children: [
+            { name: 'pc', type: 'directory', children: [
+              { name: 'mod', type: 'directory', children: [
+                { name: `mod_${modId}.archive`, type: 'file', path: `archive/pc/mod/mod_${modId}.archive` },
+              ] },
+            ] },
+          ] }] };
+        },
+      };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  impl.calls = calls;
+  return impl;
+}
+
+const record = (nexusId, updatedAt = '2026-07-01T00:00:00.000Z') => ({
+  nexus_id: nexusId, updated_at: updatedAt,
+});
+
+test('a listing is fetched once and then reused until the mod re-uploads', async () => {
+  const env = { DB: sqliteD1(), DATASET: null };
+  const index = await readNexusIndex(env);
+  const calls = [];
+
+  const first = await refreshArchives(env, fakeArchiveFetch({ calls }), {
+    records: [record('100')], index, nowIso: NOW,
+  });
+  assert.equal(first.fetched, 1);
+  assert.equal(first.written, 1);
+  assert.deepEqual(index.get('100').archives, ['mod_100.archive']);
+
+  // Same updated_at: nothing due, so no subrequest and no row write. This is
+  // the whole reason archives are affordable on a 5-minute cron.
+  const stored = await readNexusIndex(env);
+  const second = await refreshArchives(env, fakeArchiveFetch({ calls: [] }), {
+    records: [record('100')], index: stored, nowIso: NOW,
+  });
+  assert.equal(second.fetched, 0);
+  assert.equal(second.written, 0);
+  assert.deepEqual(stored.get('100').archives, ['mod_100.archive']);
+
+  // A re-upload moves updated_at, which is the refetch signal.
+  const third = await refreshArchives(env, fakeArchiveFetch({ calls: [] }), {
+    records: [record('100', '2026-07-20T00:00:00.000Z')], index: stored, nowIso: NOW,
+  });
+  assert.equal(third.fetched, 1, 'a re-upload must refetch, or the listing goes stale forever');
+  assert.equal(
+    env.DB.one('SELECT archives_at FROM nexus_cache WHERE nexus_id = ?', '100').archives_at,
+    '2026-07-20T00:00:00.000Z',
+  );
+});
+
+test('a mod that ships no .archive is not refetched every tick', async () => {
+  // `archives: []` is a real answer, so the array alone cannot say whether the
+  // listing has ever been read. Without archives_known this mod would be due on
+  // every single tick, at two subrequests a time, forever.
+  const env = { DB: sqliteD1(), DATASET: null };
+  const empty = fakeArchiveFetch({ files: 0 });
+  const index = await readNexusIndex(env);
+  await refreshArchives(env, empty, { records: [record('100')], index, nowIso: NOW });
+  assert.deepEqual(index.get('100').archives, []);
+
+  const calls = [];
+  const again = await refreshArchives(env, fakeArchiveFetch({ calls }), {
+    records: [record('100')], index: await readNexusIndex(env), nowIso: NOW,
+  });
+  assert.equal(again.fetched, 0);
+  assert.equal(calls.length, 0);
+});
+
+test('a transient failure stores nothing, so the next tick retries', async () => {
+  const env = { DB: sqliteD1(), DATASET: null };
+  const index = await readNexusIndex(env);
+  const failed = await refreshArchives(env, fakeArchiveFetch({ fail: true }), {
+    records: [record('100')], index, nowIso: NOW,
+  });
+  assert.equal(failed.fetched, 0);
+  assert.equal(failed.written, 0, 'caching a failed read would make it permanent');
+  assert.equal(failed.pending, 1);
+
+  const ok = await refreshArchives(env, fakeArchiveFetch(), {
+    records: [record('100')], index: await readNexusIndex(env), nowIso: NOW,
+  });
+  assert.equal(ok.fetched, 1);
+});
+
+test('the KV blob is carried over instead of refetched, and only while it is current', async () => {
+  // scripts/archive-seeds.json holds hand-built listings for mods whose Nexus
+  // file preview is broken. A refetch replaces those with nothing, so the
+  // carry-over is not just a cold-start optimisation.
+  const env = {
+    DB: sqliteD1(),
+    DATASET: {
+      async get() {
+        return {
+          100: { updatedAt: '2026-07-01T00:00:00.000Z', archives: ['hand_built.archive'] },
+          200: { updatedAt: '2020-01-01T00:00:00.000Z', archives: ['ancient.archive'] },
+        };
+      },
+    },
+  };
+  const calls = [];
+  const r = await refreshArchives(env, fakeArchiveFetch({ calls }), {
+    records: [record('100'), record('200')], index: await readNexusIndex(env), nowIso: NOW,
+  });
+
+  assert.equal(r.seeded, 1);
+  assert.equal(calls.some((c) => c.startsWith('router:100')), false,
+    'a current seed must not be refetched, or the hand-built listing is lost');
+  assert.equal(r.fetched, 1, 'the stale seed is refetched rather than trusted');
+  assert.deepEqual(
+    JSON.parse(env.DB.one('SELECT archives FROM nexus_cache WHERE nexus_id = ?', '100').archives),
+    ['hand_built.archive'],
+  );
+  assert.deepEqual(
+    JSON.parse(env.DB.one('SELECT archives FROM nexus_cache WHERE nexus_id = ?', '200').archives),
+    ['mod_200.archive'],
+  );
+});
+
+test('archive work is budgeted per tick and cold-fills across ticks', async () => {
+  const env = { DB: sqliteD1(), DATASET: null };
+  const records = Array.from({ length: 40 }, (_, i) => record(String(1000 + i)));
+
+  const first = await refreshArchives(env, fakeArchiveFetch(), {
+    records, index: await readNexusIndex(env), nowIso: NOW,
+  });
+  assert.ok(first.fetched < 40, `fetched ${first.fetched}: the budget must cap a cold fill`);
+  assert.equal(first.pending, 40 - first.fetched);
+
+  let done = first.fetched;
+  for (let tick = 0; tick < 6 && done < 40; tick += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    done += (await refreshArchives(env, fakeArchiveFetch(), {
+      records, index: await readNexusIndex(env), nowIso: NOW,
+    })).fetched;
+  }
+  assert.equal(done, 40, 'the fill must complete, one budget at a time');
+
+  const settled = await refreshArchives(env, fakeArchiveFetch(), {
+    records, index: await readNexusIndex(env), nowIso: NOW,
+  });
+  assert.equal(settled.fetched, 0);
+  assert.equal(settled.written, 0, 'steady state costs no D1 write at all');
+});
+
+test('an archives-only write leaves the NCZoning tag flag alone', async () => {
+  // writeRows sets nczoning_tagged unconditionally, so an archive write that
+  // did not carry the flag would silently drop the mod out of candidates.
+  const env = { DB: sqliteD1(), DATASET: null };
+  await refreshNexusCache(env, { fetchImpl: fakeNexus({ tagged: [node('100')] }), nowIso: NOW });
+  assert.deepEqual((await readCandidates(env)).map((c) => c.nexus_id), ['100']);
+
+  await refreshArchives(env, fakeArchiveFetch(), {
+    records: [record('100')], index: await readNexusIndex(env), nowIso: NOW,
+  });
+  assert.deepEqual((await readCandidates(env)).map((c) => c.nexus_id), ['100'],
+    'the mod is still tagged, and still not a location');
+});
+
+test('placeholder nexus ids are never written as rows', async () => {
+  // Nexus is stubbed to answer for these ids, so the only thing that can keep
+  // them out of the table is the code refusing to ask.
+  const env = { DB: sqliteD1({ locations: [location('l1', 'WIP'), location('l2', 'Dummy')] }) };
+  const calls = [];
+  await refreshNexusCache(env, { fetchImpl: fakeNexus({ tagged: [] }), nowIso: NOW });
+  await refreshArchives(env, fakeArchiveFetch({ calls }), {
+    records: [record('WIP'), record('Dummy')], index: await readNexusIndex(env), nowIso: NOW,
+  });
+  assert.deepEqual(calls, [], 'a placeholder is not a mod id and must not be looked up');
+  assert.equal((await readNexusCache(env)).size, 0,
+    'WIP and Dummy are placeholders, not mods; a row for one could be joined to');
+});
+
+test('readNexusIndex survives a malformed archives cell', async () => {
+  const env = { DB: sqliteD1() };
+  env.DB._db.prepare(
+    'INSERT INTO nexus_cache (nexus_id, archives, fetched_at) VALUES (?, ?, ?)',
+  ).run('100', 'not json', NOW);
+  const index = await readNexusIndex(env);
+  assert.deepEqual(index.get('100').archives, [],
+    'one unreadable cell must not take the whole refresh into last-known-good');
 });
 
 test('a location that is not tagged still gets its images backfilled', async () => {

--- a/worker/test/nexus-cache.test.js
+++ b/worker/test/nexus-cache.test.js
@@ -121,6 +121,18 @@ test('candidates exclude locations and dismissed mods', async () => {
     '100 is already a location, 200 was dismissed');
 });
 
+test('one mod supplying two locations is still one cache row and not a candidate', async () => {
+  // Measured on the live data: mod 23896 supplies both Watson Tattoo Shops
+  // pins. The join is one-to-many, so a NOT IN anti-join must still exclude it
+  // rather than counting it twice or letting it back into candidates.
+  const env = { DB: sqliteD1({ locations: [location('l1', '100'), location('l2', '100')] }) };
+  await refreshNexusCache(env, { fetchImpl: fakeNexus({ tagged: [node('100'), node('300')] }), nowIso: NOW });
+
+  assert.equal((await readNexusCache(env)).size, 2, 'two locations share one cache row');
+  assert.deepEqual((await readCandidates(env)).map((c) => c.nexus_id), ['300'],
+    'a mod with two locations is still already on the map');
+});
+
 // ------------------------------------------------------------------- limits ---
 
 test('a sweep of 300 mods stays inside D1 bound parameter limits', async () => {

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -67,13 +67,23 @@ function uidFetch(responses) {
     return { ok: r.ok ?? true, status: r.status ?? 200, json: async () => r.json };
   };
 }
-const uidNode = (i) => ({ modId: i, pictureUrl: `p${i}`, thumbnailUrl: `t${i}`, updatedAt: `u${i}` });
+const uidNode = (i) => ({
+  modId: i, name: `n${i}`, pictureUrl: `p${i}`, thumbnailUrl: `t${i}`, updatedAt: `u${i}`,
+});
 
 test('modsByUid: returns a thumb map keyed by modId', async () => {
   const impl = uidFetch([{ json: { data: { modsByUid: { nodes: [uidNode(1), uidNode(2)] } } } }]);
   const map = await fetchModsByUidThumbs(impl, ['1', '2']);
-  assert.deepEqual(map['1'], { pictureUrl: 'p1', thumbnailUrl: 't1', updatedAt: 'u1' });
-  assert.deepEqual(map['2'], { pictureUrl: 'p2', thumbnailUrl: 't2', updatedAt: 'u2' });
+  assert.deepEqual(map['1'], { name: 'n1', pictureUrl: 'p1', thumbnailUrl: 't1', updatedAt: 'u1' });
+  assert.deepEqual(map['2'], { name: 'n2', pictureUrl: 'p2', thumbnailUrl: 't2', updatedAt: 'u2' });
+});
+
+test('modsByUid: a mod with no name yields null rather than dropping the key', async () => {
+  // nexus_cache stores this, and `undefined` is not a legal D1 bind. The shape
+  // has to stay stable whether or not Nexus supplied a name.
+  const impl = uidFetch([{ json: { data: { modsByUid: { nodes: [{ modId: 1, pictureUrl: 'p1' }] } } } }]);
+  const map = await fetchModsByUidThumbs(impl, ['1']);
+  assert.equal(map['1'].name, null);
 });
 
 test('modsByUid: skips non-numeric ids and never fetches for an empty set', async () => {

--- a/worker/test/refresh-d1.test.js
+++ b/worker/test/refresh-d1.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { runRefresh } from '../src/refresh.js';
 import { KEYS } from '../src/store.js';
+import { sqliteD1 } from '../test-support/d1-sqlite.mjs';
 
 // Phase 2: the cron sourcing from D1 instead of mods.json. The load-bearing
 // test here is `both sources produce an identical dataset` -- the unit-scale
@@ -85,8 +86,10 @@ const NEXUS_PAGE = {
  * @param {object} opts
  * @param {boolean} opts.banModsJson  throw if /mods.json is fetched -- proves
  *   the D1 path does not quietly keep reading the file it replaced.
+ * @param {boolean} opts.nexusKnowsNothing  Nexus answers both queries with an
+ *   empty node list, so nothing lands in nexus_cache.
  */
-function fakeFetch({ banModsJson = false } = {}) {
+function fakeFetch({ banModsJson = false, nexusKnowsNothing = false } = {}) {
   return async (url, init) => {
     if (url.includes('/mods.json')) {
       if (banModsJson) throw new Error('D1 mode must not fetch mods.json');
@@ -100,10 +103,13 @@ function fakeFetch({ banModsJson = false } = {}) {
     if (url.includes('api.nexusmods.com')) {
       if (JSON.parse(init.body).query.includes('modsByUid')) {
         return { ok: true, json: async () => ({
-          data: { modsByUid: { nodes: [
+          data: { modsByUid: { nodes: nexusKnowsNothing ? [] : [
             { modId: 12345, pictureUrl: 'pm', thumbnailUrl: 'tm', updatedAt: '2026-07-08' },
           ] } },
         }) };
+      }
+      if (nexusKnowsNothing) {
+        return { ok: true, json: async () => ({ data: { mods: { nodes: [], totalCount: 0 } } }) };
       }
       return { ok: true, json: async () => NEXUS_PAGE };
     }
@@ -112,35 +118,38 @@ function fakeFetch({ banModsJson = false } = {}) {
   };
 }
 
-// The tag registry and the join, mirroring migration 0002. `nczoning` is
-// absent from both, exactly as in the real schema — the materializer re-adds it
-// for auto-sourced records.
-const TAG_ROWS = [
-  { slug: 'apartment', name: null, description: 'a place', sort_order: 1 },
-  { slug: 'corpo', name: null, description: 'suits', sort_order: 2 },
-];
-const LOCATION_TAG_ROWS = [{ location_id: 'm1', tag_slug: 'apartment' }];
-
+// Real SQLite on the real migrations, not a substring-matching mock. The cron
+// now sweeps `nexus_cache` as well as reading the registry, and a mock that
+// answers by matching SQL fragments can only restate the belief it was written
+// from -- it cannot show that an upsert, a foreign key or a bound-parameter
+// count behaves as D1 does.
+//
+// `apartment` is a real registry slug, so migration 0002 already seeds it and
+// location_tags.tag_slug (a real foreign key here) resolves. Those 14 rows also
+// mean the D1 path serves a longer /v1/tags than the mods.json fixture; the
+// parity test below compares the record set, which is unaffected.
 function fakeD1({
   rows = ROWS, dismissed = [{ nexus_id: '777' }], count, fail = false,
-  tagRows = TAG_ROWS, locationTagRows = LOCATION_TAG_ROWS,
 } = {}) {
+  const db = sqliteD1({
+    locations: rows,
+    locationTags: rows.some((r) => r.id === 'm1') ? [['m1', 'apartment']] : [],
+  });
+  for (const d of dismissed) {
+    db._db.prepare(
+      'INSERT INTO dismissed_candidates (nexus_id, reason, dismissed_by, dismissed_at) VALUES (?, ?, ?, ?)',
+    ).run(String(d.nexus_id), null, 'test', '2026-01-01T00:00:00Z');
+  }
   return {
+    ...db,
     prepare(sql) {
-      return {
-        async all() {
-          if (fail) throw new Error('D1 unavailable');
-          if (sql.includes('dismissed_candidates')) return { results: dismissed };
-          // Checked before `FROM locations`: "FROM location_tags" contains it.
-          if (sql.includes('FROM location_tags')) return { results: locationTagRows };
-          if (sql.includes('FROM tags')) return { results: tagRows };
-          return { results: rows };
-        },
-        async first() {
-          if (fail) throw new Error('D1 unavailable');
-          return { n: count ?? rows.length };
-        },
-      };
+      if (fail) throw new Error('D1 unavailable');
+      // The truncation fault: a result set that disagrees with the database's
+      // own COUNT(*), which is the failure that otherwise looks like success.
+      if (count !== undefined && sql.includes('COUNT(*)')) {
+        return { ...db.prepare(sql), async first() { return { n: count }; } };
+      }
+      return db.prepare(sql);
     },
   };
 }
@@ -217,6 +226,19 @@ test('a truncated result set fails the refresh rather than shrinking the map', a
   const r = await runRefresh(env, fakeFetch());
   assert.equal(r.stale, true);
   assert.match(r.error, /COUNT\(\*\)/);
+});
+
+test('an empty nexus_cache is refused rather than served image-less', async () => {
+  // Cold table plus a Nexus that answers nothing: every record would serve with
+  // thumbnail_url, picture_url and updated_at all null. That hashes cleanly and
+  // would replace a good dataset with a stripped one, so it must fail into
+  // last-known-good instead.
+  const env = {
+    DATASET: fakeKV(), DB: fakeD1(), SITE_ORIGIN: 'https://x', DATA_SOURCE: 'd1',
+  };
+  const r = await runRefresh(env, fakeFetch({ nexusKnowsNothing: true }));
+  assert.equal(r.stale, true);
+  assert.match(r.error, /nexus_cache is empty/);
 });
 
 test('an empty locations table is refused, not materialized', async () => {

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { runRefresh } from '../src/refresh.js';
 import { KEYS } from '../src/store.js';
+import { sqliteD1 } from '../test-support/d1-sqlite.mjs';
 
 // Minimal in-memory KV: get(key, 'json') + put(key, string). `_putCount` exists
 // because KV writes are the scarce resource here (1,000/day per ACCOUNT), so
@@ -21,6 +22,14 @@ function fakeKV(initial = {}) {
     _putCount: () => puts,
   };
 }
+
+// Production binds D1 in every environment, including the one still building
+// from mods.json: the cron sweeps `nexus_cache` either way, and archive
+// listings persist there rather than in KV. An env without DB is a separate
+// case, asserted in refresh-d1.test.js.
+const newEnv = (over = {}) => ({
+  DATASET: fakeKV(), DB: sqliteD1(), SITE_ORIGIN: 'https://x', ...over,
+});
 
 const TAGS = { apartment: 'a place', corpo: 'suits' };
 const EXCLUDED = { 777: 'mistagged' };
@@ -114,7 +123,7 @@ function fakeFetch({ failNexus = false, failMods = false, discordSink, archiveCa
 }
 
 test('first run writes the full dataset (changed=true)', async () => {
-  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = newEnv();
   const r = await runRefresh(env, fakeFetch());
   assert.equal(r.changed, true);
   assert.ok(r.version);
@@ -130,15 +139,30 @@ test('first run writes the full dataset (changed=true)', async () => {
 });
 
 test('manual-mod images are backfilled into full via modsByUid', async () => {
-  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = newEnv();
   await runRefresh(env, fakeFetch());
   const full = await env.DATASET.get(KEYS.full, 'json');
   assert.equal(full.m1.thumbnail_url, 'tm'); // manual mod 12345, not NCZoning-tagged
   assert.equal(full.m1.updated_at, '2026-07-08');
 });
 
+test('the tagged query is fetched once per tick, not once per consumer', async () => {
+  // The sweep and the dataset build both need the NCZoning tag set. Fetching it
+  // twice would double the tick's most expensive Nexus call for nothing, and
+  // would let the two see different answers if a mod were tagged in between.
+  const env = newEnv();
+  let tagged = 0;
+  const counting = (inner) => async (url, init) => {
+    if (String(url).includes('api.nexusmods.com')
+      && !JSON.parse(init.body).query.includes('modsByUid')) tagged += 1;
+    return inner(url, init);
+  };
+  await runRefresh(env, counting(fakeFetch()));
+  assert.equal(tagged, 1);
+});
+
 test('unchanged content on the second run skips the content write (changed=false)', async () => {
-  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = newEnv();
   await runRefresh(env, fakeFetch());
   const before = (await env.DATASET.get(KEYS.meta, 'json')).generated_at;
   const r2 = await runRefresh(env, fakeFetch());
@@ -149,7 +173,7 @@ test('unchanged content on the second run skips the content write (changed=false
 });
 
 test('an unchanged cycle advances the heartbeat once the interval has elapsed', async () => {
-  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = newEnv();
   await runRefresh(env, fakeFetch());
   const m1 = await env.DATASET.get(KEYS.meta, 'json');
   assert.ok(m1.last_refresh_at, 'first run stamps a heartbeat');
@@ -172,7 +196,7 @@ test('an unchanged cycle inside the heartbeat interval writes NOTHING', async ()
   // The write that caused the free-tier alert: the heartbeat bypasses the
   // content-hash gate, so writing it every tick costs 288 writes/day/env against
   // a 1,000/day ACCOUNT cap. Rate-limiting it must make an idle tick cost zero.
-  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = newEnv();
   await runRefresh(env, fakeFetch());          // seeds; stamps the heartbeat "now"
   const before = await env.DATASET.get(KEYS.meta, 'json');
   const writesAfterSeed = env.DATASET._putCount();
@@ -191,7 +215,7 @@ test('a missing last_refresh_at is treated as due (no permanent suppression)', a
   // NaN, and every comparison against NaN is false — so a naive `elapsed >= X`
   // guard would suppress the heartbeat forever and the monitor would read the
   // Worker as wedged. It must fall through to "write it".
-  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = newEnv();
   await runRefresh(env, fakeFetch());
   const seeded = await env.DATASET.get(KEYS.meta, 'json');
   delete seeded.last_refresh_at;
@@ -204,7 +228,7 @@ test('a missing last_refresh_at is treated as due (no permanent suppression)', a
 });
 
 test('a failed refresh still advances the heartbeat (cron ran; Nexus did not answer)', async () => {
-  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = newEnv();
   await runRefresh(env, fakeFetch()); // seed good
   const seeded = await env.DATASET.get(KEYS.meta, 'json');
   await env.DATASET.put(KEYS.meta, JSON.stringify({ ...seeded, last_refresh_at: '2000-01-01T00:00:00.000Z' }));
@@ -215,11 +239,8 @@ test('a failed refresh still advances the heartbeat (cron ran; Nexus did not ans
 });
 
 test('Nexus failure keeps last-known-good and flags stale + alerts Discord', async () => {
-  const env = {
-    DATASET: fakeKV(), SITE_ORIGIN: 'https://x',
-    // Dedicated alerts channel (preferred over the legacy DISCORD_WEBHOOK_URL).
-    NCZ_ALERTS_DISCORD_WEBHOOK_URL: 'https://discord/webhook',
-  };
+  // Dedicated alerts channel (preferred over the legacy DISCORD_WEBHOOK_URL).
+  const env = newEnv({ NCZ_ALERTS_DISCORD_WEBHOOK_URL: 'https://discord/webhook' });
   await runRefresh(env, fakeFetch()); // seed good data
   const goodFull = await env.DATASET.get(KEYS.full, 'json');
 
@@ -237,7 +258,7 @@ test('Nexus failure keeps last-known-good and flags stale + alerts Discord', asy
 });
 
 test('failure with no prior dataset returns stale with null version, no crash', async () => {
-  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = newEnv();
   const r = await runRefresh(env, fakeFetch({ failMods: true }));
   assert.equal(r.stale, true);
   assert.equal(r.version, null);
@@ -245,7 +266,7 @@ test('failure with no prior dataset returns stale with null version, no crash', 
 });
 
 test('recovery after a stale cycle rewrites and clears the stale flag', async () => {
-  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = newEnv();
   await runRefresh(env, fakeFetch());
   await runRefresh(env, fakeFetch({ failNexus: true }));
   assert.equal((await env.DATASET.get(KEYS.meta, 'json')).discovery_stale, true);
@@ -258,7 +279,7 @@ test('recovery after a stale cycle rewrites and clears the stale flag', async ()
 // ── Archive names (installed-mod detection) ─────────────────────────────────
 
 test('archive names are fetched and attached to every record', async () => {
-  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = newEnv();
   const archiveCalls = [];
   await runRefresh(env, fakeFetch({ archiveCalls }));
   const full = await env.DATASET.get(KEYS.full, 'json');
@@ -270,7 +291,7 @@ test('archive names are fetched and attached to every record', async () => {
 });
 
 test('archive cache is reused when updatedAt is unchanged (no refetch)', async () => {
-  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = newEnv();
   await runRefresh(env, fakeFetch()); // fills the cache
   const archiveCalls = [];
   await runRefresh(env, fakeFetch({ archiveCalls }));
@@ -278,7 +299,7 @@ test('archive cache is reused when updatedAt is unchanged (no refetch)', async (
 });
 
 test('archive fetch failure degrades to [] and never marks the dataset stale', async () => {
-  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = newEnv();
   const r = await runRefresh(env, fakeFetch({ failArchives: true }));
   assert.equal(r.stale, false); // archives are supplementary, not load-bearing
   assert.equal(r.changed, true);
@@ -316,7 +337,7 @@ test('archive refresh is budgeted per run and cold-fills over multiple runs', as
     throw new Error(`unexpected fetch: ${url}`);
   };
 
-  const env = { DATASET: fakeKV(), SITE_ORIGIN: 'https://x' };
+  const env = newEnv();
   const run1 = [];
   await runRefresh(env, impl(run1));
   const refreshed1 = run1.filter((c) => c === 'router').length;
@@ -334,10 +355,7 @@ test('archive refresh is budgeted per run and cold-fills over multiple runs', as
 });
 
 test('recovery posts a recovery alert exactly once (edge, not every cycle)', async () => {
-  const env = {
-    DATASET: fakeKV(), SITE_ORIGIN: 'https://x',
-    NCZ_ALERTS_DISCORD_WEBHOOK_URL: 'https://discord/webhook',
-  };
+  const env = newEnv({ NCZ_ALERTS_DISCORD_WEBHOOK_URL: 'https://discord/webhook' });
   const discordSink = [];
   await runRefresh(env, fakeFetch({ discordSink }));                  // seed good
   await runRefresh(env, fakeFetch({ failNexus: true, discordSink })); // fail → stale + alert


### PR DESCRIPTION
Phase 5, PR A1. `nexus_cache` becomes a real index the cron maintains, the dataset is built against it, and the parity gate stops feeding four fields in from the answer it is checking.

Depends on nothing. `feat/submissions-api` (PR A2, `POST /submissions`) builds on the `readCandidates` query this populates.

## What changes

**The cron sweeps `nexus_cache` every tick.** One row per mod: every NCZoning-tagged mod plus every mod the map serves a pin for. The tagged GraphQL query is fetched once and shared by the sweep and the build, so the tick's most expensive Nexus call does not double. Under `DATA_SOURCE=d1` the `modsByUid` backfill inside the build is gone entirely, because the sweep has already resolved every published record.

**`materializeFromD1` reads one channel instead of two.** It resolved images as `manualThumbs[id] || nexusThumbs[id]`, two in-memory maps that could disagree; it is now a single lookup against the index.

**Archive listings move from KV into `nexus_cache.archives`.** This is the part that was not in the kickoff's four steps, and it is what makes step 3 possible: the gate cannot compare a field D1 cannot rebuild, and nothing wrote that column. Migration 0003 gains `archives_at`, recording the `updated_at` a listing was read against. `updated_at` alone cannot carry it, because the sweep overwrites it the moment Nexus reports a re-upload, and a mod deferred past the per-tick budget would then be written with the new timestamp and never refetched.

**The parity gate covers all 18 served fields.** `FED_IN_KEYS` is empty. It is kept rather than deleted, because it is the list of fields the gate does not check and it should stay visible at zero.

## Three decisions worth reviewing

**Archives are resolved for the served record set, not for the `locations` table.** While production still builds from `mods.json` those two sets differ: a mod merged to `main` reaches `mods.json` and does not reach D1 until someone runs `sync-locations.mjs`. Driving archives off the table would ship no file list for exactly those mods. So `refreshArchives` is a second pass after the build rather than part of the sweep, gated the same way, and it still costs zero writes in steady state.

**The KV blob is read once as a carry-over source.** Not only to skip a ~20 tick cold fill: `scripts/archive-seeds.json` holds hand-built listings for mods whose Nexus "Preview file contents" is broken, and a refetch replaces those with nothing. Measured, this carried 295 of 295 across with zero refetches. **Do not delete `dataset:v1:archives` until the sweep has run against both databases.**

**Production's failure surface is deliberately unchanged.** An empty index under `DATA_SOURCE=d1` fails into last-known-good rather than serving 297 records with every image stripped, which would hash cleanly and replace a good dataset. On the `mods.json` path the same condition costs archives and never freshness: images there come from merge.js's own channel, and archives have always been allowed to degrade to `[]`. D1 does not join production's critical path ahead of the cutover.

## Verification

Against **production D1 and the live API**, running the sweep and archive pass into a local SQLite on the real migrations (no remote writes):

```
D1: 297 locations, 572 tag links, 1 dismissed
sweep: 41 tagged, 255 backfilled, 296 rows written
archives: +295 carried over, +0 fetched, 0 pending
steady state: sweep wrote 0 rows, archives wrote 0 rows
```

297 records byte-for-byte identical to live **except the one acknowledged difference**: the tag order of `0f3d60d4-dc81-40cf-9fdb-44c0f82bffa4`, `["apartment","neomilitarism","corpo"]` against `["apartment","corpo","neomilitarism"]`. Still that one record and that one field, and it resolves at release.

Two counts computed independently agree: 255 backfilled + 41 tagged = 296 index rows, and 295 of those carry a location's mod id, matching the 295 distinct numeric `nexus_id`s.

The write gate is the reason this is affordable on a 5-minute cron: 296 rows on 288 daily ticks would be 85k row-writes against a 100k/day cap. The second cycle over an unchanged corpus writes nothing at all.

**235 tests pass** (224 before). Eight negative controls were run by sabotaging one rule at a time and confirming the guarding test goes red: `archives_at` ignored, a failed fetch cached, an archives-only write dropping `nczoning_tagged`, a stale KV seed trusted, the per-tick budget removed, the empty-index guard removed, placeholder ids allowed into the table, and the tagged query fetched twice. Two of them initially stayed green, both because the test passed for a reason other than the rule; both tests were strengthened until the sabotage was detectable.

The refresh tests move onto the real SQLite harness. The substring-matching mock they used could not show that an upsert, a foreign key or a bound-parameter count behaves as D1 does, and the sweep depends on all three.

## Before merging

`parity-check.mjs` now needs a swept `nexus_cache`, and neither remote database has one yet: migration 0003 is unapplied and the sweep is undeployed. The order after merge is apply 0003 to both, deploy, let one tick run, then run the gate. The script says so rather than reporting ~300 mismatches.

Migration 0003 was edited in place rather than stacked on a 0004, verified unapplied by reading `sqlite_master` on both databases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
