### PR TITLE
feat(data): nightly D1 export to the data-snapshots branch

### DIFF
--- a/.github/workflows/export-d1-snapshot.yml
+++ b/.github/workflows/export-d1-snapshot.yml
@@ -63,7 +63,13 @@ jobs:
       # install means nothing to break at 02:17 in a job nobody is watching.
       - name: Export the registry
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # An account-owned token holding only Account -> D1 -> Read. NOT
+          # CLOUDFLARE_API_TOKEN, which deploys the Workers: that one is built
+          # from the "Edit Cloudflare Workers" template and carries no D1
+          # permission, and a read-only backup has no business holding deploy
+          # rights. No fallback to it either, so a missing secret fails here
+          # rather than half-working under the wrong identity.
+          CLOUDFLARE_D1_READ_TOKEN: ${{ secrets.CLOUDFLARE_D1_READ_TOKEN }}
           # Production `nczoning-data`. Stated rather than defaulted so the
           # database this backs up is readable from the workflow.
           D1_DATABASE_ID: 4365740b-76be-4a99-b985-16641e68703a

--- a/.github/workflows/export-d1-snapshot.yml
+++ b/.github/workflows/export-d1-snapshot.yml
@@ -1,0 +1,109 @@
+name: Export D1 snapshot
+
+# The registry's off-Cloudflare backup. D1 is the source of truth for locations
+# since the cutover; this mirrors it nightly to the `data-snapshots` orphan
+# branch, which shares no history with `main` or `dev` and is never merged.
+#
+# WHY NOT `main` OR `dev`: a nightly commit to `main` is 365 bot commits a year
+# that `dev` does not have, so "is dev in sync with main?" becomes permanently
+# false and useless as a signal. It would also trigger a nightly production
+# Pages rebuild for data the site no longer reads. Committing to `dev` is worse:
+# the same problems, in the branch PRs flow through.
+#
+# PAIRED CLOUDFLARE CONFIG, NOT IN THIS REPO: Pages preview branch control
+# (Settings -> Builds & deployments -> Branch control) must be set to build only
+# `dev`. Pages builds every non-production branch by default and would otherwise
+# deploy a preview of the snapshot branch every night.
+#
+# SCHEDULED RUNS FIRE FROM THE DEFAULT BRANCH ONLY. Until this file is on `main`
+# the cron does not exist, however green it looks on a feature branch. Use
+# workflow_dispatch to test it from a branch, which does work.
+
+on:
+  schedule:
+    # 16:17 UTC = 02:17 AEST. Off the hour: the top of the hour is when GitHub's
+    # scheduler is most congested and a cron run is most likely to be delayed.
+    - cron: '17 16 * * *'
+  workflow_dispatch:
+
+# Pushing to `data-snapshots` is the whole job. `main` is protected by ruleset
+# 13449449 and is not written here.
+permissions:
+  contents: write
+
+# Never cancel a run mid-push: a half-written snapshot is worse than a late one.
+concurrency:
+  group: export-d1-snapshot
+  cancel-in-progress: false
+
+jobs:
+  export:
+    runs-on: ubuntu-latest
+    steps:
+      # Two checkouts: the exporter comes from this ref, the tree it writes into
+      # comes from the snapshot branch. They share no history, so they cannot be
+      # the same working directory.
+      - name: Checkout the exporter
+        uses: actions/checkout@v7
+        with:
+          path: repo
+
+      - name: Checkout data-snapshots
+        uses: actions/checkout@v7
+        with:
+          ref: data-snapshots
+          path: snapshot
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      # No `npm ci`: the exporter uses only node: builtins and fetch. Nothing to
+      # install means nothing to break at 02:17 in a job nobody is watching.
+      - name: Export the registry
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # Production `nczoning-data`. Stated rather than defaulted so the
+          # database this backs up is readable from the workflow.
+          D1_DATABASE_ID: 4365740b-76be-4a99-b985-16641e68703a
+        run: node repo/scripts/export_d1_snapshot.mjs --out snapshot
+
+      - name: Commit if anything changed
+        working-directory: snapshot
+        run: |
+          git config user.name 'nczoning-bot'
+          git config user.email 'noreply@nczoning.net'
+          git add -A data
+          # An if/else, not `git diff --quiet || commit`: under `set -e` the
+          # short-circuit form exits the step with the diff's own status.
+          if git diff --cached --quiet; then
+            echo 'No change since the last snapshot. Nothing to commit.'
+          else
+            git diff --cached --stat
+            git commit -m "data: D1 snapshot $(date -u +%Y-%m-%d)"
+            git push origin HEAD:data-snapshots
+          fi
+
+      # A backup that stops running silently is not a backup. This posts through
+      # the Worker's alert fan-out, so the failure is recorded in D1 and shown in
+      # the dashboard rather than only being a red run nobody subscribes to.
+      # `|| true`: an alert about a failure must never become a second failure.
+      - name: Alert on failure
+        if: failure()
+        env:
+          ALERTS_INGEST_SECRET: ${{ secrets.ALERTS_INGEST_SECRET }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$ALERTS_INGEST_SECRET" ]; then
+            echo 'ALERTS_INGEST_SECRET not set; the run is red but nothing was alerted.'
+            exit 0
+          fi
+          BODY="The registry backup to the data-snapshots branch did not complete. Until it does, D1 Time Travel (30 days) is the only backup. Run: $RUN_URL"
+          # jq builds the JSON so the body cannot break the payload it sits in.
+          PAYLOAD=$(jq -nc --arg body "$BODY" \
+            '{source: "export", severity: "error", title: "Nightly D1 snapshot failed", body: $body}')
+          curl -sS -X POST https://api.nczoning.net/internal/alerts \
+            -H "Authorization: Bearer $ALERTS_INGEST_SECRET" \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A nightly backup of the location registry**, committed to a `data-snapshots` branch that shares no history with `main` or `dev`. It covers the nine auto-discovered records that have never existed as files, so the mirror is complete for the first time since the cutover.
+- The backup alerts under its own `export` source when a run fails, and says so in the dashboard rather than only going red in Actions.
+
+### Fixed
+
+- The importer can now restore from a snapshot: `--files-only` skips the live-API read that would duplicate the auto-discovered records, and the dismissed-candidate and tag files are accepted in both shapes.
+
 ## [2.1.0] - 2026-08-01
 
 Alerts get somewhere to live. Everything the site raises, from a new submission

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -2263,6 +2263,7 @@
     refresh: 'Dataset refresh',
     submissions: 'Submission queue',
     quota: 'Free-tier quota',
+    export: 'Nightly data snapshot',
   };
 
   async function acknowledgeAlert(id, button) {

--- a/scripts/export_d1_snapshot.mjs
+++ b/scripts/export_d1_snapshot.mjs
@@ -15,11 +15,17 @@
  *   node scripts/export_d1_snapshot.mjs --out ../snapshot --dry-run
  *
  * Env:
- *   CLOUDFLARE_API_TOKEN   required. Needs **Account → D1 → Read** (or Edit).
- *                          A token scoped only for Workers deploys will 403 on
- *                          /d1/database/.../query with code 10000. The endpoint
- *                          named in the error is what tells you which permission
- *                          is missing (learnings/wrangler-ci-token-permissions).
+ *   CLOUDFLARE_D1_READ_TOKEN  required. An ACCOUNT-owned token (Manage Account
+ *                          -> API Tokens, not My Profile) holding exactly
+ *                          Account -> D1 -> Read. Deliberately NOT the deploy
+ *                          token: that one comes from the "Edit Cloudflare
+ *                          Workers" template, which does not carry D1, and
+ *                          reusing it would give a read-only backup job
+ *                          permission to redeploy the Workers. A token without
+ *                          D1 fails on /d1/database/.../query with code 10000;
+ *                          the endpoint named in the error is what identifies
+ *                          the missing permission
+ *                          (learnings/wrangler-ci-token-permissions).
  *   CLOUDFLARE_ACCOUNT_ID  defaults to the account in worker/wrangler.jsonc.
  *   D1_DATABASE_ID         defaults to production `nczoning-data`.
  *
@@ -243,11 +249,11 @@ export function serialize(value) {
 export async function d1Query(sql, params = [], deps = {}) {
   const {
     fetchImpl = fetch,
-    token = process.env.CLOUDFLARE_API_TOKEN,
+    token = process.env.CLOUDFLARE_D1_READ_TOKEN,
     accountId = ACCOUNT_ID,
     databaseId = DATABASE_ID,
   } = deps;
-  if (!token) throw new Error('CLOUDFLARE_API_TOKEN is not set');
+  if (!token) throw new Error('CLOUDFLARE_D1_READ_TOKEN is not set');
 
   const endpoint = `${CF_API}/accounts/${accountId}/d1/database/${databaseId}/query`;
   const res = await fetchImpl(endpoint, {
@@ -263,7 +269,7 @@ export async function d1Query(sql, params = [], deps = {}) {
       .join('; ') || `HTTP ${res.status}`;
     throw new Error(
       `D1 query failed on ${endpoint}: ${detail}\n`
-      + '  If this is code 10000, the API token is missing Account → D1 → Read.',
+      + '  If this is code 10000, CLOUDFLARE_D1_READ_TOKEN is missing Account → D1 → Read.',
     );
   }
   return body.result?.[0]?.results ?? [];

--- a/scripts/export_d1_snapshot.mjs
+++ b/scripts/export_d1_snapshot.mjs
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+/**
+ * Nightly D1 → git snapshot (Part C).
+ *
+ * WHY THIS EXISTS, IN ONE LINE: since the cutover, `data/locations/*.json` is a
+ * mirror of 288 of 297 records: the nine auto-discovered `nexus-<id>` rows have
+ * never existed as files. The registry's only off-Cloudflare backup is already
+ * incomplete, today, before Phase 6 deletes anything.
+ *
+ * Writes a *working tree*, not a commit. The workflow decides whether the diff
+ * is worth committing (`git diff --quiet || commit`), so a quiet night produces
+ * no commit and the script stays testable without git.
+ *
+ *   node scripts/export_d1_snapshot.mjs --out ../snapshot
+ *   node scripts/export_d1_snapshot.mjs --out ../snapshot --dry-run
+ *
+ * Env:
+ *   CLOUDFLARE_API_TOKEN   required. Needs **Account → D1 → Read** (or Edit).
+ *                          A token scoped only for Workers deploys will 403 on
+ *                          /d1/database/.../query with code 10000. The endpoint
+ *                          named in the error is what tells you which permission
+ *                          is missing (learnings/wrangler-ci-token-permissions).
+ *   CLOUDFLARE_ACCOUNT_ID  defaults to the account in worker/wrangler.jsonc.
+ *   D1_DATABASE_ID         defaults to production `nczoning-data`.
+ *
+ * ## Why the REST API and not `wrangler d1 execute`
+ *
+ * `wrangler d1 execute --remote --json` returns 7403. Dropping `--json` works
+ * and prints JSON anyway, which means the working invocation is the one whose
+ * output format is undocumented and unpinned. The REST endpoint returns a
+ * declared envelope, needs no devDependency install, and its failures name the
+ * endpoint. See `learnings/wrangler-json-flag-7403`.
+ *
+ * ## What is deliberately NOT exported
+ *
+ * `submissions` (carries submitter contact and an IP hash), `alerts`, `users`,
+ * and `nexus_cache` (fully derived, rebuilt by the 5-minute cron). This is a
+ * backup of the *registry*, not of the database.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CF_API = process.env.CLOUDFLARE_API_BASE || 'https://api.cloudflare.com/client/v4';
+const ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID || 'b9937d8d595fad7de8d1549b22390281';
+const DATABASE_ID = process.env.D1_DATABASE_ID || '4365740b-76be-4a99-b985-16641e68703a';
+
+/** Page size for every table read. D1's REST response has a size cap and the
+ *  audit log grows without bound, so nothing here reads a whole table at once. */
+const PAGE = 500;
+
+/**
+ * Keys stripped from exported audit payloads, at every depth.
+ *
+ * `admin_notes` and dismissal `reason`s are admin-only and must never reach a
+ * public branch. The plan states this as an accepted reduction in what the mirror
+ * preserves, with D1 Time Travel's 30 days as their only backup.
+ *
+ * The list is wider than those two on purpose. `review_note` is an admin's
+ * judgement about someone else's mod (the same class of thing as a dismissal
+ * reason), and the `submitter_*` fields are contact details that are not in the
+ * audit row today but would be published the moment somebody added them. A
+ * deny-list that only covers what leaks *right now* is one refactor from being
+ * wrong, and the failure mode is publishing, which cannot be undone.
+ *
+ * Applied recursively because `before`/`after` nest: a `submission.create` row
+ * carries the payload under `after.payload`.
+ */
+export const REDACTED_KEYS = [
+  'admin_notes',
+  'reason',
+  'review_note',
+  'submitter_contact',
+  'submitter_note',
+  'submitter_ip_hash',
+];
+
+/** The marker left in place of a redacted value, so the shape of the payload
+ *  survives and a restore can tell "was empty" from "was withheld". */
+export const REDACTED = '[redacted]';
+
+// ── shaping (pure; this is the part the tests exercise) ─────────────────────
+
+/**
+ * One `locations` row → the object written to `data/locations/<id>.json`.
+ *
+ * KEY ORDER IS FIXED HERE and nowhere else. JSON.stringify emits insertion
+ * order, so a reshuffle would rewrite all 297 files in one commit and bury the
+ * one mod that actually changed. Per-location files, rather than `mods.json`,
+ * are what make a nightly diff readable.
+ *
+ * NULL handling mirrors `materializeFromD1`'s decoder exactly, because these
+ * files feed the importer and the importer's `toRow` reads them back:
+ * a NULL `z` produces a 2-element `[x, y]`, and NULL `yaw`/`credits` OMIT the
+ * key rather than emitting null.
+ *
+ * `added_at` / `modified_at` are exported even though today's files carry
+ * neither. They were recovered from git history by #906 and Phase 6 deletes
+ * that history's future; a backup that cannot reconstruct the row is not one.
+ * `owner_id` is omitted: it is NULL on every row and unused.
+ */
+export function locationFile(row, tags = []) {
+  const z = row.z === null || row.z === undefined ? undefined : row.z;
+  return {
+    id: row.id,
+    name: row.name,
+    nexus_id: row.nexus_id === null || row.nexus_id === undefined ? null : String(row.nexus_id),
+    category: row.category,
+    coordinates: z === undefined ? [row.x, row.y] : [row.x, row.y, z],
+    ...(row.yaw === null || row.yaw === undefined ? {} : { yaw: row.yaw }),
+    tags: [...tags].sort(),
+    authors: JSON.parse(row.authors ?? '[]'),
+    ...(row.credits ? { credits: row.credits } : {}),
+    description: row.description ?? '',
+    status: row.status,
+    added_at: row.added_at,
+    modified_at: row.modified_at,
+  };
+}
+
+/**
+ * Recursively drop REDACTED_KEYS. Arrays are walked; scalars pass through.
+ *
+ * Replaces rather than deletes: a missing key reads as "this record had no
+ * admin note", which is a different and misleading claim.
+ */
+export function redact(value) {
+  if (Array.isArray(value)) return value.map(redact);
+  if (value === null || typeof value !== 'object') return value;
+  const out = {};
+  for (const [k, v] of Object.entries(value)) {
+    out[k] = REDACTED_KEYS.includes(k) ? REDACTED : redact(v);
+  }
+  return out;
+}
+
+/**
+ * One `audit_log` row → one JSONL line's object.
+ *
+ * `before`/`after` are stored as JSON strings and are parsed here so redaction
+ * can reach inside them. A payload that will not parse is kept as the literal
+ * string `"[unparseable]"` rather than passed through: an unparseable blob
+ * cannot be redacted, and publishing it unredacted is the one outcome this
+ * function exists to prevent.
+ */
+export function auditLine(row) {
+  return {
+    id: row.id,
+    at: row.at,
+    actor: row.actor,
+    action: row.action,
+    target: row.target ?? null,
+    before: redactJsonString(row.before),
+    after: redactJsonString(row.after),
+  };
+}
+
+function redactJsonString(raw) {
+  if (raw === null || raw === undefined) return null;
+  try {
+    return redact(JSON.parse(raw));
+  } catch {
+    return '[unparseable]';
+  }
+}
+
+/**
+ * `dismissed_candidates` → a bare, sorted ID array.
+ *
+ * NOT the `{id: reason}` map the repo file uses: the reasons are admin-only.
+ * The IDs alone are enough to keep every already-rejected candidate off the
+ * candidates list after a restore.
+ *
+ * Sorted numerically-when-numeric so the file does not reshuffle as IDs are
+ * added. Under a plain string sort `["1000","99"]` is a diff nobody caused.
+ */
+export function excludedFile(rows) {
+  return rows
+    .map((r) => String(r.nexus_id))
+    .sort((a, b) => (/^\d+$/.test(a) && /^\d+$/.test(b) ? Number(a) - Number(b) : a.localeCompare(b)));
+}
+
+/**
+ * The `tags` table → `data/tags.json`, as an ARRAY OF ROWS, not the legacy
+ * `{slug: description}` map.
+ *
+ * The flat map cannot hold `name` or `sort_order`, both of which are curated in
+ * the dashboard and would be silently dropped by a "same file format" export.
+ * The repo's own `data/tags.json` predates those columns and is stale (last
+ * touched 13 March); it is not the format to preserve. `import-locations.mjs`
+ * accepts both shapes so a restore works either way.
+ */
+export function tagsFile(rows) {
+  return rows
+    .map((r) => ({
+      slug: r.slug,
+      name: r.name ?? null,
+      description: r.description,
+      sort_order: r.sort_order ?? null,
+      created_at: r.created_at,
+      updated_at: r.updated_at,
+    }))
+    .sort((a, b) => (a.sort_order ?? 1e9) - (b.sort_order ?? 1e9) || a.slug.localeCompare(b.slug));
+}
+
+/**
+ * Highest audit id already in the snapshot, or 0 for a fresh branch.
+ *
+ * Read from the file rather than tracked in state, so the file IS the cursor:
+ * a restored or hand-edited snapshot resumes from what it actually contains.
+ * Scans every line because the last line of a partially-written file may be
+ * truncated; a max over the parseable ones cannot resume too far ahead, and
+ * resuming too far ahead is the failure that loses rows silently.
+ */
+export function lastAuditId(text) {
+  let max = 0;
+  for (const line of String(text || '').split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const id = Number(JSON.parse(line).id);
+      if (Number.isInteger(id) && id > max) max = id;
+    } catch { /* truncated or corrupt line: the ids around it still bound us */ }
+  }
+  return max;
+}
+
+/** 4-space indent + trailing newline, matching every file in data/locations/. */
+export function serialize(value) {
+  return `${JSON.stringify(value, null, 4)}\n`;
+}
+
+// ── D1 access ───────────────────────────────────────────────────────────────
+
+/**
+ * One statement against the D1 HTTP API.
+ *
+ * Cloudflare answers 200 with `success: false` for application errors, so the
+ * HTTP status alone is not the check. The thrown message names the endpoint and
+ * the CF error code, because both past token failures in this repo were
+ * `Authentication error [code: 10000]` on *different* endpoints and the endpoint
+ * is what identified the missing permission.
+ */
+export async function d1Query(sql, params = [], deps = {}) {
+  const {
+    fetchImpl = fetch,
+    token = process.env.CLOUDFLARE_API_TOKEN,
+    accountId = ACCOUNT_ID,
+    databaseId = DATABASE_ID,
+  } = deps;
+  if (!token) throw new Error('CLOUDFLARE_API_TOKEN is not set');
+
+  const endpoint = `${CF_API}/accounts/${accountId}/d1/database/${databaseId}/query`;
+  const res = await fetchImpl(endpoint, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ sql, params }),
+  });
+  const body = await res.json().catch(() => null);
+
+  if (!res.ok || !body?.success) {
+    const detail = (body?.errors || [])
+      .map((e) => `${e.message} [code: ${e.code}]`)
+      .join('; ') || `HTTP ${res.status}`;
+    throw new Error(
+      `D1 query failed on ${endpoint}: ${detail}\n`
+      + '  If this is code 10000, the API token is missing Account → D1 → Read.',
+    );
+  }
+  return body.result?.[0]?.results ?? [];
+}
+
+/** Page through a query with a stable ORDER BY. `sqlFor(limit, offset)`. */
+async function paged(sqlFor, deps) {
+  const out = [];
+  for (let offset = 0; ; offset += PAGE) {
+    const batch = await d1Query(sqlFor(PAGE, offset), [], deps);
+    out.push(...batch);
+    if (batch.length < PAGE) return out;
+  }
+}
+
+// ── the export ──────────────────────────────────────────────────────────────
+
+/**
+ * Read the registry and write the snapshot tree under `outDir`.
+ *
+ * Location files are written as a REPLACEMENT SET: every `.json` in
+ * `data/locations/` that this run did not write is deleted. A deleted record
+ * must disappear from the mirror, and an export that only ever adds files turns
+ * the backup into an accumulation of every record that ever existed, and
+ * restoring from it resurrects them.
+ *
+ * @returns {Promise<{locations:number, deleted:number, dismissed:number, tags:number, auditAppended:number, fromAuditId:number}>}
+ */
+export async function exportSnapshot({ outDir, dryRun = false, deps = {} }) {
+  const dataDir = path.join(outDir, 'data');
+  const locDir = path.join(dataDir, 'locations');
+
+  const rows = await paged(
+    (l, o) => `SELECT id, name, nexus_id, category, x, y, z, yaw, description, credits,
+                      authors, status, added_at, modified_at
+                 FROM locations ORDER BY id LIMIT ${l} OFFSET ${o}`,
+    deps,
+  );
+  if (rows.length === 0) {
+    // An empty registry is a catastrophe upstream, not a quiet night. Writing
+    // it would replace a good snapshot with 297 deletions in one commit.
+    throw new Error('locations is empty: refusing to export (this would blank the snapshot)');
+  }
+
+  const links = await paged(
+    (l, o) => `SELECT location_id, tag_slug FROM location_tags
+                 ORDER BY location_id, tag_slug LIMIT ${l} OFFSET ${o}`,
+    deps,
+  );
+  const tagsByLocation = new Map();
+  for (const { location_id: id, tag_slug: slug } of links) {
+    if (!tagsByLocation.has(id)) tagsByLocation.set(id, []);
+    tagsByLocation.get(id).push(slug);
+  }
+
+  const dismissed = await paged(
+    (l, o) => `SELECT nexus_id FROM dismissed_candidates ORDER BY nexus_id LIMIT ${l} OFFSET ${o}`,
+    deps,
+  );
+  const tags = await paged(
+    (l, o) => `SELECT slug, name, description, sort_order, created_at, updated_at
+                 FROM tags ORDER BY slug LIMIT ${l} OFFSET ${o}`,
+    deps,
+  );
+
+  const auditPath = path.join(dataDir, 'audit_log.jsonl');
+  const existingAudit = fs.existsSync(auditPath) ? fs.readFileSync(auditPath, 'utf8') : '';
+  const fromAuditId = lastAuditId(existingAudit);
+  const auditRows = await paged(
+    (l, o) => `SELECT id, at, actor, action, target, before, after FROM audit_log
+                 WHERE id > ${fromAuditId} ORDER BY id LIMIT ${l} OFFSET ${o}`,
+    deps,
+  );
+
+  const wanted = new Map(rows.map((r) => [`${r.id}.json`, locationFile(r, tagsByLocation.get(r.id) ?? [])]));
+  const present = fs.existsSync(locDir)
+    ? fs.readdirSync(locDir).filter((f) => f.endsWith('.json'))
+    : [];
+  const stale = present.filter((f) => !wanted.has(f));
+
+  const summary = {
+    locations: wanted.size,
+    deleted: stale.length,
+    dismissed: dismissed.length,
+    tags: tags.length,
+    auditAppended: auditRows.length,
+    fromAuditId,
+  };
+  if (dryRun) return summary;
+
+  fs.mkdirSync(locDir, { recursive: true });
+  for (const [file, record] of wanted) {
+    fs.writeFileSync(path.join(locDir, file), serialize(record));
+  }
+  for (const file of stale) fs.rmSync(path.join(locDir, file));
+
+  fs.writeFileSync(path.join(dataDir, 'excluded_mods.json'), serialize(excludedFile(dismissed)));
+  fs.writeFileSync(path.join(dataDir, 'tags.json'), serialize(tagsFile(tags)));
+
+  if (auditRows.length) {
+    // Append. Rewriting would let a redaction bug or a schema change silently
+    // rewrite history, and history is the thing this file is.
+    const needsNewline = existingAudit.length > 0 && !existingAudit.endsWith('\n');
+    const lines = auditRows.map((r) => JSON.stringify(auditLine(r))).join('\n');
+    fs.appendFileSync(auditPath, `${needsNewline ? '\n' : ''}${lines}\n`);
+  } else if (!fs.existsSync(auditPath)) {
+    fs.writeFileSync(auditPath, '');
+  }
+
+  return summary;
+}
+
+// ── CLI ─────────────────────────────────────────────────────────────────────
+
+const invokedDirectly = process.argv[1]
+  && import.meta.url.endsWith(path.basename(process.argv[1]));
+
+if (invokedDirectly) {
+  const outIdx = process.argv.indexOf('--out');
+  if (outIdx === -1 || !process.argv[outIdx + 1]) {
+    console.error('usage: export_d1_snapshot.mjs --out <dir> [--dry-run]');
+    process.exit(1);
+  }
+  const outDir = path.resolve(process.argv[outIdx + 1]);
+  const dryRun = process.argv.includes('--dry-run');
+
+  exportSnapshot({ outDir, dryRun })
+    .then((s) => {
+      console.log(
+        `${dryRun ? '[dry run] ' : ''}${s.locations} location(s)`
+        + `${s.deleted ? `, ${s.deleted} removed` : ''}`
+        + `\n  ${s.dismissed} dismissed candidate id(s), ${s.tags} tag(s)`
+        + `\n  ${s.auditAppended} audit row(s) appended (resumed after id ${s.fromAuditId})`,
+      );
+    })
+    .catch((err) => {
+      console.error(String(err.stack || err));
+      process.exitCode = 1;
+    });
+}

--- a/test/export-d1-snapshot.test.js
+++ b/test/export-d1-snapshot.test.js
@@ -223,7 +223,7 @@ test('a 200 with success:false is an error, and the message names the endpoint',
 test('a missing token fails before any request is made', async () => {
   await assert.rejects(
     () => X.d1Query('SELECT 1', [], { fetchImpl: () => assert.fail('should not fetch'), token: '' }),
-    /CLOUDFLARE_API_TOKEN is not set/,
+    /CLOUDFLARE_D1_READ_TOKEN is not set/,
   );
 });
 

--- a/test/export-d1-snapshot.test.js
+++ b/test/export-d1-snapshot.test.js
@@ -1,0 +1,320 @@
+/**
+ * The nightly D1 snapshot export.
+ *
+ * TWO CLAIMS ARE TESTED SEPARATELY, because they are different claims and the
+ * cheap one hides the expensive one: that the export *wrote something*, and
+ * that it wrote the *right* thing. A run that produces a plausible tree with an
+ * admin note in it is a data leak that every "did it commit?" check passes.
+ *
+ * So the redaction tests assert on the BYTES WRITTEN TO DISK, not on the return
+ * value of `redact()`. `redact()` being correct and `exportSnapshot()` not
+ * calling it on some path is exactly the shape of failure a unit test of the
+ * pure function cannot see.
+ *
+ * The D1 layer is faked at `fetchImpl`. Nothing here touches the network, and
+ * the fake answers by inspecting the SQL, so a query that stops selecting a
+ * column gets an undefined back rather than a silently correct-looking row.
+ */
+
+const test = require('node:test');
+const { before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+let X;
+before(async () => {
+  X = await import('../scripts/export_d1_snapshot.mjs');
+});
+
+/** A `locations` row as D1 returns it: authors is a JSON string, not an array. */
+const row = (over = {}) => ({
+  id: 'aaaa-1111',
+  name: 'Cliffside Abode',
+  nexus_id: '26046',
+  category: 'new-location',
+  x: -2229.5732,
+  y: 3618.9644,
+  z: 12.2151,
+  yaw: -121.2,
+  description: 'Custom standalone home.',
+  credits: 'B1W',
+  authors: '["B1W"]',
+  status: 'published',
+  added_at: '2026-03-07T00:00:00Z',
+  modified_at: '2026-07-26T00:00:00Z',
+  ...over,
+});
+
+/**
+ * A fake D1 endpoint over in-memory tables. Dispatches on the table named in
+ * the SQL and applies the LIMIT/OFFSET the pager asked for, so the paging code
+ * is exercised rather than stubbed past.
+ */
+function fakeD1(tables = {}) {
+  const calls = [];
+  const fetchImpl = async (url, init) => {
+    const { sql } = JSON.parse(init.body);
+    calls.push({ url, sql });
+    const name = ['location_tags', 'locations', 'dismissed_candidates', 'tags', 'audit_log']
+      .find((t) => new RegExp(`FROM ${t}\\b`).test(sql));
+    let rows = tables[name] ?? [];
+    const gt = sql.match(/WHERE id > (\d+)/);
+    if (gt) rows = rows.filter((r) => r.id > Number(gt[1]));
+    const [, limit, offset] = sql.match(/LIMIT (\d+) OFFSET (\d+)/).map(Number);
+    return {
+      ok: true,
+      json: async () => ({
+        success: true,
+        result: [{ results: rows.slice(offset, offset + limit) }],
+      }),
+    };
+  };
+  return { fetchImpl, calls, deps: { fetchImpl, token: 't', accountId: 'a', databaseId: 'd' } };
+}
+
+function tmpdir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ncz-snap-'));
+}
+
+// ── locationFile ────────────────────────────────────────────────────────────
+
+test('a NULL z produces a two-element coordinate pair, not a trailing null', () => {
+  assert.deepEqual(X.locationFile(row({ z: null })).coordinates, [-2229.5732, 3618.9644]);
+});
+
+test('a NULL yaw omits the key rather than emitting null', () => {
+  assert.equal('yaw' in X.locationFile(row({ yaw: null })), false);
+});
+
+test('NULL credits omits the key, matching what the importer reads back', () => {
+  assert.equal('credits' in X.locationFile(row({ credits: null })), false);
+});
+
+test('the key order is fixed, so an unchanged record produces no diff', () => {
+  assert.deepEqual(Object.keys(X.locationFile(row(), ['house'])), [
+    'id', 'name', 'nexus_id', 'category', 'coordinates', 'yaw',
+    'tags', 'authors', 'credits', 'description', 'status', 'added_at', 'modified_at',
+  ]);
+});
+
+test('tags are sorted, so the join returning them in another order is not a diff', () => {
+  assert.deepEqual(X.locationFile(row(), ['neokitsch', 'house']).tags, ['house', 'neokitsch']);
+});
+
+test('the registry timestamps are exported (a restore cannot recover them otherwise)', () => {
+  const f = X.locationFile(row());
+  assert.equal(f.added_at, '2026-03-07T00:00:00Z');
+  assert.equal(f.modified_at, '2026-07-26T00:00:00Z');
+});
+
+// ── redact ──────────────────────────────────────────────────────────────────
+
+test('admin_notes is replaced at the top level', () => {
+  assert.equal(X.redact({ id: 'x', admin_notes: 'author is unresponsive' }).admin_notes, X.REDACTED);
+});
+
+test('admin_notes is replaced when nested inside a submission payload', () => {
+  const out = X.redact({ kind: 'edit', payload: { name: 'ok', admin_notes: 'secret' } });
+  assert.equal(out.payload.admin_notes, X.REDACTED);
+  assert.equal(out.payload.name, 'ok');
+});
+
+test('redaction reaches inside arrays', () => {
+  const out = X.redact({ items: [{ reason: 'low quality' }, { reason: 'duplicate' }] });
+  assert.deepEqual(out.items, [{ reason: X.REDACTED }, { reason: X.REDACTED }]);
+});
+
+test('a redacted key is replaced, not deleted (absent would read as "had none")', () => {
+  const out = X.redact({ admin_notes: 'note' });
+  assert.equal('admin_notes' in out, true);
+});
+
+test('every key on the deny-list is actually stripped', () => {
+  const input = Object.fromEntries(X.REDACTED_KEYS.map((k) => [k, 'sensitive']));
+  const out = X.redact(input);
+  for (const k of X.REDACTED_KEYS) assert.equal(out[k], X.REDACTED, `${k} survived redaction`);
+});
+
+test('fields that are not on the deny-list pass through untouched', () => {
+  assert.deepEqual(X.redact({ name: 'Cliffside', x: 1, tags: ['house'], z: null }), {
+    name: 'Cliffside', x: 1, tags: ['house'], z: null,
+  });
+});
+
+// ── auditLine ───────────────────────────────────────────────────────────────
+
+test('before/after are parsed so redaction can reach inside them', () => {
+  const line = X.auditLine({
+    id: 7, at: 'now', actor: 'spuddeh', action: 'location.update', target: 'x',
+    before: JSON.stringify({ admin_notes: 'old' }), after: JSON.stringify({ admin_notes: 'new' }),
+  });
+  assert.equal(line.before.admin_notes, X.REDACTED);
+  assert.equal(line.after.admin_notes, X.REDACTED);
+});
+
+test('an unparseable payload is withheld, never passed through unredacted', () => {
+  const line = X.auditLine({ id: 1, at: 'now', actor: 'a', action: 'x', before: '{not json' });
+  assert.equal(line.before, '[unparseable]');
+});
+
+test('a null payload stays null rather than becoming a redaction marker', () => {
+  const line = X.auditLine({ id: 1, at: 'now', actor: 'a', action: 'x', before: null, after: null });
+  assert.equal(line.before, null);
+  assert.equal(line.after, null);
+});
+
+// ── excludedFile / tagsFile ─────────────────────────────────────────────────
+
+test('dismissed ids export as a bare array, with the reasons gone', () => {
+  const out = X.excludedFile([{ nexus_id: '29860', reason: 'minor interior change' }]);
+  assert.deepEqual(out, ['29860']);
+});
+
+test('numeric ids sort numerically, so adding one does not reshuffle the file', () => {
+  assert.deepEqual(X.excludedFile([{ nexus_id: '1000' }, { nexus_id: '99' }]), ['99', '1000']);
+});
+
+test('tags export as full rows, keeping name and sort_order the flat map cannot hold', () => {
+  const out = X.tagsFile([
+    { slug: 'b', name: null, description: 'B', sort_order: 2, created_at: 'c', updated_at: 'u' },
+    { slug: 'a', name: 'Alpha', description: 'A', sort_order: 1, created_at: 'c', updated_at: 'u' },
+  ]);
+  assert.deepEqual(out.map((t) => t.slug), ['a', 'b']);
+  assert.equal(out[0].name, 'Alpha');
+  assert.equal(out[0].sort_order, 1);
+});
+
+// ── lastAuditId ─────────────────────────────────────────────────────────────
+
+test('a fresh snapshot resumes from 0', () => {
+  assert.equal(X.lastAuditId(''), 0);
+});
+
+test('the cursor is the highest id in the file, not the last line', () => {
+  const text = '{"id":5}\n{"id":9}\n{"id":7}\n';
+  assert.equal(X.lastAuditId(text), 9);
+});
+
+test('a truncated final line does not push the cursor past rows never written', () => {
+  const text = '{"id":5}\n{"id":9}\n{"id":1';
+  assert.equal(X.lastAuditId(text), 9);
+});
+
+// ── d1Query ─────────────────────────────────────────────────────────────────
+
+test('a 200 with success:false is an error, and the message names the endpoint', async () => {
+  const fetchImpl = async () => ({
+    ok: true,
+    json: async () => ({ success: false, errors: [{ message: 'Authentication error', code: 10000 }] }),
+  });
+  await assert.rejects(
+    () => X.d1Query('SELECT 1', [], { fetchImpl, token: 't', accountId: 'acc', databaseId: 'db' }),
+    (err) => {
+      assert.match(err.message, /\/accounts\/acc\/d1\/database\/db\/query/);
+      assert.match(err.message, /code: 10000/);
+      assert.match(err.message, /D1 → Read/);
+      return true;
+    },
+  );
+});
+
+test('a missing token fails before any request is made', async () => {
+  await assert.rejects(
+    () => X.d1Query('SELECT 1', [], { fetchImpl: () => assert.fail('should not fetch'), token: '' }),
+    /CLOUDFLARE_API_TOKEN is not set/,
+  );
+});
+
+// ── exportSnapshot: the end-to-end claims ───────────────────────────────────
+
+test('an empty locations table is refused rather than blanking the snapshot', async () => {
+  const { deps } = fakeD1({ locations: [] });
+  await assert.rejects(
+    () => X.exportSnapshot({ outDir: tmpdir(), deps }),
+    /refusing to export/,
+  );
+});
+
+test('the written file carries no admin note, however the export got there', async () => {
+  const out = tmpdir();
+  const { deps } = fakeD1({
+    locations: [row({ admin_notes: 'author is unresponsive' })],
+    audit_log: [{
+      id: 1, at: 'now', actor: 'spuddeh', action: 'location.update', target: 'aaaa-1111',
+      before: JSON.stringify({ admin_notes: 'author is unresponsive' }), after: null,
+    }],
+    dismissed_candidates: [{ nexus_id: '29860', reason: 'minor interior change' }],
+  });
+  await X.exportSnapshot({ outDir: out, deps });
+
+  const tree = fs.readdirSync(path.join(out, 'data', 'locations'))
+    .map((f) => fs.readFileSync(path.join(out, 'data', 'locations', f), 'utf8'))
+    .concat(
+      fs.readFileSync(path.join(out, 'data', 'audit_log.jsonl'), 'utf8'),
+      fs.readFileSync(path.join(out, 'data', 'excluded_mods.json'), 'utf8'),
+    )
+    .join('\n');
+
+  assert.equal(tree.includes('author is unresponsive'), false, 'an admin note reached the snapshot');
+  assert.equal(tree.includes('minor interior change'), false, 'a dismissal reason reached the snapshot');
+});
+
+test('a record deleted from D1 is deleted from the snapshot', async () => {
+  const out = tmpdir();
+  fs.mkdirSync(path.join(out, 'data', 'locations'), { recursive: true });
+  fs.writeFileSync(path.join(out, 'data', 'locations', 'gone-9999.json'), '{}');
+
+  const { deps } = fakeD1({ locations: [row()] });
+  const summary = await X.exportSnapshot({ outDir: out, deps });
+
+  assert.equal(summary.deleted, 1);
+  assert.equal(fs.existsSync(path.join(out, 'data', 'locations', 'gone-9999.json')), false);
+  assert.equal(fs.existsSync(path.join(out, 'data', 'locations', 'aaaa-1111.json')), true);
+});
+
+test('the audit log is appended to, and an unchanged night appends nothing', async () => {
+  const out = tmpdir();
+  const tables = {
+    locations: [row()],
+    audit_log: [{ id: 1, at: 'a', actor: 'x', action: 'y', target: null, before: null, after: null }],
+  };
+  const auditPath = path.join(out, 'data', 'audit_log.jsonl');
+
+  const first = await X.exportSnapshot({ outDir: out, deps: fakeD1(tables).deps });
+  assert.equal(first.auditAppended, 1);
+  const afterFirst = fs.readFileSync(auditPath, 'utf8');
+
+  // Second run, same database. Nothing new above id 1.
+  const second = await X.exportSnapshot({ outDir: out, deps: fakeD1(tables).deps });
+  assert.equal(second.fromAuditId, 1, 'the cursor was not read back from the file');
+  assert.equal(second.auditAppended, 0);
+  assert.equal(fs.readFileSync(auditPath, 'utf8'), afterFirst, 'the log was rewritten, not appended');
+
+  // A new row appends without disturbing what is already there.
+  tables.audit_log.push({ id: 2, at: 'b', actor: 'x', action: 'y', target: null, before: null, after: null });
+  const third = await X.exportSnapshot({ outDir: out, deps: fakeD1(tables).deps });
+  assert.equal(third.auditAppended, 1);
+  assert.equal(fs.readFileSync(auditPath, 'utf8').startsWith(afterFirst), true);
+});
+
+test('two identical runs produce byte-identical files, so a quiet night has no diff', async () => {
+  const out = tmpdir();
+  const tables = { locations: [row(), row({ id: 'bbbb-2222', name: 'Second' })] };
+  await X.exportSnapshot({ outDir: out, deps: fakeD1(tables).deps });
+  const snap = (f) => fs.readFileSync(path.join(out, 'data', f), 'utf8');
+  const before = [snap('locations/aaaa-1111.json'), snap('excluded_mods.json'), snap('tags.json')];
+  await X.exportSnapshot({ outDir: out, deps: fakeD1(tables).deps });
+  assert.deepEqual([snap('locations/aaaa-1111.json'), snap('excluded_mods.json'), snap('tags.json')], before);
+});
+
+test('every table is paged, so a registry larger than one page is exported whole', async () => {
+  const out = tmpdir();
+  const many = Array.from({ length: 501 }, (_, i) => row({ id: `id-${String(i).padStart(4, '0')}` }));
+  const { deps, calls } = fakeD1({ locations: many });
+  const summary = await X.exportSnapshot({ outDir: out, deps });
+  assert.equal(summary.locations, 501);
+  assert.equal(fs.readdirSync(path.join(out, 'data', 'locations')).length, 501);
+  assert.equal(calls.filter((c) => /FROM locations\b/.test(c.sql)).length, 2);
+});

--- a/worker/scripts/import-locations.mjs
+++ b/worker/scripts/import-locations.mjs
@@ -1,6 +1,21 @@
 /**
- * One-time Phase 1 import: data/locations/*.json + the live auto-discovered
- * records -> D1 `locations`; data/excluded_mods.json -> `dismissed_candidates`.
+ * Registry import: data/locations/*.json + the live auto-discovered records ->
+ * D1 `locations`; data/excluded_mods.json -> `dismissed_candidates`.
+ *
+ * TWO CALLERS, and the difference between them is `--files-only`:
+ *
+ * 1. The Phase 1 migration (the default). Manual records come from the JSON
+ *    files, auto-discovered ones from the live API, because at that moment the
+ *    nine `nexus-` records exist only in the running system.
+ * 2. DISASTER RECOVERY from the `data-snapshots` branch (`--files-only`), where
+ *    all 297 are files. Fetching the live API there would re-add the nine and
+ *    die on the primary key, and there may be no live API to fetch from: that
+ *    is the situation a restore is for.
+ *
+ *   node worker/scripts/import-locations.mjs --files-only \
+ *     --data ../snapshot/data --out worker/.import/restore.sql
+ *
+ * `--data <dir>` points at a snapshot checkout instead of the working tree.
  *
  * Emits SQL rather than executing it, for three reasons: the 296 rows are
  * reviewable before they land, `wrangler d1 execute --file` is the same command
@@ -31,9 +46,16 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
-const LOCATIONS_DIR = path.join(REPO_ROOT, 'data', 'locations');
-const EXCLUDED_FILE = path.join(REPO_ROOT, 'data', 'excluded_mods.json');
 const LIVE_API = process.env.NCZ_API_ORIGIN || 'https://api.nczoning.net';
+
+/** Resolved from `--data`; defaults to the working tree's own data directory. */
+function dataPaths(dataDir) {
+  return {
+    locations: path.join(dataDir, 'locations'),
+    excluded: path.join(dataDir, 'excluded_mods.json'),
+    tags: path.join(dataDir, 'tags.json'),
+  };
+}
 
 /**
  * SQLite string literal. Doubling the single quote is the whole escape --
@@ -79,9 +101,13 @@ function toRow(rec, stamp) {
     // Not a column any more (migration 0007). Carried on the row because
     // insertLocationTags reads it to build the join.
     tags: JSON.stringify(rec.tags ?? []),
-    status: 'published',
-    added_at: stamp,
-    modified_at: stamp,
+    // A snapshot file carries all three; a Phase 1 source file carries none.
+    // `stamp` is honest for the second case ("this is when it became a row") and
+    // wrong for the first: a restore that stamps every record with the restore
+    // time discards the dates #906 recovered from git history.
+    status: rec.status ?? 'published',
+    added_at: rec.added_at ?? stamp,
+    modified_at: rec.modified_at ?? stamp,
   };
 }
 
@@ -121,11 +147,11 @@ function insertLocationTags(row) {
   ];
 }
 
-/** Manual records: one JSON file each, UUID filenames. */
-function readManual(stamp) {
-  const files = fs.readdirSync(LOCATIONS_DIR).filter((f) => f.endsWith('.json'));
+/** Records held as files: one JSON file each, `<id>.json`. */
+function readFiles(dir, stamp) {
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith('.json'));
   return files.map((f) => {
-    const rec = JSON.parse(fs.readFileSync(path.join(LOCATIONS_DIR, f), 'utf8'));
+    const rec = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'));
     return toRow(rec, stamp);
   });
 }
@@ -149,27 +175,73 @@ async function readAuto(stamp) {
  * a location, so it becomes a dismissal, not a `locations` row with a special
  * status. `dismissed_by` is 'system': the repo records no author for these, and
  * inventing one would be a fabrication.
+ *
+ * TWO SHAPES, and getting this wrong corrupts rather than crashes. The repo file
+ * is `{ "29860": "reason" }`; the snapshot branch's is a bare `["29860"]`,
+ * because the reasons are admin-only and redacted out of the export. Running
+ * Object.entries over the array form yields `["0", "29860"]`, which imports a
+ * dismissal for nexus id `0` and loses the real one, silently.
  */
-function readDismissed(stamp) {
-  const excluded = JSON.parse(fs.readFileSync(EXCLUDED_FILE, 'utf8'));
-  return Object.entries(excluded).map(([nexusId, reason]) => (
+function readDismissed(file, stamp) {
+  const excluded = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const entries = Array.isArray(excluded)
+    ? excluded.map((id) => [String(id), null])
+    : Object.entries(excluded);
+  return entries.map(([nexusId, reason]) => (
     `INSERT INTO dismissed_candidates (nexus_id, reason, dismissed_by, dismissed_at) `
     + `VALUES (${sql(nexusId)}, ${sql(reason)}, ${sql('system')}, ${sql(stamp)});`
   ));
 }
 
+/**
+ * The tag registry, in whichever shape the source file uses.
+ *
+ * Repo file:     `{ slug: description }`      (predates `name` and `sort_order`)
+ * Snapshot file: `[{ slug, name, description, sort_order, ... }]`
+ *
+ * Returns `{ slugs, statements }`. `slugs` is what the unknown-tag warning
+ * checks against. `statements` restores the registry itself and is emitted ONLY
+ * for the full-row shape: migration 0002 seeds the tags as they stood on
+ * 2026-07-26, so a restore from a later snapshot would otherwise silently drop
+ * every tag curated in the dashboard since, and every location_tags link that
+ * referenced one. The flat shape cannot carry `name`/`sort_order`, so importing
+ * from it would overwrite curated values with nulls; it stays read-only.
+ */
+function readTags(file) {
+  const parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
+  if (!Array.isArray(parsed)) {
+    return { slugs: new Set(Object.keys(parsed)), statements: [] };
+  }
+  return {
+    slugs: new Set(parsed.map((t) => t.slug)),
+    statements: parsed.map((t) => (
+      'INSERT OR REPLACE INTO tags (slug, name, description, sort_order, created_at, updated_at) '
+      + `VALUES (${sql(t.slug)}, ${sql(t.name ?? null)}, ${sql(t.description)}, `
+      + `${sql(t.sort_order ?? null)}, ${sql(t.created_at)}, ${sql(t.updated_at)});`
+    )),
+  };
+}
+
+function arg(name) {
+  const i = process.argv.indexOf(name);
+  return i === -1 ? null : process.argv[i + 1] ?? null;
+}
+
 async function main() {
-  const outIdx = process.argv.indexOf('--out');
-  if (outIdx === -1 || !process.argv[outIdx + 1]) {
-    console.error('usage: import-locations.mjs --out <file.sql>');
+  const out = arg('--out');
+  if (!out) {
+    console.error('usage: import-locations.mjs --out <file.sql> [--files-only] [--data <dir>]');
     process.exit(1);
   }
-  const outPath = path.resolve(process.argv[outIdx + 1]);
+  const outPath = path.resolve(out);
+  const filesOnly = process.argv.includes('--files-only');
+  const dataDir = path.resolve(arg('--data') ?? path.join(REPO_ROOT, 'data'));
+  const paths = dataPaths(dataDir);
   const stamp = new Date().toISOString();
 
-  const manual = readManual(stamp);
-  const auto = await readAuto(stamp);
-  const rows = [...manual, ...auto];
+  const fromFiles = readFiles(paths.locations, stamp);
+  const auto = filesOnly ? [] : await readAuto(stamp);
+  const rows = [...fromFiles, ...auto];
 
   // Duplicate ids would be caught by the primary key on execute, but failing
   // here names both records instead of just the id.
@@ -179,15 +251,12 @@ async function main() {
     seen.set(r.id, r.name);
   }
 
-  const dismissed = readDismissed(stamp);
+  const dismissed = readDismissed(paths.excluded, stamp);
 
   // Tags the registry will drop. The filter runs in SQL against the target
   // database, so this script cannot refuse them, but a silent truncation would
-  // leave a location quietly short a tag nobody asked to remove. data/tags.json
-  // is the offline mirror of the registry and retires with it at phase 6.
-  const known = new Set(Object.keys(
-    JSON.parse(fs.readFileSync(path.join(REPO_ROOT, 'data', 'tags.json'), 'utf8')),
-  ));
+  // leave a location quietly short a tag nobody asked to remove.
+  const { slugs: known, statements: tagRows } = readTags(paths.tags);
   const unknown = new Map();
   for (const r of rows) {
     for (const t of JSON.parse(r.tags)) {
@@ -201,14 +270,21 @@ async function main() {
   );
 
   const body = [
-    `-- Phase 1 seed, generated ${stamp} by worker/scripts/import-locations.mjs`,
-    `-- ${manual.length} manual + ${auto.length} auto = ${rows.length} locations,`,
+    `-- Generated ${stamp} by worker/scripts/import-locations.mjs`,
+    `-- source: ${dataDir}${filesOnly ? ' (--files-only, no live API read)' : ` + ${LIVE_API}`}`,
+    `-- ${fromFiles.length} file(s) + ${auto.length} auto = ${rows.length} locations,`,
     `-- ${dismissed.length} dismissed candidate(s). Plain INSERTs: re-running fails.`,
     `-- ${tagLinks.length} location(s) carry tags, ${expectedLinks} link(s) expected in`,
-    '-- location_tags, assuming the target registry matches data/tags.json.',
+    '-- location_tags, assuming the target registry matches tags.json.',
     '',
     ...rows.map(insertLocation),
     '',
+    // Before the join, so the `IN (SELECT slug FROM tags)` filter below sees the
+    // registry as the snapshot recorded it rather than as migration 0002 seeded
+    // it. Empty when the source file is the legacy flat map (see readTags).
+    ...(tagRows.length
+      ? ['-- The tag registry as at the snapshot. Overwrites migration 0002\'s seed.', ...tagRows, '']
+      : []),
     '-- The join. Without these the materializer serves every location untagged.',
     ...tagLinks,
     '',
@@ -227,12 +303,13 @@ async function main() {
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
   fs.writeFileSync(outPath, body);
   console.log(
-    `wrote ${outPath}\n  ${manual.length} manual + ${auto.length} auto = ${rows.length} locations`
+    `wrote ${outPath}\n  ${fromFiles.length} file(s) + ${auto.length} auto = ${rows.length} locations`
     + `\n  ${dismissed.length} dismissed candidate(s)`
-    + `\n  ${expectedLinks} tag link(s) across ${tagLinks.length} location(s)`,
+    + `\n  ${expectedLinks} tag link(s) across ${tagLinks.length} location(s)`
+    + `\n  ${tagRows.length} tag registry row(s) restored`,
   );
   if (unknown.size) {
-    console.warn(`\n  WARNING: ${unknown.size} tag(s) are not in data/tags.json and the`);
+    console.warn(`\n  WARNING: ${unknown.size} tag(s) are not in ${paths.tags} and the`);
     console.warn('  registry filter will drop them, leaving those locations short a tag:');
     for (const [t, n] of unknown) console.warn(`    ${t} (on ${n} record(s))`);
   }

--- a/worker/src/alerts.js
+++ b/worker/src/alerts.js
@@ -27,8 +27,16 @@
  * second failure, and it must never mask the one it is reporting.
  */
 
-/** Recognised sources, matching the `source` column comment in migration 0001. */
-export const ALERT_SOURCES = ['api-health', 'refresh', 'submissions', 'quota'];
+/**
+ * Recognised sources, matching the `source` column comment in migration 0001.
+ *
+ * `export` is the nightly D1 snapshot (`.github/workflows/export-d1-snapshot.yml`),
+ * which posts through `/internal/alerts` like the health monitor does. It is its
+ * own source rather than folded into `refresh`: the 5-minute dataset cron and the
+ * nightly git mirror fail for unrelated reasons and are fixed in different places,
+ * and the dashboard's source filter is how they are told apart.
+ */
+export const ALERT_SOURCES = ['api-health', 'refresh', 'submissions', 'quota', 'export'];
 
 /** Recognised severities, matching the `severity` column comment. */
 export const ALERT_SEVERITIES = ['info', 'warn', 'error', 'recovery'];

--- a/worker/test/alerts.test.js
+++ b/worker/test/alerts.test.js
@@ -11,7 +11,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   raiseAlert, recordAlert, readAlerts, countUnacknowledged, acknowledgeAlert,
-  alertedSinceUtcMidnight, validateAlertInput,
+  alertedSinceUtcMidnight, validateAlertInput, ALERT_SOURCES,
 } from '../src/alerts.js';
 import { handleInternal } from '../src/internal.js';
 import { sqliteD1 } from '../test-support/d1-sqlite.mjs';
@@ -210,6 +210,19 @@ test('an unknown source or severity is refused, not stored', () => {
   assert.equal(validateAlertInput({ ...ALERT, severity: 'catastrophic' }).ok, false);
   assert.equal(validateAlertInput({ ...ALERT, title: '   ' }).ok, false);
   assert.equal(validateAlertInput(ALERT).ok, true);
+});
+
+test('every declared source is accepted, so no producer is rejected at the door', () => {
+  for (const source of ALERT_SOURCES) {
+    assert.equal(validateAlertInput({ ...ALERT, source }).ok, true, `${source} was refused`);
+  }
+});
+
+test('the nightly snapshot export can raise an alert under its own source', () => {
+  // The workflow posts source:'export' to /internal/alerts. A source missing
+  // from the allow-list is a 400, which turns a failed backup into a silent one.
+  assert.equal(ALERT_SOURCES.includes('export'), true);
+  assert.equal(validateAlertInput({ ...ALERT, source: 'export' }).ok, true);
 });
 
 // ----------------------------------------------------------- /internal/alerts --


### PR DESCRIPTION
Part C of the D1 programme. Closes the last item blocking Phase 6.

## Why now, rather than "before Phase 6 deletes anything"

The git mirror is **already incomplete**, and has been since the cutover:

| | count |
| --- | --- |
| live D1 records | 297 |
| of which `nexus-` (auto-discovered, never existed as files) | 9 |
| files in `data/locations/` | 288 |
| dismissed candidates in D1 | 2 |
| entries in `data/excluded_mods.json` | 1 |

Ten records exist in D1 and nowhere else. Until this lands, D1 Time Travel's 30
days is their only backup.

## What this adds

- **`scripts/export_d1_snapshot.mjs`** reads the registry over the D1 HTTP API
  and writes a working tree. It does not commit; the workflow does, only if the
  diff is non-empty, so a quiet night produces no commit.
- **`.github/workflows/export-d1-snapshot.yml`**, nightly at 16:17 UTC plus
  `workflow_dispatch`, committing to `data-snapshots`.
- **`data-snapshots`**, an orphan branch (root commit `5e3eb62`), no shared
  history with `main` or `dev`, already pushed. It is never merged, so it cannot
  conflict and cannot drift.
- **`export` as an alert source**, so a failed backup is recorded in D1 and
  shown in the dashboard rather than only going red in Actions.

## Redaction

`admin_notes` and dismissal reasons never reach the branch, **including inside
the `before`/`after` payloads of the exported audit log**, which carry them
verbatim in D1. Accepted consequence, stated in the plan: those two fields have
no git backup.

The deny-list is wider than those two (`review_note`, `submitter_*`). A
deny-list that covers only what leaks today is one refactor from being wrong,
and the failure mode is publishing.

## Three deviations from the Part C spec, each deliberate

1. **REST, not `wrangler d1 execute --json`.** The spec's command returns 7403.
   Dropping `--json` works and prints JSON anyway, which makes the working
   invocation the one whose output format is undocumented.
2. **`added_at` / `modified_at` are exported**, which "today's layout plus
   `status`" would have dropped. #906 recovered those dates from git history;
   an export without them restores 297 records all stamped with the restore
   time. 212 records have a `modified_at` that differs from `added_at`.
3. **`tags.json` is an array of full rows**, not the legacy `{slug: description}`
   map, which cannot hold `name` or `sort_order`. Both are curated in the
   dashboard.

## The importer was broken for the restore path

Found by reading it, not by the spec, which says the restore path is "built and
exercised". It is built and exercised for the *migration*, which is a different
job:

- `readManual()` reads the files **and** `readAuto()` fetches the live API. On a
  snapshot all 297 are files, so a restore imports the nine `nexus-` records
  twice. Negative control, the same restore without the new `--files-only`:
  `Error: duplicate id nexus-27618`.
- `readDismissed()` runs `Object.entries` over `excluded_mods.json` expecting
  `{id: reason}`. The export writes a bare array, because the reasons are
  redacted. `Object.entries(["26743"])` yields `["0", "26743"]`: it imports a
  dismissal for nexus id `0` and loses the real one. Corruption, not a crash.
- Migration 0002 seeds the tags as at 2026-07-26, so a restore from a later
  snapshot silently drops every tag curated since, and every `location_tags`
  link referencing one.

`--files-only`, `--data <dir>`, both file shapes accepted, and a full-row
`tags.json` now restores the registry itself.

## Verification

**Round trip, on real production data.** Production D1 dumped, the *shipped*
export code run over it, then `import-locations.mjs --files-only`, then the
generated SQL executed into a throwaway database built from migrations 0001-0007:

```
restored: { locations: 297, links: 572, dismissed: 2, tags: 14, untagged: 25 }
auto-discovered records restored: 9 (expected 9)
admin_notes restored: 0, dismissal reasons restored: 0
212 record(s) have a modified_at that differs from added_at
ROUND TRIP OK
```

Every figure matches production exactly.

**Redaction checked against the bytes on disk**, not against `redact()`'s return
value. Production has no `admin_notes` rows yet, so a canary note and a
real-shaped audit row carrying it were injected into the dump; the two dismissal
reasons are genuine. None of the four strings appears in any of the 300 written
files.

**The tests were proved able to fail**, by mutation:

| mutation | tests that went red |
| --- | --- |
| `auditLine` skips `redact` | 2 (the unit test and the on-disk one) |
| stale-file delete removed | 1 |
| audit append changed to rewrite | 1 |

Suites: site 52 → 81, worker 339 → 341. Both green.

**The SQL was validated against production**, column by column, because 0005,
0006 and 0007 renamed or dropped four of them.

## Not done, and this is not finished without them

- [ ] **Pages preview branch control → build only `dev`** (Cloudflare dashboard,
      Settings → Builds & deployments → Branch control). Pages builds every
      non-production branch by default and will deploy a preview of
      `data-snapshots` nightly. Not a repo change, so nothing here can enforce it.
- [ ] **`workflow_dispatch` twice**: first run commits, second commits nothing.
      GitHub only registers `workflow_dispatch` from the default branch, so this
      cannot run until the workflow reaches `main` (404 confirmed on this branch).
- [ ] **`CLOUDFLARE_API_TOKEN` needs Account → D1 → Read.** Unverifiable from
      here. If it is missing, the first run fails with
      `Authentication error [code: 10000]` naming `/d1/database/.../query`.

Phase 6 stays blocked until the first two are done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
