### PR TITLE
Cut 2.0.0, and correct every doc that still taught a retired submission flow

### DIFF
--- a/ASSETS.md
+++ b/ASSETS.md
@@ -51,7 +51,13 @@ If you have questions about specific uses of game assets or need an exception to
 
 ## Extracted Data Files
 
-The `data/locations/` and `data/subdistricts.json` directories contain coordinate data and metadata submitted by community members. This data is:
+Coordinate data and metadata submitted by community members. The location
+registry lives in a Cloudflare D1 database and is served publicly at
+`https://api.nczoning.net/v1/locations`; `data/subdistricts.json` (world geometry
+derived from the game) stays in this repository. `data/locations/` remains in the
+repository as the pre-cutover record and is no longer where submissions land.
+
+The terms are unchanged by where the data is stored. This data is:
 - **Original contributor work**: contributors retain ownership
 - **Licensed under MIT** (same as the software)
 - **Validated against game coordinates**: accuracy verified through player testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2026-07-31
 
 Submissions move onto the map. A location can now be added, corrected or reported
 from the map itself, and everything goes through a review queue before it appears.
@@ -22,11 +22,11 @@ The registry moves out of git into a database, with a dashboard for maintainers.
 
 ### Changed
 
-- **The location registry lives in a database rather than in git.** Nothing changes for visitors. It removes the gap where a merged pull request and the live map could disagree.
+- **The location registry lives in a database rather than in git.** The move itself changes nothing a visitor sees: same pins, same data. It removes the gap where a merged pull request and the live map could disagree.
 - **The `NCZoning` tag is prefill only.** Tagging a mod puts it in the submit form's picker with its name, description and uploader ready to use. It no longer publishes a pin on its own.
 - ⚠️ **Editing the block in a Nexus description no longer moves a pin.** Authors who kept their location up to date that way now do it from the map. Pins already on the map are unaffected.
-- **API `0.4.0` to `0.5.0`, breaking.** Two fields leave every `/v1` location record: `source` (`manual` / `auto`) and the synthetic `nczoning` tag. Nothing auto-publishes since the registry moved to D1, so `source='auto'` describes 9 legacy records rather than a category the system produces, and `nczoning` was a visible sidebar filter for a tag `/v1/tags` never listed. The **NCZONING filter button disappears** from the sidebar. Where a record came from is still readable: the auto-discovered nine keep their `nexus-<id>` ids.
-- **API `0.3.0` to `0.4.0`.** `/v1/tags` returns an array of `{slug, name, description, sort_order}` instead of a `{tag: description}` map, matching `/v1/locations` and the shape the in-game parser maps most easily. `name` falls back to the slug, so nothing renders differently. Breaking, and taken now while the pre-1.0 window makes it free.
+- **API `0.3.0` to `0.5.0`, breaking twice.** `/v1/tags` returns an array of `{slug, name, description, sort_order}` instead of a `{tag: description}` map, matching `/v1/locations` and the shape the in-game parser maps most easily; `name` falls back to the slug, so nothing renders differently. And two fields leave every location record: `source` (`manual` / `auto`) and the synthetic `nczoning` tag, neither of which describes anything now that nothing auto-publishes. Where a record came from is still readable, because the auto-discovered nine keep their `nexus-<id>` ids. **The `/v1` API is versioned separately from the site**, and is still pre-1.0, where breaking changes cost a MINOR and the path stays `/v1`. Both were taken now because the only consumers are unreleased; the API returns to `1.0.0` when the first in-game mod ships.
+- **The NCZONING filter button disappears** from the sidebar, and the small Nexus icon next to auto-discovered pins goes with it. Both marked a distinction that no longer exists: every location now arrives the same way, through the review queue.
 - Tags are registry data, edited in the dashboard rather than by pull request. A mistyped tag is refused on write instead of caught in CI afterwards.
 - `robots.txt` keeps `/admin` out of search results. The collaborator gate is what actually protects it.
 

--- a/README.md
+++ b/README.md
@@ -58,38 +58,42 @@ See [Tile Generation Guide](docs/tile-generation.md) for details.
 
 ## Submitting Your Mod
 
-### Preferred Method (NCZoning Auto-Discovery)
+Submit it from the map. No GitHub account, no Git, one way to do it.
 
