### PR TITLE
feat(api): POST /submissions, Turnstile, and the submitter retention rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The cron keeps a Nexus mod index in D1, covering every tagged mod and every mod the map serves. It backs the submissions candidate list without a live Nexus call, and it is where the four Nexus-derived fields on each location now come from.
 - The parity gate covers all 18 served fields, including the thumbnails, pictures, update times and archive listings it could not rebuild before.
+- `POST /submissions` queues a new location, an edit or a removal request for review. Anonymous, behind a Turnstile check and a limit of 5 per address per hour, and nothing it accepts reaches the map without a reviewer approving it. The map's own submit form still goes through GitHub until the modal is rebuilt.
+- A privacy note at [docs/privacy.md](docs/privacy.md). Submissions are the first personal data the site collects: a salted one-way hash of the submitter's address, kept 90 days and then cleared automatically.
 
 ### Fixed
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,69 @@
+# Privacy
+
+What NC Zoning Board stores about people, why, and for how long.
+
+Until submissions moved onto the site, this page had nothing to describe: mods
+arrived as GitHub issues and pull requests, so everything about a submitter was
+already public on GitHub and none of it was ours. `POST /submissions` is the
+first personal data the site collects itself.
+
+## Submitting a location
+
+Submitting through the map stores one submission record, holding:
+
+| What | Why | Kept for |
+| --- | --- | --- |
+| The location data you filled in | It is the submission. Once approved it becomes a public map record. | Indefinitely |
+| Your note to the reviewer, if you wrote one | Context for the person reviewing it. | Indefinitely |
+| Your contact, if you gave one | So a reviewer can ask a question about your submission. **Optional**, and used for nothing else. | Indefinitely |
+| A one-way hash of your IP address | Rate limiting, and tracing abuse if the queue is flooded. | 90 days |
+
+**The IP address itself is never stored.** What is stored is a SHA-256 hash of
+your address combined with a secret salt held by the server. The salt is what
+makes this meaningful: without one, a hash of an IPv4 address can be reversed by
+trying all four billion of them, so an unsalted hash would be a stored address
+wearing a disguise. If the salt is missing the API refuses submissions rather
+than storing anything weaker.
+
+The hash is cleared 90 days after the submission arrives, whether or not it has
+been reviewed by then. The submission itself is kept; only the hash is removed.
+
+## Bot protection
+
+The submit form uses [Cloudflare Turnstile](https://www.cloudflare.com/products/turnstile/),
+which checks that a submission comes from a browser rather than a script.
+Cloudflare receives the token from that widget and your IP address as part of
+verifying it. Turnstile is used instead of a CAPTCHA because it does not track
+you across sites and usually asks you to do nothing.
+
+## Browsing the map
+
+The map is a static site. It sets no cookies of its own, has no analytics, and
+there is no visitor account to sign in to.
+
+What it keeps is held **in your own browser** and never sent anywhere: your
+theme, which 3D asset set you chose, the width you dragged the cluster panel to,
+your flyover options, a short-lived cache of the map data so a revisit does not
+refetch it, and a flag marking that you have seen the welcome panel this
+session. Clearing your site data removes all of it.
+
+Requests to `nczoning.net` and `api.nczoning.net` pass through Cloudflare, which
+processes IP addresses to serve and protect the site and may set its own cookies
+for that purpose. That is ordinary CDN behaviour and applies to any site behind
+Cloudflare.
+
+## Admins
+
+Signing in at `/admin/` is GitHub OAuth, requesting `read:user` only. The site
+stores your GitHub user id, your login, and whether you are a collaborator on
+the repository, so the permission check does not have to be repeated on every
+request. Every change an admin makes is recorded in an append-only audit log
+with their GitHub login: with edits no longer arriving as pull requests, that
+log is what replaces the commit history.
+
+## Asking for your data, or its removal
+
+Open an issue, or use the contact route in the Discord. A submission that has
+not been approved can be withdrawn on request. An approved one is a public map
+record describing a published mod, and is handled like any other correction to
+the registry.

--- a/worker/README.md
+++ b/worker/README.md
@@ -547,19 +547,19 @@ margin. A WAF rate-limit rule is deployed as belt-and-braces (zone config,
 not `wrangler deploy`):
 
 > Dashboard → nczoning.net → **Security → Security rules → Rate limiting
-> rules**. Rule "API rate limit": match **URI Path starts with `/v1/`**,
-> characteristic **IP**, **100 requests / 10 seconds**, action **Block**,
-> duration **10 s**.
+> rules**. Rule "API rate limit": match **URI Path starts with `/v1/`**, `Or`
+> **`/submissions`**, `Or` **`/auth/`**; characteristic **IP**, **100 requests /
+> 10 seconds**, action **Block**, duration **10 s**.
 
-A second rule covers the write routes, which are not cached and not covered by
-the `/v1/` rule:
+**The free plan allows exactly one rate-limiting rule**, so the write routes are
+`Or` conditions on that rule rather than a second one with a tighter threshold.
+100 requests / 10 s is far looser than `/submissions` needs, which is acceptable
+because this is only an edge burst guard: the limit that decides how many
+submissions an address may actually queue is the per-hour one inside the Worker,
+and no zone setting can weaken it.
 
-> Rule "submissions and auth": match **URI Path starts with `/submissions`** or
-> **`/auth/`**, characteristic **IP**, **20 requests / 10 seconds**, action
-> **Block**, duration **10 s**.
-
-That is a burst guard at the edge. The per-hour limit inside the Worker is the
-one that decides how many submissions an address may actually queue.
+`/submissions` is matched without a trailing slash so it covers both the POST
+and `/submissions/candidates`.
 
 **Free-plan constraints (why it's path-based, not host-based):** the free
 rate-limiting rule only matches on **URI Path** (hostname isn't offered),

--- a/worker/README.md
+++ b/worker/README.md
@@ -457,6 +457,65 @@ Docs: `openapi.json` is the source of truth (drift-guarded by
 versa). The human-facing reference with redscript/CET snippets is
 [docs/api-reference.md](../docs/api-reference.md).
 
+## Submissions (Phase 5)
+
+`POST /submissions` is the **first public write route on this API**. Every other
+write path is a pull request or a signed-in collaborator, so this module owns
+checks that sit elsewhere for them:
+
+| Route | Auth | Does |
+| --- | --- | --- |
+| `POST /submissions` | anonymous, Turnstile + rate limit | queues a `create`, `edit` or `remove`; `201` with the id |
+| `GET /submissions/candidates` | anonymous | NCZoning-tagged mods that are neither a location nor dismissed |
+
+Nothing this route accepts reaches the map. A row lands in `submissions` with
+status `pending`; approval is a separate collaborator-gated action (PR B).
+
+**Validation is shared with the admin editor** (`validateLocationInput`), so a
+submission cannot express something the editor would refuse. On top of it,
+`status`, `admin_notes` and `source` are **refused rather than dropped**: they
+are writable by an admin and part of the same validator, and silently discarding
+them would leave an approve path applying a field the submitter chose.
+
+**Two secrets, and both fail closed when unset:**
+
+```bash
+npx wrangler secret put SUBMISSION_IP_SALT                  # production
+npx wrangler secret put SUBMISSION_IP_SALT --env staging     # and staging
+npx wrangler secret put TURNSTILE_SECRET_KEY
+npx wrangler secret put TURNSTILE_SECRET_KEY --env staging
+```
+
+Missing `SUBMISSION_IP_SALT` returns `503 submissions_unavailable` rather than
+storing an unsalted hash: SHA-256 of an IPv4 address has four billion possible
+inputs and is reversed by enumeration, so an unsalted hash is a stored address
+with extra steps. Missing `TURNSTILE_SECRET_KEY` returns `503` rather than
+skipping the bot check, and so does a `siteverify` outage. **A bot check that
+opens on error is one an attacker triggers on purpose.**
+
+The salts may differ between environments; nothing compares them.
+
+Refusals carry distinct codes so the modal can act on them:
+`turnstile_missing`, `turnstile_expired` (single-use token reused, or the form
+sat open past five minutes: re-render the widget, the submitter did nothing
+wrong), `turnstile_failed`, `rate_limited`, `invalid_submission`.
+
+**The rate limit is 5 accepted submissions per address per hour**, counted with
+a `COUNT(*)` over `submissions` rather than a counter store, so it needs no
+table and no KV write per attempt. Only accepted submissions count: someone
+fixing a validation error six times is not locked out. The check runs before
+Turnstile, so a flood does not become a flood of `siteverify` calls.
+
+`submitter_ip_hash` is cleared after 90 days by `purgeSubmitterIps()`, which
+`scheduled()` calls alongside the refresh (separately, so a failed rebuild
+cannot stop the clock on data the site promised to delete). See
+[docs/privacy.md](../docs/privacy.md), which is a ship gate for this phase
+rather than paperwork: this is the first personal data the site collects.
+
+`/submissions` is **not in `openapi.json` and does not bump `API_VERSION`**,
+following `/auth/` and `/admin/`. The spec documents the `/v1` data contract
+that in-game consumers read, and this route is not part of it.
+
 ## Versioning
 
 `API_VERSION` (served as `version` on `/v1/health`) is SemVer for the API
@@ -491,6 +550,16 @@ not `wrangler deploy`):
 > rules**. Rule "API rate limit": match **URI Path starts with `/v1/`**,
 > characteristic **IP**, **100 requests / 10 seconds**, action **Block**,
 > duration **10 s**.
+
+A second rule covers the write routes, which are not cached and not covered by
+the `/v1/` rule:
+
+> Rule "submissions and auth": match **URI Path starts with `/submissions`** or
+> **`/auth/`**, characteristic **IP**, **20 requests / 10 seconds**, action
+> **Block**, duration **10 s**.
+
+That is a burst guard at the edge. The per-hour limit inside the Worker is the
+one that decides how many submissions an address may actually queue.
 
 **Free-plan constraints (why it's path-based, not host-based):** the free
 rate-limiting rule only matches on **URI Path** (hostname isn't offered),

--- a/worker/src/config.js
+++ b/worker/src/config.js
@@ -25,3 +25,31 @@ export const RECENTLY_UPDATED_DAYS = 7;
 // the write interval, a healthy idle cron pages the alerts channel AND triggers
 // a self-heal redeploy. Never change one without the other.
 export const HEARTBEAT_MIN_INTERVAL_MS = 15 * 60 * 1000;
+
+// World extent in CET units, from the Realistic Map 8k terrain quad UV mapping.
+// Same four numbers as NCZ.WORLD_MIN_X/MAX_X/MIN_Y/MAX_Y in
+// assets/js/constants.js; derivation and why the TweakDB bounds differ are in
+// docs/coordinate-system.md.
+//
+// These are a RENDERABILITY limit, not a guess at a typical range: the whole
+// CET-to-Leaflet transform is derived from them, so a pin outside cannot be
+// projected onto the map at all.
+//
+// The website enforced +/-5000 on X/Y and +/-1000 on Z instead. Measured against
+// the 297 live records on 2026-07-27, that rule rejects four of them: Sea Wall
+// Towers Detailed at x=-5782, two canyon locations at x=5321, and Crystal Palace
+// Resort at z=1525. All four arrived through the git PR path, which never ran
+// the browser check, so the rule has been wrong in the browser without ever
+// being able to reject anything. Do not port those numbers here.
+export const WORLD_MIN_X = -6298;
+export const WORLD_MAX_X = 5815;
+export const WORLD_MIN_Y = -7684;
+export const WORLD_MAX_Y = 4427;
+
+// Z has no authoritative bound: it is elevation, and nothing projects from it.
+// This is an explicit sanity range for catching garbage, not a geometry rule.
+// Observed across the 297 live records: -10.1 to 1524.6, the maximum being
+// Crystal Palace Resort, which is in orbit. The ceiling is set well clear of
+// that so nothing legitimate is refused.
+export const COORD_Z_MIN = -1000;
+export const COORD_Z_MAX = 3000;

--- a/worker/src/config.js
+++ b/worker/src/config.js
@@ -26,31 +26,29 @@ export const RECENTLY_UPDATED_DAYS = 7;
 // a self-heal redeploy. Never change one without the other.
 export const HEARTBEAT_MIN_INTERVAL_MS = 15 * 60 * 1000;
 
-// Submission bounds: the extent of the 3D map terrain mesh, which is the outer
-// envelope of anything this site can render in either view.
+// Coordinate bounds for the write path: the extent of the 3D map terrain mesh,
+// which is the outer envelope of anything renderable in either view.
 //
-// Measured from assets/glb-meshopt/3dmap_terrain.glb on 2026-07-27, applying the
-// node transform to the quantised POSITION accessors: X [-7999.3, 7999.4] and
-// world Y [-8000.1, 8000.9], a symmetric 16km square. The water sheet sits
-// inside it at X [-7998, 7439], world Y [-7329, 5958].
+// Measured from assets/glb-meshopt/3dmap_terrain.glb, applying the node
+// transform to the quantised POSITION accessors: a symmetric 16km square, X
+// [-7999.3, 7999.4] and world Y [-8000.1, 8000.9]. The water sheet sits inside
+// it.
 //
-// NOT the same as NCZ.WORLD_MIN_X/MAX_X/MIN_Y/MAX_Y in assets/js/constants.js,
-// which are X [-6298, 5815] and Y [-7684, 4427]. Those describe the satellite
-// TILE projection, so they are the right numbers for the CET-to-Leaflet
-// transform and the wrong ones for a submission gate: they are tighter than the
-// terrain in every direction, and a location on rendered ground outside them
-// would be refused for being outside a picture rather than outside the world.
+// DELIBERATELY NOT NCZ.WORLD_MIN_X and friends (assets/js/constants.js), which
+// are X [-6298, 5815], Y [-7684, 4427]. Those describe the satellite TILE
+// projection: correct for the CET-to-Leaflet transform, wrong as a gate. They
+// are tighter than the terrain in every direction, so they would refuse a
+// location standing on rendered ground for being outside a picture. Named
+// TERRAIN_* rather than WORLD_* so the two are not synced by mistake.
 //
-// The website enforced +/-5000 on X/Y and +/-1000 on Z instead. Those appear to
-// be stale leftovers. Measured against the 297 live records, that rule rejects
-// four of them: Sea Wall Towers Detailed at x=-5782, two canyon locations at
-// x=5321, and Crystal Palace Resort at z=1525. All four arrived through the git
-// PR path, which never ran the browser check, so the rule has been wrong in the
-// browser without ever being able to reject anything. Do not port those numbers.
-export const WORLD_MIN_X = -8000;
-export const WORLD_MAX_X = 8000;
-export const WORLD_MIN_Y = -8000;
-export const WORLD_MAX_Y = 8000;
+// Do NOT adopt the browser form's +/-5000 on X/Y and +/-1000 on Z. That rule
+// rejects four records live on the map today (x=-5782, two at x=5321, and
+// z=1525), and never rejected anything because every one of them arrived
+// through the PR path rather than the form.
+export const TERRAIN_MIN_X = -8000;
+export const TERRAIN_MAX_X = 8000;
+export const TERRAIN_MIN_Y = -8000;
+export const TERRAIN_MAX_Y = 8000;
 
 // Z has no mesh to measure against: it is elevation, and nothing projects from
 // it. An explicit sanity range for catching garbage, not a geometry rule.

--- a/worker/src/config.js
+++ b/worker/src/config.js
@@ -26,30 +26,35 @@ export const RECENTLY_UPDATED_DAYS = 7;
 // a self-heal redeploy. Never change one without the other.
 export const HEARTBEAT_MIN_INTERVAL_MS = 15 * 60 * 1000;
 
-// World extent in CET units, from the Realistic Map 8k terrain quad UV mapping.
-// Same four numbers as NCZ.WORLD_MIN_X/MAX_X/MIN_Y/MAX_Y in
-// assets/js/constants.js; derivation and why the TweakDB bounds differ are in
-// docs/coordinate-system.md.
+// Submission bounds: the extent of the 3D map terrain mesh, which is the outer
+// envelope of anything this site can render in either view.
 //
-// These are a RENDERABILITY limit, not a guess at a typical range: the whole
-// CET-to-Leaflet transform is derived from them, so a pin outside cannot be
-// projected onto the map at all.
+// Measured from assets/glb-meshopt/3dmap_terrain.glb on 2026-07-27, applying the
+// node transform to the quantised POSITION accessors: X [-7999.3, 7999.4] and
+// world Y [-8000.1, 8000.9], a symmetric 16km square. The water sheet sits
+// inside it at X [-7998, 7439], world Y [-7329, 5958].
 //
-// The website enforced +/-5000 on X/Y and +/-1000 on Z instead. Measured against
-// the 297 live records on 2026-07-27, that rule rejects four of them: Sea Wall
-// Towers Detailed at x=-5782, two canyon locations at x=5321, and Crystal Palace
-// Resort at z=1525. All four arrived through the git PR path, which never ran
-// the browser check, so the rule has been wrong in the browser without ever
-// being able to reject anything. Do not port those numbers here.
-export const WORLD_MIN_X = -6298;
-export const WORLD_MAX_X = 5815;
-export const WORLD_MIN_Y = -7684;
-export const WORLD_MAX_Y = 4427;
+// NOT the same as NCZ.WORLD_MIN_X/MAX_X/MIN_Y/MAX_Y in assets/js/constants.js,
+// which are X [-6298, 5815] and Y [-7684, 4427]. Those describe the satellite
+// TILE projection, so they are the right numbers for the CET-to-Leaflet
+// transform and the wrong ones for a submission gate: they are tighter than the
+// terrain in every direction, and a location on rendered ground outside them
+// would be refused for being outside a picture rather than outside the world.
+//
+// The website enforced +/-5000 on X/Y and +/-1000 on Z instead. Those appear to
+// be stale leftovers. Measured against the 297 live records, that rule rejects
+// four of them: Sea Wall Towers Detailed at x=-5782, two canyon locations at
+// x=5321, and Crystal Palace Resort at z=1525. All four arrived through the git
+// PR path, which never ran the browser check, so the rule has been wrong in the
+// browser without ever being able to reject anything. Do not port those numbers.
+export const WORLD_MIN_X = -8000;
+export const WORLD_MAX_X = 8000;
+export const WORLD_MIN_Y = -8000;
+export const WORLD_MAX_Y = 8000;
 
-// Z has no authoritative bound: it is elevation, and nothing projects from it.
-// This is an explicit sanity range for catching garbage, not a geometry rule.
+// Z has no mesh to measure against: it is elevation, and nothing projects from
+// it. An explicit sanity range for catching garbage, not a geometry rule.
 // Observed across the 297 live records: -10.1 to 1524.6, the maximum being
-// Crystal Palace Resort, which is in orbit. The ceiling is set well clear of
-// that so nothing legitimate is refused.
+// Crystal Palace Resort, which is in orbit and is expected to stay the ceiling.
 export const COORD_Z_MIN = -1000;
-export const COORD_Z_MAX = 3000;
+export const COORD_Z_MAX = 2000;

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -20,6 +20,7 @@ import { docsPage, spec } from './docs.js';
 import { RECENTLY_UPDATED_DAYS } from './config.js';
 import { login, callback, me, logout, adminCors } from './auth.js';
 import { handleAdmin } from './admin.js';
+import { handleSubmissions, purgeSubmitterIps } from './submissions.js';
 
 const SCHEMA_VERSION = 1;
 
@@ -181,17 +182,38 @@ export default {
   // 5-minute cron: rebuild the dataset into KV (see refresh.js).
   async scheduled(controller, env, ctx) {
     ctx.waitUntil(runRefresh(env));
+    // Retention on the submitters' hashed addresses. Separate from the refresh
+    // so a failed rebuild cannot stop the clock on data the site promised to
+    // delete. An UPDATE matching nothing writes nothing, which is every tick
+    // but a handful. See docs/privacy.md.
+    if (env.DB) ctx.waitUntil(purgeSubmitterIps(env).catch(() => 0));
   },
 
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
     const isAuth = url.pathname.startsWith('/auth/');
     const isAdmin = url.pathname.startsWith('/admin/');
+    const isSubmission = url.pathname === '/submissions' || url.pathname.startsWith('/submissions/');
 
     if (request.method === 'OPTIONS') {
       // Auth routes are credentialed, so they need the caller's exact origin
       // echoed back; the wildcard CORS used by /v1/* is illegal with
       // Allow-Credentials and would fail the preflight.
+      //
+      // Submissions are anonymous and wildcard, but they still POST JSON, so
+      // they need Allow-Methods and Allow-Headers that /v1/* does not: without
+      // this branch every submission fails at the preflight, before the
+      // handler is reached.
+      if (isSubmission) {
+        return new Response(null, {
+          status: 204,
+          headers: {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type',
+          },
+        });
+      }
       return new Response(null, {
         status: 204,
         headers: isAuth || isAdmin
@@ -220,6 +242,15 @@ export default {
       if (request.method === 'GET' && url.pathname === '/auth/me') return me(request, env);
       if (request.method === 'POST' && url.pathname === '/auth/logout') return logout(request, env);
       return json(envelope({ error: 'not_found' }, null), { status: 404 });
+    }
+
+    // The public write route, before the read-only method gate below. It is
+    // anonymous by design, so its own gate is Turnstile plus a rate limit
+    // rather than a session, and nothing it accepts reaches the map without a
+    // separate, collaborator-gated approval.
+    if (isSubmission) {
+      const res = await handleSubmissions(request, env);
+      if (res) return res;
     }
 
     if (request.method !== 'GET' && request.method !== 'HEAD') {

--- a/worker/src/submissions.js
+++ b/worker/src/submissions.js
@@ -1,0 +1,325 @@
+/**
+ * The submission queue: the first PUBLIC WRITE route on this API.
+ *
+ * Every other write path is a pull request or an authenticated collaborator
+ * using the dashboard. `POST /submissions` is neither, so three checks that sit
+ * elsewhere for them belong here:
+ *
+ * - **Validation is server-side or it does not exist.** The submit form's rules
+ *   sit in the layer the submitter controls. validateLocationInput is shared
+ *   with the admin editor, so a submission cannot express something the editor
+ *   would refuse.
+ * - **Admin-only fields are refused, not ignored.** `status`, `admin_notes` and
+ *   `source` are writable by an admin and are part of the same validator, so a
+ *   payload carrying `status: 'published'` has to be rejected here. Dropping
+ *   them silently would leave an approve path applying a field the submitter
+ *   chose.
+ * - **Nothing published by this route reaches the map.** A row lands in
+ *   `submissions` with status `pending`. Approval is a separate, gated action.
+ *
+ * ## What is stored about the submitter, and why
+ *
+ * A salted SHA-256 of the IP, never the IP. The salt is a secret, and **an
+ * unset salt fails the request closed**: SHA-256 of an IPv4 address without one
+ * has four billion possible inputs and is reversed by enumeration in seconds,
+ * so an unsalted hash is a stored IP with extra steps.
+ *
+ * It exists for the rate limit and for abuse triage, and is purged at
+ * RETENTION_DAYS by purgeSubmitterIps(), which the cron calls. See docs/privacy.md.
+ *
+ * `submitter_contact` is optional, and is for a reviewer to ask a question
+ * about the submission. Nothing else reads it.
+ */
+
+import { validateLocationInput } from './validate.js';
+import { readTagSlugs } from './tag-registry.js';
+import { readCandidates } from './nexus-cache.js';
+import { writeAudit } from './audit.js';
+
+const KINDS = ['create', 'edit', 'remove'];
+
+/** Fields only an admin may set. Present in validateLocationInput's writable set. */
+const ADMIN_ONLY = ['status', 'admin_notes', 'source'];
+
+const NOTE_MAX = 1000;
+const CONTACT_MAX = 200;
+const REASON_MAX = 1000;
+
+/** Submissions accepted from one address per window. */
+const RATE_LIMIT = 5;
+const RATE_WINDOW_MS = 60 * 60 * 1000;
+
+/** How long a submitter's hashed address is kept. */
+export const RETENTION_DAYS = 90;
+
+/**
+ * CORS for the public write route.
+ *
+ * Wildcard, and deliberately NOT the credentialed adminCors: submissions are
+ * anonymous, no cookie is read, and `Allow-Credentials` with a wildcard origin
+ * is rejected by the browser outright. The preflight in index.js has to name
+ * this prefix or every POST dies before the handler runs.
+ */
+const CORS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
+const json = (body, status = 200) => new Response(JSON.stringify(body), {
+  status,
+  headers: { 'Content-Type': 'application/json; charset=utf-8', 'Cache-Control': 'no-store', ...CORS },
+});
+
+/** Hex SHA-256 of `salt:value`, via Web Crypto. */
+async function saltedHash(salt, value) {
+  const bytes = new TextEncoder().encode(`${salt}:${value}`);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Verify a Turnstile token server-side.
+ *
+ * Returns a reason rather than a boolean, because the modal has to tell a
+ * duplicate or expired token (re-render the widget, the submitter did nothing
+ * wrong) apart from a refusal. Tokens are single-use and expire after five
+ * minutes, so `timeout-or-duplicate` is the common answer for a form left open.
+ *
+ * A network failure is NOT treated as a pass. A bot check that opens on error
+ * is a bot check an attacker can trigger.
+ */
+export async function verifyTurnstile(env, token, remoteip, fetchImpl = fetch) {
+  if (!env.TURNSTILE_SECRET_KEY) return { ok: false, code: 'verification_unavailable' };
+  if (typeof token !== 'string' || !token) return { ok: false, code: 'turnstile_missing' };
+  try {
+    const res = await fetchImpl('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ secret: env.TURNSTILE_SECRET_KEY, response: token, remoteip }),
+    });
+    if (!res.ok) return { ok: false, code: 'verification_unavailable' };
+    const body = await res.json();
+    if (body?.success) return { ok: true };
+    const codes = body?.['error-codes'] ?? [];
+    return {
+      ok: false,
+      code: codes.includes('timeout-or-duplicate') ? 'turnstile_expired' : 'turnstile_failed',
+      errors: codes,
+    };
+  } catch {
+    return { ok: false, code: 'verification_unavailable' };
+  }
+}
+
+/**
+ * Submissions from this address inside the window.
+ *
+ * Counted from the `submissions` table rather than a counter store, so it needs
+ * no new table and no KV write per attempt. It counts only what was ACCEPTED:
+ * a refused submission writes no row, so a submitter fixing a validation error
+ * six times is not locked out for an hour.
+ */
+async function recentCount(env, ipHash, nowMs) {
+  const since = new Date(nowMs - RATE_WINDOW_MS).toISOString();
+  const row = await env.DB.prepare(
+    'SELECT COUNT(*) AS n FROM submissions WHERE submitter_ip_hash = ? AND created_at >= ?',
+  ).bind(ipHash, since).first();
+  return row?.n ?? 0;
+}
+
+/** The location fields of a payload, with the admin-only ones called out. */
+function checkPayload(payload, { tagNames, partial }) {
+  const errors = [];
+  if (payload === undefined || payload === null) return { errors: ['payload is required'] };
+  for (const key of ADMIN_ONLY) {
+    if (Object.prototype.hasOwnProperty.call(payload, key)) {
+      errors.push(`${key} cannot be set on a submission: it is decided at review`);
+    }
+  }
+  const stripped = { ...payload };
+  for (const key of ADMIN_ONLY) delete stripped[key];
+  const result = validateLocationInput(stripped, { tagNames, partial });
+  return { errors: [...errors, ...result.errors], values: stripped };
+}
+
+function checkText(value, { field, max, required = false }) {
+  if (value === undefined || value === null) {
+    return required ? [`${field} is required`] : [];
+  }
+  if (typeof value !== 'string') return [`${field} must be a string`];
+  if (required && !value.trim()) return [`${field} is required`];
+  if (value.length > max) return [`${field} must be at most ${max} characters`];
+  return [];
+}
+
+/** Does this location exist? An edit or removal of nothing is a mistake, not a queue item. */
+async function locationExists(env, id) {
+  if (typeof id !== 'string' || !id) return false;
+  const row = await env.DB.prepare('SELECT id FROM locations WHERE id = ?').bind(id).first();
+  return Boolean(row);
+}
+
+/**
+ * POST /submissions. 201 with the queued id, or a refusal with a distinct code
+ * so the modal can act on it rather than showing one generic error.
+ */
+async function create(request, env, { fetchImpl = fetch, nowMs = Date.now() } = {}) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: 'invalid_json' }, 400);
+  }
+  if (typeof body !== 'object' || body === null || Array.isArray(body)) {
+    return json({ error: 'invalid_body', detail: 'body must be a JSON object' }, 400);
+  }
+
+  const kind = body.kind;
+  if (!KINDS.includes(kind)) {
+    return json({ error: 'invalid_kind', detail: `kind must be one of: ${KINDS.join(', ')}` }, 400);
+  }
+
+  // The salt first: without it nothing about the submitter may be stored, and
+  // that is a server misconfiguration rather than a bad request.
+  if (!env.SUBMISSION_IP_SALT) {
+    return json({ error: 'submissions_unavailable', detail: 'server is missing its hash salt' }, 503);
+  }
+
+  const ip = request.headers.get('CF-Connecting-IP') ?? '';
+  const ipHash = await saltedHash(env.SUBMISSION_IP_SALT, ip);
+
+  // Before validation, so a refusal cannot be used to probe the validator, and
+  // before Turnstile, so a flood costs no siteverify calls.
+  if (await recentCount(env, ipHash, nowMs) >= RATE_LIMIT) {
+    return json({
+      error: 'rate_limited',
+      detail: `at most ${RATE_LIMIT} submissions per hour`,
+    }, 429);
+  }
+
+  const turnstile = await verifyTurnstile(env, body.turnstile_token, ip, fetchImpl);
+  if (!turnstile.ok) {
+    const status = turnstile.code === 'verification_unavailable' ? 503 : 403;
+    return json({ error: turnstile.code }, status);
+  }
+
+  const errors = [
+    ...checkText(body.submitter_note, { field: 'submitter_note', max: NOTE_MAX }),
+    ...checkText(body.submitter_contact, { field: 'submitter_contact', max: CONTACT_MAX }),
+  ];
+  let stored = null;
+
+  if (kind === 'create') {
+    const tagNames = await readTagSlugs(env);
+    const checked = checkPayload(body.payload, { tagNames, partial: false });
+    errors.push(...checked.errors);
+    stored = checked.values ?? null;
+  } else {
+    if (!await locationExists(env, body.location_id)) {
+      errors.push('location_id must be an existing location');
+    }
+    if (kind === 'edit') {
+      const tagNames = await readTagSlugs(env);
+      const checked = checkPayload(body.payload, { tagNames, partial: true });
+      errors.push(...checked.errors);
+      if (checked.values && Object.keys(checked.values).length === 0) {
+        errors.push('payload must contain at least one changed field');
+      }
+      stored = checked.values ?? null;
+    } else {
+      // A removal carries no location fields: there is nothing to apply, and a
+      // payload here would be a request the reviewer cannot act on.
+      if (body.payload !== undefined && body.payload !== null) {
+        errors.push('a removal carries no payload, only a reason');
+      }
+      errors.push(...checkText(body.reason, { field: 'reason', max: REASON_MAX, required: true }));
+      stored = { reason: body.reason };
+    }
+  }
+
+  if (errors.length) return json({ error: 'invalid_submission', errors }, 400);
+
+  const createdAt = new Date(nowMs).toISOString();
+  const result = await env.DB.prepare(
+    `INSERT INTO submissions
+       (kind, location_id, payload, status, submitter_note, submitter_contact,
+        submitter_ip_hash, created_at)
+     VALUES (?, ?, ?, 'pending', ?, ?, ?, ?)`,
+  ).bind(
+    kind,
+    kind === 'create' ? null : body.location_id,
+    JSON.stringify(stored ?? {}),
+    body.submitter_note ?? null,
+    body.submitter_contact ?? null,
+    ipHash,
+    createdAt,
+  ).run();
+
+  const id = result?.meta?.last_row_id ?? null;
+
+  // Audited like any other write. The actor is not a person here, and saying
+  // 'anonymous' rather than inventing one keeps the log honest about what is
+  // known. The IP hash is deliberately NOT in the audit row: it is retained
+  // for 90 days on the submission and the audit log is append-only forever.
+  await writeAudit(env, {
+    actor: 'anonymous',
+    action: `submission.${kind}`,
+    target: id === null ? null : String(id),
+    after: { kind, location_id: body.location_id ?? null, payload: stored },
+  }, nowMs);
+
+  return json({ id, kind, status: 'pending' }, 201);
+}
+
+/**
+ * GET /submissions/candidates: NCZoning-tagged mods that are neither a location
+ * nor dismissed, for the submit form's first step.
+ *
+ * A `nexus_cache` query, not a live Nexus call: this is a public route, and
+ * putting a third-party API on its critical path would make an anonymous
+ * request able to trigger one.
+ */
+async function candidates(env) {
+  return json({ candidates: await readCandidates(env) });
+}
+
+/**
+ * Clear hashed addresses older than the retention window.
+ *
+ * Applied regardless of the submission's status, which is stricter than
+ * "resolved submissions after 90 days": a submission still pending after three
+ * months is abandoned, and there is no version of abuse triage that needs its
+ * address. The row itself, and the queue, are untouched.
+ *
+ * An UPDATE matching nothing writes no rows, so this is free on the ordinary
+ * tick and needs no gate of its own.
+ */
+export async function purgeSubmitterIps(env, nowMs = Date.now()) {
+  const cutoff = new Date(nowMs - RETENTION_DAYS * 86400000).toISOString();
+  const result = await env.DB.prepare(
+    'UPDATE submissions SET submitter_ip_hash = NULL WHERE submitter_ip_hash IS NOT NULL AND created_at < ?',
+  ).bind(cutoff).run();
+  return result?.meta?.changes ?? 0;
+}
+
+/**
+ * Route `/submissions*`. Returns null for any other path, so index.js can fall
+ * through to the read routes.
+ */
+export async function handleSubmissions(request, env, opts = {}) {
+  const url = new URL(request.url);
+  if (url.pathname !== '/submissions' && !url.pathname.startsWith('/submissions/')) return null;
+
+  if (url.pathname === '/submissions/candidates') {
+    if (request.method !== 'GET') return json({ error: 'method_not_allowed' }, 405);
+    return candidates(env);
+  }
+
+  if (url.pathname === '/submissions') {
+    if (request.method !== 'POST') return json({ error: 'method_not_allowed' }, 405);
+    return create(request, env, opts);
+  }
+
+  return json({ error: 'not_found' }, 404);
+}

--- a/worker/src/validate.js
+++ b/worker/src/validate.js
@@ -22,6 +22,10 @@
  *   file format.
  */
 
+import {
+  WORLD_MIN_X, WORLD_MAX_X, WORLD_MIN_Y, WORLD_MAX_Y, COORD_Z_MIN, COORD_Z_MAX,
+} from './config.js';
+
 export const CATEGORIES = ['location-overhaul', 'new-location', 'other'];
 export const STATUSES = ['published', 'hidden', 'draft'];
 export const DESCRIPTION_MAX = 500;
@@ -93,6 +97,21 @@ export function validateLocationInput(payload, { tagNames, partial = false } = {
       // Number.isFinite matters: JSON.parse yields NaN/Infinity for neither,
       // but a client can still send them as strings that coerce badly later.
       err('coordinates must all be finite numbers');
+    } else {
+      // Range, which until Phase 5 lived only in the browser. That was survivable
+      // while every write was a collaborator using the dashboard; it stops being
+      // survivable when /submissions accepts anonymous writes, because the rule
+      // would sit entirely in the layer the submitter controls.
+      const [x, y, z] = c;
+      if (x < WORLD_MIN_X || x > WORLD_MAX_X) {
+        err(`coordinate X must be between ${WORLD_MIN_X} and ${WORLD_MAX_X}`);
+      }
+      if (y < WORLD_MIN_Y || y > WORLD_MAX_Y) {
+        err(`coordinate Y must be between ${WORLD_MIN_Y} and ${WORLD_MAX_Y}`);
+      }
+      if (c.length === 3 && (z < COORD_Z_MIN || z > COORD_Z_MAX)) {
+        err(`coordinate Z must be between ${COORD_Z_MIN} and ${COORD_Z_MAX}`);
+      }
     }
   }
 

--- a/worker/src/validate.js
+++ b/worker/src/validate.js
@@ -23,7 +23,7 @@
  */
 
 import {
-  WORLD_MIN_X, WORLD_MAX_X, WORLD_MIN_Y, WORLD_MAX_Y, COORD_Z_MIN, COORD_Z_MAX,
+  TERRAIN_MIN_X, TERRAIN_MAX_X, TERRAIN_MIN_Y, TERRAIN_MAX_Y, COORD_Z_MIN, COORD_Z_MAX,
 } from './config.js';
 
 export const CATEGORIES = ['location-overhaul', 'new-location', 'other'];
@@ -98,16 +98,15 @@ export function validateLocationInput(payload, { tagNames, partial = false } = {
       // but a client can still send them as strings that coerce badly later.
       err('coordinates must all be finite numbers');
     } else {
-      // Range, which until Phase 5 lived only in the browser. That was survivable
-      // while every write was a collaborator using the dashboard; it stops being
-      // survivable when /submissions accepts anonymous writes, because the rule
-      // would sit entirely in the layer the submitter controls.
+      // Range is enforced here rather than only in the form, because
+      // /submissions accepts anonymous writes and a browser-side rule sits
+      // entirely in the layer the submitter controls. Bounds in config.js.
       const [x, y, z] = c;
-      if (x < WORLD_MIN_X || x > WORLD_MAX_X) {
-        err(`coordinate X must be between ${WORLD_MIN_X} and ${WORLD_MAX_X}`);
+      if (x < TERRAIN_MIN_X || x > TERRAIN_MAX_X) {
+        err(`coordinate X must be between ${TERRAIN_MIN_X} and ${TERRAIN_MAX_X}`);
       }
-      if (y < WORLD_MIN_Y || y > WORLD_MAX_Y) {
-        err(`coordinate Y must be between ${WORLD_MIN_Y} and ${WORLD_MAX_Y}`);
+      if (y < TERRAIN_MIN_Y || y > TERRAIN_MAX_Y) {
+        err(`coordinate Y must be between ${TERRAIN_MIN_Y} and ${TERRAIN_MAX_Y}`);
       }
       if (c.length === 3 && (z < COORD_Z_MIN || z > COORD_Z_MAX)) {
         err(`coordinate Z must be between ${COORD_Z_MIN} and ${COORD_Z_MAX}`);

--- a/worker/test-support/d1-sqlite.mjs
+++ b/worker/test-support/d1-sqlite.mjs
@@ -64,7 +64,13 @@ function statement(db, sql, args = []) {
     async run() {
       guard();
       const info = db.prepare(sql).run(...args);
-      return { success: true, meta: { changes: Number(info.changes) } };
+      // `last_row_id` as D1 names it, not node:sqlite's `lastInsertRowid`. A
+      // caller reading the D1 name off this harness would otherwise get
+      // undefined, and undefined is a plausible-looking id.
+      return {
+        success: true,
+        meta: { changes: Number(info.changes), last_row_id: Number(info.lastInsertRowid) },
+      };
     },
     // Internal: batch() needs the pieces, not the promise.
     _sql: sql,
@@ -122,7 +128,10 @@ export function sqliteD1(seed = {}) {
             throw new Error(`D1_ERROR: too many SQL variables: ${s._args.length}`);
           }
           const info = db.prepare(s._sql).run(...s._args);
-          return { success: true, meta: { changes: Number(info.changes) } };
+          return {
+            success: true,
+            meta: { changes: Number(info.changes), last_row_id: Number(info.lastInsertRowid) },
+          };
         });
         db.exec('COMMIT');
         return out;

--- a/worker/test/submissions.test.js
+++ b/worker/test/submissions.test.js
@@ -1,0 +1,424 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sqliteD1 } from '../test-support/d1-sqlite.mjs';
+import { handleSubmissions, purgeSubmitterIps, RETENTION_DAYS } from '../src/submissions.js';
+
+// The first public write route, so the tests are mostly about what it REFUSES.
+// Real SQLite on the real migrations: the rate limit is a COUNT over the table
+// it writes to, so a mock that answers by matching SQL fragments would be
+// asserting the belief the mock was written from.
+
+const NOW = Date.parse('2026-07-28T00:00:00.000Z');
+const IP = '203.0.113.7';
+
+const LOCATION = {
+  id: 'loc-1', name: 'Existing Loft', nexus_id: '12345', category: 'new-location',
+  x: 1, y: 2, z: 3, yaw: 90, description: 'a place', credits: null,
+  authors: '["Spud"]', tags: '["apartment"]', source: 'manual', status: 'published',
+  admin_notes: null, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+};
+
+/** A payload the shared validator accepts in full. */
+const VALID = {
+  name: 'Rooftop Bar',
+  authors: ['Spud'],
+  coordinates: [100, 200, 30],
+  nexus_id: '12345',
+  description: 'A bar on a roof.',
+  category: 'new-location',
+  tags: ['apartment'],
+};
+
+// `unset` rather than undefined for the two secrets: a default parameter treats
+// an explicitly passed undefined as absent, so `envFor({ secret: undefined })`
+// would quietly hand back a configured environment and the test would assert
+// nothing.
+const unset = Symbol('unset');
+
+function envFor({ salt = 'pepper', secret = 'turnstile-secret', locations = [LOCATION] } = {}) {
+  const env = { DB: sqliteD1({ locations }) };
+  if (salt !== unset) env.SUBMISSION_IP_SALT = salt;
+  if (secret !== unset) env.TURNSTILE_SECRET_KEY = secret;
+  return env;
+}
+
+/** A siteverify stub. `calls` records each verification attempt. */
+function turnstile({ success = true, codes = [], transport = 'ok', calls = [] } = {}) {
+  const impl = async (url, init) => {
+    calls.push(JSON.parse(init.body));
+    if (transport === 'throw') throw new Error('network down');
+    if (transport === 'http-error') return { ok: false, status: 500, async json() { return {}; } };
+    return { ok: true, async json() { return { success, 'error-codes': codes }; } };
+  };
+  impl.calls = calls;
+  return impl;
+}
+
+function post(body, { ip = IP } = {}) {
+  return new Request('https://api.nczoning.net/submissions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'CF-Connecting-IP': ip },
+    body: JSON.stringify(body),
+  });
+}
+
+const submit = (env, body, opts = {}) => handleSubmissions(
+  post(body, opts), env, { fetchImpl: opts.fetchImpl ?? turnstile(), nowMs: opts.nowMs ?? NOW },
+);
+
+const rows = (env) => env.DB.rows('SELECT * FROM submissions ORDER BY id');
+const audits = (env) => env.DB.rows('SELECT * FROM audit_log ORDER BY id');
+
+// ------------------------------------------------------------ the happy path ---
+
+test('a valid create is queued as pending and nothing reaches the map', async () => {
+  const env = envFor();
+  const res = await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' });
+  assert.equal(res.status, 201);
+
+  const body = await res.json();
+  assert.equal(body.status, 'pending');
+  assert.ok(body.id, 'the submitter needs the id to be told about it later');
+
+  const queued = rows(env);
+  assert.equal(queued.length, 1);
+  assert.equal(queued[0].kind, 'create');
+  assert.equal(JSON.parse(queued[0].payload).name, 'Rooftop Bar');
+
+  assert.equal(
+    env.DB.one('SELECT COUNT(*) AS n FROM locations').n, 1,
+    'a submission must not publish: the map still holds only the seeded location',
+  );
+});
+
+test('every accepted submission produces an audit row', async () => {
+  const env = envFor();
+  await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' });
+  const log = audits(env);
+  assert.equal(log.length, 1);
+  assert.equal(log[0].action, 'submission.create');
+  assert.equal(log[0].actor, 'anonymous');
+  assert.equal(log[0].target, String(rows(env)[0].id));
+});
+
+test('a refused submission writes neither a row nor an audit entry', async () => {
+  const env = envFor();
+  const res = await submit(env, { kind: 'create', payload: { name: 'x' }, turnstile_token: 't' });
+  assert.equal(res.status, 400);
+  assert.equal(rows(env).length, 0);
+  assert.equal(audits(env).length, 0, 'the audit log records writes, not attempts');
+});
+
+// --------------------------------------------------------- admin-only fields ---
+
+test('admin-only fields are refused rather than dropped', async () => {
+  // Dropping them silently would leave an approve path applying a status the
+  // submitter chose, and the submitter believing they had set it.
+  const env = envFor();
+  for (const field of [{ status: 'published' }, { admin_notes: 'let me in' }, { source: 'auto' }]) {
+    const res = await submit(env, {
+      kind: 'create', payload: { ...VALID, ...field }, turnstile_token: 't',
+    });
+    const key = Object.keys(field)[0];
+    assert.equal(res.status, 400, `${key} must not be accepted`);
+    const { errors } = await res.json();
+    assert.ok(errors.some((e) => e.startsWith(key)), `the refusal must name ${key}: ${errors}`);
+  }
+  assert.equal(rows(env).length, 0);
+});
+
+// ------------------------------------------------------ the shared validator ---
+
+test('a coordinate outside the terrain extent is refused', async () => {
+  const env = envFor();
+  const res = await submit(env, {
+    kind: 'create', payload: { ...VALID, coordinates: [99999, 0, 0] }, turnstile_token: 't',
+  });
+  assert.equal(res.status, 400);
+  const { errors } = await res.json();
+  assert.ok(errors.some((e) => e.includes('coordinate X')), errors.join('; '));
+});
+
+test('an unknown tag is refused', async () => {
+  const env = envFor();
+  const res = await submit(env, {
+    kind: 'create', payload: { ...VALID, tags: ['not-a-real-tag'] }, turnstile_token: 't',
+  });
+  assert.equal(res.status, 400);
+  const { errors } = await res.json();
+  assert.ok(errors.some((e) => e.includes('unknown tag')), errors.join('; '));
+});
+
+// ---------------------------------------------------------------- Turnstile ---
+
+test('a failed Turnstile check is a 403 with a distinct code', async () => {
+  const env = envFor();
+  const res = await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' }, {
+    fetchImpl: turnstile({ success: false, codes: ['invalid-input-response'] }),
+  });
+  assert.equal(res.status, 403);
+  assert.equal((await res.json()).error, 'turnstile_failed');
+  assert.equal(rows(env).length, 0);
+});
+
+test('an expired or reused token is distinguishable from a refusal', async () => {
+  // Tokens are single-use and last five minutes, so a form left open produces
+  // this and the modal should re-render the widget rather than accuse anyone.
+  const env = envFor();
+  const res = await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' }, {
+    fetchImpl: turnstile({ success: false, codes: ['timeout-or-duplicate'] }),
+  });
+  assert.equal((await res.json()).error, 'turnstile_expired');
+});
+
+test('a missing token never reaches siteverify', async () => {
+  const env = envFor();
+  const calls = [];
+  const res = await submit(env, { kind: 'create', payload: VALID }, {
+    fetchImpl: turnstile({ calls }),
+  });
+  assert.equal(res.status, 403);
+  assert.equal((await res.json()).error, 'turnstile_missing');
+  assert.deepEqual(calls, []);
+});
+
+test('a siteverify outage fails closed, not open', async () => {
+  // A bot check that passes on error is a bot check an attacker triggers on
+  // purpose.
+  const env = envFor();
+  for (const transport of ['throw', 'http-error']) {
+    const res = await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' }, {
+      fetchImpl: turnstile({ transport }),
+    });
+    assert.equal(res.status, 503, transport);
+    assert.equal((await res.json()).error, 'verification_unavailable');
+  }
+  assert.equal(rows(env).length, 0);
+});
+
+test('an unset Turnstile secret closes the route instead of skipping the check', async () => {
+  const env = envFor({ secret: unset });
+  const res = await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' });
+  assert.equal(res.status, 503);
+  assert.equal(rows(env).length, 0);
+});
+
+// ------------------------------------------------------- the submitter's IP ---
+
+test('the address is stored as a salted hash and never in the clear', async () => {
+  const env = envFor();
+  await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' });
+  const stored = rows(env)[0].submitter_ip_hash;
+  assert.match(stored, /^[0-9a-f]{64}$/);
+  assert.equal(JSON.stringify(rows(env)).includes(IP), false, 'the raw address must appear nowhere');
+
+  // Same address, different salt: a different hash. Without the salt the digest
+  // of an IPv4 is reversed by enumerating four billion inputs, so the salt is
+  // what makes this a hash rather than a stored address.
+  const other = envFor({ salt: 'a-different-salt' });
+  await submit(other, { kind: 'create', payload: VALID, turnstile_token: 't' });
+  assert.notEqual(rows(other)[0].submitter_ip_hash, stored);
+});
+
+test('an unset salt refuses the write rather than storing something weaker', async () => {
+  const env = envFor({ salt: unset });
+  const res = await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' });
+  assert.equal(res.status, 503);
+  assert.equal((await res.json()).error, 'submissions_unavailable');
+  assert.equal(rows(env).length, 0);
+});
+
+// --------------------------------------------------------------- rate limit ---
+
+test('the rate limit trips, and only accepted submissions count towards it', async () => {
+  const env = envFor();
+  for (let i = 0; i < 5; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    const res = await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' });
+    assert.equal(res.status, 201, `submission ${i + 1} should be accepted`);
+  }
+  const blocked = await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' });
+  assert.equal(blocked.status, 429);
+  assert.equal((await blocked.json()).error, 'rate_limited');
+  assert.equal(rows(env).length, 5);
+
+  // A different address is unaffected: the limit is per submitter, not global.
+  const elsewhere = await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' }, { ip: '198.51.100.4' });
+  assert.equal(elsewhere.status, 201);
+});
+
+test('the window rolls forward', async () => {
+  const env = envFor();
+  for (let i = 0; i < 5; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' });
+  }
+  const later = await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' }, {
+    nowMs: NOW + 61 * 60 * 1000,
+  });
+  assert.equal(later.status, 201, 'an hour later the earlier submissions are outside the window');
+});
+
+test('a rate-limited request costs no siteverify call', async () => {
+  const env = envFor();
+  for (let i = 0; i < 5; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' });
+  }
+  const calls = [];
+  await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' }, { fetchImpl: turnstile({ calls }) });
+  assert.deepEqual(calls, [], 'a flood must not become a flood of verification requests');
+});
+
+// ------------------------------------------------------------- edit / remove ---
+
+test('an edit needs an existing location and at least one field', async () => {
+  const env = envFor();
+  const missing = await submit(env, {
+    kind: 'edit', location_id: 'no-such-id', payload: { yaw: 45 }, turnstile_token: 't',
+  });
+  assert.equal(missing.status, 400);
+
+  const empty = await submit(env, {
+    kind: 'edit', location_id: 'loc-1', payload: {}, turnstile_token: 't',
+  });
+  assert.equal(empty.status, 400);
+
+  const ok = await submit(env, {
+    kind: 'edit', location_id: 'loc-1', payload: { yaw: 45 }, turnstile_token: 't',
+  });
+  assert.equal(ok.status, 201);
+  assert.deepEqual(JSON.parse(rows(env)[0].payload), { yaw: 45 },
+    'only the changed field is queued, so the reviewer sees a diff rather than a restatement');
+});
+
+test('an edit is validated partially, but still validated', async () => {
+  const env = envFor();
+  const res = await submit(env, {
+    kind: 'edit', location_id: 'loc-1', payload: { coordinates: [0, 0, 99999] }, turnstile_token: 't',
+  });
+  assert.equal(res.status, 400);
+  const { errors } = await res.json();
+  assert.ok(errors.some((e) => e.includes('coordinate Z')), errors.join('; '));
+});
+
+test('a removal needs a reason and carries no payload', async () => {
+  const env = envFor();
+  const noReason = await submit(env, { kind: 'remove', location_id: 'loc-1', turnstile_token: 't' });
+  assert.equal(noReason.status, 400);
+
+  const withPayload = await submit(env, {
+    kind: 'remove', location_id: 'loc-1', payload: VALID, reason: 'gone from Nexus', turnstile_token: 't',
+  });
+  assert.equal(withPayload.status, 400, 'there is nothing for a reviewer to apply from a removal payload');
+
+  const ok = await submit(env, {
+    kind: 'remove', location_id: 'loc-1', reason: 'gone from Nexus', turnstile_token: 't',
+  });
+  assert.equal(ok.status, 201);
+  assert.equal(JSON.parse(rows(env)[0].payload).reason, 'gone from Nexus');
+});
+
+test('an unknown kind is refused before anything else happens', async () => {
+  const env = envFor();
+  const calls = [];
+  const res = await submit(env, { kind: 'publish', payload: VALID, turnstile_token: 't' }, {
+    fetchImpl: turnstile({ calls }),
+  });
+  assert.equal(res.status, 400);
+  assert.equal((await res.json()).error, 'invalid_kind');
+  assert.deepEqual(calls, []);
+});
+
+// ------------------------------------------------------------------- limits ---
+
+test('a large payload binds a constant number of parameters', async () => {
+  // D1 refuses more than 100 bound parameters, and the harness enforces it. The
+  // payload is bound as ONE json string rather than a placeholder per field, so
+  // a submission with many fields cannot approach the ceiling; a future change
+  // that spreads the payload across columns would fail here.
+  const env = envFor();
+  const wide = {
+    ...VALID,
+    authors: Array.from({ length: 60 }, (_, i) => `Author ${i}`),
+    description: 'x'.repeat(500),
+  };
+  const res = await submit(env, { kind: 'create', payload: wide, turnstile_token: 't' });
+  assert.equal(res.status, 201);
+  assert.equal(JSON.parse(rows(env)[0].payload).authors.length, 60);
+});
+
+// --------------------------------------------------------------- candidates ---
+
+test('candidates come from nexus_cache, not from a live Nexus call', async () => {
+  const env = envFor();
+  env.DB._db.prepare(
+    `INSERT INTO nexus_cache (nexus_id, name, thumbnail_url, nczoning_tagged, fetched_at)
+     VALUES (?, ?, ?, 1, ?)`,
+  ).run('900', 'Tagged Not Mapped', 'thumb', '2026-07-27T00:00:00Z');
+  env.DB._db.prepare(
+    `INSERT INTO nexus_cache (nexus_id, name, nczoning_tagged, fetched_at)
+     VALUES (?, ?, 1, ?)`,
+  ).run('12345', 'Already A Location', '2026-07-27T00:00:00Z');
+
+  const res = await handleSubmissions(
+    new Request('https://api.nczoning.net/submissions/candidates'), env, {},
+  );
+  assert.equal(res.status, 200);
+  const { candidates } = await res.json();
+  assert.deepEqual(candidates.map((c) => c.nexus_id), ['900'],
+    '12345 is already on the map, so it is not a candidate');
+});
+
+test('the candidates route refuses a write, and the submit route refuses a read', async () => {
+  const env = envFor();
+  const written = await handleSubmissions(
+    new Request('https://api.nczoning.net/submissions/candidates', { method: 'POST' }), env, {},
+  );
+  assert.equal(written.status, 405);
+
+  const read = await handleSubmissions(
+    new Request('https://api.nczoning.net/submissions'), env, {},
+  );
+  assert.equal(read.status, 405);
+});
+
+test('an unknown path under the prefix is a 404, not a fall-through', async () => {
+  const env = envFor();
+  const res = await handleSubmissions(
+    new Request('https://api.nczoning.net/submissions/approve', { method: 'POST' }), env, {},
+  );
+  assert.equal(res.status, 404);
+});
+
+test('a path outside the prefix is left alone', async () => {
+  const env = envFor();
+  assert.equal(
+    await handleSubmissions(new Request('https://api.nczoning.net/v1/locations'), env, {}),
+    null,
+    'returning a response here would swallow every other route',
+  );
+});
+
+// ---------------------------------------------------------------- retention ---
+
+test('hashed addresses are cleared after the retention window, and the row is kept', async () => {
+  const env = envFor();
+  await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' });
+  const old = NOW - (RETENTION_DAYS + 1) * 86400000;
+  await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' }, { nowMs: old, ip: '198.51.100.9' });
+
+  const cleared = await purgeSubmitterIps(env, NOW);
+  assert.equal(cleared, 1);
+
+  const after = rows(env);
+  assert.equal(after.length, 2, 'the queue itself is untouched');
+  assert.equal(after.filter((r) => r.submitter_ip_hash === null).length, 1);
+  assert.ok(after.find((r) => r.submitter_ip_hash !== null), 'a recent submission keeps its hash');
+});
+
+test('a purge with nothing to clear writes nothing', async () => {
+  const env = envFor();
+  await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' });
+  assert.equal(await purgeSubmitterIps(env, NOW), 0);
+});

