### PR TITLE
Flip production to D1: DATA_SOURCE mods -> d1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,54 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Submissions move onto the map. A location can now be added, corrected or reported
+from the map itself, and everything goes through a review queue before it appears.
+The registry moves out of git into a database, with a dashboard for maintainers.
+
 ### Added
 
-- D1 databases (production + staging) with the location registry schema, and a one-time import of all 296 locations plus the single exclusion. Nothing reads D1 yet; `mods.json` is still the live source.
-- A parity gate that rebuilds `/v1/locations` from D1 and diffs it byte-for-byte against the live API, with negative controls that prove the diff can fail.
-- The refresh cron can source the registry from D1 via `DATA_SOURCE=d1`. Production stays on `mods.json` until the cutover; unset never means D1.
-- A second harness that runs both source paths head-to-head across a swept clock, and fails if the swept field never varied.
-- GitHub sign-in for admins at `/admin/`, gated on repository collaborator status.
-- Admin CRUD over the location registry, with an append-only audit log: every mutation records who did it, and the record before and after. Nothing on the live map reads these writes yet.
-- The admin dashboard at `/admin/`: browse and filter every location, edit the full record, and read the audit log. Saves send only the fields that actually changed.
-- Tag management in the dashboard. A tag still attached to locations cannot be deleted; the refusal lists what is using it. Renaming a tag's identifier is locked behind an explicit unlock, because it re-points existing records and breaks `?tag=` links; the display name is the safe thing to edit.
-
-- The dashboard shows how old the served dataset is, and a Rebuild button that regenerates it on demand. Staging has no cron, so nothing there refreshed on its own and there was no way to see that.
-- `scripts/sync-locations.mjs` copies location records that exist in `data/locations/` but not yet in D1. Needed until submissions land in D1 directly: a mod merged to `main` reaches production but not the D1 registry.
-
-- The map notices when locations change while a tab is open and offers to refresh, instead of showing its load-time snapshot indefinitely. The check is served from the browser's own cache almost every time, so it costs roughly one request per tab per five minutes.
-
-- The cron keeps a Nexus mod index in D1, covering every tagged mod and every mod the map serves. It backs the submissions candidate list without a live Nexus call, and it is where the four Nexus-derived fields on each location now come from.
-- The parity gate covers all 18 served fields, including the thumbnails, pictures, update times and archive listings it could not rebuild before.
-- `POST /submissions` queues a new location, an edit or a removal request for review. Anonymous, behind a Turnstile check and a limit of 5 per address per hour, and nothing it accepts reaches the map without a reviewer approving it.
-- A privacy note at [docs/privacy.md](docs/privacy.md). Submissions are the first personal data the site collects: a salted one-way hash of the submitter's address, kept 90 days and then cleared automatically.
-- A review queue in the dashboard: pending submissions with a rendered diff of what each one changes and a mini-map of the proposed pin, and approve, reject or hold each one. Approving writes the location and rebuilds the map's data. Nothing is sent to the submitter: a review note is an internal record, and the queue says so.
-- Rebuild in the dashboard now also re-reads the page's own data, so a registry that changed underneath an open tab stops showing the copy it loaded with. A record open in the detail pane that no longer exists is closed rather than left on screen.
-- The audit log reads as sentences rather than as action names against ids: "dismissed mod 999001 “A Texture Pack” from the candidates list", not `candidate.dismiss` against `999001`. The recorded action stays beside each entry, so what the log actually holds can still be checked at a glance.
-- Nexus IDs are links to the mod page wherever the dashboard shows one, including a live one under the ID field in the editor. `WIP` and `Dummy` stay plain text, since they have no page to open.
-- A new-pin submission for a mod already on the map shows the records it would sit alongside, and how far away they are. One mod can legitimately supply several locations, so this is context rather than a warning; where the existing record is hidden, the queue offers to restore that one instead of creating a second.
-- A candidates tab listing NCZoning-tagged Nexus mods with no pin yet. Add one to the map with the editor prefilled, or dismiss it with a reason. Dismissals are reversible, which the Discord alert this replaces was not.
-- The submit form sends a location to the review queue. It starts from your mod (picked from the tagged list, or a Nexus link) and now collects the name and description the registry requires, which the block never carried.
-- Picking a tagged mod prefills its title, short description and uploader, the same three things auto-discovery took from the Nexus page. All three stay editable.
-- The coordinate boxes are checked as you type. The box that is wrong goes red, and every problem in the row is named at once rather than one per attempt.
-- Every pin can be corrected from its own popup. **Suggest a fix** opens the form filled in from the record and sends only the fields you change. Inside it, one choice switches from correcting the pin to asking for it to be taken down, which asks for a reason instead. Both go to the review queue, and the pin is unchanged until a reviewer decides.
-
-### Fixed
-
-- Share links pointed at the mod rather than the pin, so when one Nexus mod supplied two locations both pins produced the same link and it always opened the first. Links now use the location's own id. Links shared before this keep working.
-- Admin tag edits reached the legacy column but not the join the map reads, so they returned success and changed nothing. Both are now written together.
-- The API never told browsers they could read the `ETag` header, so the site's own conditional-request cache had never stored anything and its `304` handling was unreachable code. The browser's built-in cache masked it, which is why nothing looked wrong.
-- The new location added to `main` overnight reached production but not the D1 registry, so staging served one fewer mod than production.
+- **Submit a location from the map.** Pick your mod, fill in the form, send it for review. Coordinates are checked as you type, and every problem in the row is named at once beside the field it belongs to.
+- **Correct any pin from its own popup.** *Suggest a fix* opens the form filled in from the record and sends only the fields you change. The same form switches to asking for a pin to be taken down, with a reason. The pin is unchanged until a reviewer decides.
+- **A review queue.** Nothing reaches the map without a reviewer approving it. Each submission shows a diff of what it changes and a mini-map of the proposed pin. A new pin for a mod already on the map lists the records it would sit alongside and how far away they are, since one mod can legitimately supply several locations.
+- **An admin dashboard** at `/admin/`, signed in with GitHub and open to repository collaborators: browse and edit the registry, manage tags, work the queue, review tagged mods that have no pin yet, and watch API health and free-tier usage. Every change is recorded in an audit log.
+- **A privacy note** at [docs/privacy.md](docs/privacy.md). Submissions are the first personal data the site collects: a salted one-way hash of the submitter's address, kept 90 days and then cleared automatically.
+- The map notices when locations change while a tab is left open, and offers to refresh instead of showing its load-time snapshot indefinitely.
 
 ### Changed
 
