### PR TITLE
docs: correct three stale claims, and cut 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.2.1] - 2026-08-01
+
+Approving a submission no longer quietly undoes an admin's work. A submission can
+sit in the queue for days while the record it describes keeps changing, and until
+now approving it wrote the submitter's older values straight over anything edited
+in the meantime, with nothing said to anyone.
 
 ### Fixed
 
 - **Approving an edit can no longer silently overwrite an admin's change.** A submission now records the version of the location it was written against, and approving it applies only while the record still carries that version.
-- A refused approval says what changed, leaves the submission pending, and offers to apply it over the current record — which is still a guarded write, not a force.
+- A refused approval says what changed, leaves the submission pending, and offers to apply it over the current record. That retry is still a guarded write, not a force.
+- Three stale claims in the contributor docs: the location example used a tag as its category, the tag registry still referred to the retired issue form, and the reviewer guide still described the overwrite above as unavoidable.
 
 ## [2.2.0] - 2026-08-01
 

--- a/docs/adding-mods.md
+++ b/docs/adding-mods.md
@@ -17,7 +17,7 @@ you submit, and what each one means:
     "authors": ["AuthorName", "CoAuthor"],
     "coordinates": [CET_X, CET_Y, CET_Z],
     "nexus_id": "12345",
-    "category": "apartment",
+    "category": "new-location",
     "tags": ["apartment", "neokitsch"],
     "description": "Brief description of what the mod does (max 500 chars).",
     "yaw": 180.0
@@ -32,7 +32,7 @@ you submit, and what each one means:
 | `coordinates` | [number, number, number] | `[CET_X, CET_Y, CET_Z]`, in-game coordinates from CET (X=east/west, Y=north/south, Z=height) |
 | `yaw` | number | (Optional) Player facing direction in degrees from CET |
 | `nexus_id` | string | Numeric Nexus ID (Used to automatically fetch thumbnails/images via API), or "WIP" / "Dummy" |
-| `category` | string | `location-overhaul`, `new-location`, or `other` |
+| `category` | string | Exactly one of `location-overhaul`, `new-location`, `other`. Not a tag: `apartment` and the rest belong in `tags` |
 | `tags` | array[string] | Tags from `data/tags.json` (see [Tag Registry](tags.md) for the full list) |
 | `description` | string | Max 500 characters |
 | `credits` | string | (Optional) Team name or secondary acknowledgements |

--- a/docs/reviewer-guide.md
+++ b/docs/reviewer-guide.md
@@ -81,18 +81,26 @@ That is deliberate. Three of us share one registry, and without it the second
 save silently replaces the first: no error, and the person who saved first only
 finds out when their change is gone.
 
-### One case it does not cover: approving a stale submission
+### Approving a stale submission is guarded too
 
-A submission is written against the record as the **submitter** saw it, and
-approving applies it however long it has been sitting in the queue.
+A submission is written against the record as the **submitter** saw it, and it
+may sit in the queue for a while. So if you fixed something on a record while a
+submission for it was pending, approving that submission would put the
+submitter's older values back over your fix. This needs no second person: you
+editing a record and then approving a submission for it is enough.
 
-So if you fixed something on a record while a submission for it was pending,
-approving that submission puts the submitter's older values back over your fix.
-This needs no second person: you editing a record and then approving a
-submission for it is enough.
+**Approving an edit is refused when that has happened.** Nothing is written, the
+submission stays pending, and the queue reloads the record and redraws the diff
+against its current values, so you can see what you would have overwritten.
 
-**Read the diff before you approve.** It shows exactly what the submission would
-write, which is the check that catches this.
+If the submission should still apply, press **Apply anyway**. That re-sends it
+against the version now on your screen, so it is still a guarded write: if
+someone else saves in the moment between the refusal and your retry, that is
+caught too. The audit log records the approval as having been made over a newer
+version, so it is distinguishable afterwards from an ordinary one.
+
+Removals are unguarded on purpose. An approved removal pulls the pin regardless
+of what else changed on the record, which is the point of approving it.
 
 ## 📋 The audit log
 

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,6 +1,6 @@
 # Tag Registry
 
-Tags are used to describe the aesthetic, function, or intended audience of a location mod. They appear as filterable badges on the map and as checkboxes in the submission issue form.
+Tags describe the aesthetic, function, or intended audience of a location mod. They appear as filterable badges on the map and as options in the submit form.
 
 ---
 


### PR DESCRIPTION
Three claims in `docs/` that were wrong, found by re-ingesting the folder into the wiki and comparing each page against the code it describes. Plus the 2.2.1 changelog cut for #918.

## The three

**`adding-mods.md` gave an example that fails validation.** The record showed `"category": "apartment"`. `apartment` is a *tag*; the three categories are `location-overhaul`, `new-location` and `other`, and the Worker refuses anything else. Anyone copying the example got a 422 with no hint that the example itself was the problem. Fixed, and the field table now says outright that a category is not a tag.

**`tags.md` referred to a form that no longer exists** — "checkboxes in the submission issue form", deleted at the D1 cutover.

**`reviewer-guide.md` documented a bug as unavoidable.** It carried a section headed *"One case it does not cover: approving a stale submission"*, telling reviewers the only mitigation was to read the diff carefully. #918 fixed exactly that this morning. The section now describes what actually happens: the approval is refused, the submission stays pending, the diff redraws against current values, and **Apply anyway** re-sends against the version on screen. It also states why removals stay unguarded, since that asymmetry is otherwise easy to read as an oversight.

## Why these three and not others

They are not the same kind of stale. The first two are *dated* — they describe something that used to be true. The third is worse: it tells a reviewer that a hazard is unavoidable when the software now handles it, so it would train someone to distrust a guard that works.

## 2.2.1

Fix-only since 2.2.0, so PATCH. The release covers #918 and these corrections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)