### PR TITLE
Importer writes the tag join, and locations.tags is dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A restore from the location files would have produced a registry where every location had no tags. The importer wrote the tag column but not the join the map actually reads, so the database would have looked complete and served untagged. It writes both now, and the generated file ends with a check that prints what landed.
 - Location dates were all the same timestamp: the moment the registry was imported, so every record claimed it was added and last edited at the same instant on 26 July. Backfilled from git history, which is the only place the real dates survived. 288 records now carry their true dates, spanning 7 March to 26 July, and 212 of them show a modified date genuinely later than their added date. The nine auto-discovered records keep the import date, because they have never existed as files and nothing recorded when they arrived.
 
 - Two admins editing the same location no longer overwrite each other. A save applies only while the record still looks the way it did when the editor was opened; if it moved, the save is refused, nothing is written, and the current version is loaded so the change can be reapplied. Previously the second save won silently and the first admin's edit disappeared on next load.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The locations table sorts by any of Name, Category, Status, Added or Modified. Click a heading to sort, click it again to reverse. Dates start newest-first, text starts A to Z, because that is the question each one is usually being asked. Keyboard reachable, and the current sort is announced to screen readers.
 - The dashboard shows when a location was **added** and when it was last **modified**, in the locations table as well as the detail pane, alongside when the mod itself was last **updated on Nexus**. Three different dates, named so they cannot be confused: the one a `/v1` record carries is the Nexus one.
 
+### Changed
+
+- Tags are stored one way, in the join the map reads. The duplicate JSON column that was kept alongside it while the two were proven identical is gone, so there is no second copy to drift.
+
 ### Fixed
 
 - A restore from the location files would have produced a registry where every location had no tags. The importer wrote the tag column but not the join the map actually reads, so the database would have looked complete and served untagged. It writes both now, and the generated file ends with a check that prints what landed.

--- a/worker/README.md
+++ b/worker/README.md
@@ -384,11 +384,16 @@ Locations are submitted from the map now and land in D1 directly. The only
 remaining path from files into D1 is `scripts/import-locations.mjs`, which is the
 restore path rather than a routine tool.
 
-⚠️ **`import-locations.mjs` does not write `location_tags`** (see the tracking
-issue). It predates the join and fills only the legacy `locations.tags` column,
-so a database built from it alone serves every location with no tags. The
-deleted `sync-locations.mjs` did write both, and its implementation is recoverable
-from git history.
+It writes **both** `locations` and the `location_tags` join. The join is what the
+materializer reads, so a database built without it serves every location with no
+tags at all, while `locations` looks perfect. The generated file ends with a
+`SELECT` that prints the location, link and untagged counts when it runs, so a
+restore is checked rather than assumed.
+
+Tag links go through the target database's own registry
+(`WHERE je.value IN (SELECT slug FROM tags)`), so a tag that is not curated is
+dropped rather than failing the import. The generator warns about any it expects
+the registry to drop, checked against `data/tags.json`.
 
 Run it against **both** databases, and delete the script at cleanup. Keeping it
 after submissions land in D1 directly would preserve git as a second source of

--- a/worker/migrations/0007_drop_locations_tags.sql
+++ b/worker/migrations/0007_drop_locations_tags.sql
@@ -1,0 +1,32 @@
+-- Drop the legacy `locations.tags` JSON column.
+--
+-- `location_tags` has been the authoritative representation since migration
+-- 0002. That migration was additive on purpose: keeping both in step let the
+-- switch be proven byte-for-byte before either was removed. It has been, twice
+-- over. The parity gate ran green against the join, and its `tag removed`
+-- negative control now mutates the join rather than this column, so a tag
+-- difference is provably detectable.
+--
+-- WHAT HAD TO GO FIRST, and why this waited:
+--
+--   `import-locations.mjs` listed `tags` in its INSERT columns and never wrote
+--   the join at all. Dropping this column would have broken the restore path
+--   outright, and leaving it would have kept producing databases that serve
+--   every location untagged. Fixed before this ran: the importer now writes the
+--   join, verified by building a database from nothing and counting 572 links,
+--   exactly what production holds.
+--
+--   `resolveTags` fell back to this column when no join was supplied. The
+--   fallback is gone and a missing join now throws, because defaulting to an
+--   empty tag list serves 297 untagged records while looking like it worked.
+--
+--   `tag-registry.js` dual-wrote both representations. One write now.
+--
+-- NOT AN API CHANGE. The served `tags` array is built from the join and has
+-- been since Phase 4. `/v1` is byte-identical across this, so no version bump,
+-- and the parity gate cannot see it.
+--
+-- SQLite rewrites the table for a DROP COLUMN, so `location_tags` rows pointing
+-- at `locations(id)` are unaffected: the primary key does not move.
+
+ALTER TABLE locations DROP COLUMN tags;