-- **API `0.3.0` → `0.4.0`.** `/v1/tags` now returns an array of `{slug, name, description, sort_order}` instead of a `{tag: description}` map, matching `/v1/locations` and the shape the in-game parser maps most easily. `name` falls back to the slug, so nothing renders differently. Breaking, and taken now while the pre-1.0 window makes it free.
-- Tags are registry data in D1 rather than `data/tags.json`, so they can be edited in the dashboard instead of by pull request, and a mistyped tag is rejected on write rather than caught in CI afterwards. The site reads `/v1/tags`, falling back to the static file only if the API is unreachable.
-- The submit form reports every problem at once, beside the field, instead of one alert at a time. Its coordinate limits are the ones the server enforces; the older, tighter numbers would have refused four locations already on the map.
-- `robots.txt` asks crawlers to leave `/admin` alone. The collaborator gate is what actually protects it; this just keeps the dashboard out of search results.
+- **The location registry lives in a database rather than in git.** Nothing changes for visitors. It removes the gap where a merged pull request and the live map could disagree.
+- **The `NCZoning` tag is prefill only.** Tagging a mod puts it in the submit form's picker with its name, description and uploader ready to use. It no longer publishes a pin on its own.
+- ⚠️ **Editing the block in a Nexus description no longer moves a pin.** Authors who kept their location up to date that way now do it from the map. Pins already on the map are unaffected.
+- **API `0.3.0` to `0.4.0`.** `/v1/tags` returns an array of `{slug, name, description, sort_order}` instead of a `{tag: description}` map, matching `/v1/locations` and the shape the in-game parser maps most easily. `name` falls back to the slug, so nothing renders differently. Breaking, and taken now while the pre-1.0 window makes it free.
+- Tags are registry data, edited in the dashboard rather than by pull request. A mistyped tag is refused on write instead of caught in CI afterwards.
+- `robots.txt` keeps `/admin` out of search results. The collaborator gate is what actually protects it.
+
+### Fixed
+
+- Share links pointed at the mod rather than the pin, so when one Nexus mod supplied two locations both produced the same link and it always opened the first. Links now use the location's own id. Links shared before this keep working.
+- Admin tag edits reached the legacy column but not the one the map reads, so they reported success and changed nothing.
+- The API never told browsers they could read the `ETag` header, so the site's own conditional-request cache had never stored anything and its `304` handling was unreachable. The browser's built-in cache masked it, which is why nothing looked wrong.
 
 ### Removed
 
