### PR TITLE
Stop two admins silently overwriting each other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Two admins editing the same location no longer overwrite each other. A save applies only while the record still looks the way it did when the editor was opened; if it moved, the save is refused, nothing is written, and the current version is loaded so the change can be reapplied. Previously the second save won silently and the first admin's edit disappeared on next load.
+
 ## [2.0.0] - 2026-07-31
 
 Submissions move onto the map. A location can now be added, corrected or reported

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -218,16 +218,18 @@
    * Never throws on an HTTP error: the status IS the information here, and
    * callers have to branch on 403 vs 503 vs 409 rather than on "it failed".
    */
-  async function api(path, { method = 'GET', body } = {}) {
+  async function api(path, { method = 'GET', body, headers } = {}) {
     let res;
     try {
       res = await fetch(`${API}${path}`, {
         method,
         credentials: 'include',
-        ...(body === undefined ? {} : {
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
-        }),
+        ...(body === undefined
+          ? (headers ? { headers } : {})
+          : {
+            headers: { 'Content-Type': 'application/json', ...(headers || {}) },
+            body: JSON.stringify(body),
+          }),
       });
     } catch (err) {
       // Network-level: no status at all. Distinct from every HTTP status, and
@@ -259,6 +261,10 @@
         // several distinct conflicts, and one of them (another reviewer won the
         // race after this request had already written the location) is
         // specifically NOT "nothing was changed".
+        if (res.body?.error === 'stale_write') {
+          return ['error', 'This record changed after you opened it, so nothing was saved. '
+            + 'The current version has been loaded; reapply your change and save again.'];
+        }
         return ['error', res.body?.error === 'tag_exists'
           ? `A tag with the slug "${res.body.slug}" already exists.`
           : res.body?.detail || 'Conflict. Nothing was changed.'];
@@ -684,13 +690,27 @@
     button.disabled = true;
     const res = isNew
       ? await api('/admin/locations', { method: 'POST', body: payload })
-      : await api(`/admin/locations/${encodeURIComponent(loc.id)}`, { method: 'PATCH', body: payload });
+      : await api(`/admin/locations/${encodeURIComponent(loc.id)}`, {
+        method: 'PATCH',
+        body: payload,
+        // The version this editor was opened on. The server applies the write
+        // only while the record still carries it, so two admins editing the
+        // same record cannot silently overwrite each other.
+        headers: { 'If-Match': `"${loc.updated_at}"` },
+      });
     button.disabled = false;
 
     if (!res.ok) {
       const [kind, message] = describeFailure(res);
       banner(kind, message);
       if (res.status === 422) applyFieldErrors(form, res.body.errors || []);
+      // A stale write comes back with the record as it stands now. Load it, so
+      // the next save is against a version that exists and the admin can see
+      // what they would have overwritten.
+      if (res.body?.error === 'stale_write' && res.body.current) {
+        await loadLocations();
+        renderLocationEditor(res.body.current);
+      }
       return;
     }
 

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -71,6 +71,29 @@ appears within seconds. Rejecting keeps the record of the decision.
 - **Duplicate:** the queue already shows nearby records for the same mod. If it
   is a genuine duplicate rather than a second location, reject it.
 
+## ✋ When a save is refused
+
+If someone else changed a location while you had it open, your save is refused
+and **nothing is written**. The current version loads so you can see what moved,
+then reapply your change and save again.
+
+That is deliberate. Three of us share one registry, and without it the second
+save silently replaces the first: no error, and the person who saved first only
+finds out when their change is gone.
+
+### One case it does not cover: approving a stale submission
+
+A submission is written against the record as the **submitter** saw it, and
+approving applies it however long it has been sitting in the queue.
+
+So if you fixed something on a record while a submission for it was pending,
+approving that submission puts the submitter's older values back over your fix.
+This needs no second person: you editing a record and then approving a
+submission for it is enough.
+
+**Read the diff before you approve.** It shows exactly what the submission would
+write, which is the check that catches this.
+
 ## 📋 The audit log
 
 Every change records who made it and the record before and after. It replaced

--- a/worker/src/admin.js
+++ b/worker/src/admin.js
@@ -211,8 +211,20 @@ export async function handleAdmin(request, env, ctx) {
     const v = validateLocationInput(payload, { tagNames: await readTagSlugs(env), partial: true });
     if (!v.ok) return json(request, { error: 'validation_failed', errors: v.errors }, 422);
 
-    const patched = await patchLocation(env, id, payload);
+    // The version the editor was opened on. Absent means an unguarded write,
+    // which keeps older clients and curl working; the dashboard always sends it.
+    const ifMatch = (request.headers.get('If-Match') || '').replace(/^"|"$/g, '') || null;
+
+    const patched = await patchLocation(env, id, payload, undefined, { ifMatch });
     if (patched.empty) return json(request, { error: 'empty_patch' }, 400);
+    if (patched.conflict) {
+      // The current record comes back so the dashboard can show what changed
+      // rather than just refusing. Nothing was written.
+      return json(request, {
+        error: 'stale_write',
+        current: await loadAdminRecord(env, await getRow(env, id)),
+      }, 409);
+    }
 
     const after = await loadAdminRecord(env, await getRow(env, id));
     await writeAudit(env, { actor, action: 'location.update', target: id, before, after });

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -220,7 +220,10 @@ export default {
           ? {
             ...adminCors(request),
             'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
-            'Access-Control-Allow-Headers': 'Content-Type',
+            // If-Match carries the record version on a guarded PATCH. Omitting it
+            // here fails the preflight, so the write never reaches the Worker and
+            // the browser reports CORS rather than a conflict.
+            'Access-Control-Allow-Headers': 'Content-Type, If-Match',
           }
           : CORS_HEADERS,
       });

--- a/worker/src/registry.js
+++ b/worker/src/registry.js
@@ -152,8 +152,25 @@ export async function insertLocation(env, payload, nowIso = new Date().toISOStri
 /**
  * Apply a validated partial patch. `{empty: true}` when the payload names no
  * column and no tags, which is a caller error rather than a no-op write.
+ *
+ * OPTIMISTIC CONCURRENCY. Pass `ifMatch` as the `updated_at` the caller read,
+ * and the write applies only while the record still carries it. Three admins
+ * share one registry and one queue, so without this the second save silently
+ * replaces the first: the audit log records both, but nobody is told, and the
+ * admin who saved first sees their change vanish on next load.
+ *
+ * Returns `{conflict: true}` when the row moved underneath. SQLite counts a
+ * matched row as changed even when the values are identical, so `changes === 0`
+ * means the WHERE did not match rather than "nothing needed writing". The
+ * caller has already established the row exists, so the only way to miss is a
+ * stale `ifMatch`.
+ *
+ * Omitting `ifMatch` is an unguarded write, which is correct for a caller that
+ * genuinely means "apply this regardless" (see review.js).
  */
-export async function patchLocation(env, id, payload, nowIso = new Date().toISOString()) {
+export async function patchLocation(
+  env, id, payload, nowIso = new Date().toISOString(), { ifMatch = null } = {},
+) {
   const patchesTags = Object.prototype.hasOwnProperty.call(payload, 'tags');
   const { sets, binds } = buildUpdate(payload);
   if (!sets.length && !patchesTags) return { empty: true };
@@ -162,7 +179,14 @@ export async function patchLocation(env, id, payload, nowIso = new Date().toISOS
   // unconditional rather than gated on `sets`.
   sets.push('updated_at = ?');
   binds.push(nowIso, id);
-  await env.DB.prepare(`UPDATE locations SET ${sets.join(', ')} WHERE id = ?`).bind(...binds).run();
+
+  let sql = `UPDATE locations SET ${sets.join(', ')} WHERE id = ?`;
+  if (ifMatch) {
+    sql += ' AND updated_at = ?';
+    binds.push(ifMatch);
+  }
+  const res = await env.DB.prepare(sql).bind(...binds).run();
+  if (ifMatch && res?.meta?.changes === 0) return { conflict: true };
 
   if (patchesTags) await syncLocationTags(env, id, payload.tags);
   return { empty: false };

--- a/worker/src/review.js
+++ b/worker/src/review.js
@@ -189,6 +189,8 @@ async function restoreInstead(env, submission, locationId, { actor, nowIso }) {
   }
 
   const before = await loadAdminRecord(env, row);
+  // Unguarded on purpose: publishing a record this approval just restored is
+  // this call's whole job, and there is no competing version to lose.
   await patchLocation(env, locationId, { status: 'published' }, nowIso);
   const after = await loadAdminRecordById(env, locationId);
   await writeAudit(env, { actor, action: 'location.update', target: locationId, before, after });
@@ -245,6 +247,14 @@ async function applyApproval(env, submission, { actor, nowIso, restoreLocationId
     const v = validateLocationInput(payload, { tagNames: await readTagSlugs(env), partial: true });
     if (!v.ok) return { error: 'validation_failed', errors: v.errors, status: 422 };
 
+    // Unguarded, and this one is a real trade-off rather than a non-issue.
+    // A submission is written against the record as it looked when the
+    // submitter saw it, and approving applies it however long it sat in the
+    // queue. If an admin tidied the record meanwhile, approving reapplies the
+    // submitter's older values over that tidy-up. Guarding it properly needs
+    // the submission to record the version it was based on, which is a schema
+    // change; see the follow-up on #899. Until then the reviewer sees the diff
+    // before approving, which is the mitigation.
     const patched = await patchLocation(env, submission.location_id, payload, nowIso);
     if (patched.empty) {
       return { error: 'empty_patch', detail: 'this submission changes no field', status: 422 };
@@ -260,6 +270,8 @@ async function applyApproval(env, submission, { actor, nowIso, restoreLocationId
   if (before.status === 'hidden') {
     return { error: 'already_hidden', detail: 'this location is already off the map', status: 409 };
   }
+  // Unguarded on purpose: an approved removal pulls the pin regardless of what
+  // else changed on the record, which is the point of approving it.
   await patchLocation(env, submission.location_id, { status: 'hidden' }, nowIso);
   const after = await loadAdminRecordById(env, submission.location_id);
   await writeAudit(env, {

--- a/worker/test/admin.test.js
+++ b/worker/test/admin.test.js
@@ -315,6 +315,72 @@ test('editing a legacy auto record strips the nczoning marker from both writes',
   );
 });
 
+// --- optimistic concurrency (#899) ---------------------------------------
+// Three admins share one registry. Without the guard the second save silently
+// replaces the first: the audit log records both, but nobody is told.
+
+/** PATCH carrying an If-Match version, bypassing `hit` so headers can be set. */
+async function patchWithVersion(env, id, body, version) {
+  return worker.fetch(
+    await authed(`https://api.nczoning.net/admin/locations/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+      headers: version === null ? {} : { 'If-Match': `"${version}"` },
+    }),
+    env,
+    {},
+  );
+}
+
+test('a stale If-Match is refused with 409 and writes NOTHING', async () => {
+  const env = envFor();
+  const res = await patchWithVersion(env, 'loc-1', { name: 'Overwritten' }, '2020-01-01T00:00:00Z');
+  assert.equal(res.status, 409);
+  const body = await res.json();
+  assert.equal(body.error, 'stale_write');
+
+  // The refusal is only worth anything if the write really did not land.
+  const row = env.DB.one('SELECT name, updated_at FROM locations WHERE id = ?', 'loc-1');
+  assert.equal(row.name, 'Existing Loft', 'the row must be untouched');
+  assert.equal(row.updated_at, '2026-01-01T00:00:00Z', 'and updated_at must not move');
+  assert.equal(auditRows(env).length, 0, 'a refused write writes no audit row either');
+});
+
+test('the conflict response carries the current record, so the client can diff', async () => {
+  const env = envFor();
+  const res = await patchWithVersion(env, 'loc-1', { name: 'Overwritten' }, '2020-01-01T00:00:00Z');
+  const body = await res.json();
+  assert.ok(body.current, 'refusing without the current record leaves the client blind');
+  assert.equal(body.current.name, 'Existing Loft');
+  assert.equal(body.current.updated_at, '2026-01-01T00:00:00Z', 'the version to retry against');
+});
+
+test('a current If-Match is accepted', async () => {
+  const env = envFor();
+  const res = await patchWithVersion(env, 'loc-1', { name: 'Renamed' }, '2026-01-01T00:00:00Z');
+  assert.equal(res.status, 200);
+  assert.equal(env.DB.one('SELECT name FROM locations WHERE id = ?', 'loc-1').name, 'Renamed');
+});
+
+test('the second of two saves against the same version loses, rather than winning silently', async () => {
+  const env = envFor();
+  const base = '2026-01-01T00:00:00Z';
+  const first = await patchWithVersion(env, 'loc-1', { name: 'Admin A' }, base);
+  assert.equal(first.status, 200);
+
+  // B opened the editor at the same time and still holds the old version.
+  const second = await patchWithVersion(env, 'loc-1', { name: 'Admin B' }, base);
+  assert.equal(second.status, 409, "B's save must be refused, not applied over A's");
+  assert.equal(env.DB.one('SELECT name FROM locations WHERE id = ?', 'loc-1').name, 'Admin A');
+});
+
+test('no If-Match still writes, so curl and older clients keep working', async () => {
+  const env = envFor();
+  const res = await patchWithVersion(env, 'loc-1', { name: 'Unguarded' }, null);
+  assert.equal(res.status, 200);
+  assert.equal(env.DB.one('SELECT name FROM locations WHERE id = ?', 'loc-1').name, 'Unguarded');
+});
+
 test('a tags-only patch still moves updated_at', async () => {
   const env = envFor();
   const res = await hit(env, 'PATCH', '/admin/locations/loc-1', { tags: ['corpo'] });


### PR DESCRIPTION
Two admins editing the same location silently overwrote each other. `patchLocation` built `UPDATE locations SET ... WHERE id = ?` with nothing comparing versions, so the second save won. The audit log recorded both, but nobody was told: the admin who saved first saw their change vanish on next load.

## The fix

The dashboard sends the version it opened the record on as `If-Match`. The write applies only while the record still carries it. A stale version is refused with **409, nothing written**, and the current record comes back so the editor reloads and the admin can see what they would have replaced.

## Three things that shaped it

**Preflight nearly ate it.** The dashboard is on `nczoning.net` and the API on `api.nczoning.net`, so a conditional header needs `Access-Control-Allow-Headers`. Without that every guarded save fails at the preflight and the browser reports CORS rather than a conflict. `index.js` already carried a comment about being caught by exactly this once.

Verified on staging:

```
staging     Access-Control-Allow-Headers: Content-Type, If-Match
production  Access-Control-Allow-Headers: Content-Type
```

**The header, not the payload.** `validate.js` rejects unknown keys on purpose, so a version field in the body would have meant adding a non-column to `WRITABLE`.

**`changes === 0` means the WHERE missed**, not "nothing needed writing". SQLite counts a matched row as changed even when the values are identical, and the caller has already established the row exists.

## The review path stays unguarded, now explicitly

Publishing and hiding have no competing version to lose. **Applying a submission does**, and it needs no concurrency at all: fix a record while a submission for it is pending, approve that submission, and the submitter's older values go back over your fix.

Guarding it needs the submission to record the version it was based on, which is a schema change and overlaps what #898 already wants. Written up on #899; the mitigation until then is that the reviewer sees the diff, and the reviewer guide now says so.

## Verification

**315 worker + 52 site tests.** Five new, and each was confirmed capable of failing: removing the predicate turns exactly the three guard-dependent ones red, with the mutation verified present in the file before the results were read. The other two (a valid version, and no version at all) correctly stay green, because they do not depend on the guard blocking.

⚠️ **The dashboard has no automated tests**, so the recovery path (refusal banner, reload, re-render) is verified by reading, not by running. Worth a manual pass on `dev.nczoning.net/admin/`: open one location in two tabs, save the first, then save the second and confirm you get the refusal and a reloaded record rather than a silent overwrite.

Closes #899.
