### PR TITLE
Real added and modified dates from git history, and a sortable locations table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The locations table sorts by any of Name, Category, Status, Added or Modified. Click a heading to sort, click it again to reverse. Dates start newest-first, text starts A to Z, because that is the question each one is usually being asked. Keyboard reachable, and the current sort is announced to screen readers.
 - The dashboard shows when a location was **added** and when it was last **modified**, in the locations table as well as the detail pane, alongside when the mod itself was last **updated on Nexus**. Three different dates, named so they cannot be confused: the one a `/v1` record carries is the Nexus one.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The dashboard shows when a location was **added** and when it was last **modified**, in the locations table as well as the detail pane, alongside when the mod itself was last **updated on Nexus**. Three different dates, named so they cannot be confused: the one a `/v1` record carries is the Nexus one.
+
 ### Fixed
+
+- Location dates were all the same timestamp: the moment the registry was imported, so every record claimed it was added and last edited at the same instant on 26 July. Backfilled from git history, which is the only place the real dates survived. 288 records now carry their true dates, spanning 7 March to 26 July, and 212 of them show a modified date genuinely later than their added date. The nine auto-discovered records keep the import date, because they have never existed as files and nothing recorded when they arrived.
 
 - Two admins editing the same location no longer overwrite each other. A save applies only while the record still looks the way it did when the editor was opened; if it moved, the save is refused, nothing is written, and the current version is loaded so the change can be reapplied. Previously the second save won silently and the first admin's edit disappeared on next load.
 

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -302,7 +302,7 @@ th[data-sort] {
 }
 
 th[data-sort]::after {
-    content: "95";           /* up-down arrow: sortable, not yet sorted */
+    content: "↕";           /* up-down arrow: sortable, not yet sorted */
     display: inline-block;
     width: 1em;
     margin-left: var(--space-xs);
@@ -313,8 +313,8 @@ th[data-sort]:hover,
 th[data-sort]:focus-visible { color: var(--secondary); }
 
 th[data-sort].sorted { color: var(--secondary); }
-th[data-sort].sorted::after { content: "91"; opacity: 1; }
-th[data-sort].sorted.desc::after { content: "93"; }
+th[data-sort].sorted::after { content: "↑"; opacity: 1; }
+th[data-sort].sorted.desc::after { content: "↓"; }
 
 /* Zebra striping. Declared before hover/selection so those still win without
    needing !important or a specificity fight. */

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -293,6 +293,29 @@ th {
     backdrop-filter: blur(4px);
 }
 
+/* Sortable headers. The arrow is a pseudo-element so it cannot be selected with
+   the label text, and the column keeps a reserved slot for it either way: an
+   arrow that appears on sort would shift every heading sideways on each click. */
+th[data-sort] {
+    cursor: pointer;
+    user-select: none;
+}
+
+th[data-sort]::after {
+    content: "95";           /* up-down arrow: sortable, not yet sorted */
+    display: inline-block;
+    width: 1em;
+    margin-left: var(--space-xs);
+    opacity: 0.35;
+}
+
+th[data-sort]:hover,
+th[data-sort]:focus-visible { color: var(--secondary); }
+
+th[data-sort].sorted { color: var(--secondary); }
+th[data-sort].sorted::after { content: "91"; opacity: 1; }
+th[data-sort].sorted.desc::after { content: "93"; }
+
 /* Zebra striping. Declared before hover/selection so those still win without
    needing !important or a specificity fight. */
 tbody tr:nth-child(even) { background: var(--white-02); }

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -458,6 +458,8 @@
     }))),
     h('td', {},
       h('span', { class: `badge status-${loc.status}`, text: loc.status })),
+    h('td', {}, whenCell(loc.added_at)),
+    h('td', {}, whenCell(loc.modified_at)),
     // stopPropagation, or opening the mod page also selects the row behind it.
     h('td', { onclick: (e) => e.stopPropagation() }, nexusLink(loc.nexus_id)))));
 
@@ -524,7 +526,7 @@
    * This is why the API's reject-unknown-keys behaviour stays useful: if the
    * client resent the whole record every time, a field the server does not
    * know about would come back on every save and the 422 would be noise rather
-   * than a signal. It also makes `updated_at` mean something.
+   * than a signal. It also makes `modified_at` mean something.
    */
   function diffPayload(current, original) {
     const patch = {};
@@ -641,7 +643,7 @@
 
     replace($('#loc-editor'),
       h('h2', { text: isNew ? 'New location' : `Editing: ${loc.name}` }),
-      isNew ? null : h('p', { class: 'muted' }, `id ${loc.id} · updated `, timeEl(loc.updated_at)),
+      isNew ? null : h('p', { class: 'muted' }, `id ${loc.id} · modified `, timeEl(loc.modified_at)),
       form, actions);
 
     refreshDirty();
@@ -696,7 +698,7 @@
         // The version this editor was opened on. The server applies the write
         // only while the record still carries it, so two admins editing the
         // same record cannot silently overwrite each other.
-        headers: { 'If-Match': `"${loc.updated_at}"` },
+        headers: { 'If-Match': `"${loc.modified_at}"` },
       });
     button.disabled = false;
 
