### PR TITLE
fix(review): guard an approved edit against the record moving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Approving an edit can no longer silently overwrite an admin's change.** A submission now records the version of the location it was written against, and approving it applies only while the record still carries that version.
+- A refused approval says what changed, leaves the submission pending, and offers to apply it over the current record — which is still a guarded write, not a force.
+
 ## [2.2.0] - 2026-08-01
 
 The registry gets a backup again. When locations moved into the database, the

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -275,6 +275,14 @@
           return ['error', 'This record changed after you opened it, so nothing was saved. '
             + 'The current version has been loaded; reapply your change and save again.'];
         }
+        // The fallback only. An approval refused this way is handled where it
+        // happens, because the submission is still pending and the reviewer can
+        // approve it over the current record; see staleSubmission.
+        if (res.body?.error === 'stale_submission') {
+          return ['warn', 'The location changed after this submission was made, so nothing was '
+            + 'applied and the submission is still pending. Reload and review it against the '
+            + 'current record.'];
+        }
         return ['error', res.body?.error === 'tag_exists'
           ? `A tag with the slug "${res.body.slug}" already exists.`
           : res.body?.detail || 'Conflict. Nothing was changed.'];
@@ -1549,15 +1557,56 @@
       reasonEl.focus();
       return banner('warn', 'Give a reason. It is the only record of why this was turned down, and "no" on its own is not one.');
     }
+    return sendReview(sub, action, reason ? { reason } : {}, button);
+  }
 
