### PR TITLE
feat(map): every pin can be corrected from its own popup (Phase 5, PR D)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The submit form sends a location to the review queue. It starts from your mod (picked from the tagged list, or a Nexus link) and now collects the name and description the registry requires, which the block never carried.
 - Picking a tagged mod prefills its title, short description and uploader, the same three things auto-discovery took from the Nexus page. All three stay editable.
 - The coordinate boxes are checked as you type. The box that is wrong goes red, and every problem in the row is named at once rather than one per attempt.
+- Every pin can be corrected from its own popup. Suggest an edit opens the form filled in from the record and sends only the fields you change; report a problem asks for a reason and sends a removal request. Both go to the same review queue, and the pin is unchanged until a reviewer decides.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The submit form sends a location to the review queue. It starts from your mod (picked from the tagged list, or a Nexus link) and now collects the name and description the registry requires, which the block never carried.
 - Picking a tagged mod prefills its title, short description and uploader, the same three things auto-discovery took from the Nexus page. All three stay editable.
 - The coordinate boxes are checked as you type. The box that is wrong goes red, and every problem in the row is named at once rather than one per attempt.
-- Every pin can be corrected from its own popup. Suggest an edit opens the form filled in from the record and sends only the fields you change; report a problem asks for a reason and sends a removal request. Both go to the same review queue, and the pin is unchanged until a reviewer decides.
+- Every pin can be corrected from its own popup. **Suggest a fix** opens the form filled in from the record and sends only the fields you change. Inside it, one choice switches from correcting the pin to asking for it to be taken down, which asks for a reason instead. Both go to the review queue, and the pin is unchanged until a reviewer decides.
 
 ### Fixed
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1395,10 +1395,18 @@ body.cluster-panel-resizing * {
     mask-image: url("../img/icon/edit.svg");
 }
 
