### PR TITLE
feat(alerts): fan out through the Worker so alerts have a history

### DIFF
--- a/.github/workflows/monitor-api-health.yml
+++ b/.github/workflows/monitor-api-health.yml
@@ -55,8 +55,16 @@ jobs:
 
       - name: Probe /v1, alert, and self-heal a wedged cron
         env:
-          # Dedicated map-alerts channel, kept separate from submissions.
-          NCZ_ALERTS_DISCORD_WEBHOOK_URL: ${{ secrets.NCZ_ALERTS_DISCORD_WEBHOOK_URL }}
+          # Alerts go to the Worker, which records them in the `alerts` table
+          # and forwards to the map-alerts channel. Posting to Discord from here
+          # would leave the dashboard with no history of anything this monitor
+          # said. The Worker holds the webhook now; this job holds only the
+          # ingest secret.
+          #
+          # This is a GitHub Actions secret. The Worker's copy is a Cloudflare
+          # Worker secret (`wrangler secret put ALERTS_INGEST_SECRET`), a
+          # separate store: setting one does not set the other.
+          ALERTS_INGEST_SECRET: ${{ secrets.ALERTS_INGEST_SECRET }}
           # Was the API down last run? A clean run after a down one is the
           # recovery edge → the script posts a green all-clear exactly once.
           API_HEALTH_PREV_OUTAGE: ${{ steps.prev.outputs.prev_outage }}

--- a/.github/workflows/monitor-api-health.yml
+++ b/.github/workflows/monitor-api-health.yml
@@ -62,7 +62,7 @@ jobs:
           # ingest secret.
           #
           # This is a GitHub Actions secret. The Worker's copy is a Cloudflare
-          # Worker secret (`wrangler secret put ALERTS_INGEST_SECRET`), a
+          # Worker secret (`npx wrangler secret put ALERTS_INGEST_SECRET`), a
           # separate store: setting one does not set the other.
           ALERTS_INGEST_SECRET: ${{ secrets.ALERTS_INGEST_SECRET }}
           # Was the API down last run? A clean run after a down one is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A submission now tells someone it arrived.** Since the cutover a submission reached the review queue silently and the only way to find one was to open the dashboard and look. The map-alerts channel gets a post linking to the dashboard.
+- **An Alerts tab in the dashboard**, with a count beside it and an acknowledge button. Every alert is recorded before it is sent to Discord, so the history is complete even when Discord drops or buries a message.
+- **A warning when any free-tier cap passes 80% for the day**, checked hourly and said once per cap per day. This is the alert that would have caught the KV write limit before Cloudflare emailed about it.
+
 ### Changed
 
 - The locations table sorts by any of Name, Category, Status, Added or Modified. Click a heading to sort, click it again to reverse. Dates start newest-first, text starts A to Z, because that is the question each one is usually being asked. Keyboard reachable, and the current sort is announced to screen readers.

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -942,6 +942,73 @@ button.breakdown-row:hover .k { color: var(--secondary); }
 .audit-entry details { margin-top: var(--space-2xs); }
 .audit-entry summary { cursor: pointer; color: var(--gray); font-size: var(--fs-ui); }
 
+/* --------------------------------------------------------------- alerts -- */
+
+/* The dashboard's first checkbox. Baseline alignment rather than centre: it
+   sits in a toolbar row beside a <select> and a button. */
+.inline-check {
+    display: inline-flex;
+    gap: var(--space-2xs);
+    align-items: center;
+    color: var(--text-subtle);
+    font-size: var(--fs-ui);
+    white-space: nowrap;
+}
+
+.alert-entry {
+    border-bottom: var(--ui-border-thin) solid var(--border-subtle);
+    /* The stripe is the severity. A left border rather than a background so a
+       wall of warnings does not become a wall of colour. 3px matches `.notice`,
+       which is the same device carrying the same meaning. */
+    border-left: 3px solid var(--gray);
+    padding: var(--space-md);
+}
+
+.alert-entry.sev-info { border-left-color: var(--secondary); }
+.alert-entry.sev-warn { border-left-color: var(--tertiary); }
+.alert-entry.sev-error { border-left-color: var(--status-critical); }
+.alert-entry.sev-recovery { border-left-color: var(--status-ok); }
+
+/* Dealt with, kept visible. Receding rather than hiding: the history is the
+   point of the table, so an acknowledged alert stays readable. */
+.alert-entry.acknowledged { opacity: 0.55; }
+
+.alert-head {
+    display: flex;
+    gap: var(--space-md);
+    align-items: baseline;
+    flex-wrap: wrap;
+    font-size: var(--fs-ui);
+}
+
+.alert-head time { color: var(--gray); font-variant-numeric: tabular-nums; }
+.alert-head .alert-title { color: var(--white); font-weight: 600; }
+
+.alert-head .alert-sev {
+    font-size: var(--fs-micro);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-label);
+}
+
+.sev-info .alert-sev { color: var(--secondary); }
+.sev-warn .alert-sev { color: var(--tertiary); }
+.sev-error .alert-sev { color: var(--status-critical); }
+.sev-recovery .alert-sev { color: var(--status-ok); }
+
+/* Producers assemble the body as plain text with newlines, so the line breaks
+   they wrote are the ones shown. */
+.alert-body {
+    margin: var(--space-xs) 0 0;
+    color: var(--text-subtle);
+    font-size: var(--fs-ui);
+    line-height: var(--lh-body);
+    white-space: pre-wrap;
+}
+
+.alert-foot { margin-top: var(--space-xs); font-size: var(--fs-ui); }
+.alert-foot .who { color: var(--tertiary); font-weight: 600; }
+
 .diff { margin: var(--space-xs) 0 0; font-size: var(--fs-code); }
 .diff div { padding: var(--space-2xs) 0; font-family: ui-monospace, monospace; line-height: var(--lh-tight); }
 .diff .k { color: var(--gray); }

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -2235,9 +2235,96 @@
       : h('p', { class: 'muted', text: 'No entries yet.' }));
   }
 
+  // -------------------------------------------------------------- alerts --
+
+  // Severity drives the stripe colour and the word shown. Kept in the same
+  // order the Worker uses so the two cannot disagree about what exists.
+  const SEVERITY_LABEL = {
+    info: 'Info',
+    warn: 'Warning',
+    error: 'Error',
+    recovery: 'Recovered',
+  };
+
+  // Where the alert came from, in words. `source` is a machine token stored in
+  // the row; this is the only place it is turned into something readable.
+  const SOURCE_LABEL = {
+    'api-health': 'API health monitor',
+    refresh: 'Dataset refresh',
+    submissions: 'Submission queue',
+    quota: 'Free-tier quota',
+  };
+
+  async function acknowledgeAlert(id, button) {
+    button.disabled = true;
+    const res = await api(`/admin/alerts/${encodeURIComponent(id)}`, { method: 'PATCH' });
+    if (!res.ok) {
+      button.disabled = false;
+      const [kind, message] = describeFailure(res);
+      return banner(kind, message);
+    }
+    clearBanner();
+    return loadAlerts();
+  }
+
+  function alertCard(a) {
+    const severity = SEVERITY_LABEL[a.severity] ? a.severity : 'info';
+    const acknowledged = Boolean(a.acknowledged_at);
+    return h('div', { class: `alert-entry sev-${severity}${acknowledged ? ' acknowledged' : ''}` },
+      h('div', { class: 'alert-head' },
+        h('span', { class: 'alert-sev', text: SEVERITY_LABEL[severity] }),
+        h('strong', { class: 'alert-title', text: a.title }),
+        h('span', { class: 'spacer', style: 'flex:1' }),
+        h('span', { class: 'muted', text: SOURCE_LABEL[a.source] ?? a.source }),
+        timeEl(a.at)),
+      // Pre-wrap: the body is plain text assembled with newlines by the
+      // producers, not markup, and it is inserted as text so a Discord-flavoured
+      // body can never become HTML here.
+      a.body ? h('p', { class: 'alert-body', text: a.body }) : null,
+      h('div', { class: 'alert-foot' },
+        acknowledged
+          ? h('span', { class: 'muted' },
+            'Acknowledged by ',
+            h('span', { class: 'who', text: a.acknowledged_by || 'someone' }),
+            ' ',
+            timeEl(a.acknowledged_at))
+          : h('button', {
+            type: 'button',
+            class: 'btn secondary',
+            onclick: (e) => acknowledgeAlert(a.id, e.currentTarget),
+          }, 'Acknowledge')));
+  }
+
+  async function loadAlerts() {
+    const limit = $('#alerts-limit').value;
+    const unackOnly = $('#alerts-unack-only').checked;
+    const res = await api(
+      `/admin/alerts?limit=${encodeURIComponent(limit)}${unackOnly ? '&unacknowledged=1' : ''}`,
+    );
+    if (!res.ok) {
+      const [kind, message] = describeFailure(res);
+      return banner(kind, message);
+    }
+
+    const alerts = res.body.alerts || [];
+    const unacknowledged = Number(res.body.unacknowledged ?? 0);
+
+    replace($('#alerts-list'), alerts.length
+      ? alerts.map(alertCard)
+      : h('p', { class: 'muted', text: unackOnly ? 'Nothing unacknowledged.' : 'No alerts yet.' }));
+
+    $('#alerts-note').textContent = alerts.length
+      ? `${alerts.length} shown, ${unacknowledged} unacknowledged.`
+      : `${unacknowledged} unacknowledged.`;
+
+    // Same rule as the queue badge: only a non-zero count earns one.
+    $('#alerts-count').textContent = unacknowledged ? String(unacknowledged) : '';
+    return undefined;
+  }
+
   // ---------------------------------------------------------------- tabs --
 
