### PR TITLE
refactor(map): rename the submit modal off bbcode-*

### DIFF
--- a/.github/ISSUE_TEMPLATE/mod_submission.yml
+++ b/.github/ISSUE_TEMPLATE/mod_submission.yml
@@ -43,7 +43,7 @@ body:
         4. Note the **X**, **Y**, **Z**, and **Yaw** values from the output
 
         **Option 2 — Simple Location Manager:**
-        Install [Simple Location Manager](https://www.nexusmods.com/cyberpunk2077/mods/26454), save the location, then read the X, Y, Z from the saved entry. The BBCode Generator modal on the NC Zoning Board website also has this command ready to copy.
+        Install [Simple Location Manager](https://www.nexusmods.com/cyberpunk2077/mods/26454), save the location, then read the X, Y, Z from the saved entry. The submit form on the NC Zoning Board website also has this command ready to copy.
   - type: input
     id: coord_x
     attributes:

--- a/.github/ISSUE_TEMPLATE/modify_location.yml
+++ b/.github/ISSUE_TEMPLATE/modify_location.yml
@@ -51,7 +51,7 @@ body:
         4. Note the **X**, **Y**, **Z**, and **Yaw** values from the output
 
         **Option 2 — Simple Location Manager:**
-        Install [Simple Location Manager](https://www.nexusmods.com/cyberpunk2077/mods/26454), save the location, then read the X, Y, Z from the saved entry. The BBCode Generator modal on the NC Zoning Board website also has this command ready to copy.
+        Install [Simple Location Manager](https://www.nexusmods.com/cyberpunk2077/mods/26454), save the location, then read the X, Y, Z from the saved entry. The submit form on the NC Zoning Board website also has this command ready to copy.
   - type: input
     id: coord_x
     attributes:

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -2155,7 +2155,7 @@ body::before {
     display: none !important;
 }
 
-/* ── BBCode Header Button ─────────────────────────────────────────── */
+/* ── Submit Header Button ─────────────────────────────────────────── */
 .parameters-modal-content,
 .showcase-modal-content {
     max-width: 420px;
@@ -2257,30 +2257,30 @@ body::before {
     background-size: contain;
 }
 
-/* ── BBCode Generator Modal ───────────────────────────────────────── */
-.bbcode-modal-content {
+/* ── Submit a Location Modal ──────────────────────────────────────── */
+.submit-modal-content {
     max-width: 560px;
     width: 95%;
 }
 
-.bbcode-modal-body {
+.submit-modal-body {
     max-height: 80svh;
     overflow-y: auto;
 }
 
-.bbcode-form {
+.submit-form {
     display: flex;
     flex-direction: column;
 }
 
-.bbcode-field-row {
+.submit-field-row {
     display: flex;
     flex-direction: column;
     gap: var(--space-xs);
     margin-bottom: 14px;
 }
 
-.bbcode-label {
+.submit-label {
     font-family: var(--font-heading);
     font-size: var(--text-2xs);
     color: var(--secondary);
@@ -2288,7 +2288,7 @@ body::before {
     letter-spacing: 1px;
 }
 
-.bbcode-optional {
+.submit-optional {
     color: var(--gray);
     font-family: var(--font-body);
     text-transform: none;
@@ -2296,7 +2296,7 @@ body::before {
     font-size: var(--text-xs);
 }
 
-.bbcode-coord-inputs {
+.submit-coord-inputs {
     display: flex;
     gap: var(--space-sm);
     align-items: center;
@@ -2316,17 +2316,17 @@ body::before {
     min-width: var(--space-md);
 }
 
-.bbcode-coord-note {
+.submit-hint {
     font-size: var(--text-xs);
     color: var(--tertiary);
     margin-top: 0.25rem;
     font-family: var(--font-body);
 }
 
-.bbcode-coord-inputs input[type="number"],
-.bbcode-input,
-.bbcode-select,
-.bbcode-textarea {
+.submit-coord-inputs input[type="number"],
+.submit-input,
+.ui-select,
+.submit-textarea {
     transition: border-color 0.2s ease;
 
     &:focus {
@@ -2334,19 +2334,19 @@ body::before {
     }
 }
 
-.bbcode-coord-inputs {
+.submit-coord-inputs {
     input[type="number"] {
         width: 140px;
     }
 }
 
-.bbcode-tag-grid {
+.submit-tag-grid {
     display: flex;
     flex-wrap: wrap;
     gap: var(--space-xs);
 }
 
-.bbcode-tag-checkbox {
+.submit-tag-checkbox {
     display: flex;
     align-items: center;
     gap: var(--space-2xs);
@@ -2369,12 +2369,7 @@ body::before {
     }
 }
 
-.bbcode-checkbox-row {
-    flex-direction: row;
-    align-items: center;
-}
-
-.bbcode-checkbox-label {
+.ui-checkbox-label {
     display: flex;
     align-items: center;
     gap: var(--space-sm);
@@ -2394,7 +2389,7 @@ body::before {
     }
 }
 
-.bbcode-cet-command-block {
+.submit-cet-command-block {
     display: flex;
     gap: var(--space-sm);
     align-items: flex-start;
@@ -2418,7 +2413,7 @@ body::before {
 
 
 /* ── Steps & Notes ───────────────────────────────────────────────── */
-.bbcode-steps {
+.submit-steps {
     list-style: none;
     counter-reset: step;
     padding: 0;
@@ -2456,7 +2451,7 @@ body::before {
     }
 }
 
-.bbcode-note {
+.submit-intro {
     font-size: var(--text-sm);
     color: var(--gray);
     font-style: italic;
@@ -2464,12 +2459,12 @@ body::before {
 }
 
 /* ── Submit a Location ───────────────────────────────────────────────── */
-/* Layered on the .bbcode-* rules above rather than parallel to them: the two
+/* Layered on the form rules above rather than parallel to them: the two
    share every field, and only the send path is new. */
 
 /* .terminal-link is a block, sized for the sidebar. Inside a sentence it has to
    be a word. */
-.bbcode-coord-note .terminal-link {
+.submit-hint .terminal-link {
     display: inline;
     padding: 0;
     border-left: none;
@@ -2522,9 +2517,9 @@ body::before {
    class plus a bare attribute loses to it and the border stays grey. Held
    through :focus, or it reverts the moment the box being complained about is
    clicked. */
-.bbcode-modal-body .bbcode-form input[aria-invalid="true"],
-.bbcode-modal-body .bbcode-form select[aria-invalid="true"],
-.bbcode-modal-body .bbcode-form textarea[aria-invalid="true"] {
+.submit-modal-body .submit-form input[aria-invalid="true"],
+.submit-modal-body .submit-form select[aria-invalid="true"],
+.submit-modal-body .submit-form textarea[aria-invalid="true"] {
     border-color: var(--status-critical);
     background: var(--status-critical-10);
 
@@ -2573,14 +2568,14 @@ body::before {
 /* The submitted state replaces the form rather than sitting under it: the
    submission cannot be edited after sending, so leaving the fields live would
    invite an edit that goes nowhere. */
-.bbcode-form.is-submitted > *:not(#submit-done) {
+.submit-form.is-submitted > *:not(#submit-done) {
     display: none;
 }
 
 /* The steps and the note describe filling the form in, so they leave with it. */
-.bbcode-modal-body.is-submitted {
-    .bbcode-steps,
-    > .bbcode-note {
+.submit-modal-body.is-submitted {
+    .submit-steps,
+    > .submit-intro {
         display: none;
     }
 }
@@ -2614,7 +2609,7 @@ body::before {
    somewhere else. The fixed-width coordinate inputs are the only rule in the
    modal that cannot reflow on its own. */
 @media (max-width: 768px) {
-    .bbcode-coord-inputs {
+    .submit-coord-inputs {
         input[type="number"] {
             width: 100%;
         }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -36,8 +36,8 @@ document.addEventListener("DOMContentLoaded", () => {
   const aboutBtn = document.getElementById("about-btn");
   const aboutModal = document.getElementById("about-modal");
   const closeAboutBtn = document.getElementById("close-about-modal");
-  const aboutOpenBbcodeLink = document.getElementById("about-open-bbcode-link");
-  const sidebarOpenBbcodeLink = document.getElementById("sidebar-open-bbcode-link");
+  const aboutOpenSubmitLink = document.getElementById("about-open-submit-link");
+  const sidebarOpenSubmitLink = document.getElementById("sidebar-open-submit-link");
 
   aboutBtn.addEventListener("click", () => {
     aboutModal.classList.remove("hidden");
@@ -199,17 +199,17 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   // Submit a Location Modal
-  const bbcodeBtn = document.getElementById("bbcode-btn");
-  const bbcodeModal = document.getElementById("bbcode-modal");
-  const closeBbcodeModalBtn = document.getElementById("close-bbcode-modal");
-  const submitForm = bbcodeModal?.querySelector(".bbcode-form");
+  const submitOpenBtn = document.getElementById("submit-open-btn");
+  const submitModal = document.getElementById("submit-modal");
+  const closeSubmitModalBtn = document.getElementById("close-submit-modal");
+  const submitForm = submitModal?.querySelector(".submit-form");
   const modSelect = document.getElementById("submit-mod-select");
   const modManualRow = document.getElementById("submit-mod-manual");
   const modCard = document.getElementById("submit-mod-card");
   const modCardName = document.getElementById("submit-mod-card-name");
   const modThumb = document.getElementById("submit-mod-thumb");
   const nameInput = document.getElementById("submit-name");
-  const authorsInput = document.getElementById("bbcode-authors");
+  const authorsInput = document.getElementById("submit-authors");
   const descriptionInput = document.getElementById("submit-description");
   const descriptionCount = document.getElementById("submit-description-count");
   const sendBtn = document.getElementById("submit-send-btn");
@@ -226,10 +226,10 @@ document.addEventListener("DOMContentLoaded", () => {
     nexus_id: "submit-nexus-ref",
     name: "submit-name",
     description: "submit-description",
-    coordinates: "bbcode-coord-x",
-    yaw: "bbcode-yaw",
-    category: "bbcode-category",
-    authors: "bbcode-authors",
+    coordinates: "submit-coord-x",
+    yaw: "submit-yaw",
+    category: "submit-category",
+    authors: "submit-authors",
     note: "submit-note",
     contact: "submit-contact",
   };
@@ -241,13 +241,13 @@ document.addEventListener("DOMContentLoaded", () => {
   let descriptionIsPrefilled = true;
   let authorsIsPrefilled = true;
 
-  function openBbcodeModal() {
-    bbcodeModal.classList.remove("hidden");
+  function openSubmitModal() {
+    submitModal.classList.remove("hidden");
     loadCandidates();
     mountTurnstile();
   }
-  function closeBbcodeModal() {
-    bbcodeModal.classList.add("hidden");
+  function closeSubmitModal() {
+    submitModal.classList.add("hidden");
   }
 
   // ── Turnstile ──────────────────────────────────────────────────────────────
@@ -325,7 +325,7 @@ document.addEventListener("DOMContentLoaded", () => {
   // reader announces and the red border are the same fact.
   function markCoordinateAxes(axes) {
     ["x", "y", "z"].forEach((axis) => {
-      const box = document.getElementById(`bbcode-coord-${axis}`);
+      const box = document.getElementById(`submit-coord-${axis}`);
       box?.setAttribute("aria-invalid", axes.includes(axis) ? "true" : "false");
     });
   }
@@ -446,25 +446,25 @@ document.addEventListener("DOMContentLoaded", () => {
     return {
       name: nameInput?.value,
       description: descriptionInput?.value,
-      x: document.getElementById("bbcode-coord-x").value,
-      y: document.getElementById("bbcode-coord-y").value,
-      z: document.getElementById("bbcode-coord-z").value,
-      yaw: document.getElementById("bbcode-yaw").value,
-      category: document.getElementById("bbcode-category").value,
-      authors: document.getElementById("bbcode-authors").value,
-      credits: document.getElementById("bbcode-credits").value,
+      x: document.getElementById("submit-coord-x").value,
+      y: document.getElementById("submit-coord-y").value,
+      z: document.getElementById("submit-coord-z").value,
+      yaw: document.getElementById("submit-yaw").value,
+      category: document.getElementById("submit-category").value,
+      authors: document.getElementById("submit-authors").value,
+      credits: document.getElementById("submit-credits").value,
       nexusId: nexusRefValue(),
       note: document.getElementById("submit-note")?.value,
       contact: document.getElementById("submit-contact")?.value,
       tags: Array.from(
-        document.querySelectorAll("#bbcode-tag-checkboxes input:checked"),
+        document.querySelectorAll("#submit-tag-checkboxes input:checked"),
       ).map((cb) => cb.value),
     };
   }
 
   function knownTagSlugs() {
     return Array.from(
-      document.querySelectorAll("#bbcode-tag-checkboxes input"),
+      document.querySelectorAll("#submit-tag-checkboxes input"),
     ).map((cb) => cb.value);
   }
 
@@ -512,27 +512,27 @@ document.addEventListener("DOMContentLoaded", () => {
     markCoordinateAxes(problems.axes.filter((axis) => filled.has(axis)));
   }
 
-  ["bbcode-coord-x", "bbcode-coord-y", "bbcode-coord-z"].forEach((id) => {
+  ["submit-coord-x", "submit-coord-y", "submit-coord-z"].forEach((id) => {
     document.getElementById(id)?.addEventListener("input", validateCoordinatesLive);
   });
 
-  if (aboutOpenBbcodeLink) {
-    aboutOpenBbcodeLink.addEventListener("click", (event) => {
+  if (aboutOpenSubmitLink) {
+    aboutOpenSubmitLink.addEventListener("click", (event) => {
       event.preventDefault();
       aboutModal.classList.add("hidden");
-      openBbcodeModal();
+      openSubmitModal();
     });
   }
 
-  if (sidebarOpenBbcodeLink) {
-    sidebarOpenBbcodeLink.addEventListener("click", (event) => {
+  if (sidebarOpenSubmitLink) {
+    sidebarOpenSubmitLink.addEventListener("click", (event) => {
       event.preventDefault();
-      openBbcodeModal();
+      openSubmitModal();
     });
   }
 
-  if (bbcodeBtn) bbcodeBtn.addEventListener("click", openBbcodeModal);
-  if (closeBbcodeModalBtn) closeBbcodeModalBtn.addEventListener("click", closeBbcodeModal);
+  if (submitOpenBtn) submitOpenBtn.addEventListener("click", openSubmitModal);
+  if (closeSubmitModalBtn) closeSubmitModalBtn.addEventListener("click", closeSubmitModal);
 
   // \u2500\u2500 Send \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
 
@@ -579,7 +579,7 @@ document.addEventListener("DOMContentLoaded", () => {
     submitForm?.classList.add("is-submitted");
     // The steps and the note sit outside the form and describe filling it in,
     // down to "leave a contact below", so they go with it.
-    bbcodeModal?.querySelector(".bbcode-modal-body")?.classList.add("is-submitted");
+    submitModal?.querySelector(".submit-modal-body")?.classList.add("is-submitted");
     donePanel?.classList.remove("hidden");
     donePanel?.scrollIntoView({ block: "nearest" });
   }
@@ -621,14 +621,14 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function resetSubmitForm() {
-    document.getElementById("bbcode-coord-x").value = "";
-    document.getElementById("bbcode-coord-y").value = "";
-    document.getElementById("bbcode-coord-z").value = "";
-    document.getElementById("bbcode-yaw").value = "";
-    document.getElementById("bbcode-category").value = "";
-    document.getElementById("bbcode-credits").value = "";
-    document.getElementById("bbcode-authors").value = "";
-    document.querySelectorAll("#bbcode-tag-checkboxes input:checked").forEach((cb) => (cb.checked = false));
+    document.getElementById("submit-coord-x").value = "";
+    document.getElementById("submit-coord-y").value = "";
+    document.getElementById("submit-coord-z").value = "";
+    document.getElementById("submit-yaw").value = "";
+    document.getElementById("submit-category").value = "";
+    document.getElementById("submit-credits").value = "";
+    document.getElementById("submit-authors").value = "";
+    document.querySelectorAll("#submit-tag-checkboxes input:checked").forEach((cb) => (cb.checked = false));
 
     if (nameInput) nameInput.value = "";
     if (descriptionInput) descriptionInput.value = "";
@@ -648,12 +648,12 @@ document.addEventListener("DOMContentLoaded", () => {
     clearErrors();
     resetTurnstile();
     submitForm?.classList.remove("is-submitted");
-    bbcodeModal?.querySelector(".bbcode-modal-body")?.classList.remove("is-submitted");
+    submitModal?.querySelector(".submit-modal-body")?.classList.remove("is-submitted");
     donePanel?.classList.add("hidden");
   }
 
-  const bbcodeResetBtn = document.getElementById("bbcode-reset-btn");
-  if (bbcodeResetBtn) bbcodeResetBtn.addEventListener("click", resetSubmitForm);
+  const submitResetBtn = document.getElementById("submit-reset-btn");
+  if (submitResetBtn) submitResetBtn.addEventListener("click", resetSubmitForm);
 
   const submitAnotherBtn = document.getElementById("submit-another-btn");
   if (submitAnotherBtn) {
@@ -663,20 +663,20 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  const bbcodeCopyCetBtn = document.getElementById("bbcode-copy-cet-btn");
-  if (bbcodeCopyCetBtn) {
+  const copyCetBtn = document.getElementById("submit-copy-cet-btn");
+  if (copyCetBtn) {
     let cetCopyRevertTimer = null;
     const revertCetBtn = () => {
-      bbcodeCopyCetBtn.innerHTML = '<span class="ui-popup-action-link-icon" aria-hidden="true"></span>';
+      copyCetBtn.innerHTML = '<span class="ui-popup-action-link-icon" aria-hidden="true"></span>';
     };
-    bbcodeCopyCetBtn.addEventListener("click", () => {
-      const command = document.getElementById("bbcode-cet-command").textContent;
+    copyCetBtn.addEventListener("click", () => {
+      const command = document.getElementById("submit-cet-command").textContent;
       clearTimeout(cetCopyRevertTimer);
       navigator.clipboard.writeText(command).then(() => {
-        bbcodeCopyCetBtn.textContent = "Copied!";
+        copyCetBtn.textContent = "Copied!";
         cetCopyRevertTimer = setTimeout(revertCetBtn, NCZ.COPY_FEEDBACK_MS);
       }).catch(() => {
-        bbcodeCopyCetBtn.textContent = "Failed";
+        copyCetBtn.textContent = "Failed";
         cetCopyRevertTimer = setTimeout(revertCetBtn, NCZ.COPY_FEEDBACK_MS);
       });
     });
@@ -2748,17 +2748,17 @@ async function initMap() {
       });
     });
 
-    // 6. Populate BBCode generator tag checkboxes (requires tagsDict from this scope)
-    const bbcodeTagGrid = document.getElementById("bbcode-tag-checkboxes");
-    if (bbcodeTagGrid) {
+    // 6. Populate the submit form's tag checkboxes (requires tagsDict from this scope)
+    const submitTagGrid = document.getElementById("submit-tag-checkboxes");
+    if (submitTagGrid) {
       Object.keys(tagsDict)
         .sort()
         .forEach((tag) => {
           const label = document.createElement("label");
-          label.className = "bbcode-tag-checkbox";
+          label.className = "submit-tag-checkbox";
           label.title = tagsDict[tag] || "";
           label.innerHTML = `<input type="checkbox" value="${tag}"> ${tag}`;
-          bbcodeTagGrid.appendChild(label);
+          submitTagGrid.appendChild(label);
         });
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ The core frontend JS is four files loaded via `<script>` tags (no ES modules, no
 | File | Role |
 | --- | --- |
 | `constants.js` | All config values: category styles, API endpoints, cache keys, UI sizing, 3D scene constants |
-| `utils.js` | Pure functions: `escapeHtml`, `cetToLeaflet`, `cetToThree`, positioning algorithm, BBCode parser |
+| `utils.js` | Pure functions: `escapeHtml`, `cetToLeaflet`, `cetToThree`, positioning algorithm, submit-form validation (`collectLocationForm`) |
 | `services.js` | Fetch functions: the `/v1` Data API loader (`fetchLocationsFromApi()`) |
 | `app.js` | DOM logic: map init, sidebar, cluster panel, modals, image gallery, view switching |
 

--- a/docs/nczoning-auto-discovery.md
+++ b/docs/nczoning-auto-discovery.md
@@ -88,7 +88,7 @@ The Nexus uploader is always included as the first author automatically. Use `au
 - `coords` and `category` are required; mods missing either are skipped entirely
 - `coords` accepts either 2 values (`X,Y`, legacy format) or 3 values (`X,Y,Z`, new format). For new submissions, Z is required
 - `tags` that don't exist in the tag registry are silently dropped (the mod still appears)
-- All BBCode formatting is stripped before parsing, so the block still works if it loses its `[code]` wrapper or picks up stray styling (`[spoiler]`, `[size]`, `[font]`, `[color]`), e.g. from a copy-paste round-trip. The `[code]` wrapper is still recommended for readability; the generator emits it
+- All BBCode formatting is stripped before parsing, so the block still works if it loses its `[code]` wrapper or picks up stray styling (`[spoiler]`, `[size]`, `[font]`, `[color]`), e.g. from a copy-paste round-trip. The `[code]` wrapper is still recommended for readability
 
 ### Transition Note
 

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
                     </svg>
                     <span>SETTINGS</span>
                 </button>
-                <button id="bbcode-btn" class="header-action-btn header-action-btn-tertiary" aria-label="Submit a location" title="Submit a location from your mod for review">
+                <button id="submit-open-btn" class="header-action-btn header-action-btn-tertiary" aria-label="Submit a location" title="Submit a location from your mod for review">
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
                         stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <path d="M12 5v14"></path>
@@ -211,7 +211,7 @@
             </div>
             <ul id="mod-list"></ul>
             <div id="sidebar-footer">
-                <a id="sidebar-open-bbcode-link" href="#" class="terminal-link">
+                <a id="sidebar-open-submit-link" href="#" class="terminal-link">
                     <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
                         stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                         style="vertical-align: text-bottom; margin-right: 6px;">
@@ -395,7 +395,7 @@
                     community.</p>
                 <hr style="border: 0; border-top: 1px solid var(--dark-accent); margin: 15px 0;">
                 <div class="about-links">
-                    <a id="about-open-bbcode-link" href="#" class="terminal-link">
+                    <a id="about-open-submit-link" href="#" class="terminal-link">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
                             stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
                             style="vertical-align: text-bottom; margin-right: 6px;">
@@ -495,38 +495,38 @@
     </div>
 
     <!-- Submit a Location Modal -->
-    <div id="bbcode-modal" class="modal hidden">
-        <div class="modal-content nc-terminal bbcode-modal-content">
+    <div id="submit-modal" class="modal hidden">
+        <div class="modal-content nc-terminal submit-modal-content">
             <div class="terminal-header"><span class="terminal-header-theme-label" data-modal-title="SUBMIT A LOCATION">NIGHT CORP // SUBMIT A LOCATION</span>
-                <button class="terminal-close-btn ui-close-btn ui-close-btn-reverse" data-close-modal="bbcode-modal" aria-label="Close modal">
+                <button class="terminal-close-btn ui-close-btn ui-close-btn-reverse" data-close-modal="submit-modal" aria-label="Close modal">
                     <span class="ui-close-btn-icon" aria-hidden="true"></span>
                 </button>
             </div>
-            <div class="terminal-body bbcode-modal-body">
-                <ol class="bbcode-steps">
+            <div class="terminal-body submit-modal-body">
+                <ol class="submit-steps">
                     <li><strong>TAG YOUR MOD</strong>: add the <code>NCZoning</code> tag to your mod on Nexus Mods. That is all the tag does now: it puts your mod in the list below, with its title, short description and uploader ready to edit. It is optional, and a mod submitted by link is treated exactly the same.</li>
                     <li><strong>ACQUIRE COORDINATES</strong>: open CET in-game, run the command below in the console. Copy the output and paste the values below:
-                        <div class="bbcode-cet-command-block">
-                            <code id="bbcode-cet-command">local p,r = GetPlayer():GetWorldPosition(), GetPlayer():GetWorldOrientation():ToEulerAngles(); print(string.format("x=%.4f  y=%.4f  z=%.4f  yaw=%.4f", p.x, p.y, p.z, r.yaw))</code>
-                            <button id="bbcode-copy-cet-btn" class="ui-popup-action-link ui-popup-action-link-copy-cmd tertiary" title="Copy command" aria-label="Copy command"><span class="ui-popup-action-link-icon" aria-hidden="true"></span></button>
+                        <div class="submit-cet-command-block">
+                            <code id="submit-cet-command">local p,r = GetPlayer():GetWorldPosition(), GetPlayer():GetWorldOrientation():ToEulerAngles(); print(string.format("x=%.4f  y=%.4f  z=%.4f  yaw=%.4f", p.x, p.y, p.z, r.yaw))</code>
+                            <button id="submit-copy-cet-btn" class="ui-popup-action-link ui-popup-action-link-copy-cmd tertiary" title="Copy command" aria-label="Copy command"><span class="ui-popup-action-link-icon" aria-hidden="true"></span></button>
                         </div>
                     </li>
                     <li><strong>CONFIGURE METADATA</strong>: fill out the form below</li>
                     <li><strong>SUBMIT FOR REVIEW</strong>: complete the check at the bottom of the form and send it</li>
                     <li><strong>A REVIEWER DECIDES</strong>: nothing reaches the map until a reviewer approves it</li>
                 </ol>
-                <div class="bbcode-note">Submissions are anonymous, so nothing is sent back to you. Watch the map for your pin, or leave a contact below if you are happy to be asked a question about it.</div>
-                <div class="bbcode-form">
-                    <div class="bbcode-field-row">
-                        <label class="bbcode-label" for="submit-mod-select">Your mod</label>
-                        <select id="submit-mod-select" class="bbcode-select">
+                <div class="submit-intro">Submissions are anonymous, so nothing is sent back to you. Watch the map for your pin, or leave a contact below if you are happy to be asked a question about it.</div>
+                <div class="submit-form">
+                    <div class="submit-field-row">
+                        <label class="submit-label" for="submit-mod-select">Your mod</label>
+                        <select id="submit-mod-select" class="ui-select">
                             <option value="">Loading tagged mods...</option>
                         </select>
-                        <div class="bbcode-coord-note">Mods tagged <code>NCZoning</code> on Nexus appear here. Most tagged mods are already on the map, so an empty list is normal. A new tag can take about 10 minutes to reach the Nexus API and a few minutes more to reach this list, so if you have just added it, paste your mod's link instead.</div>
+                        <div class="submit-hint">Mods tagged <code>NCZoning</code> on Nexus appear here. Most tagged mods are already on the map, so an empty list is normal. A new tag can take about 10 minutes to reach the Nexus API and a few minutes more to reach this list, so if you have just added it, paste your mod's link instead.</div>
                         <div id="submit-mod-manual" class="submit-subfield hidden">
-                            <label class="bbcode-label" for="submit-nexus-ref">Nexus page URL or mod id</label>
-                            <input type="text" id="submit-nexus-ref" class="bbcode-input" placeholder="https://www.nexusmods.com/cyberpunk2077/mods/12345">
-                            <div class="bbcode-coord-note">The address of your mod's own page, or just the number at the end of it.</div>
+                            <label class="submit-label" for="submit-nexus-ref">Nexus page URL or mod id</label>
+                            <input type="text" id="submit-nexus-ref" class="submit-input" placeholder="https://www.nexusmods.com/cyberpunk2077/mods/12345">
+                            <div class="submit-hint">The address of your mod's own page, or just the number at the end of it.</div>
                         </div>
                         <p class="submit-field-error" id="submit-error-nexus_id" hidden></p>
                         <div id="submit-mod-card" class="submit-mod-card hidden">
@@ -534,45 +534,45 @@
                             <span id="submit-mod-card-name"></span>
                         </div>
                     </div>
-                    <div class="bbcode-field-row">
-                        <label class="bbcode-label" for="submit-name">Location name</label>
-                        <input type="text" id="submit-name" class="bbcode-input" placeholder="e.g. Cliffside Abode Player Home">
+                    <div class="submit-field-row">
+                        <label class="submit-label" for="submit-name">Location name</label>
+                        <input type="text" id="submit-name" class="submit-input" placeholder="e.g. Cliffside Abode Player Home">
                         <p class="submit-field-error" id="submit-error-name" hidden></p>
-                        <div class="bbcode-coord-note">Prefilled from your mod's Nexus title once you pick it above. Edit it to name the location itself, not the mod page.</div>
+                        <div class="submit-hint">Prefilled from your mod's Nexus title once you pick it above. Edit it to name the location itself, not the mod page.</div>
                     </div>
-                    <div class="bbcode-field-row">
-                        <label class="bbcode-label" for="submit-description">Description</label>
-                        <textarea id="submit-description" class="bbcode-textarea" rows="3" maxlength="500" placeholder="What is at these coordinates, in a sentence or two."></textarea>
+                    <div class="submit-field-row">
+                        <label class="submit-label" for="submit-description">Description</label>
+                        <textarea id="submit-description" class="submit-textarea" rows="3" maxlength="500" placeholder="What is at these coordinates, in a sentence or two."></textarea>
                         <p class="submit-field-error" id="submit-error-description" hidden></p>
-                        <div class="bbcode-coord-note">Prefilled from your mod's Nexus summary, the same text auto-discovery published. Edit it to describe the place rather than the mod: this is what a reviewer reads. <span id="submit-description-count">0</span>/500 characters.</div>
+                        <div class="submit-hint">Prefilled from your mod's Nexus summary, the same text auto-discovery published. Edit it to describe the place rather than the mod: this is what a reviewer reads. <span id="submit-description-count">0</span>/500 characters.</div>
                     </div>
-                    <div class="bbcode-field-row">
-                        <label class="bbcode-label">CET Coordinates</label>
-                        <div class="bbcode-coord-inputs">
+                    <div class="submit-field-row">
+                        <label class="submit-label">CET Coordinates</label>
+                        <div class="submit-coord-inputs">
                             <div class="coord-input-group">
                                 <span class="coord-label">X</span>
-                                <input type="number" id="bbcode-coord-x" placeholder="e.g. -1234.56" step="any">
+                                <input type="number" id="submit-coord-x" placeholder="e.g. -1234.56" step="any">
                             </div>
                             <div class="coord-input-group">
                                 <span class="coord-label">Y</span>
-                                <input type="number" id="bbcode-coord-y" placeholder="e.g. 789.01" step="any">
+                                <input type="number" id="submit-coord-y" placeholder="e.g. 789.01" step="any">
                             </div>
                             <div class="coord-input-group">
                                 <span class="coord-label">Z</span>
-                                <input type="number" id="bbcode-coord-z" placeholder="e.g. 42.5" step="any">
+                                <input type="number" id="submit-coord-z" placeholder="e.g. 42.5" step="any">
                             </div>
                         </div>
                         <p class="submit-field-error" id="submit-error-coordinates" hidden></p>
-                        <div class="bbcode-coord-note">Paste the three values from the CET output above, in the same order. Z is the height, so do not swap it with Y. Coordinates can be negative: include the minus sign if there is one (e.g. <code>-1234.56</code>). Night City sits within about ±4000 on X and Y and ±300 on Z; anything past ±8000, or past -1000 to 2000 on Z, is refused.</div>
+                        <div class="submit-hint">Paste the three values from the CET output above, in the same order. Z is the height, so do not swap it with Y. Coordinates can be negative: include the minus sign if there is one (e.g. <code>-1234.56</code>). Night City sits within about ±4000 on X and Y and ±300 on Z; anything past ±8000, or past -1000 to 2000 on Z, is refused.</div>
                     </div>
-                    <div class="bbcode-field-row">
-                        <label class="bbcode-label" for="bbcode-yaw">Yaw <span class="bbcode-optional">(optional: player facing direction in degrees, useful for teleport)</span></label>
-                        <input type="number" id="bbcode-yaw" class="bbcode-input" placeholder="e.g. 180.0" step="any">
+                    <div class="submit-field-row">
+                        <label class="submit-label" for="submit-yaw">Yaw <span class="submit-optional">(optional: player facing direction in degrees, useful for teleport)</span></label>
+                        <input type="number" id="submit-yaw" class="submit-input" placeholder="e.g. 180.0" step="any">
                         <p class="submit-field-error" id="submit-error-yaw" hidden></p>
                     </div>
-                    <div class="bbcode-field-row">
-                        <label class="bbcode-label" for="bbcode-category">Category</label>
-                        <select id="bbcode-category" class="bbcode-select">
+                    <div class="submit-field-row">
+                        <label class="submit-label" for="submit-category">Category</label>
+                        <select id="submit-category" class="ui-select">
                             <option value="">— Select Category —</option>
                             <option value="location-overhaul">Location Overhaul</option>
                             <option value="new-location">New Location</option>
@@ -580,40 +580,40 @@
                         </select>
                         <p class="submit-field-error" id="submit-error-category" hidden></p>
                     </div>
-                    <div class="bbcode-field-row">
-                        <label class="bbcode-label">Tags <span class="bbcode-optional">(optional)</span></label>
-                        <div id="bbcode-tag-checkboxes" class="bbcode-tag-grid"></div>
+                    <div class="submit-field-row">
+                        <label class="submit-label">Tags <span class="submit-optional">(optional)</span></label>
+                        <div id="submit-tag-checkboxes" class="submit-tag-grid"></div>
                         <p class="submit-field-error" id="submit-error-tags" hidden></p>
                     </div>
-                    <div class="bbcode-field-row">
-                        <label class="bbcode-label" for="bbcode-authors">Authors <span class="bbcode-optional">(comma-separated)</span></label>
-                        <input type="text" id="bbcode-authors" class="bbcode-input" placeholder="e.g. Author1, Author2">
+                    <div class="submit-field-row">
+                        <label class="submit-label" for="submit-authors">Authors <span class="submit-optional">(comma-separated)</span></label>
+                        <input type="text" id="submit-authors" class="submit-input" placeholder="e.g. Author1, Author2">
                         <p class="submit-field-error" id="submit-error-authors" hidden></p>
-                        <div class="bbcode-coord-note">Prefilled with the mod's Nexus uploader once you pick it above. Add anyone else who worked on the location, separated by commas.</div>
+                        <div class="submit-hint">Prefilled with the mod's Nexus uploader once you pick it above. Add anyone else who worked on the location, separated by commas.</div>
                     </div>
-                    <div class="bbcode-field-row">
-                        <label class="bbcode-label" for="bbcode-credits">Credits <span class="bbcode-optional">(optional)</span></label>
-                        <textarea id="bbcode-credits" class="bbcode-textarea" placeholder="e.g. Original map texture by XYZ" rows="2"></textarea>
+                    <div class="submit-field-row">
+                        <label class="submit-label" for="submit-credits">Credits <span class="submit-optional">(optional)</span></label>
+                        <textarea id="submit-credits" class="submit-textarea" placeholder="e.g. Original map texture by XYZ" rows="2"></textarea>
                     </div>
-                    <div class="bbcode-field-row">
-                        <label class="bbcode-label" for="submit-note">Note for the reviewer <span class="bbcode-optional">(optional)</span></label>
-                        <textarea id="submit-note" class="bbcode-textarea" rows="2" maxlength="1000" placeholder="Anything a reviewer should know before publishing this."></textarea>
+                    <div class="submit-field-row">
+                        <label class="submit-label" for="submit-note">Note for the reviewer <span class="submit-optional">(optional)</span></label>
+                        <textarea id="submit-note" class="submit-textarea" rows="2" maxlength="1000" placeholder="Anything a reviewer should know before publishing this."></textarea>
                         <p class="submit-field-error" id="submit-error-note" hidden></p>
                     </div>
-                    <div class="bbcode-field-row">
-                        <label class="bbcode-label" for="submit-contact">Contact <span class="bbcode-optional">(optional)</span></label>
-                        <input type="text" id="submit-contact" class="bbcode-input" maxlength="200" placeholder="e.g. Discord handle">
+                    <div class="submit-field-row">
+                        <label class="submit-label" for="submit-contact">Contact <span class="submit-optional">(optional)</span></label>
+                        <input type="text" id="submit-contact" class="submit-input" maxlength="200" placeholder="e.g. Discord handle">
                         <p class="submit-field-error" id="submit-error-contact" hidden></p>
-                        <div class="bbcode-coord-note">Only so a reviewer can ask you a question about this submission. Nothing else reads it, and leaving it blank does not affect the outcome. See the <a href="https://github.com/nczoning/nc-zoning-board/blob/main/docs/privacy.md" target="_blank" rel="noopener" class="terminal-link">privacy note</a> for what is stored and for how long.</div>
+                        <div class="submit-hint">Only so a reviewer can ask you a question about this submission. Nothing else reads it, and leaving it blank does not affect the outcome. See the <a href="https://github.com/nczoning/nc-zoning-board/blob/main/docs/privacy.md" target="_blank" rel="noopener" class="terminal-link">privacy note</a> for what is stored and for how long.</div>
                     </div>
-                    <div class="bbcode-field-row">
+                    <div class="submit-field-row">
                         <div id="submit-turnstile" class="submit-turnstile"></div>
                         <p class="submit-field-error" id="submit-error-turnstile" hidden></p>
                     </div>
                     <p class="submit-form-error" id="submit-form-error" role="alert" hidden></p>
                     <div class="submit-actions">
                         <button id="submit-send-btn" class="terminal-btn submit-send-btn">[ SUBMIT FOR REVIEW ]</button>
-                        <button id="bbcode-reset-btn" class="terminal-btn submit-reset-btn">[ RESET ]</button>
+                        <button id="submit-reset-btn" class="terminal-btn submit-reset-btn">[ RESET ]</button>
                     </div>
                     <div id="submit-done" class="submit-done hidden" role="status">
                         <h3 class="submit-done-title">QUEUED FOR REVIEW</h3>
@@ -622,7 +622,7 @@
                         <button id="submit-another-btn" class="terminal-btn">[ SUBMIT ANOTHER ]</button>
                     </div>
                 </div>
-                <button id="close-bbcode-modal" class="terminal-btn" style="margin-top: 10px; border-color: var(--gray); color: var(--gray);">[ CLOSE ]</button>
+                <button id="close-submit-modal" class="terminal-btn" style="margin-top: 10px; border-color: var(--gray); color: var(--gray);">[ CLOSE ]</button>
             </div>
         </div>
     </div>
@@ -639,16 +639,16 @@
                 <h3 class="parameters-section-title">Showcase Options</h3>
                 <div class="parameters-section">
                     <label class="parameters-label" for="showcase-theme">Theme</label>
-                    <select id="showcase-theme" class="bbcode-select">
+                    <select id="showcase-theme" class="ui-select">
                         <option value="cycle">Cycle (beat-driven)</option>
                         <!-- Remaining options populated from NCZ.THEMES at runtime -->
                     </select>
-                    <label class="bbcode-checkbox-label"><input type="checkbox" id="showcase-show-pins"> Show mod pins during showcase</label>
-                    <label class="bbcode-checkbox-label"><input type="checkbox" id="showcase-reveal-layers"> Stagger layer reveal at start</label>
-                    <label class="bbcode-checkbox-label"><input type="checkbox" id="showcase-district-names"> Show district names</label>
-                    <label class="bbcode-checkbox-label"><input type="checkbox" id="showcase-district-outlines"> Show district outlines</label>
-                    <label class="bbcode-checkbox-label"><input type="checkbox" id="showcase-audio" checked> Play music</label>
-                    <label class="bbcode-checkbox-label"><input type="checkbox" id="showcase-loop"> Loop showcase</label>
+                    <label class="ui-checkbox-label"><input type="checkbox" id="showcase-show-pins"> Show mod pins during showcase</label>
+                    <label class="ui-checkbox-label"><input type="checkbox" id="showcase-reveal-layers"> Stagger layer reveal at start</label>
+                    <label class="ui-checkbox-label"><input type="checkbox" id="showcase-district-names"> Show district names</label>
+                    <label class="ui-checkbox-label"><input type="checkbox" id="showcase-district-outlines"> Show district outlines</label>
+                    <label class="ui-checkbox-label"><input type="checkbox" id="showcase-audio" checked> Play music</label>
+                    <label class="ui-checkbox-label"><input type="checkbox" id="showcase-loop"> Loop showcase</label>
                 </div>
                 <div class="showcase-modal-actions">
                     <button id="showcase-start-btn" class="terminal-btn">[ START SHOWCASE ]</button>

--- a/scripts/monitor_auto_discovery.js
+++ b/scripts/monitor_auto_discovery.js
@@ -41,10 +41,10 @@ async function postDiscord(skipped) {
         title: `⚠️ Auto-discovery: ${n} NCZoning mod${n === 1 ? "" : "s"} tagged but not on the map`,
         description:
           `${n} mod${n === 1 ? " is" : "s are"} tagged **NCZoning** on Nexus but the ` +
-          `Data API skipped ${n === 1 ? "it" : "them"} — the metadata block is missing or ` +
-          `didn't parse. **Action:** ask the author to regenerate the block with the in-app ` +
-          `BBCode Generator, add a manual registry entry if it belongs on the map, or add the ` +
-          `id to \`data/excluded_mods.json\` to stop this alert.\n\n` +
+          `Data API skipped ${n === 1 ? "it" : "them"}: the metadata block is missing or ` +
+          `didn't parse. **Action:** ask the author to submit the location through the form ` +
+          `on the site, add a registry entry if it belongs on the map, or add the id to ` +
+          `\`data/excluded_mods.json\` to stop this alert.\n\n` +
           lines.join("\n"),
         color: 15105570, // amber/orange: warning, not error
         footer: { text: "NC Zoning Board • source: /v1/meta.skipped" },


### PR DESCRIPTION
Mechanical rename, on its own so the PR C diff stays readable. **No behaviour changes.** Every `bbcode-*` id, class and variable in the submit modal now names what it is.

## The mapping

| Was | Is | Why not `submit-*` |
| --- | --- | --- |
| `#bbcode-modal`, `#bbcode-btn`, `#bbcode-coord-x` … | `#submit-modal`, `#submit-open-btn`, `#submit-coord-x` … | |
| `.bbcode-form`, `.bbcode-field-row`, `.bbcode-label`, `.bbcode-steps` … | `.submit-form`, `.submit-field-row`, `.submit-label`, `.submit-steps` … | |
| `.bbcode-select` | `.ui-select` | the showcase modal uses it |
| `.bbcode-checkbox-label` | `.ui-checkbox-label` | the showcase modal uses it |
| `.bbcode-note` | `.submit-intro` | `#submit-note` is the reviewer note field |
| `.bbcode-coord-note` | `.submit-hint` | it stopped being about coordinates once every field had one |
| `.bbcode-checkbox-row` | deleted | the spoiler checkbox went with the generator |

`ui-select` and `ui-checkbox-label` follow `ui-close-btn` and `ui-popup-action-link`, already in the file. Naming a control the showcase uses after the submit form would swap one wrong name for another.

## What a token sweep missed

`getElementById(\`bbcode-coord-${axis}\`)`, built at runtime. Nothing in a literal-only rename touches it and nothing fails until the code runs, which is why the check afterwards was for the string `bbcode` in each file rather than for the tokens being replaced.

## Documents that described the generator as usable

- Both issue templates pointed at the "BBCode Generator modal" for the CET command.
- The auto-discovery Discord alert told reviewers to ask an author to **regenerate the block with the in-app generator**. That is no longer possible.
- `docs/nczoning-auto-discovery.md` said the generator emits the `[code]` wrapper.
- `docs/architecture.md` listed a BBCode parser in `utils.js`. There is not one, and has not been since it moved to `worker/src/parse.js`.

The parser itself and everything describing the block **format** are untouched: `worker/src/parse.js` still reads blocks that already exist in descriptions.

## Verified

In a browser, not only by grep: every id the script reaches for exists, the modal opens, an empty form still reports seven fields at once, the live coordinate check still reddens the offending box, and the showcase modal still gets its shared control styling. 43 site and 310 worker tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