-Add your mod to the map directly from Nexus (no GitHub account required):
+1. Get your in-game coordinates from the CET console
+2. Open [nczoning.net](https://nczoning.net) and press **[+] Submit**
+3. Pick your mod, or paste its Nexus link, then fill in the rest
+4. A maintainer reviews it, and approving it puts your pin on the map within seconds
 
-1. Tag your mod on Nexus with **NCZoning**
-2. Use the **[+] Submit** button on the map to generate your metadata block
-3. Paste the block into your mod description and save
+Tagging your mod **NCZoning** on Nexus is still worth doing: it puts your mod in
+the picker with its name, description and author already filled in. It no longer
+publishes a pin on its own.
 
-Your pin will appear on the map within a few minutes. See the **[NCZoning Auto-Discovery Guide](docs/nczoning-auto-discovery.md)** for full details.
+Already on the map? Correct your pin from its own popup with **Suggest a fix**,
+which sends only the fields you change. The same form can request removal.
 
-### GitHub Issue Method
-
-Prefer a permanent, manually curated entry? See **[docs/adding-mods.md](docs/adding-mods.md)** for instructions on submitting via GitHub issue or pull request.
+See **[docs/adding-mods.md](docs/adding-mods.md)** for the CET command and the
+full field reference.
 
 ## Documentation
 
 | Guide | Description |
 |-------|-------------|
-| [NCZoning Auto-Discovery](docs/nczoning-auto-discovery.md) | Add your mod to the map directly from Nexus |
-| [Adding Mods](docs/adding-mods.md) | GitHub issue / manual PR submission, mods.json schema |
+| [Adding Mods](docs/adding-mods.md) | Submitting from the map, CET coordinates, the field reference |
+| [The NCZoning Tag](docs/nczoning-auto-discovery.md) | What tagging your mod on Nexus prefills, and what it no longer does |
+| [Submission Pipeline](docs/submission-pipeline.md) | What happens between pressing Submit and the pin appearing |
 | [Coordinate System](docs/coordinate-system.md) | CET ↔ Leaflet transform, calibration data |
 | [Architecture](docs/architecture.md) | File structure, data flow, tech stack |
 | [Tile Generation](docs/tile-generation.md) | Map tiling, source images, upgrading resolution |
-| [Roadmap](https://github.com/orgs/nczoning/projects/1) | Current status and planned work — the project board is the roadmap |
+| [Roadmap](https://github.com/orgs/nczoning/projects/1) | Current status and planned work. The project board is the roadmap |
 
 ## Tech Stack
 
 - **[Leaflet.js](https://leafletjs.com/)**: Interactive map (`L.CRS.Simple` with custom tiles)
-- **Vanilla JS / CSS**: No frameworks, purely static files
+- **Vanilla JS / CSS**: No frameworks, no bundler
 - **[Sharp](https://sharp.pixelplumbing.com/)**: 8k map tile generation (dev dependency)
-- **GitHub Actions**: Automated JSON validation and PR pipeline
-- **Cloudflare Pages**: Static hosting (Git integration)
+- **Cloudflare Workers + D1 + KV**: the `/v1` Data API, the location registry, and the served dataset
+- **Cloudflare Pages**: hosting for the site and the admin dashboard (Git integration)
 
 ## Contributors & Community
 

--- a/docs/adding-mods.md
+++ b/docs/adding-mods.md
@@ -1,12 +1,14 @@
 # Adding Mods to the Map
 
-> **Looking for the easiest way to add your mod?** Use [NCZoning Auto-Discovery](nczoning-auto-discovery.md): tag your mod on Nexus and paste a metadata block into your description. No GitHub required.
->
-> This guide covers the GitHub issue and manual PR methods for permanent, manually curated entries.
+> **Submit from the map**, at [nczoning.net](https://nczoning.net). No GitHub
+> account and no Git. This guide covers the coordinates you need and what each
+> field means; the [Submission Pipeline](submission-pipeline.md) covers what
+> happens after you press Submit.
 
-## mods.json Schema
+## The Location Record
 
-Each mod entry is stored in its own file in `data/locations/<UUID>.json`. The schema for a mod object is:
+Every location is a row in the D1 registry. These are the fields you fill in when
+you submit, and what each one means:
 
 ```json
 {
@@ -59,28 +61,30 @@ Use [Simple Location Manager](https://www.nexusmods.com/cyberpunk2077/mods/26454
 
 See the [Coordinate System docs](coordinate-system.md) for more details and a pre-built calibration preset.
 
-## Submission Methods
+## How to Submit
 
-### Method 1: GitHub Issue Form (Recommended)
+1. Open [nczoning.net](https://nczoning.net) and press **[+] Submit**.
+2. **Pick your mod.** Tagged mods appear in a picker with their name, description
+   and uploader prefilled. If yours is not listed, paste its Nexus link.
+3. Fill in the coordinates and the rest of the fields above.
+4. Send it. A reviewer approves or rejects it, and an approved submission puts
+   your pin on the map within seconds.
 
-Best for modders who don't use Git:
+Coordinates are checked as you type, and every problem in a row is named at once
+beside the field it belongs to.
 
-1. Go to the [Issues tab](https://github.com/nczoning/nc-zoning-board/issues)
-2. Click **New Issue** → **"📍 Submit a New Mod Location"**
-3. Fill in the form fields
-4. Submit. The automated bot creates a PR (with `validate-json` running automatically)
-5. A maintainer reviews and merges → **the issue closes automatically**, pin appears on the map
+### Correcting an existing pin
 
-### Method 2: Manual Pull Request
-
-Best for modders comfortable with Git:
-
-1. Fork the repository
-2. Create a new `<UUID>.json` file in `data/locations/`.
-3. Fill in your data following the schema rules above.
-4. Run validation locally: `node scripts/build_mods.js` then `npx ajv validate -s mods.schema.json -d mods.json`
-5. Commit and open a PR
+Open the pin's popup and press **Suggest a fix**. The form arrives filled in from
+the record and sends only the fields you change, so a reviewer sees exactly what
+moved. One choice inside the same form switches to requesting removal, which asks
+for a reason instead.
 
 ### Validation
 
-All submissions are validated against `mods.schema.json` by a GitHub Actions workflow. PRs that fail validation will be flagged automatically.
+The Worker validates every write against the same rules on the way in, so a bad
+value is refused at submission rather than caught later. There is no PR to fail.
+
+> **Retired at 2.0.0:** the GitHub issue forms and the manual pull request. Both
+> wrote locations into git, and the registry lives in D1 now, so neither could
+> reach the map.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -85,10 +85,9 @@ A location record:
   "nexus_id": "27618",
   "coordinates": [-2229.57, 3618.96, 12.22],
   "yaw": 180.0,
-  "category": "new-location",
-  "tags": ["nczoning", "corpo"],
-  "authors": ["SomeModder"],
-  "source": "auto",
+  "category": "other",
+  "tags": ["entertainment"],
+  "authors": ["ellios2normandie"],
   "district": "City Center",
   "subdistrict": "Corpo Plaza",
   "recently_updated": true,
@@ -130,10 +129,10 @@ so don't substitute one for another:
 
 `version` is SemVer for the API surface.
 
-> ⚠️ **The API is currently pre-1.0 (`0.3.0`), and the rules below are inverted
+> ⚠️ **The API is currently pre-1.0 (`0.5.0`), and the rules below are inverted
 > while it is.** The surface was rolled back from `1.3.0` because nothing
-> consuming it has shipped yet, and the upcoming admin/D1 work takes shape
-> changes rather than deferring them. On a 1.x line each of those would need
+> consuming it has shipped yet, and the D1 work took shape changes rather than
+> deferring them. On a 1.x line each of those would need
 > MAJOR plus a `/v1` → `/v2` move, standing up a parallel surface with no
 > consumers to preserve.
 >
@@ -157,26 +156,31 @@ From `1.0.0` onward:
 So a consumer can read `/v1/health` once and know whether the field it wants
 exists yet, without probing for it.
 
-The three additive changes the surface has taken, in order:
+Every shape change the surface has taken, in order. The last two are breaking,
+which on a 1.x line would each have cost a MAJOR plus a path move:
 
 | Shape change | Under the 1.x numbering | Now |
 | --- | --- | --- |
 | the initial `/v1` surface | 1.0.0 | 0.0.0 |
 | `recently_updated`, `recently_updated_days` | 1.1.0 | 0.1.0 |
 | `archives` | 1.2.0 | 0.2.0 |
-| `last_refresh_at`, `refresh_age_seconds` on `/v1/health` | 1.3.0 | **0.3.0** *(current)* |
+| `last_refresh_at`, `refresh_age_seconds` on `/v1/health` | 1.3.0 | 0.3.0 |
+| **breaking:** `/v1/tags` becomes an array of records | would be 2.0.0 | 0.4.0 |
+| **breaking:** `source` and the synthetic `nczoning` tag leave every location record | would be 3.0.0 | **0.5.0** *(current)* |
 
-The rollback is mechanical: the MINOR digit is preserved and the MAJOR drops, so
-the three changes already made survive as `0.3.0`.
+The rollback was mechanical: the MINOR digit was preserved and the MAJOR dropped,
+so the three additive changes already made survived as `0.3.0`. The two breaking
+changes since then each cost a MINOR, which is the whole point of taking them
+before `1.0.0`.
 
 **Honesty note:** the marker was a static `0.1.0` until the SemVer policy landed,
 so live deploys through the site's 1.6.0 release all reported `0.1.0` regardless
 of shape ([#857](https://github.com/nczoning/nc-zoning-board/issues/857)). The
-policy backfilled it to `1.3.0`, which shipped in 1.7.0 — and it has now been
-rolled back to `0.3.0`. The middle column above is a reconstruction (what each
+policy backfilled it to `1.3.0`, which shipped in 1.7.0, and it was rolled back to
+`0.3.0` in 1.7.2. The middle column above is a reconstruction (what each
 deploy *should* have served); the right-hand column is what the API serves today.
 
-⚠️ **`0.3.0` is numerically lower than the `1.3.0` recent deploys served.**
+⚠️ **`0.5.0` is numerically lower than the `1.3.0` some earlier deploys served.**
 Nothing compares this field numerically — verified before the rollback — but a
 consumer that starts doing so must not read the decrease as a downgrade.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,58 +52,63 @@ nc-zoning-board/
 
 ## Data Flow
 
-> For a full breakdown of the bot implementation, see the [Submission Pipeline](submission-pipeline.md) documentation.
+> For what happens between pressing Submit and the pin appearing, see the
+> [Submission Pipeline](submission-pipeline.md).
 
 ```text
-┌─────────────┐     ┌──────────────┐     ┌───────────────┐
-│ Mod Author  │────▶│ GitHub Issue  │────▶│  Auto-PR Bot  │
-│ submits CET │     │   Form       │     │  (Actions)    │
-│ coordinates │     └──────────────┘     └───────┬───────┘
-└─────────────┘                                  │
-                                                 ▼
-                                         ┌──────────────┐
-                                         │ data/locations│
-                                         │ <UUID>.json  │
-                                         └──────┬───────┘
-                                                │
-                                                ▼
-                                         ┌──────────────┐
-                                         │  build_mods  │
-                                         │  → mods.json │
-                                         └──────┬───────┘
-                                                │
-                                                ▼
-                                    ┌────────────────────────┐
-                                    │     services.js        │
-                                    │  cetToLeaflet(x, y)    │
-                                    │  → [lat, lng] on map   │
-                                    └────────────┬───────────┘
-                                                 │
-                                                 ▼
-                                    ┌────────────────────────┐
-                                    │    Leaflet Map         │
-                                    │  Sidebar GUI           │
-                                    │  Category Filtering    │
-                                    │  L.marker (pins)       │
-                                    └────────────────────────┘
+┌─────────────┐     ┌────────────────────┐     ┌──────────────────┐
+│ Mod Author  │────▶│  Map: [+] Submit   │────▶│ POST /submissions│
+│ submits CET │     │  or "Suggest a fix"│     │ Turnstile + rate │
+│ coordinates │     └────────────────────┘     │ limit            │
+└─────────────┘                                └────────┬─────────┘
+                                                        │
+                                                        ▼
+                                              ┌────────────────────┐
+                                              │ D1 `submissions`   │
+                                              │ status: pending    │
+                                              └────────┬───────────┘
+                                                       │  admin approves
+                                                       ▼
+                                              ┌────────────────────┐
+                                              │ D1 `locations`     │
+                                              │ + `audit_log` row  │
+                                              └────────┬───────────┘
+                                                       │  write-through
+                                                       ▼
+                                              ┌────────────────────┐
+                                              │ materialize → KV   │
+                                              │ /v1/locations      │
+                                              └────────┬───────────┘
+                                                       │
+                                                       ▼
+                                              ┌────────────────────┐
+                                              │ services.js        │
+                                              │ cetToLeaflet(x, y) │
+                                              │ → [lat, lng]       │
+                                              └────────┬───────────┘
+                                                       │
+                                                       ▼
+                                              ┌────────────────────┐
+                                              │ Leaflet map        │
+                                              │ Three.js scene     │
+                                              │ Sidebar            │
+                                              └────────────────────┘
 ```
 
 ## Key Components
 
 ### JavaScript Architecture
 
-The core frontend JS is four files loaded via `<script>` tags (no ES modules, no bundler). All shared symbols live on the `window.NCZ` namespace.
+The frontend JS is nine files loaded via `<script>` tags (no bundler; two are ES modules). All shared symbols live on the `window.NCZ` namespace.
 
 | File | Role |
 | --- | --- |
 | `constants.js` | All config values: category styles, API endpoints, cache keys, UI sizing, 3D scene constants |
 | `utils.js` | Pure functions: `escapeHtml`, `cetToLeaflet`, `cetToThree`, positioning algorithm, submit-form validation (`collectLocationForm`) |
-| `services.js` | Fetch functions: the `/v1` Data API loader (`fetchLocationsFromApi()`) |
+| `services.js` | Fetch functions: the `/v1` Data API loader (`fetchLocationsFromApi()`) and the submissions POST |
 | `app.js` | DOM logic: map init, sidebar, cluster panel, modals, image gallery, view switching |
 
-Load order on `main`: `constants.js` → `utils.js` → `services.js` → `app.js`
-
-**Three.js migration** (in progress on `dev` branch) adds four more files:
+The 3D scene ships on `main`. These are the other five files:
 
 | File | Role |
 | --- | --- |
@@ -112,7 +117,10 @@ Load order on `main`: `constants.js` → `utils.js` → `services.js` → `app.j
 | `three-markers.js` | 3D pin/popup/tooltip/cluster layer: interactive parity with Leaflet (`NCZ.ThreeMarkers`). See [three-markers.md](three-markers.md) for the full architecture. |
 | `flyover.js` | Optional cinematic flyover showcase, include/exclude via `<script>` tag |
 
-Load order on `dev`/feature branches: `constants.js` → `utils.js` → `services.js` → `overlay.js` → `three-scene.js` (module) → `three-markers.js` (module) → `app.js` → `[flyover.js optional]`
+**Load order, identical on `main` and `dev`** (verified against `index.html`, 2026-07-31):
+
+`constants.js` → `utils.js` → `district-info.js` → `services.js` → `overlay.js` →
+`three-scene.js` (module) → `three-markers.js` (module) → `flyover.js` → `app.js`
 
 ### Map Layer (`app.js`)
 
@@ -128,12 +136,13 @@ Load order on `dev`/feature branches: `constants.js` → `utils.js` → `service
 - `NCZ.cetToThree(x, y, z)` converts CET coordinates to Three.js scene space (`[x, z||0, -y]`)
 - See [Coordinate System](coordinate-system.md) for full details
 
-### Mod Data (`data/locations/*.json`)
+### Location Data (D1)
 
-- Individual JSON files per mod to prevent merge conflicts.
-- **Attributes**: `id` (UUID), `name`, `authors` (array), `coordinates` ([X, Y]), `nexus_id` (ID string, "WIP", or "Dummy"), `category`, `tags` (array), and `description`.
-- **Credits**: Optional field for team-based acknowledgements.
-- **Validation**: Individual tags are checked against `data/tags.json` and the final compiled `mods.json` is validated against `mods.schema.json` in CI.
+- **The registry is a Cloudflare D1 database**, served at `/v1/locations`. It stopped living in git at the 2.0.0 cutover.
+- **Attributes**: `id` (UUID, or `nexus-<id>` for the nine legacy auto-discovered records), `name`, `authors` (array), `coordinates` ([X, Y, Z]), `yaw`, `nexus_id` (ID string, "WIP" or "Dummy"), `category`, `tags` (via the `location_tags` join), `description`, `credits`, `status` and `admin_notes`.
+- **Never served**: `admin_notes` is admin-only and is deliberately withheld from `/v1`.
+- **Validation** happens on the write path in the Worker, so a bad value is refused at submission rather than caught in CI afterwards.
+- `data/locations/*.json` remains in the repo as the pre-cutover record and is read by nothing. It goes at Phase 6.
 
 ### Styling (`style.css`)
 
@@ -146,15 +155,12 @@ Load order on `dev`/feature branches: `constants.js` → `utils.js` → `service
 
 ## Repo Setup (for new maintainers)
 
-The auto-PR pipeline and Discord notifications require two secrets configured in **repo Settings → Secrets and variables → Actions**:
+Discord alerting uses secrets configured in **repo Settings → Secrets and variables → Actions**. The Worker's own secrets are a **separate store**, set with `wrangler secret put`:
 
 | Secret | Value |
 | --- | --- |
-| `ACTIONS_PAT` | A GitHub Personal Access Token (fine-grained) with `Contents: Read/Write` and `Pull requests: Read/Write` on this repo |
-| `DISCORD_WEBHOOK_URL` | Webhook for the **submissions** channel: new/modified submission embeds and their PR-status edits (channel Settings → Integrations → Webhooks) |
+| `DISCORD_WEBHOOK_URL` | Legacy webhook for the retired **submissions** channel. Nothing writes to it now; it survives only as a fallback for the alerts webhook below, and retires at Phase 6 |
 | `NCZ_ALERTS_DISCORD_WEBHOOK_URL` | Webhook for the dedicated **map-alerts** channel: auto-discovery parse failures and Data API health/outage alerts, kept separate from submissions |
-
-> **Why ACTIONS_PAT?** GitHub's `GITHUB_TOKEN` cannot trigger other workflow runs (a security design). Using a PAT for `create-pull-request` allows the `validate-json` check to fire automatically on the generated PR.
 
 ### Discord Notifications
 

--- a/docs/dev-branch-maintainer-guide.md
+++ b/docs/dev-branch-maintainer-guide.md
@@ -52,7 +52,7 @@ Create the phase branch off `dev`, not `main`. This picks up all completed prior
    git fetch origin
    git merge origin/dev
    ```
-4. **Test locally**: `node scripts/build_mods.js` then `npx serve .`
+4. **Test locally**: `npx serve .` (the map reads the production API; nothing to build)
 5. **Update the changelog**: add entries under `## [Unreleased]` in `CHANGELOG.md` describing what the phase adds
 6. **Update `three-js-scene.md`** if you change any architectural decisions, add new GLB assets, or change the data pipeline
 
@@ -177,11 +177,15 @@ Python dependencies: `numpy`, `Pillow`, `trimesh`, `scipy`, `rtree`.
 ### Dev server
 
 ```bash
-node scripts/build_mods.js   # Rebuild mods.json from data/locations/*.json first
-npx serve .                   # Serve the repo root
+npx serve .   # Serve the repo root
 ```
 
-Always rebuild `mods.json` before testing: it's gitignored and won't exist on a fresh clone.
+**The map reads `/v1/locations` from the production API** from every origin,
+localhost included, so there is nothing to build first. `?api=dev` points at
+staging when you are testing an API change.
+
+`mods.json` is still built on every Cloudflare deploy and nothing reads it; it
+keeps the D1 cutover revertible and retires at Phase 6.
 
 ## Troubleshooting
 
@@ -204,7 +208,7 @@ Always rebuild `mods.json` before testing: it's gitignored and won't exist on a 
 - Verify `package.json` dependencies haven't broken
 
 **Data desync between local and deployed**
-- `mods.json` is generated at deploy time. If local testing shows stale data, run `node scripts/build_mods.js` before `npx serve .`
+- Locations come from `/v1/locations`, not from any local file. If the map shows stale data, it is the API's 5-minute cache or the browser's, not a build step you missed.
 - Location file changes on main need to be merged into dev (`git merge origin/main`)
 
 ## Finalising the migration

--- a/docs/dev-environment.md
+++ b/docs/dev-environment.md
@@ -97,7 +97,7 @@ git checkout -b feat/three-js-phase-N
 
 1. Push the feature branch to GitHub
 2. Open a PR targeting `dev` (not `main`)
-3. Verify the preview looks correct locally with `npx serve .` after running `node scripts/build_mods.js`
+3. Verify the preview looks correct locally with `npx serve .`
 4. Merge the PR into `dev`
 5. Cloudflare automatically deploys: verify at `dev.nczoning.net`
 
@@ -124,14 +124,18 @@ Once all phases of the Three.js migration are complete and verified on `dev.nczo
 
 ## Local Development
 
-Always rebuild `mods.json` before running the local server, otherwise you may be testing against stale data:
-
 ```bash
-node scripts/build_mods.js
 npx serve .
 ```
 
-`mods.json` is gitignored and is never committed: it is built fresh on every Cloudflare deploy and must be built manually for local testing.
+That is all you need. **The map reads `/v1/locations` from the production API**
+from every origin, localhost included, so locations are always live and there is
+nothing to rebuild. Use `?api=dev` to point at staging when testing an API
+change.
+
+`mods.json` is still built on every Cloudflare deploy and **nothing reads it**.
+It exists so the D1 cutover stays revertible, and it retires at Phase 6.
+Rebuilding it locally does not affect what the map shows.
 
 ---
 

--- a/docs/nczoning-auto-discovery.md
+++ b/docs/nczoning-auto-discovery.md
@@ -1,187 +1,66 @@
-# NCZoning Auto-Discovery
+# The NCZoning Tag
 
-The map can automatically discover and display your mod without a GitHub submission, by reading a structured metadata block from your Nexus mod description.
+Tagging your mod **NCZoning** on Nexus puts it in the submit form's picker, with
+its name, description and author already filled in. That is all it does.
 
-> **Results may take up to 10 minutes to appear on the map** after tagging your mod and adding the block.
+> **⚠️ The tag no longer publishes a pin**
+>
+> Until 2.0.0 (2026-07-31), tagging a mod and pasting an `[NCZoning]` metadata
+> block into its description put a pin on the map with no human step. **That path
+> is retired.** The registry lives in a database now, and nothing reaches the map
+> without a reviewer approving it.
+>
+> **If you kept your pin up to date by editing that block, it no longer works.**
+> Editing your description will not move your pin, and you will not get an error.
+> Use **Suggest a fix** on the pin's own popup instead.
+>
+> Pins already on the map are unaffected. The nine locations that arrived this
+> way are ordinary records now.
 
 ---
 
-## What the API Reads from Your Mod Page
+## What tagging gets you
 
-When your mod is discovered, the map reads these fields from the Nexus V2 GraphQL API (no authentication required, all public data):
+Tag your mod **NCZoning** on Nexus, then press **[+] Submit** on the map. Your
+mod appears in the first step's picker, and selecting it prefills:
 
-| Nexus field | Used as | Notes |
+| Nexus field | Prefills | Notes |
 | --- | --- | --- |
-| `modId` | Nexus mod ID / URL | Used to build `nexusmods.com/cyberpunk2077/mods/<id>` link |
-| `name` | Mod display name | Shown in popup title and sidebar |
-| `summary` | Popup description | Shown as the description text; truncated to 500 chars if longer |
-| `description` | Metadata source | Full BBCode body; only used to extract the `[NCZoning]` block, then discarded |
-| `uploader.name` | First author | Always prepended to the author list; additional authors come from `authors=` in the block |
-| `thumbnailUrl` | Thumbnail image | Displayed in the popup and sidebar entry |
-| `updatedAt` | Recently Updated badge | Drives the server-computed `recently_updated` bool (window = the API's `recently_updated_days`); when true, an `UPDATED` badge is shown on the pin popup, sidebar entry, and cluster flyout |
+| `modId` | The Nexus link | Builds `nexusmods.com/cyberpunk2077/mods/<id>` |
+| `name` | Mod name | Editable before you submit |
+| `summary` | Description | The short summary, not the full description. Truncated to 500 characters |
+| `uploader.name` | First author | Additional authors are yours to add |
 
-**Nothing else is read.** Tags, changelogs, version history, endorsements, file downloads, and all other mod fields are ignored.
+Everything prefilled stays editable. The tag is a convenience, never a
+requirement: if your mod is not tagged, or you would rather not tag it, paste its
+Nexus link in the same step instead.
 
----
+## What the map keeps reading from Nexus
 
-## How It Works
+Independent of the tag, for every mod that has a pin:
 
-When the map loads, it queries the Nexus Mods API for all Cyberpunk 2077 mods tagged with **NCZoning**. For each result it finds, it looks for a `[NCZoning]` metadata block inside the mod description. If a valid block is found, the mod is automatically added to the map as a live pin, with no GitHub account or pull request required.
+| Nexus field | Used as |
+| --- | --- |
+| `thumbnailUrl` | The image on the pin popup and sidebar entry |
+| `updatedAt` | The `UPDATED` badge, within the API's `recently_updated_days` window |
 
-Auto-discovered pins are identical to manually submitted ones, with a small amber **[ N ]** badge in the popup title and sidebar entry (tooltip: "Sourced automatically from Nexus Mods"). They are also automatically tagged with **nczoning**, which appears as a tag badge on their popup and can be used in the tag filter to show only auto-discovered mods. If the mod is recently updated (the API's server-computed `recently_updated` bool, within the `recently_updated_days` window), an additional **UPDATED** badge is shown alongside the title.
-
----
-
-## Step 1: Tag Your Mod on Nexus
-
-On your mod's Nexus page, go to **Tags** and add the tag: **NCZoning**
+Your mod's **description is no longer read at all**. Nothing is parsed out of it.
 
 ---
 
-## Step 2: Add the Metadata Block
-
-Paste the following block into your mod description. The easiest way to generate it is to use the **[+] Submit** button on the map itself: it builds the block from a form and copies it to your clipboard.
-
-### Block format
-
-```
-[code]
-NCZoning:
-coords=X,Y,Z
-category=new-location
-yaw=180.0
-tags=apartment,kitsch
-credits=Optional attribution line
-authors=SecondAuthor,ThirdAuthor
-[/code]
-```
-
-If you want to hide the block from casual readers, wrap it in a `[spoiler]` tag:
-
-```
-[spoiler]
-[code]
-NCZoning:
-coords=X,Y,Z
-category=new-location
-yaw=180.0
-[/code]
-[/spoiler]
-```
-
-### Fields
-
-| Field | Required | Format | Notes |
-|---|---|---|---|
-| `coords` | Yes | `X,Y,Z` | CET float values (X=east/west, Y=north/south, Z=height/elevation); see [Getting Coordinates](#getting-coordinates) |
-| `category` | Yes | enum | `location-overhaul`, `new-location`, or `other` |
-| `yaw` | No | degrees | Player facing direction in degrees from CET output |
-| `tags` | No | comma-separated | Must match tags from the [Tag Registry](tags.md); unknown tags are silently ignored |
-| `credits` | No | free text | Optional: team name or secondary acknowledgements |
-| `authors` | No | comma-separated names | Additional authors beyond the Nexus uploader |
-
-The Nexus uploader is always included as the first author automatically. Use `authors=` only for co-authors.
-
-### Parsing rules
-
-- The parser finds the `NCZoning:` marker (it can sit inline, even glued to the end of a sentence) and reads the `key=value` lines that follow it; if `NCZoning:` also appears in your prose, the real block is still found as long as its `coords`/`category` are valid
-- `coords` and `category` are required; mods missing either are skipped entirely
-- `coords` accepts either 2 values (`X,Y`, legacy format) or 3 values (`X,Y,Z`, new format). For new submissions, Z is required
-- `tags` that don't exist in the tag registry are silently dropped (the mod still appears)
-- All BBCode formatting is stripped before parsing, so the block still works if it loses its `[code]` wrapper or picks up stray styling (`[spoiler]`, `[size]`, `[font]`, `[color]`), e.g. from a copy-paste round-trip. The `[code]` wrapper is still recommended for readability
-
-### Transition Note
-
-The old `coords=X,Y` format (2 values) remains valid for existing mod descriptions during the transition period. If you update your description, we recommend upgrading to the new `coords=X,Y,Z` format. Z is the height/elevation coordinate from CET.
-
----
-
-## Getting Coordinates
+## Getting coordinates
 
 1. Stand at the location in-game
 2. Open the CET console (`~`)
 3. Run: `local p,r = GetPlayer():GetWorldPosition(), GetPlayer():GetWorldOrientation():ToEulerAngles(); print(string.format("x=%.4f  y=%.4f  z=%.4f  yaw=%.4f", p.x, p.y, p.z, r.yaw))`
-4. Use the **X**, **Y**, **Z**, and **Yaw** values from the output; do not swap X and Y
+4. Use the **X**, **Y**, **Z** and **Yaw** values from the output; do not swap X and Y
 
-See [Coordinate System](coordinate-system.md) for more detail and alternative tools like Simple Location Manager.
-
----
-
-## Editing Your Entry
-
-To update your mod's map data, edit the `[NCZoning]` block in your Nexus description and save. The map fetches live on every page load, so your changes will be reflected within a few minutes.
-
-There is no "Suggest Edit" button for auto-discovered mods. All edits go through the Nexus description directly.
-
-If you want to update your **mod name**, **summary**, or **thumbnail**, those also come from Nexus and will update automatically.
+See [Coordinate System](coordinate-system.md) for more detail and alternative
+tools like Simple Location Manager.
 
 ---
 
-## Removing Your Entry
+## See also
 
-To remove your mod from the map:
-
-1. Remove the `[NCZoning]` block from your Nexus description, **or**
-2. Remove the **NCZoning** tag from your mod on Nexus
-
-Either action will cause the mod to be skipped on the next page load. There is nothing to delete from the repository; auto-discovered entries are never committed.
-
----
-
-## Conflict Resolution
-
-If a mod has both an auto-discovered entry (via this system) and a manually submitted entry (via GitHub), the **manual entry always wins** for mod data (name, authors, coordinates, description, category, tags).
-
-However, the auto-discovery response's image and timestamp metadata (`thumbnailUrl`, `pictureUrl`, `updatedAt`) is preserved and applied to the manual entry. This means a manually registered mod that is also tagged NCZoning will still receive its thumbnail and recently-updated badge from Nexus without needing a separate API call.
-
-This means maintainers can always override an auto-discovered pin with a corrected manual submission without any extra steps.
-
----
-
-## Limitations
-
-- The **Suggest Edit** button is not shown for auto-discovered mods; to correct the data, update the `[NCZoning]` block in your Nexus description directly
-- Auto-discovered pins are not stored in the repository; they are fetched fresh on every page load
-- Description text shown in the popup comes from your Nexus mod **summary** field (max 500 characters), not the `[NCZoning]` block
-- The `nczoning` tag is applied automatically and is not part of `data/tags.json`; it cannot be added to manually submitted entries
-
----
-
-## Misuse Policy
-
-The **NCZoning** tag is provided by the Nexus Mods team specifically for this system. Maintainers reserve the right to request removal of the tag from mods that misuse it, including mods using the tag with incorrect or misleading coordinates, mods unrelated to Cyberpunk 2077 location content, or any use intended to spam or pollute the map.
-
----
-
-## Exclusion List (maintainers)
-
-Some mods carry the **NCZoning** tag but should not appear on the map: a mistaken tag, or a mod the maintainers judge too minor to register. These can't be handled by a manual entry (we don't *want* them on the map), and a tag we don't control can't simply be removed, so they are listed in `data/excluded_mods.json`:
-
-```json
-{
-  "29860": "Ripperdoc Sogo Interior Changes — minor mod, tagged without a block; kept off the map."
-}
-```
-
-The format is a flat `{ "nexusId": "reason" }` object (same shape as `data/tags.json`). The `reason` is a maintainer note only; it is never shown to users.
-
-An excluded id is honoured in two places:
-
-1. **The Data API merge (`worker/src/merge.js`)**: the mod is never rendered as a pin, *even if its block parses correctly*, and it's kept out of `/v1/meta.skipped`. This is what stops a mistakenly-tagged mod that happens to have valid coordinates from showing up. (The site has no client-side merge — it renders whatever `/v1` serves — so the exclusion only has to hold here.)
-2. **Health monitor (`scripts/monitor_auto_discovery.js`)**: reads `/v1/meta.skipped`, which the API has already filtered, so an excluded mod is never flagged. Without the exclusion an intentionally-excluded mod with no block would be reported every day.
-
-To exclude a mod, add its Nexus id and a short reason to `data/excluded_mods.json` and open a PR. To re-include it later, delete the entry.
-
----
-
-## The block is no longer generated by the site
-
-The **BBCode Generator** is gone. Click **[+] Submit** in the map header (or **Submit a New Mod Location** in the sidebar) and the modal is the **submit form**: it posts the location to a review queue, and a reviewer publishes it. Nothing there produces a block, and nothing asks an author to paste one into a description.
-
-That is deliberate. The block had to be hand-placed and hand-formatted, most attempts at it needed correcting, and it published a pin with no review step. The queue replaces both jobs.
-
-**The `NCZoning` tag stays, as prefill only.** Tagging a mod puts it in the submit form's mod picker with its name and image ready to use. It no longer publishes anything on its own.
-
-The parser documented above still runs, so a description that already carries a block keeps working until the parser retires. Records published that way are being converted to ordinary registry records.
-
-The block can be placed anywhere in your description. A common spot is at the bottom. Use the **spoiler wrap** option to keep it hidden from casual readers.
+- [Adding Mods](adding-mods.md) for the full field reference
+- [Submission Pipeline](submission-pipeline.md) for what happens after you submit

--- a/docs/nexus-api-reference.md
+++ b/docs/nexus-api-reference.md
@@ -84,7 +84,7 @@ The Nexus API silently truncates `modsByUid` responses for large batches:
 
 ### 2. `NCZoningMods` (`mods`): Auto-Discovery Query
 
-**Purpose:** Finds all mods on Nexus Mods for Cyberpunk 2077 that have been tagged `NCZoning` by their authors. These mods' descriptions are parsed for an `[NCZoning]` metadata block.
+**Purpose:** Finds all mods on Nexus Mods for Cyberpunk 2077 that have been tagged `NCZoning` by their authors. **The tag is prefill only.** A tagged mod that is neither a location nor dismissed becomes a *candidate*: it appears in the submit form's picker and in the dashboard's Candidates tab. Nothing here publishes a pin.
 
 **Query:**
 
@@ -118,7 +118,7 @@ query NCZoningMods($filter: ModsFilter!, $count: Int!, $offset: Int!) {
 - `modId`: Numeric Nexus mod ID
 - `name`: Mod title
 - `summary`: Short description; used as the pin popup description (truncated to 500 chars)
-- `description`: Full mod description; parsed for `[NCZoning]` metadata block
+- `description`: Full mod description. No longer read for content; the block parser runs only to populate the `skipped` monitoring list
 - `pictureUrl`: Featured image URL (full resolution)
 - `thumbnailUrl`: Featured image thumbnail URL
 - `updatedAt`: ISO 8601 timestamp of the mod's last update on Nexus; used to drive the recently-updated badge
@@ -140,13 +140,16 @@ The Nexus API does not document pagination for the `mods` query, but it supports
 **Caching:** Handled server-side by the Data API cron (the browser no longer caches Nexus responses); see [Caching Strategy](#caching-strategy) below.
 
 **Post-Fetch Processing:**
-1. For mods whose `modId` already exists in manual `mods.json`: collect `pictureUrl`, `thumbnailUrl`, and `updatedAt` into a `meta` map keyed by `nexusId`, then skip (manual entry wins for all other data)
-2. Parse `node.description` for `[NCZoning]` metadata block (see [`parseNcZoningBlock()`](../worker/src/parse.js) in worker/src/parse.js)
-3. If block missing or invalid, skip the mod with a log message
-4. Construct authors array: Nexus uploader name + any additional authors from the block
-5. Truncate `summary` to 500 characters for the popup description
-6. Prepend `"nczoning"` tag automatically (identifies auto-discovered mods in the UI)
-7. Store `updatedAt` as `_updatedAt` on the mod object; if within `NCZ.RECENTLY_UPDATED_DAYS` days, an `UPDATED` badge is shown in the popup, sidebar, and cluster flyout
+1. A tagged mod that already has a location contributes nothing further here: its images and `updatedAt` reach the record through `nexus_cache` like every other record's
+2. A tagged mod that is neither a location nor dismissed is a **candidate**, offered in the submit form's picker and the dashboard
+3. `name`, `summary` (truncated to 500 characters) and `uploader.name` prefill the submit form when a candidate is selected. All three stay editable
+4. `updatedAt` drives the server-computed `recently_updated` bool, which shows an `UPDATED` badge in the popup, sidebar and cluster flyout
+
+> **Retired at 2.0.0.** `node.description` used to be parsed for an `[NCZoning]`
+> metadata block, and a valid block published a pin with no human step. The
+> parser (`parseNcZoningBlock()`) still runs, but **only** to collect the
+> `skipped` list on `/v1/meta` for monitoring; it never creates a record. The
+> synthetic `nczoning` tag it used to prepend is gone from the served payload.
 
 The function returns `{ mods, meta }` where `meta` contains image/timestamp data for manually registered mods that are also NCZoning-tagged. In the worker's merge step ([`worker/src/merge.js`](../worker/src/merge.js)), `meta` is folded into each manual mod's thumbnail/`updated_at` fields without a separate `modsByUid` call. Mods covered by `meta` are excluded from the `modsByUid` batch.
 
@@ -304,6 +307,6 @@ These Nexus calls now run only inside the Data API cron (`worker/`), not the bro
 ## References
 
 - **Nexus GraphQL API Docs:** https://graphql.nexusmods.com/
-- **Auto-Discovery Workflow:** See [`docs/nczoning-auto-discovery.md`](./nczoning-auto-discovery.md) for how mod authors tag mods and provide metadata
+- **The NCZoning tag:** See [`docs/nczoning-auto-discovery.md`](./nczoning-auto-discovery.md) for what tagging prefills, and what it no longer does
 - **Nexus fetch implementation (server-side):** [`worker/src/nexus.js`](../worker/src/nexus.js), merge in [`worker/src/merge.js`](../worker/src/merge.js), block parser in [`worker/src/parse.js`](../worker/src/parse.js)
 - **Site data loader:** `fetchLocationsFromApi()` in [`assets/js/services.js`](../assets/js/services.js)

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -1,70 +1,86 @@
 # Mod Submission Reviewer Guide
 
-Welcome! If you're here, you've been asked to help review and approve new mod locations for the map. This guide covers the essential steps to ensure the map stays accurate and secure.
+If you're here, you've been asked to help review new mod locations for the map.
+Reviewing happens in the **admin dashboard** at
+[nczoning.net/admin/](https://nczoning.net/admin/), signed in with GitHub.
+
+Access is your **collaborator status on the repository**. There is no separate
+list to be added to: if you can push to `nczoning/nc-zoning-board`, you can
+review.
+
+---
 
 ## 🚀 The Review Process
 
-Reviewers are coordinated through the **[Locations Hub Discord](https://discord.gg/sc4yEx2fNf)**.
+1. Open the dashboard and go to the **Queue** tab. The tab carries a count when
+   anything is pending.
+2. Each submission renders a **field-level diff** of what it would change, and a
+   mini-map of the proposed pin.
+3. Check the three things below.
+4. **Approve**, **reject with a reason**, or **hold**.
 
-1. **Role & Channel:** Ensure you have the **Cartographer** role. You will find all notifications in the **#nc-zoning-board-submissions** channel.
-2. **Notification:** When a mod is submitted, a bot sends an "Awaiting Review" embed. You can click the **[Review PRs]** link in the embed to go straight to the PR on GitHub.
-3. **PR Creation:** The bot simultaneously parses the issue and creates the PR.
-4. **Validation:** Wait for the automated GitHub Actions to complete their validation checks.
-5. **Merge:** After a manual check (see below), you merge the PR.
+Approving writes the location and rebuilds the map's data, so an approved pin
+appears within seconds. Rejecting keeps the record of the decision.
 
-### Discord Notification Statuses
+> **Nothing is sent to the submitter.** A review note is an internal record only,
+> and the queue says so where you type it. Submissions are anonymous by design;
+> there is no address to reply to.
 
-The notification in Discord will update its colour and status automatically:
+### Three kinds of submission
 
-- ⏳ **Awaiting review** (Yellow): Initial submission, needs a human eye.
-- ✅ **Approved: pin is now live!** (Green): PR merged successfully.
-- ❌ **Closed without merging** (Red): PR was closed or rejected.
+- **Create**: a new pin. If the mod already has one, the queue lists the
+  existing records it would sit beside and how far away they are. That is
+  context, not a warning: one mod can legitimately supply several locations.
+- **Edit**: a correction sent from a pin's popup. Only the changed fields are
+  sent, so the diff is the whole story.
+- **Remove**: a takedown request with a reason. Approving sets the record to
+  `hidden`, which pulls the pin and keeps the history. It does not delete it.
 
 ---
 
 ## 🔍 What to Check
 
-Before merging any PR, please verify these three things:
+### 1. The Nexus link
 
-### 1. Nexus Mods Link
-
-- Click the link provided in the PR or Issue.
 - Does the mod actually exist?
-- Is it a "Location" or "Doms/Housing" mod? (If it's just a weapon/clothing mod, it doesn't belong on this map).
+- Is it a location or housing mod? A weapon or clothing mod does not belong on
+  this map.
 
 ### 2. Coordinates
 
-- Does the mod description on Nexus mention coordinates? If so, do they match (roughly) what was submitted?
-- If you're in-game, you can use `Game.Teleport(X, Y, Z)` in CET to verify the location yourself (optional but helpful).
-- **Red Flag:** If the X/Y values are exactly `0.0`, the submitter likely forgot to copy them.
+- The mini-map is the fastest check: is the pin somewhere plausible?
+- Does the mod's Nexus description mention coordinates? Do they roughly match?
+- In-game you can verify with `Game.Teleport(X, Y, Z)` in CET.
+- **Red flag:** X/Y of exactly `0.0` usually means the submitter forgot to copy
+  them.
 
-### 3. Tags & Category
+### 3. Tags and category
 
-- Does the category (`location-overhaul`, `new-location`, or `other`) make sense for the mod?
-- Are the selected tags reasonable? The automated validation will reject any tags not in the [registry](../data/tags.json), but a tag being valid doesn't mean it's accurate.
-
----
-
-## ✅ Merging
-
-If everything looks good:
-
-1. Go to the **Pull Request** tab on GitHub.
-2. Ensure the "Checks" (Validation) have passed.
-3. Click **Merge pull request** → **Confirm merge**.
-
-### What happens now?
-
-- The Original Issue will close automatically.
-- The Discord notification will update to "Approved".
-- The new pin will appear on the live map within minutes.
+- Does the category (`location-overhaul`, `new-location`, `other`) fit the mod?
+- Are the tags reasonable? A tag outside the registry is refused on write, but a
+  valid tag is not necessarily an accurate one.
 
 ---
 
-## 🛑 Handling Issues
+## 🛑 Handling Problems
 
-- **Incomplete Data:** Comment on the Issue asking the user for the missing info. Do not merge until fixed.
-- **Spam/Malicious:** Close the Issue and PR immediately without merging. Notify the lead maintainer.
-- **Duplicate:** Check if a pin already exists for that mod. If so, close the new submission as a duplicate.
+- **Incomplete data:** reject with a reason saying what was missing, or approve
+  and fix it yourself in the editor. There is no submitter to ask.
+- **Spam or malicious:** reject. If it is a tagged Nexus mod you never want
+  offered again, dismiss it in the **Candidates** tab, which is reversible.
+- **Duplicate:** the queue already shows nearby records for the same mod. If it
+  is a genuine duplicate rather than a second location, reject it.
+
+## 📋 The audit log
+
+Every change records who made it and the record before and after. It replaced
+`git log` for data changes, so it answers "who changed this pin, and when".
+
+---
+
+> **Retired at 2.0.0:** reviewing used to mean merging a bot-authored pull
+> request, with a Discord bot editing its own message in place to show the
+> outcome. Discord was acting as the queue's UI. The dashboard holds that state
+> now, and the submission issue forms and their workflows are gone.
 
 *Thanks for keeping Night City mapped!* 🌃

--- a/docs/skills-and-roles.md
+++ b/docs/skills-and-roles.md
@@ -42,7 +42,7 @@ Current active work: **[Spuddeh](https://www.nexusmods.com/profile/Spuddeh/mods?
 
 ### ⚙️ GitHub Automation & Tools
 
-Into DevOps and automation? We maintain the **GitHub Actions submission pipeline**, **tile generation**, **deployment workflow**, and **Discord integrations**. Node.js + YAML + a bit of GitHub API knowledge.
+Into DevOps and automation? We maintain the **Cloudflare Worker and its D1 registry**, **tile generation**, **deployment workflows**, **API health monitoring** and **Discord alerting**. Node.js + YAML + a bit of Cloudflare and GitHub API knowledge.
 
 Areas that sometimes need tweaks: submission workflows, CI/CD validation, secrets management, tile generation improvements.
 


### PR DESCRIPTION
The CHANGELOG was still `[Unreleased]` while the release was already live on production, and the docs still walked contributors through two submission paths that no longer reach the map.

## Cut as `2.0.0`

Two documented submission methods were removed outright rather than deprecated. Under the SemVer this project claims to follow, that is a MAJOR: anyone following CONTRIBUTING, the README, or a Discord post from last week now finds a dead route.

Three corrections to the release notes themselves:

- **Two API bumps read as two bumps.** `0.4.0 → 0.5.0` was listed *above* `0.3.0 → 0.4.0`. They ship together, so the net is what matters: **`0.3.0 → 0.5.0`**, in one bullet.
- **"pre-1.0" one line under "2.0.0" reads as a contradiction.** Now says outright that the `/v1` API is versioned separately from the site.
- **A user-visible removal was missing.** The Nexus icon on auto-discovered pins went with `source`, and nothing said so.

## Docs

Every one of these taught something that no longer works:

| File | Was |
| --- | --- |
| `README.md` | Both submission methods; a Tech Stack claiming "purely static files" for a site with a Worker, D1 and KV |
| `docs/adding-mods.md` | "Method 1: GitHub Issue Form", "Method 2: Manual Pull Request" |
| `docs/nczoning-auto-discovery.md` | 187 lines about the retired metadata block |
| `docs/reviewer-guide.md` | Reviewing meant merging a PR and reading Discord embed colours |
| `docs/nexus-api-reference.md` | The tagged query described as publishing pins |
| `docs/api-reference.md` | A served record carrying `source` and an `nczoning` tag; version history stopping at `0.3.0` |
| `docs/architecture.md` | The data-flow diagram; `ACTIONS_PAT`, whose pipeline is gone; a load order claiming `main` and `dev` differ |
| `docs/dev-environment.md`, `docs/dev-branch-maintainer-guide.md` | "Always rebuild `mods.json` before testing, otherwise you may be testing against stale data" |
| `ASSETS.md` | A licensing statement locating contributed data in `data/locations/` |
| `docs/skills-and-roles.md` | The retired pipeline offered as a contribution area |

The dev-docs one was the most actively harmful: the map reads `/v1/locations` from the **production** API on every origin including localhost, so rebuilding `mods.json` locally does nothing at all. It sent developers down a pointless path and implied the site still reads that file.

`ASSETS.md` needed care because it is a **licensing and ownership statement**, not a description. The location of the data changed; the contributor-ownership and MIT terms are preserved word for word.

## Also

`CLAUDE.md`'s load order was wrong in a way nobody had caught: it listed `district-info.js` last when it loads third. Corrected locally, but it is gitignored on purpose so the fix cannot propagate to other clones.

## Verification

310 worker + 52 site tests pass. A sweep for retired-flow instructions across `README.md`, `CONTRIBUTING.md`, `ASSETS.md` and `docs/*.md` returns nothing outside explicit "retired at 2.0.0" notes.