@@ -789,8 +791,9 @@
         // Internal, and never served on /v1. Worth showing plainly here.
         row('Admin notes', loc.admin_notes),
         row('ID', loc.id, 'mono'),
-        row('Created', timeEl(loc.created_at)),
-        row('Updated', timeEl(loc.updated_at)),
+        row('Added', timeEl(loc.added_at)),
+        row('Modified', timeEl(loc.modified_at)),
+        row('Updated on Nexus', loc.nexus_updated_at ? timeEl(loc.nexus_updated_at) : null),
       )),
       h('div', { class: 'editor-actions' },
         h('button', {
@@ -2014,9 +2017,9 @@
     for (const key of keys) {
       const from = before ? before[key] : undefined;
       const to = after ? after[key] : undefined;
-      // updated_at moves on every write; showing it as a change is noise that
+      // modified_at moves on every write; showing it as a change is noise that
       // makes the real change harder to find.
-      if (key === 'updated_at') continue;
+      if (key === 'modified_at') continue;
       if (sameValue(from, to)) continue;
       rows.push(h('div', {},
         h('span', { class: 'k', text: `${key}: ` }),
@@ -2031,7 +2034,7 @@
   function changedFields(before, after) {
     if (!before || !after) return [];
     return [...new Set([...Object.keys(before), ...Object.keys(after)])]
-      .filter((k) => k !== 'updated_at' && !sameValue(before[k], after[k]))
+      .filter((k) => k !== 'modified_at' && !sameValue(before[k], after[k]))
       .sort();
   }
 

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -87,6 +87,10 @@
     filter: {
       q: '', status: '', category: '', tag: '', district: '', special: '',
     },
+    // The API returns locations ordered by name, which is the default here too.
+    // Sorting is client-side: the whole registry is already in memory, so a
+    // round trip per sort would be slower and would fight the active filter.
+    sort: { key: 'name', dir: 'asc' },
   };
 
   /** Human label for a filter, used on the chips. */
@@ -442,8 +446,77 @@
     replace($('#loc-chips'), chips);
   }
 
+  /**
+   * Value to sort a row on. Dates compare as plain strings because they are all
+   * ISO in UTC: the backfill normalises git's local offsets to `Z` precisely so
+   * this holds. Mixed offsets would sort by their text, not by their instant.
+   */
+  function sortValue(loc, key) {
+    if (key === 'added_at' || key === 'modified_at') return loc[key] ?? '';
+    return String(loc[key] ?? '').toLowerCase();
+  }
+
+  function sortLocations(rows) {
+    const { key, dir } = state.sort;
+    const sign = dir === 'desc' ? -1 : 1;
+    const isDate = key === 'added_at' || key === 'modified_at';
+    return [...rows].sort((a, b) => {
+      const av = sortValue(a, key);
+      const bv = sortValue(b, key);
+      // Ties fall back to name, so a re-sort of the same data cannot reshuffle
+      // rows that compare equal.
+      if (av === bv) return String(a.name).localeCompare(String(b.name));
+      // Dates compare by codepoint, NOT localeCompare. They are fixed-format
+      // ISO in UTC, so codepoint order is chronological order, whereas locale
+      // collation is free to reorder the punctuation these are full of.
+      if (isDate) return sign * (av < bv ? -1 : 1);
+      // Text does use localeCompare: names carry accents and case that a
+      // codepoint comparison orders in ways nobody reading the table expects.
+      return sign * av.localeCompare(bv);
+    });
+  }
+
+  /**
+   * Click a header to sort by it, click the same one again to reverse.
+   *
+   * A new column starts descending for the dates and ascending for the text
+   * ones, because "most recently modified" is the question a date column is
+   * there to answer, and "A first" is the question a name column is.
+   */
+  function setSort(key) {
+    const dateKey = key === 'added_at' || key === 'modified_at';
+    state.sort = state.sort.key === key
+      ? { key, dir: state.sort.dir === 'asc' ? 'desc' : 'asc' }
+      : { key, dir: dateKey ? 'desc' : 'asc' };
+    renderLocations();
+  }
+
+  /** Wire the sortable headers once, and keep aria-sort in step with state. */
+  function renderSortHeaders() {
+    for (const th of document.querySelectorAll('#loc-table th[data-sort]')) {
+      const key = th.dataset.sort;
+      const active = state.sort.key === key;
+      th.setAttribute('aria-sort', active
+        ? (state.sort.dir === 'asc' ? 'ascending' : 'descending')
+        : 'none');
+      th.classList.toggle('sorted', active);
+      th.classList.toggle('desc', active && state.sort.dir === 'desc');
+      if (!th.dataset.wired) {
+        th.dataset.wired = '1';
+        th.tabIndex = 0;
+        th.addEventListener('click', () => setSort(key));
+        // Keyboard parity: a header that only responds to a mouse is a control
+        // half the people using it cannot reach.
+        th.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSort(key); }
+        });
+      }
+    }
+  }
+
   function renderLocations() {
-    const shown = state.locations.filter((l) => locationMatches(l, state.filter));
+    renderSortHeaders();
+    const shown = sortLocations(state.locations.filter((l) => locationMatches(l, state.filter)));
 
     replace($('#loc-rows'), shown.map((loc) => h('tr', {
       'aria-selected': loc.id === state.selectedLocation ? 'true' : 'false',

--- a/admin/index.html
+++ b/admin/index.html
@@ -133,7 +133,7 @@
         <table>
           <thead>
             <tr>
-              <th>Name</th><th>Category</th><th>Tags</th><th>Status</th><th>Nexus</th>
+              <th>Name</th><th>Category</th><th>Tags</th><th>Status</th><th>Added</th><th>Modified</th><th>Nexus</th>
             </tr>
           </thead>
           <tbody id="loc-rows"></tbody>

--- a/admin/index.html
+++ b/admin/index.html
@@ -130,10 +130,16 @@
            visible reason reads as missing data. -->
       <div class="toolbar filter-chips" id="loc-chips"></div>
       <div class="table-wrap">
-        <table>
+        <table id="loc-table">
           <thead>
             <tr>
-              <th>Name</th><th>Category</th><th>Tags</th><th>Status</th><th>Added</th><th>Modified</th><th>Nexus</th>
+              <th data-sort="name" scope="col">Name</th>
+              <th data-sort="category" scope="col">Category</th>
+              <th scope="col">Tags</th>
+              <th data-sort="status" scope="col">Status</th>
+              <th data-sort="added_at" scope="col">Added</th>
+              <th data-sort="modified_at" scope="col">Modified</th>
+              <th scope="col">Nexus</th>
             </tr>
           </thead>
           <tbody id="loc-rows"></tbody>

--- a/worker/migrations/0006_rename_location_dates.sql
+++ b/worker/migrations/0006_rename_location_dates.sql
@@ -1,0 +1,38 @@
+-- Rename the location registry's own timestamps.
+--
+--   created_at -> added_at      when we logged the location
+--   updated_at -> modified_at   when we last edited the record
+--
+-- WHY. There were two different things called `updated_at`, and the collision is
+-- part of why nobody noticed these columns were meaningless.
+--
+--   locations.updated_at    a registry timestamp, never served
+--   nexus_cache.updated_at  when the MOD last changed on Nexus, and the
+--                           `updated_at` that every /v1 record actually carries
+--
+-- Renaming only the registry side leaves one `updated_at` in the codebase, and
+-- it means what a reader expects. `nexus_cache.updated_at` is untouched: it is a
+-- served field name and a Nexus concept, not ours to rename.
+--
+-- SCOPE. `locations` only. `submissions.created_at`, `tags.created_at` and
+-- `tags.updated_at` keep their names; they were never ambiguous and renaming
+-- them would be churn.
+--
+-- NOT AN API CHANGE. Neither column is served. The /v1 record carries
+-- `updated_at` from `nexus_cache`, and `materialize.js` reads neither of these.
+-- So no version bump, and the parity gate cannot see this.
+--
+-- THE VALUES ARE STILL WRONG AFTER THIS RUNS. Every row currently holds the
+-- moment the Phase 1 importer ran (2026-07-26), because that is when the rows
+-- were created, so both columns say the same thing for all 297 records. The
+-- real history lives in git: `data/locations/*.json` carries a first-commit date
+-- and a last-modified date per file, 288 of 288 files, spanning 2026-03-07 to
+-- 2026-07-26. `scripts/backfill-location-dates.mjs` derives them and emits SQL.
+--
+-- The nine auto-discovered records have never existed as files, so git has
+-- nothing for them and they keep the import date. Decided rather than
+-- overlooked: inventing a plausible date from Nexus data would be worse than an
+-- honest "this is when it became a row".
+
+ALTER TABLE locations RENAME COLUMN created_at TO added_at;
+ALTER TABLE locations RENAME COLUMN updated_at TO modified_at;

--- a/worker/scripts/backfill-location-dates.mjs
+++ b/worker/scripts/backfill-location-dates.mjs
@@ -1,0 +1,139 @@
+/**
+ * Backfill `locations.added_at` and `locations.modified_at` from git history.
+ *
+ *   node worker/scripts/backfill-location-dates.mjs --out worker/.import/dates.sql
+ *   npx wrangler d1 execute nczoning-data --remote --file worker/.import/dates.sql
+ *
+ * WHY THIS EXISTS. Both columns currently hold the moment the Phase 1 importer
+ * ran, because that is when the rows were created. So every record in the
+ * dashboard claims it was added and last edited at the same instant on
+ * 2026-07-26, which makes both columns decoration rather than information.
+ *
+ * The real history is in git, and only in git: each `data/locations/<uuid>.json`
+ * has a first commit (the location was logged) and a last commit (the record
+ * was last edited). Measured 2026-07-31: 288 of 288 files have history, spanning
+ * 2026-03-07 to 2026-07-26, and 212 of them were edited after being added, so
+ * `modified_at` is genuinely a different date from `added_at` for most records.
+ *
+ * ONE PASS, NOT 576 INVOCATIONS. `git log --reverse --name-only` walks the whole
+ * history once, oldest first, so the first time a path appears is when it was
+ * added and the last time is when it last changed. Per-file `git log` calls
+ * would be two spawns per record.
+ *
+ * NORMALISED TO UTC. Git author dates carry the committer's local offset, so a
+ * raw `%aI` mixes `+10:00` and `Z` in one column. Every existing row is `Z`, and
+ * the dashboard sorts on these columns: comparing ISO strings with different
+ * offsets lexicographically gives the wrong order. Parsed and re-emitted as `Z`.
+ *
+ * THE FILENAME IS THE ID. `data/locations/<uuid>.json` and the record's `id` are
+ * the same uuid; verified before relying on it.
+ *
+ * THE NINE AUTO-DISCOVERED RECORDS ARE NOT TOUCHED. They have never existed as
+ * files, so git has nothing for them and they keep the import date. Decided
+ * rather than overlooked: a plausible-looking date invented from Nexus data
+ * would be worse than an honest "this is when it became a row". They are
+ * reported at the end so the count is visible rather than implied.
+ *
+ * EMITS SQL, NEVER EXECUTES IT, matching import-locations.mjs: the statements
+ * are reviewable before they touch a database, and re-running the generator is
+ * free.
+ *
+ * This is a ONE-TIME repair. `patchLocation` stamps `modified_at` on every
+ * write, so the columns stay honest from here without it.
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const LOCATIONS_DIR = path.join(REPO_ROOT, 'data', 'locations');
+
+const fail = (msg) => { console.error(`\n${msg}`); process.exit(1); };
+
+/** SQLite string literal. Doubling the quote is the whole escape. */
+const sql = (v) => `'${String(v).replace(/'/g, "''")}'`;
+
+/**
+ * First and last commit date per location file, from one reverse walk.
+ *
+ * `--reverse` makes "first seen" the add and "last seen" the most recent
+ * change, so no per-file work is needed. A rename would break the add date and
+ * `--follow` fixes that, but `--follow` takes a single path. No location file
+ * has ever been renamed: the uuid IS the filename, so a rename would change the
+ * record's identity.
+ */
+function datesFromGit() {
+  const out = execFileSync(
+    'git',
+    ['log', '--reverse', '--format=C%aI', '--name-only', '--', 'data/locations/'],
+    { cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+  );
+
+  const added = new Map();
+  const modified = new Map();
+  let commit = null;
+
+  for (const line of out.split('\n')) {
+    const text = line.trim();
+    if (!text) continue;
+    if (text.startsWith('C') && text.includes('T')) { commit = text.slice(1); continue; }
+    if (!text.startsWith('data/locations/') || !text.endsWith('.json')) continue;
+    const id = path.basename(text, '.json');
+    // Normalise the offset away, so the column holds one comparable format.
+    const iso = new Date(commit).toISOString();
+    if (!added.has(id)) added.set(id, iso);
+    modified.set(id, iso);
+  }
+  return { added, modified };
+}
+
+function main() {
+  const outIdx = process.argv.indexOf('--out');
+  if (outIdx === -1) fail('usage: backfill-location-dates.mjs --out <file.sql>');
+  const outPath = path.resolve(REPO_ROOT, process.argv[outIdx + 1]);
+
+  const onDisk = fs.readdirSync(LOCATIONS_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => path.basename(f, '.json'));
+
+  const { added, modified } = datesFromGit();
+
+  const missing = onDisk.filter((id) => !added.has(id));
+  if (missing.length) {
+    // A file with no history means it was never committed, so the working copy
+    // and the repo disagree. Refusing beats writing a date derived from nothing.
+    fail(`${missing.length} location file(s) have no git history: ${missing.slice(0, 5).join(', ')}`);
+  }
+
+  const statements = onDisk.map((id) => (
+    `UPDATE locations SET added_at = ${sql(added.get(id))}, `
+    + `modified_at = ${sql(modified.get(id))} WHERE id = ${sql(id)};`
+  ));
+
+  const edited = onDisk.filter((id) => added.get(id) !== modified.get(id)).length;
+  const dates = onDisk.map((id) => added.get(id)).sort();
+
+  const header = [
+    '-- Generated by backfill-location-dates.mjs',
+    `-- ${statements.length} location(s), dated from git history.`,
+    `-- Earliest ${dates[0]}, latest ${dates[dates.length - 1]}.`,
+    `-- ${edited} were edited after being added, so modified_at differs from added_at.`,
+    '--',
+    '-- Records with no file (the auto-discovered ones) are deliberately not',
+    '-- touched and keep the import timestamp: git has no history for them.',
+    '',
+  ].join('\n');
+
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  fs.writeFileSync(outPath, `${header}${statements.join('\n')}\n`, 'utf8');
+
+  console.log(`wrote ${outPath}`);
+  console.log(`  ${statements.length} locations dated from git`);
+  console.log(`  ${edited} edited after being added`);
+  console.log(`  range ${dates[0]} .. ${dates[dates.length - 1]}`);
+  console.log('  records with no file keep the import date and are not in this file');
+}
+
+main();

--- a/worker/scripts/import-locations.mjs
+++ b/worker/scripts/import-locations.mjs
@@ -78,15 +78,15 @@ function toRow(rec, stamp) {
     authors: JSON.stringify(rec.authors ?? []),
     tags: JSON.stringify(rec.tags ?? []),
     status: 'published',
-    created_at: stamp,
-    updated_at: stamp,
+    added_at: stamp,
+    modified_at: stamp,
   };
 }
 
 const COLUMNS = [
   'id', 'name', 'nexus_id', 'category', 'x', 'y', 'z', 'yaw',
   'description', 'credits', 'authors', 'tags', 'status',
-  'created_at', 'updated_at',
+  'added_at', 'modified_at',
 ];
 
 function insertLocation(row) {

--- a/worker/src/admin.js
+++ b/worker/src/admin.js
@@ -20,6 +20,7 @@ import {
 import { introspectDatasets, introspectType, readQuota } from './quota.js';
 import {
   getRow, rowToAdmin, loadAdminRecord, materializeAfterWrite, insertLocation, patchLocation,
+  readNexusUpdatedMap,
 } from './registry.js';
 import { handleReview } from './review.js';
 
@@ -172,7 +173,12 @@ export async function handleAdmin(request, env, ctx) {
     const { results } = await env.DB.prepare('SELECT * FROM locations ORDER BY name').all();
     const rows = results ?? [];
     const tagMap = await readTagsForLocations(env, rows.map((r) => r.id));
-    return json(request, { locations: rows.map((r) => rowToAdmin(r, tagMap.get(r.id) ?? [])) });
+    const nexusMap = await readNexusUpdatedMap(env);
+    return json(request, {
+      locations: rows.map((r) => rowToAdmin(
+        r, tagMap.get(r.id) ?? [], nexusMap.get(String(r.nexus_id)) ?? null,
+      )),
+    });
   }
 
   // ---- create ------------------------------------------------------------

--- a/worker/src/registry.js
+++ b/worker/src/registry.js
@@ -40,7 +40,7 @@ export async function getRow(env, id) {
  * registry row, so it has no join rows). That is correct for an editor: it is
  * not a tag an admin owns, and the materializer re-adds it for auto records.
  */
-export function rowToAdmin(row, tags = []) {
+export function rowToAdmin(row, tags = [], nexusUpdatedAt = null) {
   return {
     id: row.id,
     name: row.name,
@@ -54,15 +54,37 @@ export function rowToAdmin(row, tags = []) {
     tags,
     status: row.status,
     admin_notes: row.admin_notes,
-    created_at: row.created_at,
-    updated_at: row.updated_at,
+    added_at: row.added_at,
+    modified_at: row.modified_at,
+    // The MOD's update time on Nexus, which is a different thing from both of
+    // the above and is the `updated_at` a /v1 record carries. Named in full here
+    // so the dashboard cannot show three dates that look interchangeable.
+    nexus_updated_at: nexusUpdatedAt,
   };
 }
 
-/** One location, joined to its tags. */
+/**
+ * `nexus_id` -> the mod's Nexus update time, for every cached mod.
+ *
+ * One query for the whole list rather than a lookup per record: the admin list
+ * route already reads tags in bulk for the same reason.
+ */
+export async function readNexusUpdatedMap(env) {
+  const { results } = await env.DB.prepare(
+    'SELECT nexus_id, updated_at FROM nexus_cache',
+  ).all();
+  const map = new Map();
+  for (const r of results ?? []) map.set(String(r.nexus_id), r.updated_at ?? null);
+  return map;
+}
+
+/** One location, joined to its tags and the mod's Nexus update time. */
 export async function loadAdminRecord(env, row) {
   const map = await readTagsForLocations(env, [row.id]);
-  return rowToAdmin(row, map.get(row.id) ?? []);
+  const nexus = await env.DB.prepare(
+    'SELECT updated_at FROM nexus_cache WHERE nexus_id = ?',
+  ).bind(String(row.nexus_id)).first();
+  return rowToAdmin(row, map.get(row.id) ?? [], nexus?.updated_at ?? null);
 }
 
 /** The same, by id. Returns null when the record is gone. */
@@ -130,7 +152,7 @@ export async function insertLocation(env, payload, nowIso = new Date().toISOStri
 
   await env.DB.prepare(`
     INSERT INTO locations (id, name, nexus_id, category, x, y, z, yaw, description,
-      credits, authors, tags, status, admin_notes, created_at, updated_at)
+      credits, authors, tags, status, admin_notes, added_at, modified_at)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).bind(
     id, payload.name, payload.nexus_id, payload.category,
@@ -153,7 +175,7 @@ export async function insertLocation(env, payload, nowIso = new Date().toISOStri
  * Apply a validated partial patch. `{empty: true}` when the payload names no
  * column and no tags, which is a caller error rather than a no-op write.
  *
- * OPTIMISTIC CONCURRENCY. Pass `ifMatch` as the `updated_at` the caller read,
+ * OPTIMISTIC CONCURRENCY. Pass `ifMatch` as the `modified_at` the caller read,
  * and the write applies only while the record still carries it. Three admins
  * share one registry and one queue, so without this the second save silently
  * replaces the first: the audit log records both, but nobody is told, and the
@@ -175,14 +197,14 @@ export async function patchLocation(
   const { sets, binds } = buildUpdate(payload);
   if (!sets.length && !patchesTags) return { empty: true };
 
-  // A tags-only patch still has to move updated_at, so the column write is
+  // A tags-only patch still has to move modified_at, so the column write is
   // unconditional rather than gated on `sets`.
-  sets.push('updated_at = ?');
+  sets.push('modified_at = ?');
   binds.push(nowIso, id);
 
   let sql = `UPDATE locations SET ${sets.join(', ')} WHERE id = ?`;
   if (ifMatch) {
-    sql += ' AND updated_at = ?';
+    sql += ' AND modified_at = ?';
     binds.push(ifMatch);
   }
   const res = await env.DB.prepare(sql).bind(...binds).run();

--- a/worker/test/admin.test.js
+++ b/worker/test/admin.test.js
@@ -83,7 +83,7 @@ const ROW = {
   id: 'loc-1', name: 'Existing Loft', nexus_id: '12345', category: 'new-location',
   x: 1, y: 2, z: 3, yaw: 90, description: 'a place', credits: null,
   authors: '["Spud"]', tags: '["apartment"]', status: 'published',
-  admin_notes: null, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+  admin_notes: null, added_at: '2026-01-01T00:00:00Z', modified_at: '2026-01-01T00:00:00Z',
 };
 
 const FRESH_USER = (collab = 1) => ({
@@ -208,7 +208,7 @@ test('update: patches only what was sent', async () => {
   const row = env.DB.one('SELECT * FROM locations WHERE id = ?', 'loc-1');
   assert.equal(row.name, 'Renamed Loft');
   assert.equal(row.category, 'new-location', 'untouched fields must survive');
-  assert.notEqual(row.updated_at, '2026-01-01T00:00:00Z', 'updated_at must move');
+  assert.notEqual(row.modified_at, '2026-01-01T00:00:00Z', 'modified_at must move');
   assert.deepEqual(tagsOf(env, 'loc-1'), ['apartment'], 'a patch that omits tags must not clear them');
 });
 
@@ -340,9 +340,9 @@ test('a stale If-Match is refused with 409 and writes NOTHING', async () => {
   assert.equal(body.error, 'stale_write');
 
   // The refusal is only worth anything if the write really did not land.
-  const row = env.DB.one('SELECT name, updated_at FROM locations WHERE id = ?', 'loc-1');
+  const row = env.DB.one('SELECT name, modified_at FROM locations WHERE id = ?', 'loc-1');
   assert.equal(row.name, 'Existing Loft', 'the row must be untouched');
-  assert.equal(row.updated_at, '2026-01-01T00:00:00Z', 'and updated_at must not move');
+  assert.equal(row.modified_at, '2026-01-01T00:00:00Z', 'and modified_at must not move');
   assert.equal(auditRows(env).length, 0, 'a refused write writes no audit row either');
 });
 
@@ -352,7 +352,7 @@ test('the conflict response carries the current record, so the client can diff',
   const body = await res.json();
   assert.ok(body.current, 'refusing without the current record leaves the client blind');
   assert.equal(body.current.name, 'Existing Loft');
-  assert.equal(body.current.updated_at, '2026-01-01T00:00:00Z', 'the version to retry against');
+  assert.equal(body.current.modified_at, '2026-01-01T00:00:00Z', 'the version to retry against');
 });
 
 test('a current If-Match is accepted', async () => {
@@ -386,7 +386,7 @@ test('a tags-only patch still moves updated_at', async () => {
   const res = await hit(env, 'PATCH', '/admin/locations/loc-1', { tags: ['corpo'] });
   assert.equal(res.status, 200);
   assert.notEqual(
-    env.DB.one('SELECT updated_at FROM locations WHERE id = ?', 'loc-1').updated_at,
+    env.DB.one('SELECT modified_at FROM locations WHERE id = ?', 'loc-1').modified_at,
     '2026-01-01T00:00:00Z',
   );
 });

--- a/worker/test/materialize.test.js
+++ b/worker/test/materialize.test.js
@@ -27,7 +27,7 @@ const row = (over = {}) => ({
   authors: '["Spud"]', tags: '["apartment"]',
   status: 'published',
   admin_notes: null, owner_id: null,
-  created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+  added_at: '2026-01-01T00:00:00Z', modified_at: '2026-01-01T00:00:00Z',
   ...over,
 });
 

--- a/worker/test/nexus-cache.test.js
+++ b/worker/test/nexus-cache.test.js
@@ -52,7 +52,7 @@ const node = (modId, over = {}) => ({
 const location = (id, nexusId) => ({
   id, name: `Loc ${id}`, nexus_id: nexusId, category: 'new-location',
   x: 0, y: 0, z: 0, authors: '["a"]', description: '',
-  status: 'published', created_at: NOW, updated_at: NOW,
+  status: 'published', added_at: NOW, modified_at: NOW,
 });
 
 // --------------------------------------------------------------- write gate ---

--- a/worker/test/refresh-d1.test.js
+++ b/worker/test/refresh-d1.test.js
@@ -51,14 +51,14 @@ const ROWS = [
     x: 250, y: 250, z: 10, yaw: null, description: 'x', credits: null,
     authors: '["Spud"]', tags: '["apartment"]', status: 'published',
     admin_notes: null, owner_id: null,
-    created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+    added_at: '2026-01-01T00:00:00Z', modified_at: '2026-01-01T00:00:00Z',
   },
   {
     id: 'nexus-888', name: 'Auto Bar', nexus_id: '888', category: 'other',
     x: 600, y: 600, z: null, yaw: null, description: 'auto', credits: null,
     authors: '["Up888"]', tags: '[]', status: 'published',
     admin_notes: null, owner_id: null,
-    created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+    added_at: '2026-01-01T00:00:00Z', modified_at: '2026-01-01T00:00:00Z',
   },
 ];
 

--- a/worker/test/review.test.js
+++ b/worker/test/review.test.js
@@ -20,7 +20,7 @@ const LOCATION = {
   id: 'loc-1', name: 'Existing Loft', nexus_id: '12345', category: 'new-location',
   x: 1, y: 2, z: 3, yaw: 90, description: 'a place', credits: null,
   authors: '["Spud"]', tags: '["apartment"]', status: 'published',
-  admin_notes: null, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+  admin_notes: null, added_at: '2026-01-01T00:00:00Z', modified_at: '2026-01-01T00:00:00Z',
 };
 
 const FRESH_USER = (collab = 1) => ({
@@ -85,7 +85,7 @@ async function hit(env, method, path, body, ctx = {}) {
 }
 
 const subRows = (env) => env.DB.rows('SELECT * FROM submissions ORDER BY id');
-const locRows = (env) => env.DB.rows('SELECT * FROM locations ORDER BY created_at, id');
+const locRows = (env) => env.DB.rows('SELECT * FROM locations ORDER BY added_at, id');
 const auditRows = (env) => env.DB.rows('SELECT * FROM audit_log ORDER BY id');
 const actions = (env) => auditRows(env).map((r) => r.action);
 const firstId = (env) => subRows(env)[0].id;
@@ -227,7 +227,7 @@ test('approving an edit applies only the fields the submission names', async () 
   const row = locRows(env).find((r) => r.id === 'loc-1');
   assert.equal(row.yaw, 45);
   assert.equal(row.name, 'Existing Loft', 'an unnamed field must not move');
-  assert.notEqual(row.updated_at, '2026-01-01T00:00:00Z', 'but updated_at must');
+  assert.notEqual(row.modified_at, '2026-01-01T00:00:00Z', 'but modified_at must');
   assert.deepEqual(actions(env), ['location.update', 'submission.approve']);
 });
 

--- a/worker/test/submissions.test.js
+++ b/worker/test/submissions.test.js
@@ -15,7 +15,7 @@ const LOCATION = {
   id: 'loc-1', name: 'Existing Loft', nexus_id: '12345', category: 'new-location',
   x: 1, y: 2, z: 3, yaw: 90, description: 'a place', credits: null,
   authors: '["Spud"]', tags: '["apartment"]', status: 'published',
-  admin_notes: null, created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+  admin_notes: null, added_at: '2026-01-01T00:00:00Z', modified_at: '2026-01-01T00:00:00Z',
 };
 
 /** A payload the shared validator accepts in full. */


### PR DESCRIPTION
Every location in the dashboard showed the same two timestamps: the moment the Phase 1 importer ran. All 297 records claimed they were added and last edited at the same instant on 26 July, which made both columns decoration.

## Real dates, from the only place they survived

`backfill-location-dates.mjs` derives them from one reverse `git log --name-only` walk over `data/locations/`:

- **288 of 288 files have history**, spanning 2026-03-07 to 2026-07-26
- **212 were edited after being added**, so the second date earns its place
- The **9 auto-discovered records keep the import date**: they have never existed as files, and nothing recorded when they arrived. Decided, not overlooked; a plausible-looking date invented from Nexus data would be worse

Emits SQL rather than executing it, matching `import-locations.mjs`.

Verified on staging against numbers with no slack in them: 9/9 auto records untouched, 76 files never edited, 212 edited later (76 + 212 = 288, + 9 = 297), and **0 records where `modified_at` precedes `added_at`**, which would have meant the reverse walk got its ordering wrong.

## Renamed, because the names were half the problem

There were two different things called `updated_at`:

| | |
| --- | --- |
| `locations.updated_at` | a registry timestamp, never served |
| `nexus_cache.updated_at` | when the **mod** changed on Nexus, and the `updated_at` every `/v1` record actually carries |

Migration `0006` renames the registry side only: `created_at` to `added_at`, `updated_at` to `modified_at`. `nexus_cache` keeps its name; it is a served field and a Nexus concept.

## Sorting, because a Modified column you cannot sort by answers nothing

Name, Category, Status, Added and Modified. Click to sort, click again to reverse. Dates start newest-first, text starts A to Z. Keyboard reachable with `aria-sort` kept in step.

Client-side: the whole registry is already in memory, so a round trip per sort would be slower and would fight the active filter.

## Two format traps worth recording

**Git author dates carry the committer's local offset**, so a raw `%aI` mixed `+10:00` and `Z` in one column. Every existing row is `Z`. Parsed and re-emitted as `Z`.

That is not cosmetic: **the sort depends on it.** Dates compare by codepoint rather than `localeCompare`, because fixed-format UTC strings make codepoint order chronological order, whereas locale collation is free to reorder the punctuation ISO strings are full of. With mixed offsets that sort would have been quietly wrong on any record committed in a different timezone.

**The sort arrows shipped broken to dev** and were caught by eye, not by tests: the escape was written through a Python string where `\21` is an octal escape, so the CSS held byte `0x11` and the literal text `95`. Uses literal characters now, matching `content: "filter →"` already in that file.

## Not an API change

`materialize.js` reads neither column. `/v1` is untouched, no version bump, and the parity gate cannot see this.

## ⚠️ Deploying this has an unavoidable window

A column rename has **no safe ordering**. Old code writes `updated_at`, new code writes `modified_at`, and whichever lands first breaks the other until they match.

**Only admin saves are affected. The public map is not**, because `materialize.js` reads neither column, so `/v1` and the map serve normally throughout.

Immediately after the deploy:

```bash
npx wrangler d1 migrations apply nczoning-data --remote
npx wrangler d1 execute nczoning-data --remote --file worker/.import/dates.sql
```

## Verification

315 worker + 52 site tests. Backfill and sorting both exercised on dev.

Closes #907.