--- a/worker/test/validate.test.js
+++ b/worker/test/validate.test.js
@@ -5,6 +5,9 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { validateLocationInput, CATEGORIES } from '../src/validate.js';
+import {
+  WORLD_MIN_X, WORLD_MAX_X, WORLD_MIN_Y, WORLD_MAX_Y, COORD_Z_MIN, COORD_Z_MAX,
+} from '../src/config.js';
 
 const require = createRequire(import.meta.url);
 const Ajv = require('ajv');
@@ -127,4 +130,68 @@ test('non-finite coordinates are rejected', () => {
     const r = validateLocationInput({ ...asInput(RECORDS[0]), coordinates: bad }, { tagNames: TAG_NAMES });
     assert.equal(r.ok, false, JSON.stringify(bad));
   }
+});
+
+// ------------------------------------------------------- coordinate range ---
+// ajv has no opinion here: `mods.schema.json` never carried a range, so these
+// are write-path-only. The rule lived in the browser until Phase 5, which was
+// survivable while every writer was an authenticated collaborator and stops
+// being so the moment /submissions accepts anonymous writes.
+
+test('coordinates outside the world bounds are rejected', () => {
+  const base = asInput(RECORDS[0]);
+  const cases = [
+    ['X below min', [WORLD_MIN_X - 1, 0, 0], /coordinate X/],
+    ['X above max', [WORLD_MAX_X + 1, 0, 0], /coordinate X/],
+    ['Y below min', [0, WORLD_MIN_Y - 1, 0], /coordinate Y/],
+    ['Y above max', [0, WORLD_MAX_Y + 1, 0], /coordinate Y/],
+    ['Z below min', [0, 0, COORD_Z_MIN - 1], /coordinate Z/],
+    ['Z above max', [0, 0, COORD_Z_MAX + 1], /coordinate Z/],
+    ['a pasted nonsense value', [999999, 999999, 999999], /coordinate/],
+  ];
+  for (const [label, coordinates, pattern] of cases) {
+    const r = validateLocationInput({ ...base, coordinates }, { tagNames: TAG_NAMES });
+    assert.equal(r.ok, false, `accepted ${label}: ${JSON.stringify(coordinates)}`);
+    assert.match(r.errors.join(' '), pattern, label);
+  }
+});
+
+test('the bounds admit the real corpus, including its four extremes', () => {
+  // The guard on the whole change. The browser rule of +/-5000 on X/Y and
+  // +/-1000 on Z rejects four records that are live on the map right now, so
+  // porting those numbers would have refused real data. Named individually
+  // because a corpus-wide loop that silently stopped covering them would still
+  // pass. Measured 2026-07-27.
+  const extremes = [
+    ['Sea Wall Towers Detailed', -5782.011, 1781.279, 195.898],
+    ['Outdoor V - Canyon Forest', 5321.252, -226.151, 99.817],
+    ['Forest Canyon Campsite', 5320.874, -240.78528, 97.97386],
+    ['Crystal Palace Resort', 322.9296, -1017.5965, 1524.5823],
+  ];
+  for (const [name, x, y, z] of extremes) {
+    const inCorpus = RECORDS.find((r) => r.name === name);
+    assert.ok(inCorpus, `${name} has left data/locations, so this test no longer guards anything`);
+    assert.deepEqual(
+      inCorpus.coordinates.map(Number), [x, y, z],
+      `${name} moved; re-measure the bounds rather than editing this expectation`,
+    );
+    const r = validateLocationInput({ ...asInput(inCorpus) }, { tagNames: TAG_NAMES });
+    assert.equal(r.ok, true, `bounds reject the live record ${name}: ${r.errors.join('; ')}`);
+  }
+});
+
+test('partial mode still range-checks coordinates that are present', () => {
+  const ok = validateLocationInput({ coordinates: [0, 0, 0] }, { tagNames: TAG_NAMES, partial: true });
+  assert.equal(ok.ok, true);
+  const bad = validateLocationInput({ coordinates: [999999, 0, 0] }, { tagNames: TAG_NAMES, partial: true });
+  assert.equal(bad.ok, false, 'a PATCH could smuggle an out-of-range coordinate past the check');
+});
+
+test('a two-element coordinate skips the Z check rather than reading undefined', () => {
+  // [X, Y] is still valid input. Reading c[2] as a number here would compare
+  // undefined against the bounds and quietly pass, or throw, depending on order.
+  const r = validateLocationInput(
+    { ...asInput(RECORDS[0]), coordinates: [0, 0] }, { tagNames: TAG_NAMES },
+  );
+  assert.equal(r.ok, true, r.errors.join('; '));
 });