-- The BBCode generator. Nothing is pasted into a Nexus description any more: the `NCZoning` tag now only puts a mod in the submit form's picker, with its name and image ready to use. The block had to be placed and formatted by hand, most attempts needed correcting, and it published a pin with no review step.
+- **The BBCode generator.** The block had to be placed and formatted by hand, most attempts needed correcting, and it published a pin with no review step. The submit form replaces it.
 
 ## [1.7.2] - 2026-07-26
 

--- a/worker/scripts/parity-check.mjs
+++ b/worker/scripts/parity-check.mjs
@@ -262,14 +262,23 @@ async function main() {
     ['name changed', (r) => ({ ...r, name: `${r.name} ` }), null],
     ['coordinate nudged', (r) => ({ ...r, x: r.x + 0.0001 }), null],
     ['z dropped to NULL', (r) => ({ ...r, z: null }), null],
-    ['tag removed', (r) => ({ ...r, tags: JSON.stringify(JSON.parse(r.tags).slice(1)) }), null],
+    // Mutates the JOIN, not `locations.tags`. Migration 0002 made location_tags
+    // authoritative and resolveTags ignores the JSON column whenever the join is
+    // supplied, which it always is here -- so the original column mutation landed
+    // on a field nothing reads and the control could not fail. Do not move it back.
+    ['tag removed', null, null, (m) => {
+      const key = rows[0].id;
+      const slugs = m.get(key);
+      if (!slugs || !slugs.length) fail(`negative control cannot run: no location_tags rows for ${key}`);
+      return new Map(m).set(key, slugs.slice(1));
+    }],
     ['thumbnail_url changed', null, (e) => ({ ...e, thumbnailUrl: `${e.thumbnailUrl}?x` })],
     ['picture_url dropped', null, (e) => ({ ...e, pictureUrl: null })],
     ['updated_at moved', null, (e) => ({ ...e, updatedAt: '2020-01-01T00:00:00.000Z' })],
     ['archive name changed', null, (e) => ({ ...e, archives: [...e.archives, 'ghost.archive'] })],
   ];
   let controlsPassed = 0;