-  const TABS = ['overview', 'locations', 'queue', 'candidates', 'tags', 'audit'];
+  const TABS = ['overview', 'locations', 'queue', 'candidates', 'tags', 'alerts', 'audit'];
 
   function switchTab(name) {
     for (const btn of document.querySelectorAll('nav.tabs button')) {
@@ -2247,6 +2334,7 @@
       $(`#tab-${id}`).hidden = id !== name;
     }
     if (name === 'audit') loadAudit();
+    if (name === 'alerts') loadAlerts();
     // A Leaflet map built while its pane was display:none measured a zero-sized
     // container, so it has to be told the size it actually has now.
     if (name === 'queue') state.reviewMap?.invalidateSize?.();
@@ -2300,6 +2388,9 @@
     $('#tag-new').onclick = () => selectTag('');
     $('#audit-refresh').onclick = loadAudit;
     $('#audit-limit').onchange = loadAudit;
+    $('#alerts-refresh').onclick = loadAlerts;
+    $('#alerts-limit').onchange = loadAlerts;
+    $('#alerts-unack-only').onchange = loadAlerts;
     $('#rebuild').onclick = (e) => rebuildDataset(e.currentTarget);
     $('#queue-refresh').onclick = loadQueue;
     $('#queue-status').onchange = (e) => {
@@ -2314,7 +2405,7 @@
     // Both feed counts the Overview and the tab badges derive from, so they
     // load at boot rather than on first visit to their tab. A badge that only
     // appears once you have already gone looking is not a notification.
-    await Promise.all([loadQueue(), loadCandidates()]);
+    await Promise.all([loadQueue(), loadCandidates(), loadAlerts()]);
     await refreshFreshness();
     // Overview is the landing tab, and its numbers come from what was just
     // loaded, so it is rendered after both rather than on its own fetch.

--- a/admin/index.html
+++ b/admin/index.html
@@ -44,6 +44,9 @@
     <button type="button" role="tab" data-tab="queue" aria-selected="false">Queue<span class="tab-count" id="queue-count"></span></button>
     <button type="button" role="tab" data-tab="candidates" aria-selected="false">Candidates<span class="tab-count" id="candidates-count"></span></button>
     <button type="button" role="tab" data-tab="tags" aria-selected="false">Tags</button>
+    <!-- Unacknowledged only. An alert that someone has already dealt with is
+         history, not a thing to badge. -->
+    <button type="button" role="tab" data-tab="alerts" aria-selected="false">Alerts<span class="tab-count" id="alerts-count"></span></button>
     <button type="button" role="tab" data-tab="audit" aria-selected="false">Audit</button>
   </nav>
   <span class="spacer"></span>
@@ -237,6 +240,31 @@
 
     <div class="panel" id="tag-editor">
       <p class="muted">Select a tag to edit it, or create a new one.</p>
+    </div>
+  </section>
+
+  <!-- --------------------------------------------------------- alerts -- -->
+  <!--
+    Every alert the Worker has fanned out, whether or not Discord kept it. The
+    table is written BEFORE the Discord post, so this list is the complete
+    record and the channel is the copy that can go missing.
+  -->
+  <section id="tab-alerts" hidden>
+    <div class="panel">
+      <div class="toolbar">
+        <span class="muted" id="alerts-note"></span>
+        <span class="spacer" style="flex:1"></span>
+        <label class="inline-check">
+          <input type="checkbox" id="alerts-unack-only"> Unacknowledged only
+        </label>
+        <select id="alerts-limit" aria-label="How many alerts">
+          <option value="50">Last 50</option>
+          <option value="100" selected>Last 100</option>
+          <option value="500">Last 500</option>
+        </select>
+        <button type="button" class="btn secondary" id="alerts-refresh">Refresh</button>
+      </div>
+      <div id="alerts-list"></div>
     </div>
   </section>
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,18 +160,42 @@ Discord alerting uses secrets configured in **repo Settings → Secrets and vari
 | Secret | Value |
 | --- | --- |
 | `DISCORD_WEBHOOK_URL` | Legacy webhook for the retired **submissions** channel. Nothing writes to it now; it survives only as a fallback for the alerts webhook below, and retires at Phase 6 |
-| `NCZ_ALERTS_DISCORD_WEBHOOK_URL` | Webhook for the dedicated **map-alerts** channel: auto-discovery parse failures and Data API health/outage alerts, kept separate from submissions |
+| `NCZ_ALERTS_DISCORD_WEBHOOK_URL` | Webhook for the dedicated **map-alerts** channel. Held by the **Worker** now (`wrangler secret put`), because the Worker is what posts to Discord. The Actions copy is unused |
+| `ALERTS_INGEST_SECRET` | Bearer token for `POST /internal/alerts`. Needed in **both** stores: a GitHub Actions secret for `monitor_api_health.js`, and a Cloudflare Worker secret for the Worker that checks it. Setting one does not set the other |
 
-### Discord Notifications
+### Alerts
 
-One channel now. The **submissions** channel (`DISCORD_WEBHOOK_URL`) covered the
-mod submission lifecycle: a bot posted an embed when a submission PR opened, then
+Every alert goes through one place: **`POST /internal/alerts` on the Worker**,
+which **records it in the `alerts` table and then forwards it to Discord**.
+
+The ordering is the point. The table exists so alert history survives Discord
+burying or dropping a message, and forwarding first would mean a Discord outage
+loses the record as well as the notification. The two steps fail independently:
+a failed D1 write still notifies, and a failed Discord post still leaves the
+alert in the dashboard's **Alerts** tab, where it can be acknowledged.
+
+Alerts come from four sources, and the `source` column names them:
+
+| Source | Raised by | When |
+| --- | --- | --- |
+| `api-health` | `monitor-api-health.yml`, every 15 min | The Data API (`/v1`) is not serving, **or** its refresh cron has wedged (a frozen `/v1/health.last_refresh_at` heartbeat older than 45 min; the API can serve stale data silently, see #849). On a wedged cron it also **self-heals**: it dispatches `deploy-api.yml` to redeploy the affected Worker (re-registers the Cron Trigger), capped at 2 redeploys/env/hour before escalating for a human |
+| `refresh` | `worker/src/refresh.js`, on the 5-minute cron | A dataset rebuild failed (amber: last-known-good is still served), and the matching all-clear when one later succeeds |
+| `submissions` | `worker/src/submissions.js` | A submission reached the review queue. A plain "one is waiting" post linking to the dashboard, deliberately not the old edit-in-place embed |
+| `quota` | `worker/src/quota.js`, hourly on the cron | A free-tier cap passed 80% for the UTC day. Checked on one tick an hour, and suppressed to once per cap per UTC day |
+
+**In-Worker producers call `raiseAlert()` directly** rather than making an HTTP
+request to their own Worker. `/internal/alerts` is the remote entry point to the
+same function, and exists because a GitHub Action cannot hold a session.
+
+**Why `/internal/` and not `/admin/`.** Every `/admin/*` route is gated on GitHub
+collaborator status, and `index.js` states that as an invariant. The machine
+surface authenticates with a shared secret instead, so it sits on its own prefix
+and the invariant stays literally true. Reading and acknowledging alerts *are*
+on `/admin/alerts`, behind the session, because those are done by a person.
+
+The legacy **submissions** channel (`DISCORD_WEBHOOK_URL`) covered the mod
+submission lifecycle: a bot posted an embed when a submission PR opened, then
 edited that message in place to show merged or closed. Discord was acting as the
 queue's UI. The dashboard holds that state now, and all three producing workflows
-retired at the D1 cutover, so nothing writes to that webhook any more. It is kept
-only as a legacy fallback for the alerts webhook below, and retires at Phase 6.
-
-**Alerts** (`NCZ_ALERTS_DISCORD_WEBHOOK_URL`) covers operational health:
-
-- **`monitor-auto-discovery.yml`**: Daily scan; alerts when a NCZoning-tagged mod fails to parse and isn't covered by a manual entry.
-- **`monitor-api-health.yml`**: Every 15 min; alerts when the Data API (`/v1`) isn't serving **or** its refresh cron has wedged (a frozen `/v1/health.last_refresh_at` heartbeat older than 45 min; the API can serve stale data silently, see #849). On a wedged cron it also **self-heals**: it dispatches `deploy-api.yml` to redeploy the affected Worker (re-registers the Cron Trigger), capped at 2 redeploys/env/hour before escalating for a human. The Worker's own refresh-failure alert (`worker/src/refresh.js`) posts here too (Cloudflare Worker secret, set separately via `wrangler secret put`).
+retired at the D1 cutover. It survives only as a fallback for the alerts webhook,
+and retires at Phase 6.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,12 +155,21 @@ The 3D scene ships on `main`. These are the other five files:
 
 ## Repo Setup (for new maintainers)
 
-Discord alerting uses secrets configured in **repo Settings → Secrets and variables → Actions**. The Worker's own secrets are a **separate store**, set with `wrangler secret put`:
+Discord alerting uses secrets configured in **repo Settings → Secrets and variables → Actions**. The Worker's own secrets are a **separate store**, set with `npx wrangler secret put` from inside `worker/`:
+
+```powershell
+cd worker
+$env:CLOUDFLARE_ACCOUNT_ID='b9937d8d595fad7de8d1549b22390281'
+npx wrangler secret put <NAME>              # production
+npx wrangler secret put <NAME> --env staging
+```
+
+`wrangler` is a devDependency of `worker/`, not a global install, so it resolves only through `npx` (or an npm script, which puts `node_modules/.bin` on PATH). Running it from the repo root fails twice over: npm cannot find the binary, and `wrangler.jsonc` is not there either.
 
 | Secret | Value |
 | --- | --- |
 | `DISCORD_WEBHOOK_URL` | Legacy webhook for the retired **submissions** channel. Nothing writes to it now; it survives only as a fallback for the alerts webhook below, and retires at Phase 6 |
-| `NCZ_ALERTS_DISCORD_WEBHOOK_URL` | Webhook for the dedicated **map-alerts** channel. Held by the **Worker** now (`wrangler secret put`), because the Worker is what posts to Discord. The Actions copy is unused |
+| `NCZ_ALERTS_DISCORD_WEBHOOK_URL` | Webhook for the dedicated **map-alerts** channel. Held by the **Worker** now (`npx wrangler secret put`), because the Worker is what posts to Discord. The Actions copy is unused |
 | `ALERTS_INGEST_SECRET` | Bearer token for `POST /internal/alerts`. Needed in **both** stores: a GitHub Actions secret for `monitor_api_health.js`, and a Cloudflare Worker secret for the Worker that checks it. Setting one does not set the other |
 
 ### Alerts

--- a/scripts/monitor_api_health.js
+++ b/scripts/monitor_api_health.js
@@ -42,9 +42,11 @@
  *
  * Run: node scripts/monitor_api_health.js
  * Targets: API_HEALTH_TARGETS (comma-separated), default https://api.nczoning.net
- * Alerts:  NCZ_ALERTS_DISCORD_WEBHOOK_URL, the dedicated map-alerts channel,
- *          kept separate from the submissions webhook (prints a preview instead
- *          of sending if unset).
+ * Alerts:  POST to {NCZ_API_BASE}/internal/alerts with ALERTS_INGEST_SECRET as
+ *          a bearer token. The Worker records the alert and forwards it to the
+ *          map-alerts channel, so the dashboard keeps a history of everything
+ *          this monitor has said. Prints a preview instead of sending if the
+ *          secret is unset. NCZ_API_BASE defaults to https://api.nczoning.net.
  * Self-heal env: API_HEALTH_SELF_HEAL=true + GH_TOKEN (+ GITHUB_REPOSITORY,
  *          GITHUB_API_URL — set by Actions). Absent → alert only.
  * Exit:    0 when every target is serving fresh data; 1 on any outage, a wedged
@@ -296,8 +298,7 @@ async function selfHeal(results) {
 // `recovered` = the previous run reported an outage and this one is clean, so
 // this post is the down→up edge (a green all-clear) rather than a page.
 // `selfHeal` = { healed, escalated } from an auto-redeploy attempt this run.
-async function postDiscord(results, { recovered = false, selfHeal: heal = null } = {}) {
-  const url = process.env.NCZ_ALERTS_DISCORD_WEBHOOK_URL;
+async function postHealthAlert(results, { recovered = false, selfHeal: heal = null } = {}) {
   const down = results.filter((r) => r.issues.length);
   const frozen = results.filter((r) => r.stale);
   const anyWarning = results.some((r) => r.warnings.length);
@@ -366,31 +367,63 @@ async function postDiscord(results, { recovered = false, selfHeal: heal = null }
   // Fold the self-heal outcome into the alert body (one post per run).
   if (healLines.length) description += `\n\n${healLines.join("\n")}`;
 
-  const body = {
-    embeds: [
-      {
-        title,
-        description,
-        color,
-        fields,
-        footer: { text: "NC Zoning Board • Data API health monitor" },
-      },
-    ],
-  };
+  // Per-target detail, flattened into the body. The embed used to carry these
+  // as `fields`; the `alerts` table is title + body, so a structured field list
+  // cannot be recorded. Flattening here rather than widening the schema keeps
+  // one shape for every producer, which is the point of routing through the
+  // Worker at all.
+  const detail = fields.map((f) => `**${f.name}**\n${f.value}`).join("\n\n");
 
-  if (!url) {
-    console.log("\n--- NCZ_ALERTS_DISCORD_WEBHOOK_URL not set — preview of payload that would be sent ---");
-    console.log(JSON.stringify(body, null, 2));
+  await sendAlert({
+    severity: color === 15158332 ? "error" : recovered ? "recovery" : "warn",
+    // The leading icon is added by the Worker from the severity, so it is not
+    // repeated here; the emoji in `title` above is stripped for the same reason.
+    title: title.replace(/^[^\p{L}\d]+/u, "").trim(),
+    body: detail ? `${description}\n\n${detail}` : description,
+  });
+}
+
+/**
+ * Hand an alert to the Worker, which records it and forwards it to Discord.
+ *
+ * This posts to `/internal/alerts` rather than to the Discord webhook directly.
+ * Posting straight to Discord would leave the dashboard with no history of
+ * anything this monitor ever said, which is the gap #901 exists to close: the
+ * alerts table has to be complete by construction, not by each producer
+ * remembering to write to it as well.
+ *
+ * The secret is a GitHub Actions secret here and a Cloudflare Worker secret at
+ * the other end. Same name, two separate stores, and setting one does not set
+ * the other. See learnings/discord-webhook-two-secret-stores.
+ */
+async function sendAlert({ severity, title, body }) {
+  const base = process.env.NCZ_API_BASE || "https://api.nczoning.net";
+  const secret = process.env.ALERTS_INGEST_SECRET;
+  const payload = { source: "api-health", severity, title, body };
+
+  if (!secret) {
+    console.log("\n--- ALERTS_INGEST_SECRET not set — preview of the alert that would be sent ---");
+    console.log(JSON.stringify(payload, null, 2));
     console.log("--- end preview (nothing was sent) ---");
     return;
   }
-  const res = await fetch(url, {
+
+  const res = await fetch(`${base}/internal/alerts`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json", Authorization: `Bearer ${secret}` },
+    body: JSON.stringify(payload),
   });
-  if (!res.ok) throw new Error(`Discord webhook HTTP ${res.status}: ${await res.text()}`);
-  console.log("Posted Discord health alert.");
+  if (!res.ok) throw new Error(`Alert ingest HTTP ${res.status}: ${await res.text()}`);
+
+  // The endpoint reports the two halves separately. A recorded-but-not-forwarded
+  // alert is in the dashboard and not in Discord, which is worth saying out loud
+  // in the job log rather than reading as a clean run.
+  const result = await res.json().catch(() => ({}));
+  if (result.forwarded === false) {
+    console.log("Alert recorded, but Discord did not accept it (check the Worker's webhook secret).");
+  } else {
+    console.log("Alert recorded and forwarded.");
+  }
 }
 
 (async () => {
@@ -441,7 +474,7 @@ async function postDiscord(results, { recovered = false, selfHeal: heal = null }
     const prevOutage = process.env.API_HEALTH_PREV_OUTAGE === "true";
     const recovered = prevOutage && !anyOutage && !anyStale;
 
-    if (anyOutage || anyStale || anyWarning || recovered) await postDiscord(results, { recovered, selfHeal: heal });
+    if (anyOutage || anyStale || anyWarning || recovered) await postHealthAlert(results, { recovered, selfHeal: heal });
 
     if (anyOutage || anyStale) {
       console.error(

--- a/worker/src/admin.js
+++ b/worker/src/admin.js
@@ -12,6 +12,7 @@ import { resolveSession } from './auth.js';
 import { adminCors } from './auth.js';
 import { validateLocationInput } from './validate.js';
 import { writeAudit, readAudit } from './audit.js';
+import { readAlerts, countUnacknowledged, acknowledgeAlert } from './alerts.js';
 import { runRefresh } from './refresh.js';
 import {
   validateTagInput, readTagSlugs, readTagsWithUsage, readTagUsers, readTag,
@@ -72,6 +73,33 @@ export async function handleAdmin(request, env, ctx) {
   if (url.pathname === '/admin/audit' && method === 'GET') {
     return json(request, { entries: await readAudit(env, url.searchParams.get('limit')) });
   }
+
+  // ---- alerts --------------------------------------------------------------
+  //
+  // Reading and acknowledging only. Alerts are WRITTEN at /internal/alerts,
+  // which carries a shared secret because its callers are GitHub Actions rather
+  // than a signed-in human. Keeping the write off this surface is what lets the
+  // gate above stay uniform.
+  if (url.pathname === '/admin/alerts' && method === 'GET') {
+    return json(request, {
+      alerts: await readAlerts(env, {
+        limit: url.searchParams.get('limit'),
+        unacknowledged: url.searchParams.get('unacknowledged') === '1',
+      }),
+      unacknowledged: await countUnacknowledged(env),
+    });
+  }
+
+  const alertMatch = url.pathname.match(/^\/admin\/alerts\/([^/]+)$/);
+  if (alertMatch && method === 'PATCH') {
+    const alert = await acknowledgeAlert(env, alertMatch[1], actor);
+    if (!alert) return json(request, { error: 'not_found' }, 404);
+    // No audit row. The audit log records changes to the registry, and an
+    // acknowledgement changes no data a visitor can see; the acknowledged_by
+    // and acknowledged_at columns are already the record of who cleared it.
+    return json(request, { alert });
+  }
+  if (alertMatch) return json(request, { error: 'method_not_allowed' }, 405);
 
   // ---- quota: dataset introspection --------------------------------------
   //

--- a/worker/src/alerts.js
+++ b/worker/src/alerts.js
@@ -1,0 +1,224 @@
+/**
+ * The alert fan-out. One place records an alert and one place forwards it, so
+ * the dashboard's history is complete by construction rather than by every
+ * producer remembering to double-write.
+ *
+ * Alerts originate from three places: this Worker (refresh failures, quota
+ * thresholds, new submissions), and GitHub Actions (`monitor_api_health.js`).
+ * In-Worker producers call `raiseAlert()` directly. The Actions monitor cannot,
+ * so it POSTs `/internal/alerts`, which is the same function behind a shared
+ * secret. There is deliberately no second implementation for the remote path.
+ *
+ * ## Record before forwarding
+ *
+ * The table exists precisely so alert history survives Discord burying or
+ * dropping a message. Forwarding first and recording second would mean a
+ * Discord outage loses the record as well as the notification, which defeats
+ * the point of having the table at all.
+ *
+ * The two steps fail independently and neither blocks the other:
+ *
+ * - D1 write fails, Discord succeeds: degraded to exactly the old behaviour, a
+ *   notification with no history. Still better than silence.
+ * - D1 write succeeds, Discord fails: the alert is in the dashboard, which is
+ *   the surface that is supposed to outlive Discord.
+ *
+ * So `raiseAlert()` never throws. An alert about a failure must not become a
+ * second failure, and it must never mask the one it is reporting.
+ */
+
+/** Recognised sources, matching the `source` column comment in migration 0001. */
+export const ALERT_SOURCES = ['api-health', 'refresh', 'submissions', 'quota'];
+
+/** Recognised severities, matching the `severity` column comment. */
+export const ALERT_SEVERITIES = ['info', 'warn', 'error', 'recovery'];
+
+/**
+ * Discord embed colours. Amber is the brand warning colour already used by
+ * `refresh.js`; green matches its recovery embed. Keeping them here means the
+ * channel looks the same whichever producer raised the alert, which is the
+ * visible half of "one place fans out".
+ */
+const SEVERITY_COLOR = {
+  info: 0x00f0ff,
+  warn: 0xffb300,
+  error: 0xe74c3c,
+  recovery: 0x2ecc71,
+};
+
+const SEVERITY_ICON = {
+  info: 'ℹ️',
+  warn: '⚠️',
+  error: '🚨',
+  recovery: '✅',
+};
+
+/** Discord rejects an embed description over 4096; stay well clear. */
+const BODY_MAX = 1500;
+
+/**
+ * Normalise and validate an alert. Returns `{ ok, alert }` or `{ ok, error }`.
+ *
+ * Exported because `/internal/alerts` validates an untrusted body with it, and
+ * the endpoint must reject a bad payload rather than write a row that renders
+ * as `undefined` in the dashboard forever.
+ */
+export function validateAlertInput(input) {
+  const errors = [];
+  const source = typeof input?.source === 'string' ? input.source.trim() : '';
+  const severity = typeof input?.severity === 'string' ? input.severity.trim() : '';
+  const title = typeof input?.title === 'string' ? input.title.trim() : '';
+  const body = input?.body == null ? null : String(input.body).slice(0, BODY_MAX);
+
+  if (!ALERT_SOURCES.includes(source)) {
+    errors.push(`source must be one of: ${ALERT_SOURCES.join(', ')}`);
+  }
+  if (!ALERT_SEVERITIES.includes(severity)) {
+    errors.push(`severity must be one of: ${ALERT_SEVERITIES.join(', ')}`);
+  }
+  if (!title) errors.push('title is required');
+  if (title.length > 200) errors.push('title must be 200 characters or fewer');
+
+  if (errors.length) return { ok: false, errors };
+  return { ok: true, alert: { source, severity, title, body } };
+}
+
+/**
+ * Insert the alert and return its id. Throws on a D1 failure; the caller
+ * decides whether that is fatal (it is not, for `raiseAlert`).
+ */
+export async function recordAlert(env, { source, severity, title, body = null }, nowMs = Date.now()) {
+  const { meta } = await env.DB.prepare(
+    'INSERT INTO alerts (at, source, severity, title, body) VALUES (?, ?, ?, ?, ?)',
+  ).bind(new Date(nowMs).toISOString(), source, severity, title, body).run();
+  return meta?.last_row_id ?? null;
+}
+
+/**
+ * Post the alert to the map-alerts channel.
+ *
+ * Prefers the dedicated webhook and falls back to the legacy submissions one,
+ * matching what `refresh.js` did before this module existed. Both secrets are
+ * Cloudflare Worker secrets here; the same names also exist as GitHub Actions
+ * secrets and are a SEPARATE store. See `learnings/discord-webhook-two-secret-stores`.
+ *
+ * Returns true if Discord accepted it, false in every other case including
+ * "no webhook configured". Never throws.
+ */
+export async function forwardToDiscord(env, alert, fetchImpl = fetch) {
+  const webhook = env.NCZ_ALERTS_DISCORD_WEBHOOK_URL || env.DISCORD_WEBHOOK_URL;
+  if (!webhook) return false;
+  try {
+    const res = await fetchImpl(webhook, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ embeds: [toEmbed(alert)] }),
+    });
+    return Boolean(res?.ok);
+  } catch {
+    return false;
+  }
+}
+
+/** The embed one alert renders as, in the map-alerts channel. */
+function toEmbed({ source, severity, title, body }) {
+  return {
+    title: `${SEVERITY_ICON[severity] ?? ''} ${title}`.trim(),
+    description: body ? String(body).slice(0, BODY_MAX) : undefined,
+    color: SEVERITY_COLOR[severity] ?? SEVERITY_COLOR.info,
+    footer: { text: `NC Zoning Board • ${source}` },
+  };
+}
+
+/**
+ * Record an alert, then forward it. The one entry point every producer uses.
+ *
+ * Never throws: see the module comment. The return value reports what actually
+ * happened, so a caller that cares (the tests, and `/internal/alerts`) can tell
+ * a fully successful fan-out from a half-successful one.
+ *
+ * @returns {Promise<{id: number|null, recorded: boolean, forwarded: boolean}>}
+ */
+export async function raiseAlert(env, alert, { fetchImpl = fetch, nowMs = Date.now() } = {}) {
+  let id = null;
+  let recorded = false;
+
+  if (env.DB) {
+    try {
+      id = await recordAlert(env, alert, nowMs);
+      recorded = true;
+    } catch {
+      // Fall through and still notify. A missing history row is a degradation;
+      // a missing notification is the failure this whole issue exists to fix.
+    }
+  }
+
+  const forwarded = await forwardToDiscord(env, alert, fetchImpl);
+  return { id, recorded, forwarded };
+}
+
+/**
+ * Has this exact alert already gone out today (UTC)?
+ *
+ * Used by the quota threshold, which is evaluated on a 5-minute cron: without
+ * this it would re-post every tick for the rest of the day once a cap crossed
+ * 80%. The alerts table is the dedup store, which only works because recording
+ * happens BEFORE forwarding. An ordering chosen so history survives a Discord
+ * outage turns out to be what makes "have I already said this" answerable.
+ *
+ * Day boundary is UTC to match the caps themselves, which reset at UTC
+ * midnight (see `quota.js`). A local-midnight window would reopen the alert
+ * partway through a quota day and post a duplicate.
+ */
+export async function alertedSinceUtcMidnight(env, { source, title }, nowMs = Date.now()) {
+  if (!env.DB) return false;
+  const midnight = new Date(nowMs);
+  midnight.setUTCHours(0, 0, 0, 0);
+  const row = await env.DB.prepare(
+    'SELECT 1 AS hit FROM alerts WHERE source = ? AND title = ? AND at >= ? LIMIT 1',
+  ).bind(source, title, midnight.toISOString()).first();
+  return Boolean(row);
+}
+
+/**
+ * Most recent first, matching `readAudit`. `unacknowledged` filters to the ones
+ * still needing a human, which is what the dashboard badge counts.
+ */
+export async function readAlerts(env, { limit = 100, unacknowledged = false } = {}) {
+  const capped = Math.min(Math.max(Number(limit) || 100, 1), 500);
+  const where = unacknowledged ? 'WHERE acknowledged_at IS NULL' : '';
+  const { results } = await env.DB.prepare(
+    `SELECT id, at, source, severity, title, body, acknowledged_by, acknowledged_at
+       FROM alerts ${where} ORDER BY id DESC LIMIT ?`,
+  ).bind(capped).all();
+  return results ?? [];
+}
+
+/** How many alerts are still waiting on a human. Drives the tab's badge. */
+export async function countUnacknowledged(env) {
+  const row = await env.DB.prepare(
+    'SELECT COUNT(*) AS n FROM alerts WHERE acknowledged_at IS NULL',
+  ).first();
+  return Number(row?.n ?? 0);
+}
+
+/**
+ * Acknowledge one alert. Returns the updated row, or null if the id does not
+ * exist.
+ *
+ * Acknowledging an already-acknowledged alert is a no-op that returns the row
+ * unchanged rather than an error: two admins clearing the same backlog is
+ * expected, and the first one to arrive is the one who dealt with it.
+ */
+export async function acknowledgeAlert(env, id, actor, nowMs = Date.now()) {
+  const numeric = Number(id);
+  if (!Number.isInteger(numeric)) return null;
+  await env.DB.prepare(
+    `UPDATE alerts SET acknowledged_by = ?, acknowledged_at = ?
+      WHERE id = ? AND acknowledged_at IS NULL`,
+  ).bind(actor, new Date(nowMs).toISOString(), numeric).run();
+  return env.DB.prepare(
+    `SELECT id, at, source, severity, title, body, acknowledged_by, acknowledged_at
+       FROM alerts WHERE id = ?`,
+  ).bind(numeric).first();
+}

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -21,6 +21,7 @@ import { RECENTLY_UPDATED_DAYS } from './config.js';
 import { login, callback, me, logout, adminCors } from './auth.js';
 import { handleAdmin } from './admin.js';
 import { handleSubmissions, purgeSubmitterIps } from './submissions.js';
+import { handleInternal } from './internal.js';
 
 const SCHEMA_VERSION = 1;
 
@@ -253,6 +254,15 @@ export default {
     // separate, collaborator-gated approval.
     if (isSubmission) {
       const res = await handleSubmissions(request, env);
+      if (res) return res;
+    }
+
+    // The machine surface, before the read-only method gate below: it is a POST
+    // and it is neither a browser nor a person. Its gate is a shared secret
+    // rather than a session, which is exactly why it does not live under
+    // /admin/ (see internal.js).
+    if (url.pathname.startsWith('/internal/')) {
+      const res = await handleInternal(request, env);
       if (res) return res;
     }
 

--- a/worker/src/internal.js
+++ b/worker/src/internal.js
@@ -1,0 +1,109 @@
+/**
+ * The machine surface. Routes for callers that are not a browser and not a
+ * person: right now that is `monitor_api_health.js`, running in GitHub Actions.
+ *
+ * ## Why this is not under /admin/
+ *
+ * `handleAdmin` gates every `/admin/*` route on GitHub collaborator status, and
+ * `index.js` states that as an invariant: there is no path through it that
+ * reaches a mutation ungated. A GitHub Action has no session and cannot get
+ * one, so putting a shared-secret write inside `/admin/*` would mean a reader
+ * of that invariant has to know about an exception to it.
+ *
+ * Keeping the machine surface on its own prefix leaves the invariant literally
+ * true and makes the two authentication models visible in the URL. The human
+ * half of the alerts feature (reading, acknowledging) stays on `/admin/alerts`
+ * behind the session, where it belongs.
+ *
+ * ## No CORS, deliberately
+ *
+ * Nothing here is called from a browser, so no `Access-Control-*` headers are
+ * emitted and a cross-origin fetch cannot read a response. The secret is not
+ * safe in a browser anyway; withholding CORS makes accidentally putting it
+ * there fail loudly rather than work.
+ */
+
+import { raiseAlert, validateAlertInput } from './alerts.js';
+
+const json = (body, status = 200) => new Response(JSON.stringify(body), {
+  status,
+  headers: { 'Content-Type': 'application/json; charset=utf-8', 'Cache-Control': 'no-store' },
+});
+
+/**
+ * Compare two secrets without leaking their relationship through timing.
+ *
+ * Both sides are hashed first so the comparison always runs over 32 equal
+ * bytes: a raw byte-by-byte compare of the strings would return early on the
+ * first mismatch AND leak the expected length. `crypto.subtle.timingSafeEqual`
+ * is not used directly because it throws on a length mismatch, which is itself
+ * the signal being hidden.
+ */
+async function secretsMatch(presented, expected) {
+  if (typeof presented !== 'string' || typeof expected !== 'string') return false;
+  if (!presented || !expected) return false;
+  const enc = new TextEncoder();
+  const [a, b] = await Promise.all([
+    crypto.subtle.digest('SHA-256', enc.encode(presented)),
+    crypto.subtle.digest('SHA-256', enc.encode(expected)),
+  ]);
+  const av = new Uint8Array(a);
+  const bv = new Uint8Array(b);
+  let diff = 0;
+  for (let i = 0; i < av.length; i += 1) diff |= av[i] ^ bv[i];
+  return diff === 0;
+}
+
+/**
+ * Gate. Returns null when the caller is authorised, or the Response to send.
+ *
+ * A missing `ALERTS_INGEST_SECRET` is 503, not 403: the endpoint is
+ * misconfigured rather than the caller being wrong, and an unset secret must
+ * never be satisfiable by an unset header.
+ */
+async function requireSharedSecret(request, env) {
+  if (!env.ALERTS_INGEST_SECRET) {
+    return json({ error: 'ingest_unconfigured' }, 503);
+  }
+  const header = request.headers.get('Authorization') || '';
+  const presented = header.startsWith('Bearer ') ? header.slice(7) : '';
+  if (!(await secretsMatch(presented, env.ALERTS_INGEST_SECRET))) {
+    return json({ error: 'unauthorized' }, 401);
+  }
+  return null;
+}
+
+/**
+ * Route `/internal/*`.
+ * @returns {Promise<Response|null>} null when the path is not an internal route.
+ */
+export async function handleInternal(request, env) {
+  const url = new URL(request.url);
+  if (!url.pathname.startsWith('/internal/')) return null;
+
+  if (url.pathname === '/internal/alerts') {
+    if (request.method !== 'POST') return json({ error: 'method_not_allowed' }, 405);
+
+    const denied = await requireSharedSecret(request, env);
+    if (denied) return denied;
+
+    let payload;
+    try {
+      payload = await request.json();
+    } catch {
+      return json({ error: 'invalid_json' }, 400);
+    }
+
+    const check = validateAlertInput(payload);
+    if (!check.ok) return json({ error: 'invalid_alert', errors: check.errors }, 400);
+
+    // The result is reported rather than collapsed into 200/500. A caller that
+    // gets recorded:true, forwarded:false knows the history is intact and only
+    // the Discord hop failed, which is a different operational problem from
+    // the alert never landing anywhere.
+    const result = await raiseAlert(env, check.alert);
+    return json(result, 202);
+  }
+
+  return json({ error: 'not_found' }, 404);
+}

--- a/worker/src/quota.js
+++ b/worker/src/quota.js
@@ -18,6 +18,8 @@
  * is exactly the reading that would make this panel lie.
  */
 
+import { raiseAlert, alertedSinceUtcMidnight } from './alerts.js';
+
 const GRAPHQL_ENDPOINT = 'https://api.cloudflare.com/client/v4/graphql';
 
 /**
@@ -186,6 +188,69 @@ export async function readQuota(env, { nowMs = Date.now(), fetchImpl = fetch } =
       kv_action_types: [...new Set((account.kv ?? []).map((r) => r.dimensions?.actionType))],
     },
   };
+}
+
+/** Fraction of a cap at which the burn-down stops being informational. */
+export const QUOTA_ALERT_PCT = 80;
+
+/**
+ * Alert when any cap passes 80% of its daily allowance.
+ *
+ * The plan calls this "the alert that would have pre-empted this entire
+ * thread": the KV write limit was discovered from a Cloudflare email, after the
+ * fact, with the numbers already on the dashboard and nobody looking at them.
+ *
+ * ## Once an hour, not every tick
+ *
+ * The refresh cron runs every 5 minutes. Querying Cloudflare's analytics API on
+ * all 288 ticks to police quota would be a quota-watching feature that is
+ * itself one of the heavier things running, so the check is gated to the tick
+ * whose UTC minute is under 5. That is exactly one tick an hour, it needs no
+ * stored "last checked" state (which on a 1,000/day cap would itself be a KV
+ * write worth avoiding), and it is derived from the clock rather than from a
+ * counter that a redeploy resets.
+ *
+ * ## Once a day per cap, not once an hour
+ *
+ * `alertedSinceUtcMidnight` suppresses the repeat. The window is UTC because
+ * the caps reset at UTC midnight; a local-midnight window would reopen partway
+ * through a quota day and post a duplicate for a cap already reported.
+ *
+ * Never throws: quota alerting must not be able to fail a refresh that
+ * otherwise succeeded.
+ */
+export async function checkQuotaThresholds(env, fetchImpl = fetch, nowMs = Date.now()) {
+  try {
+    if (new Date(nowMs).getUTCMinutes() >= 5) return { checked: false, raised: [] };
+    if (!env.CF_ANALYTICS_TOKEN) return { checked: false, raised: [] };
+
+    const quota = await readQuota(env, { nowMs, fetchImpl });
+    if (!quota.ok) return { checked: false, raised: [] };
+
+    const raised = [];
+    for (const row of quota.data.usage) {
+      if (row.pct == null || row.pct < QUOTA_ALERT_PCT) continue;
+      // The title is the dedup key, so it names the cap and nothing that varies
+      // within a day. Putting the percentage in it would defeat the suppression
+      // the moment usage ticked from 81% to 82%.
+      const title = `Quota ${QUOTA_ALERT_PCT}%: ${row.label}`;
+      if (await alertedSinceUtcMidnight(env, { source: 'quota', title }, nowMs)) continue;
+      await raiseAlert(env, {
+        source: 'quota',
+        severity: row.pct >= 100 ? 'error' : 'warn',
+        title,
+        body: `${row.label} is at ${row.pct}% of the daily free-tier cap `
+          + `(${row.used} of ${row.cap}) after ${quota.data.utc_hours_elapsed} UTC hours`
+          + `${row.projected == null ? '' : `, projecting ${row.projected} by UTC midnight`}.`
+          + `\n\nCaps are per ACCOUNT and reset at UTC midnight. Nothing degrades `
+          + `until the cap is hit, at which point the cron simply stops.`,
+      }, { fetchImpl, nowMs });
+      raised.push(title);
+    }
+    return { checked: true, raised };
+  } catch {
+    return { checked: false, raised: [] };
+  }
 }
 
 /**

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -25,6 +25,8 @@ import { HEARTBEAT_MIN_INTERVAL_MS } from './config.js';
 import {
   KEYS, contentHash, readMeta, writeDataset, writeMeta,
 } from './store.js';
+import { raiseAlert } from './alerts.js';
+import { checkQuotaThresholds } from './quota.js';
 
 const SCHEMA_VERSION = 1;
 
@@ -36,57 +38,37 @@ async function fetchJson(fetchImpl, origin, path) {
 }
 
 /**
- * Post a failure embed to Discord if a webhook is configured. Prefers the
- * dedicated map-alerts channel (NCZ_ALERTS_DISCORD_WEBHOOK_URL), falling back
- * to the legacy submissions webhook so there's no alerting gap until the new
- * Cloudflare Worker secret is set (`wrangler secret put
- * NCZ_ALERTS_DISCORD_WEBHOOK_URL` for BOTH the prod and staging Workers).
+ * Refresh failed: keep serving last-known-good and say so.
+ *
+ * Goes through `raiseAlert` rather than posting to the webhook directly, so the
+ * dashboard gets a history row as well as the channel getting a message. That
+ * call never throws, which preserves the rule this function has always had:
+ * alerting must never mask the original failure.
  */
-async function alertDiscord(env, fetchImpl, reason) {
-  const webhook = env.NCZ_ALERTS_DISCORD_WEBHOOK_URL || env.DISCORD_WEBHOOK_URL;
-  if (!webhook) return;
-  try {
-    await fetchImpl(webhook, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        embeds: [{
-          title: '⚠️ Data API refresh failed',
-          description: String(reason).slice(0, 1500),
-          color: 0xffb300,
-          footer: { text: 'Serving last-known-good dataset (discovery_stale=true)' },
-        }],
-      }),
-    });
-  } catch {
-    // Alerting must never mask the original failure.
-  }
+async function alertRefreshFailed(env, fetchImpl, reason) {
+  await raiseAlert(env, {
+    source: 'refresh',
+    // warn, not error: the dataset is still being served. A failed refresh
+    // degrades freshness (discovery_stale=true) and takes nothing down, which
+    // is why this embed has always been amber. `error` is for not serving.
+    severity: 'warn',
+    title: 'Data API refresh failed',
+    body: `${String(reason).slice(0, 1200)}\n\nServing last-known-good dataset (discovery_stale=true).`,
+  }, { fetchImpl });
 }
 
 /**
- * Post a recovery embed: the previous cycle marked the dataset discovery_stale
- * and this cycle rebuilt it cleanly, so this is the down→up edge. Fires once
- * (the next successful cycle sees discovery_stale=false and stays quiet).
+ * The previous cycle marked the dataset discovery_stale and this cycle rebuilt
+ * it cleanly, so this is the down to up edge. Fires once (the next successful
+ * cycle sees discovery_stale=false and stays quiet).
  */
-async function alertDiscordRecovered(env, fetchImpl) {
-  const webhook = env.NCZ_ALERTS_DISCORD_WEBHOOK_URL || env.DISCORD_WEBHOOK_URL;
-  if (!webhook) return;
-  try {
-    await fetchImpl(webhook, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        embeds: [{
-          title: '✅ Data API refresh recovered',
-          description: 'A refresh succeeded after an earlier failure — the dataset is fresh again (discovery_stale=false).',
-          color: 0x2ecc71,
-          footer: { text: 'NC Zoning Board • Data API refresh' },
-        }],
-      }),
-    });
-  } catch {
-    // A missed all-clear is not worth throwing over.
-  }
+async function alertRefreshRecovered(env, fetchImpl) {
+  await raiseAlert(env, {
+    source: 'refresh',
+    severity: 'recovery',
+    title: 'Data API refresh recovered',
+    body: 'A refresh succeeded after an earlier failure. The dataset is fresh again (discovery_stale=false).',
+  }, { fetchImpl });
 }
 
 /**
@@ -309,7 +291,8 @@ export async function runRefresh(env, fetchImpl = fetch) {
         last_refresh_at: generatedAt, // liveness heartbeat (see #849)
       },
     });
-    if (recovered) await alertDiscordRecovered(env, fetchImpl);
+    if (recovered) await alertRefreshRecovered(env, fetchImpl);
+    await checkQuotaThresholds(env, fetchImpl, Date.parse(generatedAt));
     return { changed: true, version, stale: false, recovered };
   } catch (err) {
     // Keep last-known-good; flag stale; alert. Never wipe the dataset.
@@ -325,7 +308,7 @@ export async function runRefresh(env, fetchImpl = fetch) {
         last_refresh_at: generatedAt,
       });
     }
-    await alertDiscord(env, fetchImpl, err);
+    await alertRefreshFailed(env, fetchImpl, err);
     return {
       changed: false,
       version: prev?.dataset_version ?? null,

--- a/worker/src/submissions.js
+++ b/worker/src/submissions.js
@@ -35,6 +35,7 @@ import { validateLocationInput } from './validate.js';
 import { readTagSlugs } from './tag-registry.js';
 import { readCandidates } from './nexus-cache.js';
 import { writeAudit } from './audit.js';
+import { raiseAlert } from './alerts.js';
 
 const KINDS = ['create', 'edit', 'remove'];
 
@@ -268,6 +269,30 @@ async function create(request, env, { fetchImpl = fetch, nowMs = Date.now() } = 
     target: id === null ? null : String(id),
     after: { kind, location_id: body.location_id ?? null, payload: stored },
   }, nowMs);
+
+  // Tell someone. Until this existed, a submission reached the queue and nobody
+  // was told: the three workflows retired at the D1 cutover had carried the only
+  // notification, and the dashboard replaced the queue's UI without replacing
+  // its doorbell. See learnings/retiring-a-channel-took-the-only-submission-
+  // notification-with-it.
+  //
+  // Deliberately a plain "one is waiting" post that links to the dashboard. The
+  // old webhook posted an embed and then EDITED it in place to show merged or
+  // closed, which made Discord the queue's UI; the dashboard holds that state
+  // now and the message-editing machinery is not being rebuilt.
+  //
+  // Nothing from the submitter is quoted. The note and contact are unreviewed
+  // free text from an anonymous caller, and this posts to a channel; the
+  // reviewer reads them in the dashboard, behind the collaborator gate.
+  await raiseAlert(env, {
+    source: 'submissions',
+    severity: 'info',
+    title: `New ${kind} submission awaiting review`,
+    // Plain /admin/, not a deep link: the dashboard has no hash routing, so
+    // /admin/#queue would silently open on Overview and read as a broken link.
+    body: `A ${kind} submission is pending${id === null ? '' : ` (#${id})`}.`
+      + `\n\nReview it in the Queue tab at ${env.SITE_ORIGIN ?? 'https://nczoning.net'}/admin/`,
+  }, { nowMs });
 
   return json({ id, kind, status: 'pending' }, 201);
 }

--- a/worker/test/alerts.test.js
+++ b/worker/test/alerts.test.js
@@ -1,0 +1,290 @@
+/**
+ * The alert fan-out.
+ *
+ * The load-bearing claim is the ORDERING: an alert is recorded before it is
+ * forwarded, so a Discord outage costs the notification and not the history.
+ * That is the whole reason the `alerts` table exists, and it is not observable
+ * from a passing happy path, so most of what is here is failure cases.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  raiseAlert, recordAlert, readAlerts, countUnacknowledged, acknowledgeAlert,
+  alertedSinceUtcMidnight, validateAlertInput,
+} from '../src/alerts.js';
+import { handleInternal } from '../src/internal.js';
+import { sqliteD1 } from '../test-support/d1-sqlite.mjs';
+
+const WEBHOOK = 'https://discord/webhook';
+
+/** Collects what would have been posted to Discord. */
+function fakeDiscord({ fail = false, throws = false } = {}) {
+  const sent = [];
+  const impl = async (url, init) => {
+    if (throws) throw new Error('network down');
+    sent.push({ url, body: JSON.parse(init.body) });
+    return { ok: !fail, status: fail ? 500 : 204, text: async () => 'x' };
+  };
+  impl.sent = sent;
+  return impl;
+}
+
+const newEnv = (over = {}) => ({
+  DB: sqliteD1(), NCZ_ALERTS_DISCORD_WEBHOOK_URL: WEBHOOK, ...over,
+});
+
+const ALERT = { source: 'refresh', severity: 'warn', title: 'Something happened', body: 'detail' };
+
+// ---------------------------------------------------------------- ordering --
+
+test('the row exists BEFORE Discord is called', async () => {
+  // The ordering is the design, and none of the surrounding tests can see it:
+  // they pass whether the code records first or forwards first, because a
+  // failed forward is swallowed either way. What the ordering actually buys is
+  // survival of the gap between the two steps, so the only way to observe it is
+  // to look at the database from inside the forward.
+  //
+  // Reversing the two statements in raiseAlert turns this red and nothing else.
+  const env = newEnv();
+  let rowsAtForwardTime = null;
+  const inspectingDiscord = async () => {
+    rowsAtForwardTime = (await readAlerts(env)).length;
+    return { ok: true, status: 204, text: async () => '' };
+  };
+
+  await raiseAlert(env, ALERT, { fetchImpl: inspectingDiscord });
+
+  assert.equal(rowsAtForwardTime, 1, 'Discord was called before the alert was recorded');
+});
+
+test('the alert is recorded even when Discord refuses it', async () => {
+  const env = newEnv();
+  const discord = fakeDiscord({ fail: true });
+
+  const result = await raiseAlert(env, ALERT, { fetchImpl: discord });
+
+  assert.equal(result.recorded, true, 'the row must be written');
+  assert.equal(result.forwarded, false, 'Discord said no');
+  const rows = await readAlerts(env);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].title, 'Something happened');
+});
+
+test('the alert is recorded even when Discord is unreachable', async () => {
+  const env = newEnv();
+  const result = await raiseAlert(env, ALERT, { fetchImpl: fakeDiscord({ throws: true }) });
+
+  assert.equal(result.recorded, true);
+  assert.equal(result.forwarded, false);
+  assert.equal((await readAlerts(env)).length, 1);
+});
+
+test('a D1 failure still lets the notification through', async () => {
+  // The inverse case. Losing the history is a degradation; losing the
+  // notification is the failure the whole issue exists to fix, so a broken
+  // database must not silence Discord.
+  const env = newEnv({
+    DB: { prepare() { throw new Error('D1 unavailable'); } },
+  });
+  const discord = fakeDiscord();
+
+  const result = await raiseAlert(env, ALERT, { fetchImpl: discord });
+
+  assert.equal(result.recorded, false);
+  assert.equal(result.forwarded, true);
+  assert.equal(discord.sent.length, 1);
+});
+
+test('raiseAlert never throws, whatever fails', async () => {
+  const env = { DB: { prepare() { throw new Error('nope'); } }, NCZ_ALERTS_DISCORD_WEBHOOK_URL: WEBHOOK };
+  const result = await raiseAlert(env, ALERT, { fetchImpl: fakeDiscord({ throws: true }) });
+  assert.deepEqual(result, { id: null, recorded: false, forwarded: false });
+});
+
+test('with no webhook configured the alert is still recorded', async () => {
+  const env = newEnv({ NCZ_ALERTS_DISCORD_WEBHOOK_URL: undefined });
+  const result = await raiseAlert(env, ALERT, { fetchImpl: fakeDiscord() });
+  assert.equal(result.recorded, true);
+  assert.equal(result.forwarded, false);
+});
+
+test('the legacy submissions webhook is the fallback, not a second post', async () => {
+  const env = newEnv({ NCZ_ALERTS_DISCORD_WEBHOOK_URL: undefined, DISCORD_WEBHOOK_URL: 'https://legacy' });
+  const discord = fakeDiscord();
+  await raiseAlert(env, ALERT, { fetchImpl: discord });
+  assert.equal(discord.sent.length, 1);
+  assert.equal(discord.sent[0].url, 'https://legacy');
+});
+
+// ------------------------------------------------------------------ embeds --
+
+test('severity drives the embed colour and icon', async () => {
+  const env = newEnv();
+  const discord = fakeDiscord();
+  await raiseAlert(env, { ...ALERT, severity: 'recovery', title: 'Back up' }, { fetchImpl: discord });
+  const embed = discord.sent[0].body.embeds[0];
+  assert.equal(embed.title, '✅ Back up');
+  assert.equal(embed.color, 0x2ecc71);
+  assert.equal(embed.footer.text, 'NC Zoning Board • refresh');
+});
+
+// -------------------------------------------------------------------- dedup --
+
+test('alertedSinceUtcMidnight is per UTC day, not per rolling 24 hours', async () => {
+  const env = newEnv();
+  // 23:50 UTC: recorded yesterday by the time the 00:10 tick runs.
+  const lateYesterday = Date.parse('2026-07-30T23:50:00Z');
+  const earlyToday = Date.parse('2026-07-31T00:10:00Z');
+
+  await raiseAlert(env, { ...ALERT, source: 'quota', title: 'Quota 80%: KV writes' },
+    { fetchImpl: fakeDiscord(), nowMs: lateYesterday });
+
+  // 20 minutes later in wall-clock terms, but a different quota day: the caps
+  // have reset, so the alert is allowed to fire again.
+  assert.equal(
+    await alertedSinceUtcMidnight(env, { source: 'quota', title: 'Quota 80%: KV writes' }, earlyToday),
+    false,
+  );
+  // Same day as the write: suppressed.
+  assert.equal(
+    await alertedSinceUtcMidnight(env, { source: 'quota', title: 'Quota 80%: KV writes' }, lateYesterday + 60_000),
+    true,
+  );
+});
+
+test('dedup is per title, so a different cap still alerts', async () => {
+  const env = newEnv();
+  const now = Date.parse('2026-07-31T09:00:00Z');
+  await raiseAlert(env, { source: 'quota', severity: 'warn', title: 'Quota 80%: KV writes' },
+    { fetchImpl: fakeDiscord(), nowMs: now });
+  assert.equal(await alertedSinceUtcMidnight(env, { source: 'quota', title: 'Quota 80%: D1 rows written' }, now), false);
+});
+
+// ------------------------------------------------------------ acknowledging --
+
+test('acknowledging records who and when, and clears the unacknowledged count', async () => {
+  const env = newEnv();
+  const id = await recordAlert(env, ALERT);
+  assert.equal(await countUnacknowledged(env), 1);
+
+  const row = await acknowledgeAlert(env, id, 'spuddeh');
+  assert.equal(row.acknowledged_by, 'spuddeh');
+  assert.ok(row.acknowledged_at);
+  assert.equal(await countUnacknowledged(env), 0);
+});
+
+test('the first acknowledgement wins, and the second is not an error', async () => {
+  // Two admins clearing the same backlog is expected. The one who actually
+  // dealt with it is the one who got there first, so a second press must not
+  // overwrite the name.
+  const env = newEnv();
+  const id = await recordAlert(env, ALERT);
+  await acknowledgeAlert(env, id, 'kaoziun');
+  const row = await acknowledgeAlert(env, id, 'akiway');
+  assert.equal(row.acknowledged_by, 'kaoziun');
+});
+
+test('acknowledging an id that does not exist is null, not a crash', async () => {
+  const env = newEnv();
+  assert.equal(await acknowledgeAlert(env, 9999, 'spuddeh'), null);
+  assert.equal(await acknowledgeAlert(env, 'not-a-number', 'spuddeh'), null);
+});
+
+test('unacknowledged filter returns only what still needs a human', async () => {
+  const env = newEnv();
+  const first = await recordAlert(env, ALERT);
+  await recordAlert(env, { ...ALERT, title: 'Second' });
+  await acknowledgeAlert(env, first, 'spuddeh');
+
+  const open = await readAlerts(env, { unacknowledged: true });
+  assert.equal(open.length, 1);
+  assert.equal(open[0].title, 'Second');
+  assert.equal((await readAlerts(env)).length, 2, 'the full list still has both');
+});
+
+// -------------------------------------------------------------- validation --
+
+test('an unknown source or severity is refused, not stored', () => {
+  assert.equal(validateAlertInput({ ...ALERT, source: 'made-up' }).ok, false);
+  assert.equal(validateAlertInput({ ...ALERT, severity: 'catastrophic' }).ok, false);
+  assert.equal(validateAlertInput({ ...ALERT, title: '   ' }).ok, false);
+  assert.equal(validateAlertInput(ALERT).ok, true);
+});
+
+// ----------------------------------------------------------- /internal/alerts --
+
+const post = (body, { secret = 'right-secret', headers } = {}) => new Request(
+  'https://api.test/internal/alerts',
+  {
+    method: 'POST',
+    headers: headers ?? (secret === null
+      ? { 'Content-Type': 'application/json' }
+      : { 'Content-Type': 'application/json', Authorization: `Bearer ${secret}` }),
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  },
+);
+
+const ingestEnv = (over = {}) => newEnv({ ALERTS_INGEST_SECRET: 'right-secret', ...over });
+
+test('a correct secret records and forwards', async () => {
+  const env = ingestEnv();
+  const res = await handleInternal(post(ALERT), env);
+  assert.equal(res.status, 202);
+  const body = await res.json();
+  assert.equal(body.recorded, true);
+  assert.equal((await readAlerts(env)).length, 1);
+});
+
+test('a wrong secret is refused and writes nothing', async () => {
+  const env = ingestEnv();
+  const res = await handleInternal(post(ALERT, { secret: 'wrong' }), env);
+  assert.equal(res.status, 401);
+  assert.equal((await readAlerts(env)).length, 0, 'a refused call must not record');
+});
+
+test('a missing Authorization header is refused', async () => {
+  const env = ingestEnv();
+  const res = await handleInternal(post(ALERT, { secret: null }), env);
+  assert.equal(res.status, 401);
+});
+
+test('an unset server secret is 503, and an unset header cannot satisfy it', async () => {
+  // The dangerous shape: "" === "" would authorise anyone the moment the secret
+  // goes missing from the Worker.
+  const env = newEnv({ ALERTS_INGEST_SECRET: undefined });
+  const res = await handleInternal(post(ALERT, { secret: null }), env);
+  assert.equal(res.status, 503);
+  assert.equal((await readAlerts(env)).length, 0);
+});
+
+test('a bad payload is refused after authentication, and records nothing', async () => {
+  const env = ingestEnv();
+  const res = await handleInternal(post({ ...ALERT, source: 'nope' }), env);
+  assert.equal(res.status, 400);
+  assert.equal((await readAlerts(env)).length, 0);
+});
+
+test('invalid JSON is a 400, not a crash', async () => {
+  const env = ingestEnv();
+  const res = await handleInternal(post('{not json', {}), env);
+  assert.equal(res.status, 400);
+});
+
+test('GET is refused: the ingest is write-only', async () => {
+  const env = ingestEnv();
+  const req = new Request('https://api.test/internal/alerts', { method: 'GET' });
+  assert.equal((await handleInternal(req, env)).status, 405);
+});
+
+test('the ingest emits no CORS headers, so a browser cannot read it', async () => {
+  const env = ingestEnv();
+  const res = await handleInternal(post(ALERT), env);
+  assert.equal(res.headers.get('Access-Control-Allow-Origin'), null);
+});
+
+test('a non-internal path is not claimed by this handler', async () => {
+  const env = ingestEnv();
+  const req = new Request('https://api.test/v1/locations', { method: 'GET' });
+  assert.equal(await handleInternal(req, env), null);
+});

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -129,12 +129,23 @@
 			"*/5 * * * *"
 		]
 	},
-	// Refresh-failure alerts post to the dedicated map-alerts channel:
+	// Every alert (refresh failure, quota threshold, new submission, and the
+	// api-health monitor's) is recorded in the `alerts` table and forwarded to
+	// the dedicated map-alerts channel by the Worker:
 	//   wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL           (production)
 	//   wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL --env staging
 	// Falls back to the legacy DISCORD_WEBHOOK_URL secret if the new one isn't
 	// set (no alerting gap during the move). Secrets aren't committed here.
-	// Optional: refresh runs without either.
+	// Optional: refresh runs without either, and the alert is still recorded.
+	//
+	// POST /internal/alerts lets scripts/monitor_api_health.js (GitHub Actions)
+	// use that same fan-out. It authenticates with a shared secret:
+	//   wrangler secret put ALERTS_INGEST_SECRET                      (production)
+	//   wrangler secret put ALERTS_INGEST_SECRET --env staging
+	// The SAME value must also be a GitHub Actions secret of the same name.
+	// They are separate stores; setting one does not set the other. Unset here,
+	// the endpoint answers 503 and records nothing rather than accepting an
+	// empty bearer token.
 
 	"env": {
 		// Staging: pulls source files from the dev site, writes to a separate

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -132,16 +132,17 @@
 	// Every alert (refresh failure, quota threshold, new submission, and the
 	// api-health monitor's) is recorded in the `alerts` table and forwarded to
 	// the dedicated map-alerts channel by the Worker:
-	//   wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL           (production)
-	//   wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL --env staging
+	//   npx wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL           (production)
+	//   npx wrangler secret put NCZ_ALERTS_DISCORD_WEBHOOK_URL --env staging
 	// Falls back to the legacy DISCORD_WEBHOOK_URL secret if the new one isn't
 	// set (no alerting gap during the move). Secrets aren't committed here.
 	// Optional: refresh runs without either, and the alert is still recorded.
 	//
 	// POST /internal/alerts lets scripts/monitor_api_health.js (GitHub Actions)
 	// use that same fan-out. It authenticates with a shared secret:
-	//   wrangler secret put ALERTS_INGEST_SECRET                      (production)
-	//   wrangler secret put ALERTS_INGEST_SECRET --env staging
+	//   npx wrangler secret put ALERTS_INGEST_SECRET                      (production)
+	//   npx wrangler secret put ALERTS_INGEST_SECRET --env staging
+	// (from inside worker/: wrangler is a devDependency, not a global install)
 	// The SAME value must also be a GitHub Actions secret of the same name.
 	// They are separate stores; setting one does not set the other. Unset here,
 	// the endpoint answers 503 and records nothing rather than accepting an


### PR DESCRIPTION
Closes #901.

The `alerts` table has existed since migration `0001` and nothing had ever written to it. Each producer posted straight to Discord, so the dashboard had no alert history and Discord was the only record.

## What changed

One path: **`POST /internal/alerts`** records the alert in `alerts`, then forwards it to the map-alerts channel.

| Source | Raised by | When |
| --- | --- | --- |
| `submissions` | `worker/src/submissions.js` | **A submission reached the queue.** This was live-broken |
| `refresh` | `worker/src/refresh.js` | A rebuild failed, and the all-clear when one later succeeds |
| `quota` | `worker/src/quota.js` | A free-tier cap passed 80% for the UTC day |
| `api-health` | `monitor_api_health.js` | Outage or wedged cron, unchanged detection |

In-Worker producers call `raiseAlert()` **directly**. The endpoint is the remote entry point to that same function and exists because a GitHub Action cannot hold a session. There is no second implementation.

## Record before forward

The table exists so history survives Discord burying or dropping a message. Forwarding first means one outage loses the notification **and** the record, which is the whole thing the table was for.

The two halves fail independently and neither blocks the other:

- D1 fails, Discord succeeds: degraded to exactly the old behaviour. Still notified.
- D1 succeeds, Discord fails: it is in the dashboard, which is the surface meant to outlive Discord.

So `raiseAlert()` never throws. An alert about a failure must not become a second failure.

That ordering pays off twice: it also makes the `alerts` table usable as the dedup store for the quota threshold, since "have I already said this today" is only answerable if recording happens first.

## `/internal/` rather than `/admin/`

The plan said `POST /admin/alerts`. [`index.js`](worker/src/index.js#L233-L234) states an invariant: *"handleAdmin gates every one of them on collaborator status itself, so there is no path through here that reaches a mutation ungated."* A shared-secret write under `/admin/*` would require that sentence to carry an exception, and anyone reading it to know so.

Machine surface on its own prefix, human surface unchanged:

```
POST  /internal/alerts   shared secret   (GitHub Actions)
GET   /admin/alerts      collaborator    (dashboard)
PATCH /admin/alerts/:id  collaborator    (acknowledge)
```

No CORS headers on `/internal/`, so putting the secret in a browser fails loudly instead of working.

## The 80% quota alert

The plan calls this *"the alert that would have pre-empted this entire thread"*: the KV write cap was found from a Cloudflare email, with the numbers already on the dashboard and nobody watching them.

Two suppressions, for two different reasons:

- **Once an hour**, gated on the tick whose UTC minute is under 5. Querying Cloudflare analytics on all 288 cron ticks would make the quota-watcher one of the heavier things running. Clock-derived, so it needs no stored state (which on a 1,000/day KV cap would itself be a write worth avoiding).
- **Once per cap per UTC day**, via the alerts table. UTC because the caps reset at UTC midnight; a rolling window would reopen partway through a quota day.

## Verification

**24 new tests, 339 worker total, 52 site.** All green.

Each load-bearing behaviour was mutated to confirm the tests could actually fail, and each turned **exactly one** test red:

| Mutation | Test that went red |
| --- | --- |
| Forward before record | `the row exists BEFORE Discord is called` |
| Drop the unset-secret 503 | `an unset server secret is 503...` |
| UTC day becomes rolling 24h | `alertedSinceUtcMidnight is per UTC day...` |

The ordering test was added **because the first draft could not see it**. Asserting "recorded even when Discord fails" passes whichever order the two statements are in, since a failed forward is swallowed either way. It now inspects the database from inside the forward, which is the only vantage point where the ordering is observable.

One existing test caught a real error: I had promoted refresh-failure from amber `warn` to red `error` while refactoring. `recovery posts a recovery alert exactly once` pins the embed title, and its emoji is load-bearing, because red pages a human and amber does not. Reverted; **that test passes unchanged**, which is the evidence the refresh path's behaviour is preserved.

## ⚠️ Deploy steps, needed before this works

`ALERTS_INGEST_SECRET` does not exist yet and must be the **same value in two separate stores** (the trap in `learnings/discord-webhook-two-secret-stores`):

```
gh secret set ALERTS_INGEST_SECRET --repo nczoning/nc-zoning-board
wrangler secret put ALERTS_INGEST_SECRET
wrangler secret put ALERTS_INGEST_SECRET --env staging
```

The Actions workflow linter flags the reference as unknown until the first of those is run. That warning is correct.

Until it is set, the monitor prints a preview and posts nothing, and the endpoint answers 503 rather than accepting an empty bearer token. In-Worker alerts (submissions, refresh, quota) do **not** depend on it and work as soon as this deploys.

## Not done, and it needs you

**The dashboard has no automated tests.** Per the standing rule, the Alerts tab needs a human at the screen before this is called done. Worth checking:

- The tab badge appears at load, not only after visiting the tab (it is in the boot `Promise.all` for that reason).
- Acknowledge clears the badge and the entry recedes rather than vanishing.
- The severity stripe colours read correctly, and "Unacknowledged only" filters.
- This adds the dashboard's **first checkbox**, so `.inline-check` has no precedent to copy.

## Note on conflicts

Touches `docs/architecture.md` and `CHANGELOG.md`, both of which #913 also edits. Expect a conflict in the alerts section depending on merge order; #913 removes the retired auto-discovery monitor from the same list this rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)