--- a/worker/test/validate.test.js
+++ b/worker/test/validate.test.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
 import { validateLocationInput, CATEGORIES } from '../src/validate.js';
 import {
-  WORLD_MIN_X, WORLD_MAX_X, WORLD_MIN_Y, WORLD_MAX_Y, COORD_Z_MIN, COORD_Z_MAX,
+  TERRAIN_MIN_X, TERRAIN_MAX_X, TERRAIN_MIN_Y, TERRAIN_MAX_Y, COORD_Z_MIN, COORD_Z_MAX,
 } from '../src/config.js';
 
 const require = createRequire(import.meta.url);
@@ -141,10 +141,10 @@ test('non-finite coordinates are rejected', () => {
 test('coordinates outside the world bounds are rejected', () => {
   const base = asInput(RECORDS[0]);
   const cases = [
-    ['X below min', [WORLD_MIN_X - 1, 0, 0], /coordinate X/],
-    ['X above max', [WORLD_MAX_X + 1, 0, 0], /coordinate X/],
-    ['Y below min', [0, WORLD_MIN_Y - 1, 0], /coordinate Y/],
-    ['Y above max', [0, WORLD_MAX_Y + 1, 0], /coordinate Y/],
+    ['X below min', [TERRAIN_MIN_X - 1, 0, 0], /coordinate X/],
+    ['X above max', [TERRAIN_MAX_X + 1, 0, 0], /coordinate X/],
+    ['Y below min', [0, TERRAIN_MIN_Y - 1, 0], /coordinate Y/],
+    ['Y above max', [0, TERRAIN_MAX_Y + 1, 0], /coordinate Y/],
     ['Z below min', [0, 0, COORD_Z_MIN - 1], /coordinate Z/],
     ['Z above max', [0, 0, COORD_Z_MAX + 1], /coordinate Z/],
     ['a pasted nonsense value', [999999, 999999, 999999], /coordinate/],
@@ -157,11 +157,10 @@ test('coordinates outside the world bounds are rejected', () => {
 });
 
 test('the bounds admit the real corpus, including its four extremes', () => {
-  // The guard on the whole change. The browser rule of +/-5000 on X/Y and
-  // +/-1000 on Z rejects four records that are live on the map right now, so
-  // porting those numbers would have refused real data. Named individually
-  // because a corpus-wide loop that silently stopped covering them would still
-  // pass. Measured 2026-07-27.
+  // These four sit outside the browser form's +/-5000 X/Y and +/-1000 Z, so
+  // they are what stops those numbers being adopted here. Named individually
+  // rather than left to the corpus-wide loop, which would still pass if it
+  // silently stopped covering them.
   const extremes = [
     ['Sea Wall Towers Detailed', -5782.011, 1781.279, 195.898],
     ['Outdoor V - Canyon Forest', 5321.252, -226.151, 99.817],


### PR DESCRIPTION
Phase 5, PR A2. The submission queue's server side.

Supersedes #892, which GitHub closed rather than retargeted when its base branch `feat/nexus-cache` was deleted on merging #891. Same six commits, rebased onto `dev`. No review had happened on it, so nothing is lost.

Depends on #891, now merged: `GET /submissions/candidates` is a `readCandidates` call against `nexus_cache`.

## What this adds

| Route | Auth | Does |
| --- | --- | --- |
| `POST /submissions` | anonymous, Turnstile + rate limit | queues a `create`, `edit` or `remove`; `201` with the id |
| `GET /submissions/candidates` | anonymous | NCZoning-tagged mods that are neither a location nor dismissed |

Nothing this route accepts reaches the map. A row lands in `submissions` as `pending`; approval is a separate collaborator-gated action, which is PR B.

The three commits already on this branch (server-side coordinate range, the terrain-extent bounds, the `TERRAIN_*` rename) are unchanged and were rebased onto #891.

## The decisions worth arguing with

**Admin-only fields are refused, not dropped.** `status`, `admin_notes` and `source` are writable by an admin and part of the same validator this route reuses. A payload carrying `status: 'published'` gets a 400 naming the field. Stripping them silently would leave an approve path applying a field the submitter chose, and the submitter believing they had set it.

**Both secrets fail closed.** No `SUBMISSION_IP_SALT` returns 503 rather than storing an unsalted hash: SHA-256 of an IPv4 address has four billion possible inputs, so an unsalted hash is a stored address with extra steps. No `TURNSTILE_SECRET_KEY`, and any `siteverify` outage, returns 503 rather than letting the submission through. A bot check that opens on error is one an attacker triggers on purpose. Both mean **the route is dead until the secrets are set**, which is the intended failure direction.

**Retention is 90 days regardless of status**, which is stricter than the plan's "resolved submissions after 90 days". A submission still pending after three months is abandoned, and no version of abuse triage needs its address. The row and the queue are untouched; only the hash is cleared. It runs from `scheduled()` separately from the refresh, so a failed rebuild cannot stop the clock on data the site promised to delete.

**The rate limit counts rows, not attempts.** 5 accepted submissions per address per hour, via `COUNT(*)` over `submissions`: no new table, no KV write per attempt. Only accepted submissions count, so someone fixing a validation error six times is not locked out. The check runs before Turnstile, so a flood does not become a flood of `siteverify` calls.

**No `API_VERSION` bump and not in `openapi.json`**, following `/auth/` and `/admin/`. The spec documents the `/v1` contract in-game consumers read, and this route is not part of it. Say so if you would rather it were versioned.

## Verification

**266 tests pass** (239 before), 27 of them new. Ten negative controls were run by sabotaging one rule at a time and confirming the guarding test goes red: admin-only fields dropped instead of refused, Turnstile opening on a network failure, an unset secret skipping the check, the salt removed from the hash, an unset salt falling back, the rate limit removed, the limit counted globally rather than per address, an edit accepting a location that does not exist, the retention purge clearing nothing, and the router swallowing paths outside its prefix.

Two things the tests assert that are easy to get wrong by accident:

- **The raw address appears nowhere.** Asserted by searching the serialised rows for it, not by checking that the hash column looks like a hash.
- **The same address under a different salt hashes differently.** A hash that ignored the salt would still look correct in every other assertion.

One test-harness bug surfaced and is fixed here: `run()` returned no `last_row_id`, so reading D1's name for it off the harness gave `undefined`, and `undefined` is a plausible-looking id.

## Before this can serve traffic

Four things, all yours:

1. `wrangler secret put SUBMISSION_IP_SALT` on **production and staging** (the salts may differ; nothing compares them).
2. A Turnstile widget, then `wrangler secret put TURNSTILE_SECRET_KEY` on both. The site key is a frontend value and lands with the modal in PR C.
3. The WAF rate-limit rule for `/submissions` and `/auth/`, documented in the README's rate limiting section. Never zone-wide Bot Fight Mode: it would 403 `/v1/*` and every in-game consumer.
4. A read of [docs/privacy.md](docs/privacy.md) before it is public. It makes commitments about retention and about what is never stored, and it is the first such page the repo has had.

Until then the route answers 503, which is correct and is what the tests assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