-  for (const [label, mutateRow, mutateIndex] of controls) {
+  for (const [label, mutateRow, mutateIndex, mutateTags] of controls) {
     const mutatedRows = mutateRow ? rows.map((r, i) => (i === 0 ? mutateRow(r) : r)) : rows;
     let mutatedIndex = nexusIndex;
     if (mutateIndex) {
@@ -281,9 +290,10 @@ async function main() {
       if (!entry) fail(`negative control cannot run: no nexus_cache row for ${key}`);
       mutatedIndex.set(key, mutateIndex(entry));
     }
+    const mutatedTags = mutateTags ? mutateTags(locationTags) : locationTags;
     let differs;
     try {
-      const out = buildFromRows(mutatedRows, dismissedIds, tagsDict, subdistricts.districts, mutatedIndex, nowMs, locationTags);
+      const out = buildFromRows(mutatedRows, dismissedIds, tagsDict, subdistricts.districts, mutatedIndex, nowMs, mutatedTags);
       differs = !compare(out, liveRecords);
     } catch {
       differs = true; // a throw is also a detection

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -59,10 +59,20 @@
 		// Anything other than "d1" means mods.json, INCLUDING unset. Absent
 		// config must never read as "switch production to the new source".
 		//
-		// Do not flip until parity-ab.mjs and parity-check.mjs are both green
-		// (worker/README.md). Tags and subdistricts still come from SITE_ORIGIN
-		// either way; they move to D1 at Phase 4.
-		"DATA_SOURCE": "mods",
+		// FLIPPED 2026-07-31 (#888 stage 5). Both gates were green against
+		// production D1 first: parity-check byte-for-byte identical on 297
+		// records with 9/9 negative controls, and parity-ab agreeing at all 10
+		// swept clocks with recently_updated actually varying. Note that
+		// parity-check can no longer fail from here, because the live API it
+		// diffs against IS this database now.
+		//
+		// ROLLBACK IS THIS WORD. Set it back to "mods" and production serves
+		// exactly what it served before, off a build already known to work.
+		// mods.json is still built and still unread, which is what keeps that
+		// true; it goes at Phase 6, not before.
+		//
+		// Tags and subdistricts still come from SITE_ORIGIN either way.
+		"DATA_SOURCE": "d1",
 		// --- Admin auth (Phase 3) -------------------------------------------
 		// Not secrets: an App id and an OAuth client id are both public. The
 		// private key and client secret are Worker secrets — see README.


### PR DESCRIPTION
Stage 5 of #888. One word: `"DATA_SOURCE": "mods"` becomes `"d1"` in the production block.

**Production starts reading the location registry from D1 when this deploys.**

## The gates that had to pass first, and why they had to pass *before* this

Both were run against production D1 while the live API was still `mods.json`-sourced. That is the only window in which either can fail: once this merges, `parity-check.mjs` diffs the live API against the database that now *is* the live API, and compares a thing to itself.

- **`parity-check.mjs`** — byte-for-byte identical, 297 records, 270173 bytes. **9/9 negative controls detected.** Green twice, across a cron tick boundary.
- **`parity-ab.mjs`** — both materializers agree at all 10 swept clocks (-90d to +365d), and the swept field genuinely varied: `recently_updated` went 61 to 27 to 10 to 6 to 5 to 3 to 0. The harness fails if the swept field never varies, so a sweep that did not sweep would not have passed.

One control was broken and the harness caught it: `tag removed` mutated `locations.tags`, a column `resolveTags` stopped reading when migration 0002 made the join authoritative. It reported byte-for-byte identical and then **refused to certify**, exiting 1. Fixed in `ee4d643`.

## Stage 3 was not run, deliberately

The checklist assumed production D1 was a stale 2026-07-26 snapshot needing a wipe and re-import. `sync-locations.mjs` had already closed that gap: D1 held 297 locations and 572 `location_tags` rows, and the gate was green against them. Running the read-only check before the destructive one is what established that, and no write was made to production D1 at any point.

## What changes for users

- **Auto-publish ends.** A `NCZoning`-tagged mod with a valid block becomes a *candidate*, not a pin. `materialize.js` never creates a record from a parsed block.
- **Editing the block in a Nexus description no longer moves a pin**, and gives no error. Authors use the map from here.
- The 9 existing `source='auto'` records are unaffected. They are D1 rows and keep their pins.

## What does not change, and is a trap until Phase 6

The mod-submission issue templates and their workflows still exist. After this merges, that path still accepts a submission, still opens a PR, still passes `validate-json`, still merges green, and **the pin never appears**. #888 Stage 7 now requires retiring those templates and deleting `sync-locations.mjs` as one change rather than two.

## Rollback

Set `DATA_SOURCE` back to `"mods"`. Production then serves exactly what it served before, off a build already known to work. `mods.json` is still built and still unread, which is precisely what keeps that true, and it is not removed until Phase 6.

That is why this is its own PR: it is the one change that has to be revertible without unpicking #904.

## Also in this PR

Two commits that are inert in production: the CHANGELOG rewrite (`cedf29d`) and the parity control fix (`ee4d643`, a development script). Neither affects the served surface, and neither needs to be part of a rollback.