+  /**
+   * The record moved after the submission was made, so the approval was
+   * refused and nothing was written. The submission is still pending.
+   *
+   * Reloading first is not politeness: the diff is drawn against the location
+   * list, so until that is refreshed the reviewer is reading the approval
+   * against the very values it was refused for. Apply anyway re-sends against
+   * the version now on screen, which means a third admin saving in between is
+   * still caught rather than silently overwritten.
+   */
+  async function staleSubmission(sub, action, body, current) {
+    await loadLocations();
+    await loadQueue();
+    // Clears the banner, so the banner is set after it. Same trap as saveLocation.
+    selectSubmission(sub.id);
+
+    const onScreen = state.locations.find((l) => l.id === current.id) ?? current;
+    banner('warn',
+      `"${onScreen.name}" changed after this submission was made, so nothing was applied. `
+      + 'What it changes now compares against the current record. ',
+      h('button', {
+        class: 'btn', type: 'button', text: 'Apply anyway',
+        title: 'Approves this submission over the record as it stands now, which replaces whatever changed.',
+        onclick: (e) => sendReview(
+          sub, action, { ...body, base_modified_at: onScreen.modified_at }, e.currentTarget,
+        ),
+      }));
+  }
+
+  /**
+   * One review request and everything that follows from the answer.
+   *
+   * Split out from reviewAction because the stale-submission retry re-sends the
+   * same decision after the queue has been reloaded, and by then the textarea
+   * the reason was typed into no longer exists.
+   */
+  async function sendReview(sub, action, body, button) {
     button.disabled = true;
-    const res = await api(`/admin/submissions/${sub.id}/${action}`, {
-      method: 'POST',
-      body: reason ? { reason } : {},
-    });
+    const res = await api(`/admin/submissions/${sub.id}/${action}`, { method: 'POST', body });
     button.disabled = false;
 
     if (!res.ok) {
+      // Its own path rather than a message: nothing was written, the submission
+      // is still pending, and there is something the reviewer can do about it.
+      if (res.body?.error === 'stale_submission' && res.body.current) {
+        return staleSubmission(sub, action, body, res.body.current);
+      }
       const [kind, message] = describeFailure(res);
       banner(kind, message);
       // Someone else got there first, or the payload can no longer be applied.
@@ -2196,7 +2245,12 @@
           return ['approved submission #', target, ' by restoring ',
             quoted(name ?? 'a hidden record'), ' rather than creating a second one'];
         }
-        return ['approved submission #', target, name ? [', applied to ', quoted(name)] : ''];
+        return ['approved submission #', target, name ? [', applied to ', quoted(name)] : '',
+          // The reviewer approved over a record that had moved since the
+          // submission was made. The before/after pair says what changed; this
+          // says it was a decision rather than the silent overwrite this
+          // approval would have been before the guard existed.
+          after.base_override ? ', over a newer version of the record' : ''];
       }
       case 'submission.reject': {
         const note = shortNote(after.review_note);

--- a/worker/migrations/0008_submission_base_modified_at.sql
+++ b/worker/migrations/0008_submission_base_modified_at.sql
@@ -1,0 +1,38 @@
+-- The version of the location a submission was written against.
+--
+-- WHY. A submission sits in the queue for as long as it takes someone to review
+-- it, and the registry does not stand still meanwhile. An admin fixes a typo on
+-- the record, the reviewer approves the older submission, and the submitter's
+-- stale values overwrite the fix with no error and no warning. The audit log
+-- records both writes, so the history survives; the person who made the fix is
+-- told nothing.
+--
+-- `patchLocation` has taken an `ifMatch` since the dashboard editor needed one
+-- (worker/src/registry.js). It could not be used from the review path because
+-- nothing recorded WHICH version the submitter saw. This column is that value:
+-- `locations.modified_at` as it stood when the submission was accepted.
+--
+-- THE NAME. Matches `locations.modified_at`, which is what it holds. NOT
+-- `base_updated_at`: migration 0006 exists specifically to kill the
+-- `updated_at` collision, because `updated_at` on a served /v1 record is the
+-- NEXUS mod date out of `nexus_cache`. Reintroducing that name here recreates
+-- the ambiguity that hid a bug once already.
+--
+-- NULL MEANS UNGUARDED, and that is deliberate rather than a gap:
+--   * a `create` submission has no base by construction -- `location_id` is
+--     NULL for a create, there is no record to be stale against, and the
+--     approval inserts rather than patches;
+--   * every submission accepted before this migration has no base either.
+-- Treating NULL as "apply regardless" keeps those approvable, which is the
+-- behaviour they have today. A NULL that refused would strand them.
+--
+-- NO BACKFILL. `submissions` held 0 rows in production at the time this ran
+-- (all statuses, checked 2026-08-01), so there is nothing to fill in and
+-- nothing pending to break.
+--
+-- CAPTURED FOR `remove` TOO, though approving a removal stays unguarded on
+-- purpose: an approved removal pulls the pin regardless of what else changed.
+-- The value is recorded because it is the honest answer to "what did the
+-- submitter see", and it costs one column read at submission time.
+
+ALTER TABLE submissions ADD COLUMN base_modified_at TEXT;

--- a/worker/src/registry.js
+++ b/worker/src/registry.js
@@ -184,8 +184,11 @@ export async function insertLocation(env, payload, nowIso = new Date().toISOStri
  * caller has already established the row exists, so the only way to miss is a
  * stale `ifMatch`.
  *
- * Omitting `ifMatch` is an unguarded write, which is correct for a caller that
- * genuinely means "apply this regardless" (see review.js).
+ * Omitting `ifMatch` is an unguarded write. That is correct only for a caller
+ * that genuinely means "apply this regardless": approving a REMOVAL, which
+ * pulls the pin whatever else changed, and restoring a hidden record, which has
+ * no competing version to lose. Approving an EDIT is guarded like any other
+ * write, on the version the submission was made against; see review.js.
  */
 export async function patchLocation(
   env, id, payload, nowIso = new Date().toISOString(), { ifMatch = null } = {},

--- a/worker/src/review.js
+++ b/worker/src/review.js
@@ -39,6 +39,19 @@
  * make. An admin who does want it gone can delete it afterwards from the
  * editor, deliberately.
  *
+ * ## An approved edit is guarded, and a removal is not
+ *
+ * A submission carries `base_modified_at`: the version of the location it was
+ * written against (migration 0008). Approving an `edit` applies the payload
+ * only while the record still carries that version, so an admin's edit made
+ * while the submission sat in the queue cannot be silently replaced by the
+ * submitter's older values. A refusal is `stale_submission`, and it leaves the
+ * submission PENDING with the current record attached, so the reviewer can see
+ * what they would have overwritten and approve again against that version.
+ *
+ * A `remove` is unguarded, and a NULL base is unguarded. Both are decisions,
+ * and both are stated where they apply rather than here.
+ *
  * ## What is never sent to the client
  *
  * `submitter_ip_hash`. It exists for the rate limit and for abuse triage
@@ -209,7 +222,7 @@ async function restoreInstead(env, submission, locationId, { actor, nowIso }) {
  * submission pending: a submission that could not be applied has not been
  * reviewed, and marking it approved anyway would lose it.
  */
-async function applyApproval(env, submission, { actor, nowIso, restoreLocationId }) {
+async function applyApproval(env, submission, { actor, nowIso, restoreLocationId, baseOverride }) {
   const payload = parsePayload(submission.payload);
 
   if (submission.kind === 'create') {
@@ -247,17 +260,36 @@ async function applyApproval(env, submission, { actor, nowIso, restoreLocationId
     const v = validateLocationInput(payload, { tagNames: await readTagSlugs(env), partial: true });
     if (!v.ok) return { error: 'validation_failed', errors: v.errors, status: 422 };
 
-    // Unguarded, and this one is a real trade-off rather than a non-issue.
-    // A submission is written against the record as it looked when the
+    // GUARDED. A submission is written against the record as it looked when the
     // submitter saw it, and approving applies it however long it sat in the
-    // queue. If an admin tidied the record meanwhile, approving reapplies the
-    // submitter's older values over that tidy-up. Guarding it properly needs
-    // the submission to record the version it was based on, which is a schema
-    // change; see the follow-up on #899. Until then the reviewer sees the diff
-    // before approving, which is the mitigation.
-    const patched = await patchLocation(env, submission.location_id, payload, nowIso);
+    // queue. Without this, an admin who tidied the record meanwhile has that
+    // tidy-up silently replaced by the submitter's older values.
+    //
+    // `base_modified_at` is what the submitter saw (migration 0008), and
+    // `baseOverride` is what the REVIEWER saw: after a refusal the dashboard
+    // reloads the record, shows the diff against its current values, and
+    // re-sends with that version. So the second attempt is still guarded, just
+    // rebased onto a version a human looked at, rather than a force flag that
+    // would lose a third admin's write landing in between.
+    //
+    // NULL applies unguarded, and must: a submission accepted before 0008 has
+    // no base, and one that refused would be unapprovable forever.
+    const ifMatch = baseOverride ?? submission.base_modified_at ?? null;
+    const patched = await patchLocation(env, submission.location_id, payload, nowIso, { ifMatch });
     if (patched.empty) {
       return { error: 'empty_patch', detail: 'this submission changes no field', status: 422 };
+    }
+    if (patched.conflict) {
+      // Nothing was written. The record comes back so the dashboard can show
+      // what this approval would have overwritten, and it is re-read rather
+      // than reusing `before`: the point of the refusal is that the row moves
+      // under this request, so the freshest read is the only honest one.
+      return {
+        error: 'stale_submission',
+        detail: `"${beforeRow.name}" changed after this submission was made, so nothing was applied`,
+        current: await loadAdminRecordById(env, submission.location_id),
+        status: 409,
+      };
     }
     const after = await loadAdminRecordById(env, submission.location_id);
     await writeAudit(env, {
@@ -312,6 +344,12 @@ async function act(request, env, ctx, { id, action, actor }) {
   if (body.restore_location_id !== undefined && typeof body.restore_location_id !== 'string') {
     errors.push('restore_location_id must be a string');
   }
+  // The version the REVIEWER is approving against, sent only on a second
+  // attempt after a `stale_submission` refusal. See applyApproval's edit branch.
+  if (body.base_modified_at !== undefined
+    && (typeof body.base_modified_at !== 'string' || !body.base_modified_at)) {
+    errors.push('base_modified_at must be a non-empty string');
+  }
   if (errors.length) return json(request, { error: 'invalid_review', errors }, 400);
 
   const row = await readSubmission(env, id);
@@ -324,6 +362,15 @@ async function act(request, env, ctx, { id, action, actor }) {
     return json(request, {
       error: 'invalid_review',
       errors: ['restore_location_id applies only to approving a create'],
+    }, 400);
+  }
+  // Same shape of mistake: a create inserts and a removal is unguarded on
+  // purpose, so neither has a base to rebase onto. Accepting the field there
+  // would read as a guard that is not running.
+  if (body.base_modified_at && !(action === 'approve' && row.kind === 'edit')) {
+    return json(request, {
+      error: 'invalid_review',
+      errors: ['base_modified_at applies only to approving an edit'],
     }, 400);
   }
   if (row.status !== PENDING) {
@@ -339,13 +386,20 @@ async function act(request, env, ctx, { id, action, actor }) {
   let applied = null;
   if (action === 'approve') {
     applied = await applyApproval(env, row, {
-      actor, nowIso, restoreLocationId: body.restore_location_id ?? null,
+      actor,
+      nowIso,
+      restoreLocationId: body.restore_location_id ?? null,
+      baseOverride: body.base_modified_at ?? null,
     });
     if (applied.error) {
+      // `current` is set only on a stale_submission. The reviewer has to see
+      // the record as it stands before deciding whether to approve over it.
+      // The submission is untouched and still pending: resolve() has not run.
       return json(request, {
         error: applied.error,
         detail: applied.detail,
         errors: applied.errors,
+        current: applied.current,
       }, applied.status);
     }
   }
@@ -378,6 +432,10 @@ async function act(request, env, ctx, { id, action, actor }) {
       // inserted nothing and an approval that inserted a record are different
       // events, and the log is the only place that distinction survives.
       granted_by: applied ? (applied.restored ? 'restore' : 'apply') : null,
+      // The reviewer approved an edit over a record that had moved since the
+      // submission was made. The before/after pair above shows what changed;
+      // this says the overwrite was a decision rather than a race.
+      base_override: applied && body.base_modified_at ? true : undefined,
     },
   });
 

--- a/worker/src/submissions.js
+++ b/worker/src/submissions.js
@@ -154,11 +154,19 @@ function checkText(value, { field, max, required = false }) {
   return [];
 }
 
-/** Does this location exist? An edit or removal of nothing is a mistake, not a queue item. */
-async function locationExists(env, id) {
-  if (typeof id !== 'string' || !id) return false;
-  const row = await env.DB.prepare('SELECT id FROM locations WHERE id = ?').bind(id).first();
-  return Boolean(row);
+/**
+ * The location this submission acts on, or null if there is no such record. An
+ * edit or removal of nothing is a mistake, not a queue item.
+ *
+ * Returns `modified_at` as well as existence, because the two are one question
+ * asked at one moment: the version the submitter's payload was written against
+ * is the version that was there when the submission was accepted. Reading it in
+ * a second query would let the record move between the check and the capture,
+ * and store a base the submitter never saw.
+ */
+async function readLocationBase(env, id) {
+  if (typeof id !== 'string' || !id) return null;
+  return env.DB.prepare('SELECT id, modified_at FROM locations WHERE id = ?').bind(id).first();
 }
 
 /**
@@ -210,6 +218,9 @@ async function create(request, env, { fetchImpl = fetch, nowMs = Date.now() } = 
     ...checkText(body.submitter_contact, { field: 'submitter_contact', max: CONTACT_MAX }),
   ];
   let stored = null;
+  // The version of the record this submission is written against. NULL for a
+  // create, which has no base: see migration 0008.
+  let baseModifiedAt = null;
 
   if (kind === 'create') {
     const tagNames = await readTagSlugs(env);
@@ -217,8 +228,11 @@ async function create(request, env, { fetchImpl = fetch, nowMs = Date.now() } = 
     errors.push(...checked.errors);
     stored = checked.values ?? null;
   } else {
-    if (!await locationExists(env, body.location_id)) {
+    const base = await readLocationBase(env, body.location_id);
+    if (!base) {
       errors.push('location_id must be an existing location');
+    } else {
+      baseModifiedAt = base.modified_at ?? null;
     }
     if (kind === 'edit') {
       const tagNames = await readTagSlugs(env);
@@ -245,8 +259,8 @@ async function create(request, env, { fetchImpl = fetch, nowMs = Date.now() } = 
   const result = await env.DB.prepare(
     `INSERT INTO submissions
        (kind, location_id, payload, status, submitter_note, submitter_contact,
-        submitter_ip_hash, created_at)
-     VALUES (?, ?, ?, 'pending', ?, ?, ?, ?)`,
+        submitter_ip_hash, created_at, base_modified_at)
+     VALUES (?, ?, ?, 'pending', ?, ?, ?, ?, ?)`,
   ).bind(
     kind,
     kind === 'create' ? null : body.location_id,
@@ -255,6 +269,7 @@ async function create(request, env, { fetchImpl = fetch, nowMs = Date.now() } = 
     body.submitter_contact ?? null,
     ipHash,
     createdAt,
+    baseModifiedAt,
   ).run();
 
   const id = result?.meta?.last_row_id ?? null;

--- a/worker/test/review.test.js
+++ b/worker/test/review.test.js
@@ -247,6 +247,152 @@ test('approving a removal hides the location and keeps the record', async () => 
   assert.equal(rows[0].status, 'hidden');
 });
 
+// ---------------------------------------------- the concurrency guard (#898) ---
+//
+// A submission sits in the queue while the registry keeps moving. Approving an
+// edit must not reapply the submitter's older values over an admin's change
+// made meanwhile. Every case here asserts the ROW, not just the status: a guard
+// that returns 409 and writes anyway is the failure being ruled out.
+
+/** The record after an admin edited it, past the version the submitter saw. */
+const MOVED = {
+  ...LOCATION, name: 'Admin Fixed Loft', modified_at: '2026-02-02T00:00:00Z',
+};
+
+/** An edit written against LOCATION as it stood on 2026-01-01. */
+const editOf = (over = {}) => submission({
+  kind: 'edit',
+  location_id: 'loc-1',
+  payload: JSON.stringify({ name: 'Submitter Name', yaw: 45 }),
+  base_modified_at: '2026-01-01T00:00:00Z',
+  ...over,
+});
+
+const approveOf = (env) => `/admin/submissions/${firstId(env)}/approve`;
+
+test('an edit applies when the record has not moved since it was made', async () => {
+  const env = envFor({ submissions: [editOf()] });
+  const res = await hit(env, 'POST', approveOf(env));
+  assert.equal(res.status, 200);
+
+  const row = locRows(env)[0];
+  assert.equal(row.name, 'Submitter Name');
+  assert.equal(row.yaw, 45);
+  assert.equal(subRows(env)[0].status, 'approved');
+});
+
+test('an edit is refused when the record moved, and the admin\'s values survive', async () => {
+  const env = envFor({ locations: [MOVED], submissions: [editOf()] });
+  const res = await hit(env, 'POST', approveOf(env));
+  assert.equal(res.status, 409);
+
+  const body = await res.json();
+  assert.equal(body.error, 'stale_submission');
+  assert.equal(body.current.name, 'Admin Fixed Loft',
+    'the record as it stands, so the reviewer can see what they would overwrite');
+
+  const row = locRows(env)[0];
+  assert.equal(row.name, 'Admin Fixed Loft', 'the write must not have landed');
+  assert.equal(row.yaw, 90);
+  assert.equal(row.modified_at, '2026-02-02T00:00:00Z', 'and modified_at must not have moved');
+  assert.equal(auditRows(env).length, 0, 'nothing was written, so nothing is logged');
+});
+
+test('a refused edit stays pending, and can be approved against the version the reviewer saw', async () => {
+  const env = envFor({ locations: [MOVED], submissions: [editOf()] });
+  const refused = await hit(env, 'POST', approveOf(env));
+  assert.equal(refused.status, 409);
+  assert.equal(subRows(env)[0].status, 'pending',
+    'a submission that could not be applied has not been reviewed');
+
+  // What the dashboard does next: reload the record, show the diff against its
+  // current values, and re-send with the version the reviewer has now read.
+  const current = (await refused.json()).current;
+  const res = await hit(env, 'POST', approveOf(env), { base_modified_at: current.modified_at });
+  assert.equal(res.status, 200);
+
+  const row = locRows(env)[0];
+  assert.equal(row.name, 'Submitter Name');
+  assert.equal(subRows(env)[0].status, 'approved');
+
+  const approval = auditRows(env).find((r) => r.action === 'submission.approve');
+  assert.equal(JSON.parse(approval.after).base_override, true,
+    'approving over a newer record is a decision, and the log has to say so');
+});
+
+test('a stale base_modified_at is refused too, so a rebase cannot lose a third write', async () => {
+  // The retry is guarded, not forced. A write landing between the refusal and
+  // the second approve is exactly what a bare force flag would lose.
+  const env = envFor({ locations: [MOVED], submissions: [editOf()] });
+  const res = await hit(env, 'POST', approveOf(env),
+    { base_modified_at: '2026-01-15T00:00:00Z' });
+  assert.equal(res.status, 409);
+  assert.equal((await res.json()).error, 'stale_submission');
+  assert.equal(locRows(env)[0].name, 'Admin Fixed Loft');
+});
+
+test('an edit with no recorded base applies unguarded', async () => {
+  // Every submission accepted before migration 0008, and one that refused would
+  // be unapprovable forever.
+  const env = envFor({
+    locations: [MOVED], submissions: [editOf({ base_modified_at: null })],
+  });
+  const res = await hit(env, 'POST', approveOf(env));
+  assert.equal(res.status, 200);
+  assert.equal(locRows(env)[0].name, 'Submitter Name');
+});
+
+test('approving a removal is unguarded even when the record moved', async () => {
+  // An approved removal pulls the pin regardless of what else changed, which is
+  // the point of approving it.
+  const env = envFor({
+    locations: [MOVED],
+    submissions: [submission({
+      kind: 'remove',
+      location_id: 'loc-1',
+      payload: JSON.stringify({ reason: 'mod was pulled' }),
+      base_modified_at: '2026-01-01T00:00:00Z',
+    })],
+  });
+  const res = await hit(env, 'POST', approveOf(env));
+  assert.equal(res.status, 200);
+  assert.equal(locRows(env)[0].status, 'hidden');
+});
+
+test('base_modified_at is refused on anything but approving an edit', async () => {
+  // A create inserts and a removal is unguarded on purpose, so neither has a
+  // base to rebase onto. Accepting it there would read as a guard not running.
+  const env = envFor({
+    submissions: [
+      submission(),
+      submission({ kind: 'remove', location_id: 'loc-1', payload: JSON.stringify({ reason: 'x' }) }),
+      editOf(),
+    ],
+  });
+  const [create, remove, edit] = subRows(env);
+
+  for (const row of [create, remove]) {
+    const res = await hit(env, 'POST', `/admin/submissions/${row.id}/approve`,
+      { base_modified_at: '2026-01-01T00:00:00Z' });
+    assert.equal(res.status, 400, `kind ${row.kind} must refuse a base`);
+  }
+  const onReject = await hit(env, 'POST', `/admin/submissions/${edit.id}/reject`,
+    { reason: 'no', base_modified_at: '2026-01-01T00:00:00Z' });
+  assert.equal(onReject.status, 400);
+
+  assert.equal(subRows(env).filter((r) => r.status === 'pending').length, 3);
+  assert.equal(locRows(env).length, 1);
+});
+
+test('base_modified_at must be a non-empty string', async () => {
+  const env = envFor({ submissions: [editOf()] });
+  for (const value of [42, '', null]) {
+    const res = await hit(env, 'POST', approveOf(env), { base_modified_at: value });
+    assert.equal(res.status, 400, `${JSON.stringify(value)} must be refused`);
+  }
+  assert.equal(subRows(env)[0].status, 'pending');
+});
+
 test('approval revalidates against the tag registry as it stands now', async () => {
   // A tag can be deleted between submission and review. Applying the payload
   // anyway would write a location whose join rows silently go missing.

--- a/worker/test/submissions.test.js
+++ b/worker/test/submissions.test.js
@@ -91,6 +91,32 @@ test('a valid create is queued as pending and nothing reaches the map', async ()
   );
 });
 
+test('an edit records the version of the record it was written against', async () => {
+  // The value the approval is guarded on (#898). Captured here because this is
+  // the only moment it is knowable: the record keeps moving while the
+  // submission sits in the queue.
+  const env = envFor();
+  await submit(env, {
+    kind: 'edit', location_id: 'loc-1', payload: { yaw: 45 }, turnstile_token: 't',
+  });
+  assert.equal(rows(env)[0].base_modified_at, '2026-01-01T00:00:00Z');
+});
+
+test('a removal records its base too, and a create has none', async () => {
+  // A create has no base by construction: there is no record to be stale
+  // against. A removal is approved unguarded, and the value is still the honest
+  // answer to what the submitter saw.
+  const env = envFor();
+  await submit(env, {
+    kind: 'remove', location_id: 'loc-1', reason: 'the mod was pulled', turnstile_token: 't',
+  });
+  await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' });
+
+  const [removal, create] = rows(env);
+  assert.equal(removal.base_modified_at, '2026-01-01T00:00:00Z');
+  assert.equal(create.base_modified_at, null);
+});
+
 test('every accepted submission produces an audit row', async () => {
   const env = envFor();
   await submit(env, { kind: 'create', payload: VALID, turnstile_token: 't' });


### PR DESCRIPTION
Closes the concurrency guard deferred from #899. **Not** the scope #898's body describes (the resubmission diff and restore-and-apply) — that is still open; the guard was folded into #898 by the release tracker (#903) rather than by an edit to the issue. A scope note has since been added to #898 so the next reader is not caught by the same gap.

## The bug, on production today

1. A submitter sends an `edit` for location X. It sits in the queue.
2. An admin fixes something on X through the dashboard.
3. The admin approves the submission.
4. The submitter's older values overwrite the fix. No error, no warning. The audit log records both writes, so the history is intact — nobody is told, and the admin's change is gone.

`patchLocation` has taken an `ifMatch` since the dashboard editor needed one (`admin.js` sends it as an `If-Match` header). The review path could not use it because nothing recorded **which version the submitter saw**.

## What changed

| | before | after |
|---|---|---|
| `edit` approve | unguarded | guarded on `base_modified_at` |
| `remove` approve | unguarded | unguarded — deliberate, an approved removal pulls the pin regardless |
| `create` approve | inserts | inserts; no base exists by construction |
| pre-0008 submission | applies | applies — NULL means unguarded |

- **Migration 0008** adds `submissions.base_modified_at TEXT`. Named to match `locations.modified_at`, **not** `base_updated_at`: migration 0006 exists specifically to kill the `updated_at` collision, because `updated_at` on a served `/v1` record is the *Nexus* mod date out of `nexus_cache`.
- **Captured at submission time**, in the same query that already checked the location exists — the check and the capture are one question asked at one moment, so the record cannot move between them.
- **Used at approve time** in the `edit` branch only. A conflict returns `409 stale_submission` with the current record. Nothing is written, and the submission stays `pending` because the registry write already happens before `resolve()` flips the status.

## The escape hatch, and why it is not a force flag

A bare refusal would strand the submission: `base_modified_at` never changes, so a conflicted edit could never be approved. Instead the dashboard reloads the record, redraws "What it changes" against its **current** values, and offers **Apply anyway**, which re-sends with the `modified_at` now on screen.

That retry is still a guarded write. A `force: true` would skip the guard entirely, so a third admin saving between the refusal and the retry would be lost silently — which is the bug being fixed. The retry is rebased, not unguarded, and `submission.approve` records `base_override: true` so the audit log distinguishes a deliberate overwrite from a race.

## Backfill

None needed: `submissions` held 0 rows in production (all statuses, checked 2026-08-01), so there is nothing to fill in and nothing pending to break.

## Tests — 351, up from 341

Proved by mutation, not by passing:

- Dropping `{ ifMatch }` from the `patchLocation` call turns **exactly 3** red: the refusal, the pending-then-retry case, and the stale-rebase case. Nothing else moves.
- Setting the captured base to `null` turns **exactly 2** red: the two capture tests.

Every guard case asserts the **row**, not just the status code — a guard that returns 409 and writes anyway is the failure being ruled out.

## Migrations

Both applied and independently confirmed with `pragma_table_info`, ahead of the code that reads the column:

- `nczoning-data-staging` — **applied.**
- `nczoning-data` (production) — **applied.**

## API version

No bump. `openapi.json` covers `/v1/*` only; `/admin/submissions/{id}/approve` is not in it, so the new error response is not a documented-surface change. Stays 0.5.0.

## Needs a human at the screen

`admin/` has no automated tests. Approve an edit on staging after changing the record underneath it, and check that the banner, the redrawn diff, and **Apply anyway** all read correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