-.ui-popup-action-link-report .ui-popup-action-link-icon {
-    background-color: currentColor;
-    -webkit-mask-image: url("../img/icon/flag.svg");
-    mask-image: url("../img/icon/flag.svg");
+/* Carries a word as well as a glyph: a pencil alone reads as "edit what?", and
+   this one also covers asking for the pin to be removed. */
+.ui-popup-action-link-edit {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2xs);
+    white-space: nowrap;
+
+    .ui-popup-action-link-icon {
+        width: 1rem;
+        height: 1rem;
+    }
 }
 
 .ui-popup-action-link-copy-link .ui-popup-action-link-icon {
@@ -2499,6 +2507,12 @@ body::before {
 .submit-form.is-edit .submit-create-only,
 .submit-form.is-report .submit-create-only,
 .submit-form.is-report #submit-location-fields {
+    display: none;
+}
+
+/* The intent choice only exists against an existing pin: a new one cannot be
+   asking for a removal. */
+.submit-form:not(.is-edit):not(.is-report) .submit-edit-only {
     display: none;
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1395,6 +1395,12 @@ body.cluster-panel-resizing * {
     mask-image: url("../img/icon/edit.svg");
 }
 
+.ui-popup-action-link-report .ui-popup-action-link-icon {
+    background-color: currentColor;
+    -webkit-mask-image: url("../img/icon/flag.svg");
+    mask-image: url("../img/icon/flag.svg");
+}
+
 .ui-popup-action-link-copy-link .ui-popup-action-link-icon {
     background-color: currentColor;
     -webkit-mask-image: url("../img/icon/link.svg");
@@ -2473,6 +2479,27 @@ body::before {
     &:hover {
         background: transparent;
     }
+}
+
+/* Edit and report run the same form against a record the map already holds, so
+   the parts that only make sense for a new pin are hidden rather than rebuilt
+   in a second modal. */
+.submit-target {
+    border-left: 2px solid var(--secondary);
+    padding: var(--space-xs) var(--space-md);
+    margin-bottom: var(--space-md);
+    color: var(--gray);
+    font-size: var(--text-md);
+}
+
+.submit-target-name {
+    color: var(--secondary);
+}
+
+.submit-form.is-edit .submit-create-only,
+.submit-form.is-report .submit-create-only,
+.submit-form.is-report #submit-location-fields {
+    display: none;
 }
 
 .submit-subfield {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1395,20 +1395,6 @@ body.cluster-panel-resizing * {
     mask-image: url("../img/icon/edit.svg");
 }
 
-/* Carries a word as well as a glyph: a pencil alone reads as "edit what?", and
-   this one also covers asking for the pin to be removed. */
-.ui-popup-action-link-edit {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2xs);
-    white-space: nowrap;
-
-    .ui-popup-action-link-icon {
-        width: 1rem;
-        height: 1rem;
-    }
-}
-
 .ui-popup-action-link-copy-link .ui-popup-action-link-icon {
     background-color: currentColor;
     -webkit-mask-image: url("../img/icon/link.svg");
@@ -2292,6 +2278,13 @@ body::before {
     flex-direction: column;
     gap: var(--space-xs);
     margin-bottom: 14px;
+
+    /* An author `display` beats the user agent's [hidden] rule, so a row the
+       script hides would otherwise stay on screen with its hidden property
+       reading true. */
+    &[hidden] {
+        display: none;
+    }
 }
 
 .submit-label {
@@ -2514,6 +2507,48 @@ body::before {
    asking for a removal. */
 .submit-form:not(.is-edit):not(.is-report) .submit-edit-only {
     display: none;
+}
+
+/* Built on .submit-tag-checkbox, the same bordered pill the tag row uses, so
+   the two choices read as controls of this form rather than as browser
+   defaults. The selected one takes the accent, since it decides what the whole
+   form is asking for. */
+.submit-intent-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+}
+
+.submit-intent-option {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    padding: var(--space-xs) var(--space-sm);
+    border: var(--ui-border-thin) solid var(--border-subtle);
+    border-radius: var(--ui-radius-sm);
+    color: var(--gray);
+    font-size: var(--text-sm);
+    cursor: pointer;
+    transition: all 0.15s ease;
+    user-select: none;
+
+    input[type="radio"] {
+        accent-color: var(--secondary);
+        width: 14px;
+        height: 14px;
+        margin: 0;
+    }
+
+    &:hover {
+        border-color: var(--tertiary);
+        color: var(--tertiary);
+    }
+
+    &:has(input:checked) {
+        border-color: var(--secondary);
+        background: var(--secondary-05);
+        color: var(--white);
+    }
 }
 
 .submit-subfield {

--- a/assets/img/icon/flag.svg
+++ b/assets/img/icon/flag.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V4s-1 1-4 1-5-2-8-2-4 1-4 1z"/>
-  <line x1="4" y1="22" x2="4" y2="15"/>
-</svg>

--- a/assets/img/icon/flag.svg
+++ b/assets/img/icon/flag.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V4s-1 1-4 1-5-2-8-2-4 1-4 1z"/>
+  <line x1="4" y1="22" x2="4" y2="15"/>
+</svg>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -216,10 +216,15 @@ document.addEventListener("DOMContentLoaded", () => {
   const donePanel = document.getElementById("submit-done");
   const formErrorEl = document.getElementById("submit-form-error");
 
+  const reasonInput = document.getElementById("submit-reason");
+  const targetBanner = document.getElementById("submit-target");
+  const stepsList = document.getElementById("submit-steps");
+  const introLine = document.getElementById("submit-intro");
+
   const MANUAL_MOD_VALUE = "__manual__";
   const ERROR_FIELDS = [
     "nexus_id", "name", "description", "coordinates", "yaw", "category",
-    "tags", "authors", "note", "contact", "turnstile",
+    "tags", "authors", "reason", "note", "contact", "turnstile",
   ];
   // The control to focus when a field is refused, in the order the form reads.
   const FIELD_CONTROL = {
@@ -230,6 +235,7 @@ document.addEventListener("DOMContentLoaded", () => {
     yaw: "submit-yaw",
     category: "submit-category",
     authors: "submit-authors",
+    reason: "submit-reason",
     note: "submit-note",
     contact: "submit-contact",
   };
@@ -241,13 +247,115 @@ document.addEventListener("DOMContentLoaded", () => {
   let descriptionIsPrefilled = true;
   let authorsIsPrefilled = true;
 
-  function openSubmitModal() {
+  // ── Modes ──────────────────────────────────────────────────────────────────
+  //
+  // One modal, three jobs: propose a new pin, propose a change to one, or ask
+  // for one to be taken down. They post the same three shapes to the same route
+  // and share every field, so a second modal would be the same form twice with
+  // two sets of validation to keep in step.
+  //
+  // `create` is the only mode that picks a mod; `remove` carries a reason and no
+  // location fields at all, because there is nothing for a reviewer to apply.
+
+  const MODES = {
+    create: {
+      title: "SUBMIT A LOCATION",
+      send: "[ SUBMIT FOR REVIEW ]",
+      done: "QUEUED FOR REVIEW",
+      doneBody: "is in the review queue. A reviewer checks the coordinates before anything is published, and nothing appears on the map until one approves it.",
+    },
+    edit: {
+      title: "SUGGEST AN EDIT",
+      send: "[ SEND THE CHANGES ]",
+      done: "CHANGES QUEUED",
+      doneBody: "is in the review queue. The pin on the map is unchanged until a reviewer approves the edit.",
+    },
+    remove: {
+      title: "REPORT A PROBLEM",
+      send: "[ SEND THE REPORT ]",
+      done: "REPORT QUEUED",
+      doneBody: "is in the review queue. The pin stays on the map until a reviewer decides.",
+    },
+  };
+
+  let formMode = "create";
+  // The record an edit or a report is against, held so the diff has something to
+  // compare with. Null in create mode.
+  let editTarget = null;
+
+  // The modal header is rebuilt from data-modal-title on every theme change, so
+  // the mode has to write the attribute rather than the text.
+  function setSubmitModalTitle(title) {
+    const label = submitModal?.querySelector(".terminal-header-theme-label[data-modal-title]");
+    if (!label) return;
+    label.dataset.modalTitle = title;
+    const prefix = label.textContent.split("//")[0].trim();
+    label.textContent = `${prefix} // ${title}`;
+  }
+
+  function applyMode(mode, record) {
+    formMode = mode;
+    editTarget = record ?? null;
+    const config = MODES[mode];
+
+    submitForm?.classList.toggle("is-edit", mode === "edit");
+    submitForm?.classList.toggle("is-report", mode === "remove");
+    submitModal?.querySelectorAll(".submit-report-only").forEach((el) => {
+      el.hidden = mode !== "remove";
+    });
+
+    // The steps describe finding coordinates for a pin that does not exist yet.
+    if (stepsList) stepsList.hidden = mode !== "create";
+    if (introLine) introLine.hidden = mode !== "create";
+
+    if (targetBanner) {
+      targetBanner.classList.toggle("hidden", !record);
+      if (record) {
+        const verb = mode === "remove" ? "Reporting" : "Editing";
+        targetBanner.innerHTML = `${verb} <span class="submit-target-name"></span>`;
+        targetBanner.querySelector(".submit-target-name").textContent = record.name;
+      }
+    }
+
+    setSubmitModalTitle(config.title);
+    if (sendBtn) sendBtn.textContent = config.send;
+  }
+
+  function openSubmitModal(mode = "create", record = null) {
+    resetSubmitForm({ keepMode: true });
+    applyMode(mode, record);
+    if (record && mode === "edit") prefillFromRecord(record);
     submitModal.classList.remove("hidden");
-    loadCandidates();
+    submitModal.querySelector(".submit-modal-body").scrollTop = 0;
+    if (mode === "create") loadCandidates();
     mountTurnstile();
   }
+
   function closeSubmitModal() {
     submitModal.classList.add("hidden");
+  }
+
+  // Fill the form from a record the map is already holding. No fetch: an edit is
+  // proposed against exactly the copy the submitter is looking at.
+  function prefillFromRecord(record) {
+    const [x, y, z] = record.coordinates ?? [];
+    const set = (id, value) => {
+      const el = document.getElementById(id);
+      if (el) el.value = value ?? "";
+    };
+    set("submit-name", record.name);
+    set("submit-description", record.description);
+    set("submit-coord-x", x);
+    set("submit-coord-y", y);
+    set("submit-coord-z", z);
+    set("submit-yaw", record.yaw);
+    set("submit-category", record.category);
+    set("submit-authors", (record.authors ?? []).join(", "));
+    set("submit-credits", record.credits);
+    document.querySelectorAll("#submit-tag-checkboxes input").forEach((cb) => {
+      cb.checked = (record.tags ?? []).includes(cb.value);
+    });
+    updateDescriptionCount();
   }
 
   // ── Turnstile ──────────────────────────────────────────────────────────────
@@ -456,6 +564,7 @@ document.addEventListener("DOMContentLoaded", () => {
       nexusId: nexusRefValue(),
       note: document.getElementById("submit-note")?.value,
       contact: document.getElementById("submit-contact")?.value,
+      reason: reasonInput?.value,
       tags: Array.from(
         document.querySelectorAll("#submit-tag-checkboxes input:checked"),
       ).map((cb) => cb.value),
@@ -531,7 +640,9 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  if (submitOpenBtn) submitOpenBtn.addEventListener("click", openSubmitModal);
+  // Wrapped, not passed directly: openSubmitModal's first parameter is the mode,
+  // and addEventListener would hand it a MouseEvent.
+  if (submitOpenBtn) submitOpenBtn.addEventListener("click", () => openSubmitModal());
   if (closeSubmitModalBtn) closeSubmitModalBtn.addEventListener("click", closeSubmitModal);
 
   // \u2500\u2500 Send \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
@@ -574,8 +685,16 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function showSubmitted(id) {
+    const config = MODES[formMode];
     const idEl = document.getElementById("submit-done-id");
     if (idEl) idEl.textContent = id === null || id === undefined ? "" : `#${id}`;
+
+    const title = donePanel?.querySelector(".submit-done-title");
+    if (title) title.textContent = config.done;
+    const detail = document.getElementById("submit-done-detail");
+    if (detail) detail.textContent = config.doneBody;
+    const againBtn = document.getElementById("submit-another-btn");
+    if (againBtn) againBtn.textContent = formMode === "create" ? "[ SUBMIT ANOTHER ]" : "[ CLOSE ]";
     submitForm?.classList.add("is-submitted");
     // The steps and the note sit outside the form and describe filling it in,
     // down to "leave a contact below", so they go with it.
@@ -584,33 +703,91 @@ document.addEventListener("DOMContentLoaded", () => {
     donePanel?.scrollIntoView({ block: "nearest" });
   }
 
+  // The submission this form is currently describing, or the errors stopping it.
+  //
+  // A removal deliberately never reads the location fields: they are hidden in
+  // that mode, and the server refuses a payload on `kind: 'remove'` because
+  // there is nothing for a reviewer to apply.
+  function buildSubmission(raw, token) {
+    const meta = NCZ.collectSubmissionMeta(raw);
+    const errors = { ...meta.errors };
+    if (!token) errors.turnstile = "Complete the check above before submitting.";
+
+    if (formMode === "remove") {
+      const reason = String(raw.reason ?? "").trim();
+      if (!reason) {
+        errors.reason = "Say what is wrong with this pin, so a reviewer can act on it.";
+      } else if (reason.length > NCZ.SUBMISSION_NOTE_MAX) {
+        errors.reason = `Keep this to ${NCZ.SUBMISSION_NOTE_MAX} characters or fewer.`;
+      }
+      return {
+        errors,
+        body: {
+          kind: "remove",
+          location_id: editTarget?.id,
+          reason,
+          turnstile_token: token,
+          ...meta.values,
+        },
+      };
+    }
+
+    const collected = NCZ.collectLocationForm(raw, {
+      knownTags: knownTagSlugs(),
+      // An edit never asks which mod this is: the record answers that, and its
+      // id may be one the new-pin path would refuse.
+      fixedNexusId: formMode === "edit" ? editTarget?.nexus_id : undefined,
+    });
+    Object.assign(errors, collected.errors);
+
+    if (formMode === "edit") {
+      const changed = NCZ.diffLocation(editTarget, collected.values);
+      return {
+        errors,
+        empty: Object.keys(changed).length === 0,
+        body: {
+          kind: "edit",
+          location_id: editTarget?.id,
+          payload: changed,
+          turnstile_token: token,
+          ...meta.values,
+        },
+      };
+    }
+
+    return {
+      errors,
+      body: {
+        kind: "create",
+        payload: collected.values,
+        turnstile_token: token,
+        ...meta.values,
+      },
+    };
+  }
+
   if (sendBtn) {
     sendBtn.addEventListener("click", async () => {
       clearErrors();
       const raw = readForm();
-      const { values, errors } = NCZ.collectLocationForm(raw, { knownTags: knownTagSlugs() });
-      const meta = NCZ.collectSubmissionMeta(raw);
-      const token = turnstileToken();
+      const { body, errors, empty } = buildSubmission(raw, turnstileToken());
 
-      const allErrors = { ...errors, ...meta.errors };
-      if (!token) {
-        allErrors.turnstile = "Complete the check above before submitting.";
+      if (Object.keys(errors).length) {
+        showErrors(errors);
+        return;
       }
-      if (Object.keys(allErrors).length) {
-        showErrors(allErrors);
+      if (empty) {
+        // Not a validation failure: everything here is valid, there is just
+        // nothing to review. The server would refuse it for the same reason.
+        setFormError("Nothing has changed yet. Edit a field, then send.", { tone: "notice" });
         return;
       }
 
       sendBtn.disabled = true;
       sendBtn.textContent = "[ SENDING... ]";
-      const result = await NCZ.postSubmission({
-        kind: "create",
-        payload: values,
-        turnstile_token: token,
-        ...meta.values,
-      });
+      const result = await NCZ.postSubmission(body);
       sendBtn.disabled = false;
-      sendBtn.textContent = "[ SUBMIT FOR REVIEW ]";
+      sendBtn.textContent = MODES[formMode].send;
 
       if (result.ok) {
         showSubmitted(result.data?.id);
@@ -620,7 +797,7 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  function resetSubmitForm() {
+  function resetSubmitForm({ keepMode = false } = {}) {
     document.getElementById("submit-coord-x").value = "";
     document.getElementById("submit-coord-y").value = "";
     document.getElementById("submit-coord-z").value = "";
@@ -645,11 +822,18 @@ document.addEventListener("DOMContentLoaded", () => {
     authorsIsPrefilled = true;
     onModSelectionChange();
 
+    if (reasonInput) reasonInput.value = "";
+
     clearErrors();
     resetTurnstile();
     submitForm?.classList.remove("is-submitted");
     submitModal?.querySelector(".submit-modal-body")?.classList.remove("is-submitted");
     donePanel?.classList.add("hidden");
+
+    // Reset lands back on `create` unless the caller is about to set a mode
+    // itself, so the Reset button inside an edit does not silently turn it into
+    // a new-pin submission carrying that pin's values.
+    if (!keepMode && formMode !== "create") applyMode("create", null);
   }
 
   const submitResetBtn = document.getElementById("submit-reset-btn");
@@ -658,10 +842,41 @@ document.addEventListener("DOMContentLoaded", () => {
   const submitAnotherBtn = document.getElementById("submit-another-btn");
   if (submitAnotherBtn) {
     submitAnotherBtn.addEventListener("click", () => {
+      // After an edit or a report there is nothing to do again: the pin it was
+      // about is the one the submitter just finished with.
+      if (formMode !== "create") {
+        closeSubmitModal();
+        resetSubmitForm();
+        return;
+      }
       resetSubmitForm();
       modSelect?.focus();
     });
   }
+
+  // ── The popup actions, for both views ──────────────────────────────────────
+  //
+  // One delegated listener rather than a handler bound per popup. Leaflet
+  // rebuilds a popup's DOM every time it opens and the Three.js layer builds a
+  // CSS2DObject card per pin, so binding at open time means two wirings, in two
+  // files, that have to be kept in step. The buttons carry the location id and
+  // this reads it wherever the click lands.
+  document.addEventListener("click", (event) => {
+    const editBtn = event.target.closest("[data-edit-location]");
+    const reportBtn = event.target.closest("[data-report-location]");
+    if (!editBtn && !reportBtn) return;
+
+    const id = (editBtn ?? reportBtn).dataset.editLocation
+      ?? (editBtn ?? reportBtn).dataset.reportLocation;
+    const record = NCZ.locationsById?.get(id);
+    if (!record) {
+      // The dataset moved under an open popup, which the passive update check
+      // makes possible. Saying so beats opening a form against nothing.
+      alert("That pin is no longer in the loaded map data. Refresh and try again.");
+      return;
+    }
+    openSubmitModal(editBtn ? "edit" : "remove", record);
+  });
 
   const copyCetBtn = document.getElementById("submit-copy-cet-btn");
   if (copyCetBtn) {
@@ -2190,6 +2405,12 @@ async function initMap() {
     modCountEl.textContent = `(${mods.length})`;
 
     const sortedMods = mods.sort(NCZ.sortModsByUpdated);
+    // The popup's edit and report actions carry a location id and nothing else,
+    // so the delegated handler needs one place to resolve it. Built from the
+    // same array the pins and the 3D layer are built from, and the passive
+    // update check announces rather than re-renders, so this cannot describe a
+    // different data set from the one on screen.
+    NCZ.locationsById = new Map(sortedMods.map((mod) => [String(mod.id), mod]));
     // Hand the same data set to the 3D pin layer; pins won't appear until ThreeScene
     // is initialised (first switch to SCHEMA), but the call is safe before that and the
     // data is held internally so the layer can build pins on attach.

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -271,9 +271,9 @@ document.addEventListener("DOMContentLoaded", () => {
       doneBody: "is in the review queue. The pin on the map is unchanged until a reviewer approves the edit.",
     },
     remove: {
-      title: "REPORT A PROBLEM",
-      send: "[ SEND THE REPORT ]",
-      done: "REPORT QUEUED",
+      title: "REQUEST A REMOVAL",
+      send: "[ SEND THE REQUEST ]",
+      done: "REMOVAL REQUESTED",
       doneBody: "is in the review queue. The pin stays on the map until a reviewer decides.",
     },
   };
@@ -300,6 +300,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
     submitForm?.classList.toggle("is-edit", mode === "edit");
     submitForm?.classList.toggle("is-report", mode === "remove");
+    // Kept in step whether the mode came from the radios or from opening the
+    // modal, so the form never describes one intent and post another.
+    submitModal?.querySelectorAll("input[name='submit-intent']").forEach((radio) => {
+      radio.checked = radio.value === (mode === "remove" ? "remove" : "edit");
+    });
     submitModal?.querySelectorAll(".submit-report-only").forEach((el) => {
       el.hidden = mode !== "remove";
     });
@@ -311,7 +316,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (targetBanner) {
       targetBanner.classList.toggle("hidden", !record);
       if (record) {
-        const verb = mode === "remove" ? "Reporting" : "Editing";
+        const verb = mode === "remove" ? "Asking to remove" : "Editing";
         targetBanner.innerHTML = `${verb} <span class="submit-target-name"></span>`;
         targetBanner.querySelector(".submit-target-name").textContent = record.name;
       }
@@ -862,20 +867,28 @@ document.addEventListener("DOMContentLoaded", () => {
   // files, that have to be kept in step. The buttons carry the location id and
   // this reads it wherever the click lands.
   document.addEventListener("click", (event) => {
-    const editBtn = event.target.closest("[data-edit-location]");
-    const reportBtn = event.target.closest("[data-report-location]");
-    if (!editBtn && !reportBtn) return;
+    const fixBtn = event.target.closest("[data-edit-location]");
+    if (!fixBtn) return;
 
-    const id = (editBtn ?? reportBtn).dataset.editLocation
-      ?? (editBtn ?? reportBtn).dataset.reportLocation;
-    const record = NCZ.locationsById?.get(id);
+    const record = NCZ.locationsById?.get(fixBtn.dataset.editLocation);
     if (!record) {
       // The dataset moved under an open popup, which the passive update check
       // makes possible. Saying so beats opening a form against nothing.
       alert("That pin is no longer in the loaded map data. Refresh and try again.");
       return;
     }
-    openSubmitModal(editBtn ? "edit" : "remove", record);
+    openSubmitModal("edit", record);
+  });
+
+  // The intent radios switch between proposing changes and asking for the pin
+  // to come off. Same record, same open form: only the shape of what gets sent
+  // changes, so this re-applies the mode rather than reopening anything.
+  submitModal?.querySelectorAll("input[name='submit-intent']").forEach((radio) => {
+    radio.addEventListener("change", () => {
+      if (!radio.checked || !editTarget) return;
+      clearErrors();
+      applyMode(radio.value === "remove" ? "remove" : "edit", editTarget);
+    });
   });
 
   const copyCetBtn = document.getElementById("submit-copy-cet-btn");

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -285,12 +285,16 @@ NCZ.modLinkId = function (mod) {
  * The pin popup, for both views: Leaflet binds this string and the Three.js
  * layer puts it in a CSS2DObject card.
  *
- * The edit and report actions are BUTTONS carrying the location id, not links,
- * and nothing here binds a handler. One delegated listener in app.js serves
- * every pin in both views; a per-popup listener would have to be attached twice,
- * once in each view's popup-open path, and the two would drift.
+ * The fix action is a BUTTON carrying the location id, not a link, and nothing
+ * here binds a handler. One delegated listener in app.js serves every pin in
+ * both views; a per-popup listener would have to be attached twice, once in
+ * each view's popup-open path, and the two would drift.
  *
- * Both actions render on every record. The edit link they replace was hidden on
+ * ONE action, not two. Asking for a pin to be taken down is a kind of
+ * correction, chosen inside the form, rather than a second button beside it:
+ * everything a separate report could say, the form already asks for.
+ *
+ * It renders on every record. The edit link it replaces was hidden on
  * auto-discovered pins, which made sense when the only way to correct one was to
  * edit a Nexus description. A submission goes to the same queue whatever the
  * record's provenance.
@@ -356,8 +360,7 @@ NCZ.buildPopupHtml = function (mod, catStyle, nexusThumbs, tagsDict) {
         <div class="popup-actions">
           <a href="${NCZ.escapeHtml(nexusUrl)}" target="_blank" class="ui-popup-action-link ui-popup-action-link-nexus">${NCZ.escapeHtml(nexusLabel)}</a>
           <button type="button" class="ui-popup-action-link ui-popup-action-link-copy-link tertiary" data-copy-url="${NCZ.escapeHtml(copyLinkUrl)}" aria-label="Copy link to this pin" title="Copy link"><span class="ui-popup-action-link-icon" aria-hidden="true"></span></button>
-          <button type="button" class="ui-popup-action-link ui-popup-action-link-edit tertiary" data-edit-location="${NCZ.escapeHtml(String(mod.id))}" aria-label="Suggest an edit" title="Suggest an edit"><span class="ui-popup-action-link-icon" aria-hidden="true"></span></button>
-          <button type="button" class="ui-popup-action-link ui-popup-action-link-report tertiary" data-report-location="${NCZ.escapeHtml(String(mod.id))}" aria-label="Report a problem" title="Report a problem"><span class="ui-popup-action-link-icon" aria-hidden="true"></span></button>
+          <button type="button" class="ui-popup-action-link ui-popup-action-link-edit tertiary" data-edit-location="${NCZ.escapeHtml(String(mod.id))}" title="Suggest a correction to this pin, or ask for it to be taken down. A reviewer decides."><span class="ui-popup-action-link-icon" aria-hidden="true"></span>Suggest a fix</button>
         </div>
       </div>
     </div>

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -281,6 +281,20 @@ NCZ.modLinkId = function (mod) {
   return mod.id;
 };
 
+/**
+ * The pin popup, for both views: Leaflet binds this string and the Three.js
+ * layer puts it in a CSS2DObject card.
+ *
+ * The edit and report actions are BUTTONS carrying the location id, not links,
+ * and nothing here binds a handler. One delegated listener in app.js serves
+ * every pin in both views; a per-popup listener would have to be attached twice,
+ * once in each view's popup-open path, and the two would drift.
+ *
+ * Both actions render on every record. The edit link they replace was hidden on
+ * auto-discovered pins, which made sense when the only way to correct one was to
+ * edit a Nexus description. A submission goes to the same queue whatever the
+ * record's provenance.
+ */
 NCZ.buildPopupHtml = function (mod, catStyle, nexusThumbs, tagsDict) {
   const nexus_id_lower = String(mod.nexus_id).toLowerCase();
   let nexusUrl = `https://www.nexusmods.com/cyberpunk2077/mods/${mod.nexus_id}`;
@@ -294,10 +308,6 @@ NCZ.buildPopupHtml = function (mod, catStyle, nexusThumbs, tagsDict) {
   }
 
   const copyLinkUrl = `${NCZ.SITE_URL}?${NCZ.URL_PARAM_MOD}=${encodeURIComponent(NCZ.modLinkId(mod))}`;
-
-  const [cX, cY, cZ] = mod.coordinates;
-  const yawParam = mod.yaw != null ? `&yaw=${mod.yaw}` : "";
-  const editUrl = `https://github.com/nczoning/nc-zoning-board/issues/new?template=modify_location.yml&location_id=${mod.id}&mod_name=${encodeURIComponent(mod.name)}&authors=${encodeURIComponent(mod.authors.join(", "))}&coord_x=${cX}&coord_y=${cY}&coord_z=${cZ ?? ""}&yaw=${mod.yaw ?? ""}${yawParam}`;
 
   const nexusThumb = nexusThumbs[String(mod.nexus_id)];
   const thumbSrc = nexusThumb?.thumbnailUrl || null;
@@ -346,7 +356,8 @@ NCZ.buildPopupHtml = function (mod, catStyle, nexusThumbs, tagsDict) {
         <div class="popup-actions">
           <a href="${NCZ.escapeHtml(nexusUrl)}" target="_blank" class="ui-popup-action-link ui-popup-action-link-nexus">${NCZ.escapeHtml(nexusLabel)}</a>
           <button type="button" class="ui-popup-action-link ui-popup-action-link-copy-link tertiary" data-copy-url="${NCZ.escapeHtml(copyLinkUrl)}" aria-label="Copy link to this pin" title="Copy link"><span class="ui-popup-action-link-icon" aria-hidden="true"></span></button>
-          ${!mod._source ? `<a href="${NCZ.escapeHtml(editUrl)}" target="_blank" class="ui-popup-action-link ui-popup-action-link-edit tertiary" aria-label="Suggest Edit" title="Suggest Edit"><span class="ui-popup-action-link-icon" aria-hidden="true"></span></a>` : ""}
+          <button type="button" class="ui-popup-action-link ui-popup-action-link-edit tertiary" data-edit-location="${NCZ.escapeHtml(String(mod.id))}" aria-label="Suggest an edit" title="Suggest an edit"><span class="ui-popup-action-link-icon" aria-hidden="true"></span></button>
+          <button type="button" class="ui-popup-action-link ui-popup-action-link-report tertiary" data-report-location="${NCZ.escapeHtml(String(mod.id))}" aria-label="Report a problem" title="Report a problem"><span class="ui-popup-action-link-icon" aria-hidden="true"></span></button>
         </div>
       </div>
     </div>
@@ -509,8 +520,12 @@ NCZ.summaryToDescription = function (summary) {
 // @param {object} [opts]
 // @param {string[]} [opts.knownTags]  tag slugs the registry knows; unknown tags
 //   are an error, matching the server rather than dropping them
+// @param {string} [opts.fixedNexusId]  the mod id an EDIT is against. An edit
+//   does not ask which mod this is, so there is no field to parse, and the
+//   stored value may be "WIP" or "Dummy", which the public form refuses for a
+//   new pin but must not refuse for an edit to an existing one.
 // @returns {{values: object, errors: object}}  errors is keyed by field name
-NCZ.collectLocationForm = function (raw, { knownTags } = {}) {
+NCZ.collectLocationForm = function (raw, { knownTags, fixedNexusId } = {}) {
   const errors = {};
   const text = (v) => String(v ?? "").trim();
 
@@ -549,7 +564,9 @@ NCZ.collectLocationForm = function (raw, { knownTags } = {}) {
     if (unknown.length) errors.tags = `Unknown tag(s): ${unknown.join(", ")}.`;
   }
 
-  const ref = NCZ.parseNexusRef(raw.nexusId);
+  const ref = fixedNexusId
+    ? { id: String(fixedNexusId) }
+    : NCZ.parseNexusRef(raw.nexusId);
   if (ref.error) errors.nexus_id = ref.error;
 
   const credits = text(raw.credits);
@@ -567,6 +584,42 @@ NCZ.collectLocationForm = function (raw, { knownTags } = {}) {
   };
 
   return { values, errors };
+};
+
+// The fields of an edit that actually changed, against the record the map is
+// already holding.
+//
+// An edit submission sends only these. Sending the whole record would make
+// every proposal look like a rewrite in the review queue's diff, and the
+// reviewer's job is to see that the yaw moved, not to re-read the description.
+// The server agrees: `kind: 'edit'` validates with `partial: true` and refuses a
+// payload with no fields in it.
+//
+// Arrays compare by content, not by identity: `tags` and `authors` are rebuilt
+// from the form on every read, so a reference test would call every submission
+// a change to both.
+//
+// @param {object} original  the stored record, as /v1 serves it
+// @param {object} values    collectLocationForm().values
+// @returns {object} the changed subset, empty when nothing moved
+NCZ.diffLocation = function (original, values) {
+  const changed = {};
+  const same = (a, b) => {
+    if (Array.isArray(a) || Array.isArray(b)) {
+      const left = Array.isArray(a) ? a : [];
+      const right = Array.isArray(b) ? b : [];
+      return left.length === right.length && left.every((v, i) => v === right[i]);
+    }
+    // null and "" both mean "no credits" on a record, and a form cannot tell
+    // them apart, so clearing a field that was already empty is not a change.
+    if ((a ?? "") === "" && (b ?? "") === "") return true;
+    return a === b;
+  };
+
+  for (const [key, value] of Object.entries(values)) {
+    if (!same(original?.[key], value)) changed[key] = value;
+  }
+  return changed;
 };
 
 // The submission envelope fields, which sit beside the payload rather than in

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -360,7 +360,7 @@ NCZ.buildPopupHtml = function (mod, catStyle, nexusThumbs, tagsDict) {
         <div class="popup-actions">
           <a href="${NCZ.escapeHtml(nexusUrl)}" target="_blank" class="ui-popup-action-link ui-popup-action-link-nexus">${NCZ.escapeHtml(nexusLabel)}</a>
           <button type="button" class="ui-popup-action-link ui-popup-action-link-copy-link tertiary" data-copy-url="${NCZ.escapeHtml(copyLinkUrl)}" aria-label="Copy link to this pin" title="Copy link"><span class="ui-popup-action-link-icon" aria-hidden="true"></span></button>
-          <button type="button" class="ui-popup-action-link ui-popup-action-link-edit tertiary" data-edit-location="${NCZ.escapeHtml(String(mod.id))}" title="Suggest a correction to this pin, or ask for it to be taken down. A reviewer decides."><span class="ui-popup-action-link-icon" aria-hidden="true"></span>Suggest a fix</button>
+          <button type="button" class="ui-popup-action-link ui-popup-action-link-edit tertiary" data-edit-location="${NCZ.escapeHtml(String(mod.id))}" aria-label="Suggest a fix" title="Suggest a correction to this pin, or ask for it to be taken down. A reviewer decides."><span class="ui-popup-action-link-icon" aria-hidden="true"></span></button>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -535,6 +535,11 @@
                             <span id="submit-mod-card-name"></span>
                         </div>
                     </div>
+                    <div class="submit-field-row submit-edit-only">
+                        <label class="submit-label">What are you asking for?</label>
+                        <label class="ui-checkbox-label"><input type="radio" name="submit-intent" value="edit" checked> Correct this pin</label>
+                        <label class="ui-checkbox-label"><input type="radio" name="submit-intent" value="remove"> Take this pin off the map</label>
+                    </div>
                     <div id="submit-location-fields">
                     <div class="submit-field-row">
                         <label class="submit-label" for="submit-name">Location name</label>

--- a/index.html
+++ b/index.html
@@ -537,8 +537,10 @@
                     </div>
                     <div class="submit-field-row submit-edit-only">
                         <label class="submit-label">What are you asking for?</label>
-                        <label class="ui-checkbox-label"><input type="radio" name="submit-intent" value="edit" checked> Correct this pin</label>
-                        <label class="ui-checkbox-label"><input type="radio" name="submit-intent" value="remove"> Take this pin off the map</label>
+                        <div class="submit-intent-options">
+                            <label class="submit-intent-option"><input type="radio" name="submit-intent" value="edit" checked> Correct this pin</label>
+                            <label class="submit-intent-option"><input type="radio" name="submit-intent" value="remove"> Take this pin off the map</label>
+                        </div>
                     </div>
                     <div id="submit-location-fields">
                     <div class="submit-field-row">

--- a/index.html
+++ b/index.html
@@ -503,7 +503,8 @@
                 </button>
             </div>
             <div class="terminal-body submit-modal-body">
-                <ol class="submit-steps">
+                <div id="submit-target" class="submit-target hidden"></div>
+                <ol id="submit-steps" class="submit-steps">
                     <li><strong>TAG YOUR MOD</strong>: add the <code>NCZoning</code> tag to your mod on Nexus Mods. That is all the tag does now: it puts your mod in the list below, with its title, short description and uploader ready to edit. It is optional, and a mod submitted by link is treated exactly the same.</li>
                     <li><strong>ACQUIRE COORDINATES</strong>: open CET in-game, run the command below in the console. Copy the output and paste the values below:
                         <div class="submit-cet-command-block">
@@ -515,9 +516,9 @@
                     <li><strong>SUBMIT FOR REVIEW</strong>: complete the check at the bottom of the form and send it</li>
                     <li><strong>A REVIEWER DECIDES</strong>: nothing reaches the map until a reviewer approves it</li>
                 </ol>
-                <div class="submit-intro">Submissions are anonymous, so nothing is sent back to you. Watch the map for your pin, or leave a contact below if you are happy to be asked a question about it.</div>
+                <div id="submit-intro" class="submit-intro">Submissions are anonymous, so nothing is sent back to you. Watch the map for your pin, or leave a contact below if you are happy to be asked a question about it.</div>
                 <div class="submit-form">
-                    <div class="submit-field-row">
+                    <div class="submit-field-row submit-create-only">
                         <label class="submit-label" for="submit-mod-select">Your mod</label>
                         <select id="submit-mod-select" class="ui-select">
                             <option value="">Loading tagged mods...</option>
@@ -534,17 +535,18 @@
                             <span id="submit-mod-card-name"></span>
                         </div>
                     </div>
+                    <div id="submit-location-fields">
                     <div class="submit-field-row">
                         <label class="submit-label" for="submit-name">Location name</label>
                         <input type="text" id="submit-name" class="submit-input" placeholder="e.g. Cliffside Abode Player Home">
                         <p class="submit-field-error" id="submit-error-name" hidden></p>
-                        <div class="submit-hint">Prefilled from your mod's Nexus title once you pick it above. Edit it to name the location itself, not the mod page.</div>
+                        <div class="submit-hint"><span class="submit-create-only">Prefilled from your mod's Nexus title once you pick it above.</span> Name the location itself, not the mod page.</div>
                     </div>
                     <div class="submit-field-row">
                         <label class="submit-label" for="submit-description">Description</label>
                         <textarea id="submit-description" class="submit-textarea" rows="3" maxlength="500" placeholder="What is at these coordinates, in a sentence or two."></textarea>
                         <p class="submit-field-error" id="submit-error-description" hidden></p>
-                        <div class="submit-hint">Prefilled from your mod's Nexus summary, the same text auto-discovery published. Edit it to describe the place rather than the mod: this is what a reviewer reads. <span id="submit-description-count">0</span>/500 characters.</div>
+                        <div class="submit-hint"><span class="submit-create-only">Prefilled from your mod's Nexus summary, the same text auto-discovery published.</span> Describe the place rather than the mod: this is what a reviewer reads. <span id="submit-description-count">0</span>/500 characters.</div>
                     </div>
                     <div class="submit-field-row">
                         <label class="submit-label">CET Coordinates</label>
@@ -589,11 +591,18 @@
                         <label class="submit-label" for="submit-authors">Authors <span class="submit-optional">(comma-separated)</span></label>
                         <input type="text" id="submit-authors" class="submit-input" placeholder="e.g. Author1, Author2">
                         <p class="submit-field-error" id="submit-error-authors" hidden></p>
-                        <div class="submit-hint">Prefilled with the mod's Nexus uploader once you pick it above. Add anyone else who worked on the location, separated by commas.</div>
+                        <div class="submit-hint"><span class="submit-create-only">Prefilled with the mod's Nexus uploader once you pick it above.</span> Everyone who worked on the location, separated by commas.</div>
                     </div>
                     <div class="submit-field-row">
                         <label class="submit-label" for="submit-credits">Credits <span class="submit-optional">(optional)</span></label>
                         <textarea id="submit-credits" class="submit-textarea" placeholder="e.g. Original map texture by XYZ" rows="2"></textarea>
+                    </div>
+                    </div>
+                    <div class="submit-field-row submit-report-only" hidden>
+                        <label class="submit-label" for="submit-reason">What is wrong with this pin?</label>
+                        <textarea id="submit-reason" class="submit-textarea" rows="3" maxlength="1000" placeholder="e.g. the mod was taken down, or this pin is in the wrong place and I am not the author."></textarea>
+                        <p class="submit-field-error" id="submit-error-reason" hidden></p>
+                        <div class="submit-hint">A reviewer reads this and decides. Removing a pin takes it off the map and keeps the record, so a mistake here is reversible.</div>
                     </div>
                     <div class="submit-field-row">
                         <label class="submit-label" for="submit-note">Note for the reviewer <span class="submit-optional">(optional)</span></label>
@@ -617,7 +626,7 @@
                     </div>
                     <div id="submit-done" class="submit-done hidden" role="status">
                         <h3 class="submit-done-title">QUEUED FOR REVIEW</h3>
-                        <p class="submit-done-body">Submission <span id="submit-done-id" class="submit-done-id"></span> is in the review queue. A reviewer checks the coordinates before anything is published, and nothing appears on the map until one approves it.</p>
+                        <p class="submit-done-body">Submission <span id="submit-done-id" class="submit-done-id"></span> <span id="submit-done-detail"></span></p>
                         <p class="submit-done-body">Submissions are anonymous, so there is no reply to wait for and no status page to check. Watch the map.</p>
                         <button id="submit-another-btn" class="terminal-btn">[ SUBMIT ANOTHER ]</button>
                     </div>

--- a/index.html
+++ b/index.html
@@ -523,7 +523,7 @@
                         <select id="submit-mod-select" class="ui-select">
                             <option value="">Loading tagged mods...</option>
                         </select>
-                        <div class="submit-hint">Mods tagged <code>NCZoning</code> on Nexus appear here. Most tagged mods are already on the map, so an empty list is normal. A new tag can take about 10 minutes to reach the Nexus API and a few minutes more to reach this list, so if you have just added it, paste your mod's link instead.</div>
+                        <div class="submit-hint">Mods tagged <code>NCZoning</code> on Nexus appear here. Most tagged mods are already on the map, so an empty list is normal. A new tag can take about 10 minutes to reach the Nexus API and a few minutes more to reach this list, so if you have just added it, paste your mod's link instead. A mod whose pin was taken off the map is not listed either; paste its link and say in the note why it belongs back.</div>
                         <div id="submit-mod-manual" class="submit-subfield hidden">
                             <label class="submit-label" for="submit-nexus-ref">Nexus page URL or mod id</label>
                             <input type="text" id="submit-nexus-ref" class="submit-input" placeholder="https://www.nexusmods.com/cyberpunk2077/mods/12345">

--- a/test/submit-form.test.js
+++ b/test/submit-form.test.js
@@ -318,6 +318,15 @@ test('a blank reference is refused', () => {
   assert.ok(NCZ.collectLocationForm({ ...complete(), nexusId: '' }).errors.nexus_id);
 });
 
+test('an edit takes the mod id from the record, including a WIP one', () => {
+  // The edit modal hides the mod picker: the record answers which mod this is.
+  // Without the override the form would refuse every edit for a missing Nexus
+  // reference, and refuse the WIP records outright.
+  const wip = NCZ.collectLocationForm({ ...complete(), nexusId: '' }, { fixedNexusId: 'WIP' });
+  assert.equal(wip.errors.nexus_id, undefined);
+  assert.equal(wip.values.nexus_id, 'WIP');
+});
+
 test('WIP is refused from the form, though the server allows it', () => {
   // Stricter on purpose: "WIP" and "Dummy" are reviewer calls. A submitter
   // cannot evidence a mod that has no page.
@@ -332,6 +341,81 @@ test('blank credits are null, not an empty string', () => {
   // means in the stored record.
   const { values } = NCZ.collectLocationForm({ ...complete(), credits: '   ' });
   assert.equal(values.credits, null);
+});
+
+// ── the edit diff ─────────────────────────────────────────────────────────────
+// An edit sends only what moved. The queue renders a diff, and a payload
+// carrying every field would make each proposal read as a rewrite.
+
+/** A stored record, in the shape /v1 serves. */
+const record = () => ({
+  id: 'abc-123',
+  name: 'Cliffside Abode Player Home',
+  authors: ['Spuddeh', 'Akiway'],
+  description: 'A player home on the cliffs north of the city.',
+  coordinates: [-1234.56, 789.01, 42.5],
+  yaw: 180,
+  category: 'new-location',
+  tags: ['player-home'],
+  nexus_id: '12345',
+  credits: 'Original texture by XYZ',
+});
+
+test('an untouched form produces no changes at all', () => {
+  const { values } = NCZ.collectLocationForm(complete());
+  assert.deepEqual(NCZ.diffLocation(record(), values), {});
+});
+
+test('only the field that moved is sent', () => {
+  const { values } = NCZ.collectLocationForm({ ...complete(), yaw: '90' });
+  assert.deepEqual(NCZ.diffLocation(record(), values), { yaw: 90 });
+});
+
+test('a coordinate change sends the whole triple, because the server takes it whole', () => {
+  const { values } = NCZ.collectLocationForm({ ...complete(), z: '43' });
+  assert.deepEqual(NCZ.diffLocation(record(), values), { coordinates: [-1234.56, 789.01, 43] });
+});
+
+test('arrays compare by content, not by identity', () => {
+  // tags and authors are rebuilt from the form on every read, so a reference
+  // test would report both as changed on every single edit.
+  const { values } = NCZ.collectLocationForm(complete());
+  assert.equal('tags' in NCZ.diffLocation(record(), values), false);
+  assert.equal('authors' in NCZ.diffLocation(record(), values), false);
+
+  const reordered = NCZ.collectLocationForm({ ...complete(), authors: 'Akiway, Spuddeh' });
+  assert.deepEqual(NCZ.diffLocation(record(), reordered.values).authors, ['Akiway', 'Spuddeh'],
+    'order is content: the first author is the one the map shows');
+});
+
+test('a tag added and a tag removed are both a change', () => {
+  const added = NCZ.collectLocationForm({ ...complete(), tags: ['player-home', 'interior'] });
+  assert.deepEqual(NCZ.diffLocation(record(), added.values).tags, ['player-home', 'interior']);
+
+  const removed = NCZ.collectLocationForm({ ...complete(), tags: [] });
+  assert.deepEqual(NCZ.diffLocation(record(), removed.values).tags, []);
+});
+
+test('clearing a field that was already empty is not a change', () => {
+  // The record stores "none" as null OR as an empty string, and the form only
+  // ever produces null, so a strict compare would propose an edit to every
+  // record holding "" for a field nobody touched.
+  const stored = { ...record(), credits: '' };
+  const { values } = NCZ.collectLocationForm({ ...complete(), credits: '' });
+  assert.equal(values.credits, null);
+  assert.equal('credits' in NCZ.diffLocation(stored, values), false);
+});
+
+test('clearing a field that had a value IS a change', () => {
+  const { values } = NCZ.collectLocationForm({ ...complete(), credits: '' });
+  assert.deepEqual(NCZ.diffLocation(record(), values), { credits: null });
+});
+
+test('a record missing a key is a change rather than a match', () => {
+  const stored = { ...record() };
+  delete stored.yaw;
+  const { values } = NCZ.collectLocationForm(complete());
+  assert.equal(NCZ.diffLocation(stored, values).yaw, 180);
 });
 
 // ── the submission envelope ───────────────────────────────────────────────────


### PR DESCRIPTION
Phase 5, PR D, the last of the four. The **Suggest Edit** link opened a GitHub issue form; it now opens the submit form, prefilled from the record, and sends what changed to the review queue. A second action beside it **reports a problem** with a pin.

## One modal, three modes

`create`, `edit` and `remove` post three shapes to one route and share every field. A second modal would be the same form twice, with two sets of validation to keep in step.

| | create | edit | remove |
| --- | --- | --- | --- |
| Mod picker | yes | hidden | hidden |
| Location fields | yes | prefilled | **hidden** |
| Reason | | | required |
| Sends | full payload | only what changed | `location_id` + reason |

`remove` shows no location fields because the server refuses a payload on a removal: there is nothing for a reviewer to apply.

## Decisions worth a look

**The edit sends only what moved.** `NCZ.diffLocation` compares against the record already in memory (no fetch), so the queue's diff reads "yaw changed" rather than restating the record. Two subtleties, both tested:

- **Arrays compare by content.** `tags` and `authors` are rebuilt from the form on every read, so an identity test would report both as changed on every edit.
- **Empty-to-empty is not a change.** A record stores "none" as `null` *or* as `""`, and the form only ever produces `null`, so a strict compare would propose an edit to every record holding `""` in a field nobody touched.

**An edit takes its mod id from the record**, through a new `fixedNexusId` option. The picker is hidden in that mode so there is nothing to parse, and the stored id may be `WIP` or `Dummy`, which the public form refuses for a new pin and must not refuse for an edit to an existing one. Without this the edit path could not be sent at all, which is how it was found.

**One delegated listener, as the plan required.** The actions are buttons carrying a location id. Leaflet rebuilds a popup's DOM on every open and the Three.js layer builds a `CSS2DObject` card per pin, so binding at open time means two wirings in two files that drift. `NCZ.locationsById` resolves the id from the same array the pins are built from.

**Both actions render on every record.** The old link was hidden on auto-discovered pins, which made sense when correcting one meant editing a Nexus description. A submission goes to the same queue whatever the record's provenance.

## Found by driving it, not by reading it

The header button was handed `openSubmitModal` directly, so `addEventListener` passed a **MouseEvent as the mode**. Create mode opened with an edit's title, no steps and the wrong send button. Nothing in the unit tests could have seen it.

## Tests

52 site tests. **Six more negative controls**, each turned its guarding test red, each restored from a snapshot.

One control found a test passing for the wrong reason: the empty-field case used `null` in the record, which matches `null` from the form whether or not the rule under test exists. Rewritten to use the `""` the rule is actually there for. A second mutation silently failed to apply because the working copy is CRLF and the pattern was multi-line, which is why the runner reports "MUTATION DID NOT APPLY" as its own verdict rather than counting it as a pass.

## Driven in a browser

Edit: opens from the popup button, title and banner name the record, steps and picker hidden, fields prefilled including tags. Sending unchanged reports "Nothing has changed yet"; changing the yaw posts `{kind: "edit", location_id, payload: {yaw: 90}}` and nothing else. Report: location fields hidden, empty reason refused, sending posts `{kind: "remove", location_id, reason}` with no payload. Create still opens clean from the header button after both, with nothing leaking between modes.

## Not verified

A real edit or removal against staging, for the same reason as PR C: Turnstile refuses the automated browser. The three payload shapes were captured at the boundary with `postSubmission` stubbed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