--- a/worker/scripts/import-locations.mjs
+++ b/worker/scripts/import-locations.mjs
@@ -76,6 +76,8 @@ function toRow(rec, stamp) {
     // gate on truthiness, so '' and NULL alike omit the key from /v1.
     credits: rec.credits ? rec.credits : null,
     authors: JSON.stringify(rec.authors ?? []),
+    // Not a column any more (migration 0007). Carried on the row because
+    // insertLocationTags reads it to build the join.
     tags: JSON.stringify(rec.tags ?? []),
     status: 'published',
     added_at: stamp,
@@ -85,7 +87,7 @@ function toRow(rec, stamp) {
 
 const COLUMNS = [
   'id', 'name', 'nexus_id', 'category', 'x', 'y', 'z', 'yaw',
-  'description', 'credits', 'authors', 'tags', 'status',
+  'description', 'credits', 'authors', 'status',
   'added_at', 'modified_at',
 ];
 

--- a/worker/scripts/import-locations.mjs
+++ b/worker/scripts/import-locations.mjs
@@ -94,6 +94,31 @@ function insertLocation(row) {
   return `INSERT INTO locations (${COLUMNS.join(', ')}) VALUES (${values});`;
 }
 
+/**
+ * The tag links for one row. THE JOIN, NOT JUST THE COLUMN.
+ *
+ * `materialize.js` treats `location_tags` as authoritative, so a database built
+ * without these rows serves every location with no tags at all. `locations`
+ * looks correct and only the join is empty, which makes the failure silent.
+ *
+ * Reads the record's own tag array rather than `locations.tags`, so this keeps
+ * working when that column is dropped (planned, #888 stage 7).
+ *
+ * `IN (SELECT slug FROM tags)` filters through the registry as it exists in the
+ * target database at import time, which drops anything not curated without this
+ * script needing to know the registry. Same rule migration 0002 used for its
+ * backfill. Callers are warned about tags this will drop.
+ */
+function insertLocationTags(row) {
+  const tags = JSON.parse(row.tags);
+  if (!tags.length) return [];
+  return [
+    'INSERT INTO location_tags (location_id, tag_slug)\n'
+    + `  SELECT ${sql(row.id)}, je.value FROM json_each(${sql(row.tags)}) je\n`
+    + '  WHERE je.value IN (SELECT slug FROM tags);',
+  ];
+}
+
 /** Manual records: one JSON file each, UUID filenames. */
 function readManual(stamp) {
   const files = fs.readdirSync(LOCATIONS_DIR).filter((f) => f.endsWith('.json'));
@@ -154,14 +179,46 @@ async function main() {
 
   const dismissed = readDismissed(stamp);
 
+  // Tags the registry will drop. The filter runs in SQL against the target
+  // database, so this script cannot refuse them, but a silent truncation would
+  // leave a location quietly short a tag nobody asked to remove. data/tags.json
+  // is the offline mirror of the registry and retires with it at phase 6.
+  const known = new Set(Object.keys(
+    JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'data', 'tags.json'), 'utf8')),
+  ));
+  const unknown = new Map();
+  for (const r of rows) {
+    for (const t of JSON.parse(r.tags)) {
+      if (!known.has(t)) unknown.set(t, (unknown.get(t) ?? 0) + 1);
+    }
+  }
+
+  const tagLinks = rows.flatMap(insertLocationTags);
+  const expectedLinks = rows.reduce(
+    (n, r) => n + JSON.parse(r.tags).filter((t) => known.has(t)).length, 0,
+  );
+
   const body = [
     `-- Phase 1 seed, generated ${stamp} by worker/scripts/import-locations.mjs`,
     `-- ${manual.length} manual + ${auto.length} auto = ${rows.length} locations,`,
     `-- ${dismissed.length} dismissed candidate(s). Plain INSERTs: re-running fails.`,
+    `-- ${tagLinks.length} location(s) carry tags, ${expectedLinks} link(s) expected in`,
+    '-- location_tags, assuming the target registry matches data/tags.json.',
     '',
     ...rows.map(insertLocation),
     '',
+    '-- The join. Without these the materializer serves every location untagged.',
+    ...tagLinks,
+    '',
     ...dismissed,
+    '',
+    '-- Printed when this file is executed. `links` must match the header count,',
+    '-- and `untagged` must be the number of locations that genuinely have none.',
+    'SELECT (SELECT COUNT(*) FROM locations) AS locations,',
+    '       (SELECT COUNT(*) FROM location_tags) AS links,',
+    '       (SELECT COUNT(*) FROM locations l',
+    '          WHERE NOT EXISTS (SELECT 1 FROM location_tags lt WHERE lt.location_id = l.id))',
+    '         AS untagged;',
     '',
   ].join('\n');
 
@@ -169,8 +226,14 @@ async function main() {
   fs.writeFileSync(outPath, body);
   console.log(
     `wrote ${outPath}\n  ${manual.length} manual + ${auto.length} auto = ${rows.length} locations`
-    + `\n  ${dismissed.length} dismissed candidate(s)`,
+    + `\n  ${dismissed.length} dismissed candidate(s)`
+    + `\n  ${expectedLinks} tag link(s) across ${tagLinks.length} location(s)`,
   );
+  if (unknown.size) {
+    console.warn(`\n  WARNING: ${unknown.size} tag(s) are not in data/tags.json and the`);
+    console.warn('  registry filter will drop them, leaving those locations short a tag:');
+    for (const [t, n] of unknown) console.warn(`    ${t} (on ${n} record(s))`);
+  }
 }
 
 main().catch((err) => {

--- a/worker/src/materialize.js
+++ b/worker/src/materialize.js
@@ -57,19 +57,22 @@ export function rowToEntry(row, locationTags) {
 /**
  * Tags for one record.
  *
- * When `locationTags` is supplied it is authoritative — that is the join, and
- * the production path. Without it the legacy `locations.tags` JSON column is
- * used; migration 0002 keeps both in sync precisely so the switch can be
- * proven byte-for-byte before the column is dropped.
+ * `locationTags` is REQUIRED, and a missing map throws rather than defaulting.
+ * There used to be a fallback to the legacy `locations.tags` JSON column, kept
+ * while migration 0002 held both in sync so the switch could be proven
+ * byte-for-byte. That column is gone, and a silent default here would serve
+ * every record untagged while looking like it worked, which is the failure this
+ * whole area keeps producing.
  *
  * The synthetic `nczoning` marker is NOT added. It used to be prepended for
  * auto-sourced records, which made it a visible filter for a tag `/v1/tags` does
- * not list. Nothing auto-publishes any more, so `source='auto'` is a closed set
- * of 9 legacy records rather than a category the system produces, and the marker
- * described nothing a consumer could act on.
+ * not list. Nothing auto-publishes any more, so the marker described nothing a
+ * consumer could act on.
  */
 function resolveTags(row, locationTags) {
-  if (!locationTags) return JSON.parse(row.tags ?? '[]');
+  if (!locationTags) {
+    throw new Error('materializeFromD1: locationTags is required; tags come from the join');
+  }
   return [...(locationTags.get(row.id) ?? [])];
 }
 

--- a/worker/src/registry.js
+++ b/worker/src/registry.js
@@ -31,14 +31,11 @@ export async function getRow(env, id) {
 /**
  * Row -> the admin representation (everything, including admin-only fields).
  *
- * `tags` comes from the `location_tags` join, passed in by the caller, NOT from
- * the legacy `locations.tags` column. The join is what the materializer reads,
- * so it is what the dashboard must show. Rendering the column would let an
- * edit that never reached the join look like it had landed.
+ * `tags` comes from the `location_tags` join, passed in by the caller. That is
+ * the only representation since migration 0007 dropped the JSON column.
  *
- * The synthetic `nczoning` marker is absent here by construction (it is not a
- * registry row, so it has no join rows). That is correct for an editor: it is
- * not a tag an admin owns, and the materializer re-adds it for auto records.
+ * The synthetic `nczoning` marker is absent by construction: it is not a
+ * registry row, so it has no join rows. Nothing adds it at serve time either.
  */
 export function rowToAdmin(row, tags = [], nexusUpdatedAt = null) {
   return {
@@ -152,15 +149,15 @@ export async function insertLocation(env, payload, nowIso = new Date().toISOStri
 
   await env.DB.prepare(`
     INSERT INTO locations (id, name, nexus_id, category, x, y, z, yaw, description,
-      credits, authors, tags, status, admin_notes, added_at, modified_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      credits, authors, status, admin_notes, added_at, modified_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).bind(
     id, payload.name, payload.nexus_id, payload.category,
     x, y, z === undefined ? null : z,
     payload.yaw ?? null,
     payload.description ?? '',
     payload.credits || null,
-    JSON.stringify(payload.authors), JSON.stringify(payload.tags),
+    JSON.stringify(payload.authors),
     payload.status ?? 'published',
     payload.admin_notes ?? null, nowIso, nowIso,
   ).run();

--- a/worker/src/tag-registry.js
+++ b/worker/src/tag-registry.js
@@ -4,17 +4,15 @@
  * `location_tags` join.
  *
  * Phase 4b moved tags into D1 but only wired up the read path. Phase 4a's admin
- * writes predate it and still set the legacy `locations.tags` JSON column, which
- * the materializer stopped reading the moment the join became authoritative. An
- * admin editing tags therefore got a 200 and no change on the map. That is the
- * gap this module closes, and it is why every location write now goes through
- * `syncLocationTags` rather than a bare column update.
+ * writes predate it and set a `locations.tags` JSON column the materializer had
+ * stopped reading, so an admin editing tags got a 200 and no change on the map.
+ * That is the gap this module closes, and it is why every location write goes
+ * through `syncLocationTags` rather than a bare column update.
  *
- * DUAL WRITE, on purpose. `locations.tags` is kept byte-compatible with the join
- * until a later migration drops the column. Migration 0002 is additive
- * specifically so the switch can be proven byte-for-byte first; writing to only
- * one of the two would make the parity gate compare a live column against a
- * frozen one and call the difference a regression.
+ * ONE WRITE. `location_tags` is the only representation. The JSON column was
+ * kept byte-compatible with the join while migration 0002's additive overlap
+ * let the switch be proven byte-for-byte; migration 0007 drops it, so there is
+ * no second copy to keep in step.
  */
 
 /** Never a registry row: a marker auto-discovery prepends, not a curated tag. */
@@ -210,15 +208,12 @@ export async function readTagsForLocations(env, ids) {
  */
 export async function syncLocationTags(env, locationId, slugs) {
   const clean = [...new Set(slugs.filter((s) => !RESERVED_SLUGS.has(s)))].sort();
-  const legacy = clean;
 
   const statements = [
     env.DB.prepare('DELETE FROM location_tags WHERE location_id = ?').bind(locationId),
     ...clean.map((slug) => env.DB.prepare(
       'INSERT INTO location_tags (location_id, tag_slug) VALUES (?, ?)',
     ).bind(locationId, slug)),
-    env.DB.prepare('UPDATE locations SET tags = ? WHERE id = ?')
-      .bind(JSON.stringify(legacy), locationId),
   ];
 
   // Batched so the join is never briefly empty for a location that has tags.

--- a/worker/test/admin.test.js
+++ b/worker/test/admin.test.js
@@ -82,7 +82,7 @@ function refreshFetch() {
 const ROW = {
   id: 'loc-1', name: 'Existing Loft', nexus_id: '12345', category: 'new-location',
   x: 1, y: 2, z: 3, yaw: 90, description: 'a place', credits: null,
-  authors: '["Spud"]', tags: '["apartment"]', status: 'published',
+  authors: '["Spud"]', status: 'published',
   admin_notes: null, added_at: '2026-01-01T00:00:00Z', modified_at: '2026-01-01T00:00:00Z',
 };
 
@@ -287,32 +287,25 @@ test('a tag edit reaches location_tags, not just the legacy column', async () =>
   assert.deepEqual((await res.json()).location.tags, ['corpo', 'photos']);
 });
 
-test('the legacy column is kept byte-compatible with the join', async () => {
-  // Migration 0002 is additive so parity can be proven before the column drops.
-  // Writing only one of the two would make the gate compare a live column
-  // against a frozen one and call the difference a regression.
+test('a tag edit is stored sorted and deduplicated, in the join', async () => {
+  // There used to be a second assertion here on a legacy locations.tags column
+  // kept byte-compatible with this. Migration 0007 dropped it: one
+  // representation, so there is no second copy to disagree.
   const env = envFor();
-  await hit(env, 'PATCH', '/admin/locations/loc-1', { tags: ['photos', 'corpo'] });
-  const row = env.DB.one('SELECT tags FROM locations WHERE id = ?', 'loc-1');
-  assert.deepEqual(JSON.parse(row.tags), ['corpo', 'photos'], 'sorted, matching the join');
+  await hit(env, 'PATCH', '/admin/locations/loc-1', { tags: ['photos', 'corpo', 'photos'] });
+  assert.deepEqual(tagsOf(env, 'loc-1'), ['corpo', 'photos']);
 });
 
 test('editing a legacy auto record strips the nczoning marker from both writes', async () => {
-  // The marker used to be re-added to the legacy column on every write, so that
-  // editing an auto record did not reshape it away from the other auto rows.
-  // Nothing auto-publishes now, so the marker is gone from both paths and an
-  // edit is what clears it from a row that still carries it.
+  // The marker used to be prepended on every write. Nothing auto-publishes now,
+  // so it is gone from the write path entirely and RESERVED_SLUGS keeps it out
+  // even when a caller sends it.
   const env = envFor({
-    locations: [{ ...ROW, id: 'auto-1', tags: '["nczoning","apartment"]' }],
+    locations: [{ ...ROW, id: 'auto-1' }],
     locationTags: [['auto-1', 'apartment']],
   });
   await hit(env, 'PATCH', '/admin/locations/auto-1', { tags: ['corpo'] });
   assert.deepEqual(tagsOf(env, 'auto-1'), ['corpo'], 'the join never held the marker');
-  assert.deepEqual(
-    JSON.parse(env.DB.one('SELECT tags FROM locations WHERE id = ?', 'auto-1').tags),
-    ['corpo'],
-    'and the legacy column no longer has it re-added',
-  );
 });
 
 // --- optimistic concurrency (#899) ---------------------------------------

--- a/worker/test/materialize.test.js
+++ b/worker/test/materialize.test.js
@@ -24,16 +24,25 @@ const row = (over = {}) => ({
   id: 'aaaa-1111', name: 'Alpha', nexus_id: '12345', category: 'new-location',
   x: 250, y: 250, z: 10, yaw: 90,
   description: 'A record.', credits: 'Thanks',
-  authors: '["Spud"]', tags: '["apartment"]',
+  authors: '["Spud"]',
   status: 'published',
   admin_notes: null, owner_id: null,
   added_at: '2026-01-01T00:00:00Z', modified_at: '2026-01-01T00:00:00Z',
   ...over,
 });
 
+// locationTags is required: the join is the only representation since 0007.
+// Defaulted to a map giving every fixture row the same tag, so tests that are
+// not about tags do not have to care.
 const build = (rows, over = {}) => materializeFromD1({
-  rows, dismissed: [], tagsDict: TAGS, nexusNodes: [], districts: DISTRICTS,
-  nowMs: Date.parse('2026-01-10T00:00:00Z'), ...over,
+  rows,
+  dismissed: [],
+  tagsDict: TAGS,
+  nexusNodes: [],
+  districts: DISTRICTS,
+  locationTags: new Map(rows.map((r) => [r.id, ['apartment']])),
+  nowMs: Date.parse('2026-01-10T00:00:00Z'),
+  ...over,
 });
 
 /** readNexusIndex()'s shape, for the four Nexus-derived fields. */
@@ -167,14 +176,15 @@ test('a WIP record stays image-less rather than borrowing another mod images', (
   assert.equal(full['aaaa-1111'].thumbnail_url, null);
 });
 
-test('rowToEntry parses the JSON array columns', () => {
-  const entry = rowToEntry(row({ authors: '["A","B"]', tags: '["x"]' }));
+test('rowToEntry parses authors from JSON and takes tags from the join', () => {
+  const r = row({ authors: '["A","B"]' });
+  const entry = rowToEntry(r, new Map([[r.id, ['x']]]));
   assert.deepEqual(entry.authors, ['A', 'B']);
-  assert.deepEqual(entry.tags, ['x']);
+  assert.deepEqual(entry.tags, ['x'], 'tags come from the join, never from the row');
 });
 
-test('rowToEntry tolerates NULL authors/tags columns', () => {
-  const entry = rowToEntry(row({ authors: null, tags: null }));
+test('rowToEntry tolerates a NULL authors column and a record with no tag links', () => {
+  const entry = rowToEntry(row({ authors: null }), new Map());
   assert.deepEqual(entry.authors, []);
-  assert.deepEqual(entry.tags, []);
+  assert.deepEqual(entry.tags, [], 'no join rows is an empty array, not undefined');
 });

--- a/worker/test/refresh-d1.test.js
+++ b/worker/test/refresh-d1.test.js
@@ -49,14 +49,14 @@ const ROWS = [
   {
     id: 'm1', name: 'Manual Loft', nexus_id: '12345', category: 'new-location',
     x: 250, y: 250, z: 10, yaw: null, description: 'x', credits: null,
-    authors: '["Spud"]', tags: '["apartment"]', status: 'published',
+    authors: '["Spud"]', status: 'published',
     admin_notes: null, owner_id: null,
     added_at: '2026-01-01T00:00:00Z', modified_at: '2026-01-01T00:00:00Z',
   },
   {
     id: 'nexus-888', name: 'Auto Bar', nexus_id: '888', category: 'other',
     x: 600, y: 600, z: null, yaw: null, description: 'auto', credits: null,
-    authors: '["Up888"]', tags: '[]', status: 'published',
+    authors: '["Up888"]', status: 'published',
     admin_notes: null, owner_id: null,
     added_at: '2026-01-01T00:00:00Z', modified_at: '2026-01-01T00:00:00Z',
   },

--- a/worker/test/review.test.js
+++ b/worker/test/review.test.js
@@ -19,7 +19,7 @@ const fakeKv = () => ({ async get() { return null; }, async put() {} });
 const LOCATION = {
   id: 'loc-1', name: 'Existing Loft', nexus_id: '12345', category: 'new-location',
   x: 1, y: 2, z: 3, yaw: 90, description: 'a place', credits: null,
-  authors: '["Spud"]', tags: '["apartment"]', status: 'published',
+  authors: '["Spud"]', status: 'published',
   admin_notes: null, added_at: '2026-01-01T00:00:00Z', modified_at: '2026-01-01T00:00:00Z',
 };
 

--- a/worker/test/submissions.test.js
+++ b/worker/test/submissions.test.js
@@ -14,7 +14,7 @@ const IP = '203.0.113.7';
 const LOCATION = {
   id: 'loc-1', name: 'Existing Loft', nexus_id: '12345', category: 'new-location',
   x: 1, y: 2, z: 3, yaw: 90, description: 'a place', credits: null,
-  authors: '["Spud"]', tags: '["apartment"]', status: 'published',
+  authors: '["Spud"]', status: 'published',
   admin_notes: null, added_at: '2026-01-01T00:00:00Z', modified_at: '2026-01-01T00:00:00Z',
 };
 

--- a/worker/test/tags.test.js
+++ b/worker/test/tags.test.js
@@ -26,7 +26,7 @@ function fakeDb({ tags = [], links = [] } = {}) {
 const row = (over = {}) => ({
   id: 'a', name: 'Alpha', nexus_id: '1', category: 'other',
   x: 1, y: 2, z: 3, yaw: null, description: 'd', credits: null,
-  authors: '["Spud"]', tags: '["legacy-column-value"]',
+  authors: '["Spud"]',
   status: 'published',
   created_at: 'x', updated_at: 'x', ...over,
 });
@@ -69,17 +69,17 @@ test('readLocationTags groups slugs by location', async () => {
   assert.equal(map.get('missing'), undefined);
 });
 
-test('the join is authoritative when supplied, not the legacy column', async () => {
+test('the join is the only source of tags', async () => {
   const full = build([row()], new Map([['a', ['apartment', 'corpo']]]));
   assert.deepEqual(full.a.tags, ['apartment', 'corpo']);
-  assert.equal(full.a.tags.includes('legacy-column-value'), false);
 });
 
-test('without the join it falls back to the legacy column', async () => {
-  // Migration 0002 keeps both in sync on purpose, so the fallback is a
-  // transitional path rather than a silent inconsistency.
-  const full = build([row()], null);
-  assert.deepEqual(full.a.tags, ['legacy-column-value']);
+test('a missing join THROWS rather than serving every record untagged', async () => {
+  // There used to be a fallback to the legacy locations.tags column, kept while
+  // migration 0002 held both in step. Migration 0007 dropped that column, and a
+  // silent default here would serve 297 untagged records while looking like it
+  // worked, which is the exact failure this area keeps producing.
+  assert.throws(() => build([row()], null), /locationTags is required/);
 });
 
 test('the synthetic nczoning marker is never added, for any record', async () => {


### PR DESCRIPTION
Two changes that had to happen in this order: fix the importer, then drop the column it was mishandling. Together they close the last open box on #888 stage 7.

## `ba5f27d` — the importer wrote the column, never the join

A restore built from `data/locations/` produced a registry where **every location had no tags**. `import-locations.mjs` wrote `locations.tags` and never `location_tags`, and the materializer treats the join as authoritative, so `locations` looked complete while the map would have served 297 untagged records.

Silent by construction: the table nobody checks is the one that is empty.

It reads the record's own tag array rather than `locations.tags`, so it survives the drop below. Filtering happens in SQL against the target database's registry (`IN (SELECT slug FROM tags)`), the same rule migration 0002 used, so an uncurated tag is dropped rather than failing the whole import.

**No silent truncation.** The generator warns about tags it expects the registry to drop, and the emitted file ends with a `SELECT` printing location, link and untagged counts when it runs.

Verified by building a database from nothing: 297 locations, **572 links**, 25 untagged. 572 is exactly what production holds, which is independent confirmation the generator agrees with the live registry. Control with the join statements stripped: **297 locations, 0 links.**

## `8e4922a` — drop `locations.tags`

`location_tags` has been authoritative since migration 0002, which was additive on purpose so the switch could be proven byte-for-byte before either copy was removed. It has been, and the parity gate's tag control now mutates the join rather than the column, so a tag difference is provably detectable.

Three things had to go first:

- **The importer** (above), or the restore path breaks outright
- **`resolveTags`'s fallback** to the column when no join was supplied. Gone, and a missing join now **throws**. A silent default would serve 297 untagged records while looking like it worked
- **`tag-registry.js`'s dual write.** One write now

## Deploy ordering: this one is safe

Unlike the rename in #911, there is no window. The new code never touches the column, so having it present is harmless. Deploy first, drop after, at any interval.

Already proven on staging: column gone, 572 links intact, 297 locations.

```bash
npx wrangler d1 migrations apply nczoning-data --remote
```

## Not an API change

The served `tags` array has come from the join since Phase 4. `/v1` is byte-identical, no version bump, and the parity gate cannot see this.

## Verification

Built a database from nothing on all seven migrations: `locations` has no `tags` column, and the seed still produces 297 locations, 572 links, 25 untagged. Identical to the run before the drop.

315 worker + 52 site tests. Tests updated to assert the new contract rather than deleted: the dual-write test had nothing left to check and now asserts sorting and deduplication in the join, and the fallback test now asserts the throw.

Closes #905.
