### PR TITLE
feat(admin): plain language, and a mobile layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- The admin dashboard says "the registry", never "D1", in every string a person reads: the stats panel, the health rows and the rebuild banner.
+- The audit log renders field names and enum values in English, with the verbatim record kept one fold deeper so the sentence stays checkable.
+
+### Added
+
+- A mobile layout for the dashboard: a nav drawer that keeps its badge counts on the closed button, a collapsing header, touch-sized rows, and a list-to-editor view switch that the Android back gesture closes.
+
 ## [2.3.0] - 2026-08-02
 
 The folder of location files in git is gone. It had been read by nothing since

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -108,7 +108,20 @@ a { color: var(--secondary); }
     line-height: 1;
 }
 
-.topbar .spacer { flex: 1; }
+/* Everything that is not navigation: rebuild, who is signed in, sign out.
+   `margin-left: auto` rather than a spacer element, so the same markup can be
+   lifted into the drawer below the nav breakpoint without leaving an orphan. */
+.topbar-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-lg);
+    flex-wrap: wrap;
+    margin-left: auto;
+}
+
+/* Above the nav breakpoint the drawer is not a box at all: its children become
+   direct flex items of the top bar and lay out as though it were not there. */
+.topbar-drawer { display: contents; }
 
 .who { color: var(--tertiary); font-weight: 600; }
 
@@ -151,6 +164,47 @@ nav.tabs button[aria-selected="true"] {
     border-color: var(--secondary-30);
     background: var(--secondary-05);
 }
+
+/* ------------------------------------------------------------ nav drawer -- */
+
+/*
+ * Two breakpoints, and they are deliberately different numbers.
+ *
+ * 70rem is where `.split` stacks, so it is where opening a record stops meaning
+ * "fill the pane beside the list" and starts meaning "replace the list".
+ * 60rem is where eight uppercase tabs stop fitting on one row: they measure
+ * around 55rem on their own, before the wordmark and the freshness pill. So the
+ * nav folds at 60rem, and between the two widths you get stacked panes under a
+ * full tab row.
+ *
+ * admin.js reads both numbers back (NARROW, MENU). If either moves here, move it
+ * there in the same commit: this file decides what the reader sees, that one
+ * decides whether the back gesture has anything to dismiss, and a disagreement
+ * means back walks out of the dashboard.
+ */
+
+/* No button above the nav breakpoint: the tabs are all visible. */
+.nav-toggle { display: none; }
+
+.nav-backdrop { display: none; }
+
+.detail-back {
+    display: none;
+    flex-basis: 100%;
+    background: transparent;
+    border: none;
+    border-top: var(--ui-border-thin) solid var(--secondary-20);
+    margin: var(--space-xs) calc(var(--space-lg) * -1) calc(var(--space-md) * -1);
+    padding: var(--space-sm) var(--space-lg);
+    color: var(--secondary);
+    font-size: var(--fs-ui);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-label);
+    text-align: left;
+    cursor: pointer;
+}
+
+.detail-back::before { content: "← "; }
 
 main { padding: var(--space-lg); }
 
@@ -691,6 +745,17 @@ button.breakdown-row:hover .k { color: var(--secondary); }
 
     .split > .panel { overflow: visible; max-height: none; }
     .split .table-wrap { overflow-x: auto; }
+
+    /*
+     * Stacked, the editor is not beside the list, it is below it and off the
+     * bottom of the screen. Selecting a row has to REPLACE the list or the tap
+     * appears to do nothing at all.
+     *
+     * `body.detail-open` is set from a popstate handler, never written directly,
+     * so the class and the session history cannot disagree. See admin.js.
+     */
+    body.detail-open .split > .panel:first-child { display: none; }
+    body.detail-open .detail-back { display: block; }
 }
 
 .field { margin-bottom: var(--space-lg); }
@@ -907,6 +972,171 @@ button.breakdown-row:hover .k { color: var(--secondary); }
     .candidate { grid-template-columns: minmax(0, 1fr); }
 }
 
+/* ----------------------------------------------------------- narrow nav -- */
+
+/* Below here the tabs do not fit a row. See the note above `.nav-toggle`. */
+@media (max-width: 60rem) {
+    /*
+     * `backdrop-filter: none` is load-bearing, not a visual preference.
+     *
+     * A backdrop-filter (like a filter or a transform) makes the element a
+     * containing block for its `position: fixed` descendants. With the blur on,
+     * the drawer below resolves `bottom: 0` against the TOP BAR rather than the
+     * viewport and renders as a sliver a few pixels tall.
+     *
+     * So the bar goes solid here instead. `--surface-panel` is 95% opaque, which
+     * is what the blur was buying: text scrolling under a sticky bar that is
+     * only 80% opaque and no longer blurred would read through it.
+     */
+    .topbar {
+        gap: var(--space-md);
+        padding: var(--space-sm) var(--space-md);
+        background: var(--surface-panel);
+        backdrop-filter: none;
+        transition: padding 0.15s ease;
+    }
+
+    .topbar h1 { font-size: var(--fs-ui); }
+
+    /* Collapsed, the wordmark is what goes. The menu badge and the freshness
+       pill are the two things in this bar that report something, and a header
+       that reclaims its height by dropping those has saved the wrong pixels. */
+    body.scrolled .topbar { padding-block: var(--space-2xs); }
+    body.scrolled .topbar h1 { display: none; }
+
+    .nav-toggle {
+        display: inline-flex;
+        position: relative;
+        flex: 0 0 auto;
+        align-items: center;
+        justify-content: center;
+        /* 44px. Anything under this is a tap target that misses. */
+        width: 2.75rem;
+        height: 2.75rem;
+        padding: 0;
+        background: transparent;
+        border: var(--ui-border-thin) solid var(--secondary-30);
+        border-radius: var(--ui-radius-sm);
+        cursor: pointer;
+    }
+
+    .nav-toggle-bars { position: relative; }
+
+    .nav-toggle-bars,
+    .nav-toggle-bars::before,
+    .nav-toggle-bars::after {
+        display: block;
+        width: 1.25rem;
+        height: 2px;
+        background: var(--secondary);
+    }
+
+    .nav-toggle-bars::before,
+    .nav-toggle-bars::after { content: ""; position: absolute; left: 0; }
+    .nav-toggle-bars::before { top: -6px; }
+    .nav-toggle-bars::after { top: 6px; }
+
+    /* The count the closed menu still reports. Absolutely positioned because
+       the button is a fixed square and a two-digit badge must not resize it. */
+    .nav-toggle .tab-count {
+        position: absolute;
+        top: -0.4rem;
+        right: -0.4rem;
+        margin: 0;
+    }
+
+    .topbar-drawer {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-lg);
+        position: fixed;
+        top: var(--topbar-h, 4rem);
+        right: 0;
+        bottom: 0;
+        width: min(22rem, 85vw);
+        padding: var(--space-lg);
+        /* Fully opaque, not `--surface-panel`. The drawer covers most of the
+           screen, and at 95% the table behind it ghosts through the tab labels. */
+        background: var(--primary);
+        border-left: var(--ui-border-thin) solid var(--secondary-30);
+        overflow-y: auto;
+        transform: translateX(100%);
+        transition: transform 0.18s ease;
+        z-index: 12;
+    }
+
+    body.menu-open .topbar-drawer { transform: none; }
+
+    /* The page behind a full-height drawer must not scroll under it. */
+    body.menu-open { overflow: hidden; }
+
+    nav.tabs { flex-direction: column; }
+    nav.tabs button { text-align: left; padding: var(--space-md) var(--space-lg); }
+
+    /* Pinned to the bottom of the drawer: sign-out and rebuild are the two
+       things here that should never be reachable by an accidental thumb on the
+       way to a tab. */
+    .topbar-meta {
+        margin: auto 0 0;
+        flex-direction: column;
+        align-items: stretch;
+        gap: var(--space-md);
+    }
+
+    .topbar-meta .btn { justify-content: center; }
+
+    .nav-backdrop {
+        display: block;
+        position: fixed;
+        inset: 0;
+        background: rgb(0 0 0 / 0.5);
+        z-index: 11;
+    }
+}
+
+/* ---------------------------------------------------------- narrow body -- */
+
+@media (max-width: 50rem) {
+    main { padding: var(--space-md); }
+    .panel { padding: var(--space-md); }
+
+    /* Tap targets. The default cell padding gives rows about 30px tall, which
+       puts two records inside one thumb. */
+    th, td { padding: var(--space-md) var(--space-sm); }
+
+    /*
+     * The list answers "which record"; the editor answers everything else.
+     *
+     * Four of the seven columns are detail the editor already shows in full, and
+     * keeping them here buys a sideways scroll on the one screen where a
+     * sideways scroll is most easily read as the end of the row. Nothing is
+     * lost: every hidden column is one tap away.
+     */
+    #loc-table th:nth-child(3), #loc-table td:nth-child(3),   /* Tags */
+    #loc-table th:nth-child(5), #loc-table td:nth-child(5),   /* Added */
+    #loc-table th:nth-child(6), #loc-table td:nth-child(6),   /* Modified */
+    #loc-table th:nth-child(7), #loc-table td:nth-child(7) {  /* Nexus */
+        display: none;
+    }
+
+    /* Stacked and full width. Side by side these are three controls too narrow
+       to read the options in. */
+    .toolbar input[type="search"],
+    .toolbar select,
+    .toolbar > .btn { width: 100%; }
+
+    .toolbar > .btn { justify-content: center; }
+
+    .detail dl { grid-template-columns: minmax(0, 1fr); gap: 0 0; }
+    .detail dt { padding-top: var(--space-sm); }
+
+    .editor-actions .btn { flex: 1 1 auto; justify-content: center; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .topbar, .topbar-drawer { transition: none; }
+}
+
 /* ----------------------------------------------------------------- audit -- */
 
 .audit-entry {
@@ -1043,11 +1273,42 @@ button.breakdown-row:hover .k { color: var(--secondary); }
 
 #overview-alerts .btn { margin-top: var(--space-xs); }
 
-.diff { margin: var(--space-xs) 0 0; font-size: var(--fs-code); }
-.diff div { padding: var(--space-2xs) 0; font-family: ui-monospace, monospace; line-height: var(--lh-tight); }
+/* The diff renders field names and enum values in English, so it is prose and
+   set in the body face. The verbatim record below it is JSON, and is the only
+   part here that takes the monospace. */
+.diff { margin: var(--space-xs) 0 0; font-size: var(--fs-ui); }
+.diff div { padding: var(--space-2xs) 0; line-height: var(--lh-body); overflow-wrap: anywhere; }
 .diff .k { color: var(--gray); }
 .diff .from { color: var(--status-critical); }
 .diff .to { color: var(--status-ok); }
+
+/* Everything above this is a translation, and a translated audit log has to stay
+   checkable or it is only a claim. Collapsed and muted so it costs nothing until
+   it is wanted; present so the friendly rendering can always be verified against
+   what the Worker actually stored. Same contract as `.audit-head .action`. */
+.raw-record { margin-top: var(--space-xs); }
+
+.raw-record summary {
+    cursor: pointer;
+    color: var(--text-dim);
+    font-size: var(--fs-label);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-label);
+}
+
+.raw-record summary:hover { color: var(--secondary); }
+
+.raw-record pre {
+    margin: var(--space-xs) 0 0;
+    padding: var(--space-sm);
+    background: var(--black-30);
+    border-radius: var(--ui-radius-xs);
+    font-family: ui-monospace, monospace;
+    font-size: var(--fs-code);
+    line-height: var(--lh-tight);
+    color: var(--text-subtle);
+    overflow-x: auto;
+}
 
 /* ---------------------------------------------------------------- gate -- */
 

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -77,6 +77,10 @@
     selectedLocation: null,   // id, or '' for a new record
     selectedTag: null,        // slug, or '' for a new tag
     selectedSubmission: null, // submission id
+    // Which tab's detail pane the stacked layout is currently showing, so the
+    // one back control and the one history entry know what to close. Null on a
+    // wide screen, where the pane is beside the list rather than over it.
+    detailTab: null,          // 'locations' | 'tags' | 'queue' | null
     queueStatus: 'pending',   // '' for every status
     // The queue's mini-map, held so it can be torn down before its container
     // is replaced. A Leaflet map on a removed node keeps its resize and zoom
@@ -839,6 +843,9 @@
     }
     banner('ok', `Deleted "${loc.name}". The record is in the audit log if you need it back.`);
     state.selectedLocation = null;
+    // This clears the pane itself rather than going through selectLocation, so
+    // it has to unwind the stacked-layout view switch on its own.
+    closeDetail();
     await loadLocations();
     replace($('#loc-editor'), h('p', { class: 'muted', text: 'Select a location to view it, or create a new one.' }));
   }
@@ -911,6 +918,7 @@
     state.editing = id === '';   // a new record has nothing to view
     clearBanner();
     if (id === null) {
+      closeDetail();
       renderLocations();
       return replace($('#loc-editor'),
         h('p', { class: 'muted', text: 'Select a location to view it, or create a new one.' }));
@@ -920,7 +928,10 @@
     const loc = id === ''
       ? { ...BLANK_LOCATION, ...(prefill || {}) }
       : state.locations.find((l) => l.id === id);
+    // Nothing to show, so nothing to navigate to: a stacked layout that switched
+    // view here would leave the reader on an empty pane with no list behind it.
     if (!loc) return;
+    openDetail('locations');
     if (state.editing) renderLocationEditor(loc);
     else renderLocationDetail(loc);
   }
@@ -1146,6 +1157,7 @@
     state.selectedTag = slug;
     clearBanner();
     if (slug === null) {
+      closeDetail();
       renderTags();
       return replace($('#tag-editor'),
         h('p', { class: 'muted', text: 'Select a tag to view it, or create a new one.' }));
@@ -1153,6 +1165,7 @@
     renderTags();
     const tag = slug === '' ? { ...BLANK_TAG } : state.tags.find((t) => t.slug === slug);
     if (!tag) return;
+    openDetail('tags');
     // A new tag has nothing to view, so it opens straight in the form.
     if (slug === '') renderTagEditor(tag);
     else renderTagDetail(tag);
@@ -1246,6 +1259,7 @@
     // Only a non-zero count earns a badge: a "0" beside the tab is a standing
     // invitation to check a queue that has nothing in it.
     $('#queue-count').textContent = pending ? String(pending) : '';
+    syncNavBadge();
   }
 
   async function loadQueue() {
@@ -1533,13 +1547,16 @@
     state.selectedSubmission = id;
     clearBanner();
     if (id === null) {
+      closeDetail();
       releaseReviewMap();
       renderQueue();
       return replace($('#queue-review'), h('p', { class: 'muted', text: 'Select a submission to review it.' }));
     }
     renderQueue();
     const sub = state.submissions.find((s) => s.id === id);
-    if (sub) renderSubmissionReview(sub);
+    if (!sub) return;
+    openDetail('queue');
+    renderSubmissionReview(sub);
   }
 
   const REVIEW_VERB = { approve: 'Approved', reject: 'Rejected', hold: 'Put on hold' };
@@ -1741,6 +1758,7 @@
     $('#candidates-note').textContent =
       `${candidates.length} waiting, ${dismissed.length} dismissed.`;
     $('#candidates-count').textContent = candidates.length ? String(candidates.length) : '';
+    syncNavBadge();
   }
 
   async function loadCandidates() {
@@ -1843,7 +1861,20 @@
     return results.every(Boolean);
   }
 
-  /** Rebuild the served dataset from whatever DATA_SOURCE says. */
+  /**
+   * The store a dataset was built from, in words.
+   *
+   * The Worker records and returns the machine token `d1` (`worker/src/admin.js`,
+   * both the `/admin/refresh` response and the `dataset.refresh` audit target).
+   * "D1" is the name of a Cloudflare product, not a thing an admin has any
+   * reason to know. Two call sites read it (the rebuild banner and the audit
+   * sentence), so it is one map. A token this page has not been taught renders
+   * as itself rather than as a blank.
+   */
+  const DATASET_SOURCE_LABEL = { d1: 'the registry' };
+  const datasetSource = (s) => DATASET_SOURCE_LABEL[s] ?? s;
+
+  /** Rebuild the served dataset from the registry. */
   async function rebuildDataset(button) {
     button.disabled = true;
     button.textContent = 'Rebuilding…';
@@ -1871,8 +1902,8 @@
     // If the admin just edited a record and the rebuild reports no change,
     // that is worth knowing rather than smoothing over.
     banner('ok', res.body.changed
-      ? `Rebuilt from ${res.body.source}, and reloaded this page's data. New dataset version ${res.body.dataset_version}.`
-      : `Rebuilt from ${res.body.source}, and reloaded this page's data. The content hash was unchanged, so nothing was rewritten.`);
+      ? `Rebuilt from ${datasetSource(res.body.source)}, and reloaded this page's data. New dataset version ${res.body.dataset_version}.`
+      : `Rebuilt from ${datasetSource(res.body.source)}, and reloaded this page's data. The content hash was unchanged, so nothing was rewritten.`);
   }
 
   // ------------------------------------------------------------ overview --
@@ -1970,7 +2001,7 @@
     const untagged = records.filter((r) => !r.tags.length).length;
 
     replace($('#stat-registry'),
-      stat(records.length, 'in D1', null, {}),
+      stat(records.length, 'records', null, {}),
       stat(published.length, 'published', 'good', { status: 'published' }),
       stat(hidden, 'hidden', hidden ? 'warn' : null, { status: 'hidden' }),
       stat(records.filter((r) => r.status === 'draft').length, 'draft', null, { status: 'draft' }),
@@ -2056,10 +2087,12 @@
       ds === true ? 'bad' : ds === false ? 'ok' : null));
     }
 
-    // Two independent counts of the same thing.
-    rows.push(kvRow('registry (D1)', String(records.length)));
-    rows.push(kvRow('published in D1', String(published.length)));
-    rows.push(kvRow('served by /v1', servedCount === null ? 'unknown' : String(servedCount),
+    // Two independent counts of the same thing. The pair is the point: what the
+    // registry holds against what the public API hands the map. Renaming them
+    // must not collapse them into one number.
+    rows.push(kvRow('in the registry', String(records.length)));
+    rows.push(kvRow('published in the registry', String(published.length)));
+    rows.push(kvRow('served to the map', servedCount === null ? 'unknown' : String(servedCount),
       servedCount === null ? null : servedCount === published.length ? 'ok' : 'bad'));
     if (servedCount !== null && servedCount !== published.length) {
       rows.push(kvRow('drift',
@@ -2143,7 +2176,133 @@
   // --------------------------------------------------------------- audit --
 
   /** Field-level diff between two audit snapshots. */
-  function renderDiff(before, after) {
+  /**
+   * Column name -> what the field IS, in words.
+   *
+   * The audit sentence is prose; the record expanded under it is column names.
+   * `granted_by: "apply"` is the stored shape and it means nothing to anyone who
+   * has not read `worker/src/review.js`.
+   *
+   * Deliberately incomplete, and `fieldLabel` falls back to the raw key: a
+   * column added to the Worker must show up here as itself rather than
+   * disappear. A label map that silently drops unknown fields would make this
+   * log quietly lie by omission, which is the one thing it cannot do.
+   */
+  const FIELD_LABEL = {
+    // A location record.
+    id: 'ID',
+    name: 'Name',
+    nexus_id: 'Nexus mod ID',
+    category: 'Category',
+    coordinates: 'Coordinates',
+    yaw: 'Facing',
+    description: 'Description',
+    credits: 'Credits',
+    authors: 'Authors',
+    tags: 'Tags',
+    status: 'Status',
+    admin_notes: 'Admin notes',
+    added_at: 'Added',
+    modified_at: 'Last changed',
+    // Three different dates that would otherwise read as interchangeable.
+    nexus_updated_at: 'Mod last updated on Nexus',
+
+    // A tag record.
+    slug: 'Tag ID',
+    sort_order: 'Sort order',
+    created_at: 'Created',
+    updated_at: 'Last changed',
+
+    // A submission, and a review decision on one.
+    kind: 'Kind of request',
+    location_id: 'Location',
+    payload: 'What was submitted',
+    review_note: 'Reviewer note',
+    granted_by: 'How it was applied',
+    base_override: 'Approved over a newer version',
+    reason: 'Reason',
+    dismissed_by: 'Dismissed by',
+    owner_id: 'Owner',
+  };
+
+  const fieldLabel = (key) => FIELD_LABEL[key] ?? key;
+
+  /**
+   * The same label, for the middle of a sentence.
+   *
+   * `FIELD_LABEL` is written for a column heading, so it is capitalised. Dropped
+   * into "updated X (name, status)" that reads as a list of proper nouns. Any
+   * label carrying a capital past the first character is a real one (Nexus,
+   * ID) and is left exactly as it is.
+   */
+  const fieldPhrase = (key) => {
+    const label = fieldLabel(key);
+    return /[A-Z]/.test(label.slice(1)) ? label : label.charAt(0).toLowerCase() + label.slice(1);
+  };
+
+  /**
+   * Machine token -> English, per field.
+   *
+   * Only for fields whose values are a closed set. A name, a note or a reason is
+   * already prose and must be shown exactly as recorded, never "tidied".
+   */
+  const VALUE_LABEL = {
+    granted_by: {
+      apply: 'applied to the existing record',
+      restore: 'put a hidden record back, rather than creating a second one',
+    },
+    status: {
+      published: 'on the map',
+      hidden: 'off the map',
+      draft: 'draft',
+      pending: 'waiting for review',
+      approved: 'approved',
+      rejected: 'rejected',
+      held: 'on hold',
+    },
+    kind: {
+      create: 'a new pin',
+      edit: 'an edit to a pin',
+      remove: 'a request to take a pin off the map',
+    },
+  };
+
+  /**
+   * One diff value, for reading rather than for parsing.
+   *
+   * Absent, `null` and `''` are three different facts, so each gets its own
+   * word rather than one shared rendering. Objects stay as JSON: a submission
+   * payload is a nested record, and there is no flat rendering of one that is
+   * not simply a worse JSON.
+   */
+  function humanValue(key, v) {
+    if (v === undefined) return 'not recorded';
+    if (v === null) return 'not set';
+    if (typeof v === 'boolean') return v ? 'yes' : 'no';
+    if (Array.isArray(v)) return v.length ? v.join(', ') : 'none';
+    if (typeof v === 'object') return JSON.stringify(v);
+    return VALUE_LABEL[key]?.[String(v)] ?? (v === '' ? 'empty' : String(v));
+  }
+
+  /**
+   * The verbatim values, one fold deeper.
+   *
+   * Everything above this is a TRANSLATION, and a translated audit log has to
+   * stay checkable or it is only a claim. Same reasoning as the raw `action`
+   * string kept beside the sentence: what was stored must remain reachable, not
+   * merely have been stored. Collapsed, so it costs nothing until it is wanted.
+   */
+  function rawValues(before, after, label) {
+    if (!before && !after) return null;
+    const payload = {};
+    if (before) payload.before = before;
+    if (after) payload.after = after;
+    return h('details', { class: 'raw-record' },
+      h('summary', { text: label }),
+      h('pre', { text: JSON.stringify(payload, null, 2) }));
+  }
+
+  function renderDiff(before, after, rawLabel = 'Show the raw values') {
     const keys = [...new Set([...Object.keys(before || {}), ...Object.keys(after || {})])].sort();
     const rows = [];
     for (const key of keys) {
@@ -2154,19 +2313,28 @@
       if (key === 'modified_at') continue;
       if (sameValue(from, to)) continue;
       rows.push(h('div', {},
-        h('span', { class: 'k', text: `${key}: ` }),
-        before ? h('span', { class: 'from', text: JSON.stringify(from) }) : null,
+        h('span', { class: 'k', text: `${fieldLabel(key)}: ` }),
+        before ? h('span', { class: 'from', text: humanValue(key, from) }) : null,
         before && after ? ' → ' : null,
-        after ? h('span', { class: 'to', text: JSON.stringify(to) }) : null));
+        after ? h('span', { class: 'to', text: humanValue(key, to) }) : null));
     }
-    return rows.length ? h('div', { class: 'diff' }, rows) : h('p', { class: 'muted', text: 'No field changes recorded.' });
+    return h('div', { class: 'diff-block' },
+      rows.length
+        ? h('div', { class: 'diff' }, rows)
+        : h('p', { class: 'muted', text: 'No field changes recorded.' }),
+      rawValues(before, after, rawLabel));
   }
 
-  /** Fields that actually moved between two audit snapshots. */
+  /**
+   * Fields that actually moved between two audit snapshots, named the way the
+   * expanded record names them. The sentence and the diff under it have to call
+   * the same field the same thing, or the sentence stops being a summary of it.
+   */
   function changedFields(before, after) {
     if (!before || !after) return [];
     return [...new Set([...Object.keys(before), ...Object.keys(after)])]
       .filter((k) => k !== 'modified_at' && !sameValue(before[k], after[k]))
+      .map(fieldPhrase)
       .sort();
   }
 
@@ -2224,8 +2392,11 @@
           ' to ', h('code', { text: target })];
       case 'tag.delete': return ['deleted the tag ', h('code', { text: target })];
 
+      // The stored target is the machine token `d1`. Mapped here rather than at
+      // the write: the audit log is append-only and the stored value is what was
+      // true at the time. Rewriting history to read better is not an option.
       case 'dataset.refresh':
-        return [`rebuilt the served dataset from ${target || 'its source'}`];
+        return [`rebuilt the served dataset from ${target ? datasetSource(target) : 'its source'}`];
 
       // Written by the public route, so the actor is 'anonymous'.
       case 'submission.create':
@@ -2295,7 +2466,8 @@
           // The machine-readable pair, kept visible so the sentence above can
           // always be checked against what was actually recorded.
           h('code', { class: 'action', title: `recorded as ${e.action} on ${e.target ?? 'nothing'}`, text: e.action })),
-        h('details', {}, h('summary', { text: 'The full record' }), renderDiff(e.before, e.after))))
+        h('details', {}, h('summary', { text: 'The full record' }),
+          renderDiff(e.before, e.after, 'Show exactly what was recorded'))))
       : h('p', { class: 'muted', text: 'No entries yet.' }));
   }
 
@@ -2384,6 +2556,7 @@
 
     // Same rule as the queue badge: only a non-zero count earns one.
     $('#alerts-count').textContent = unacknowledged ? String(unacknowledged) : '';
+    syncNavBadge();
 
     state.alerts = alerts;
     state.alertsUnacknowledged = unacknowledged;
@@ -2433,11 +2606,129 @@
       }, total > SHOWN ? `See all ${total} open alerts` : 'Open the Alerts tab'));
   }
 
+  // -------------------------------------------------- narrow-screen nav --
+
+  /**
+   * The two widths admin.css changes shape at, read back here so the two files
+   * agree. 70rem is where `.split` stacks; 60rem is where the tabs fold into the
+   * drawer. Both are `matchMedia` rather than a resize handler, so crossing a
+   * breakpoint is one event instead of a hundred.
+   *
+   * If either number moves in the stylesheet it moves here in the same commit.
+   * The stylesheet decides what the reader sees; this decides whether the back
+   * gesture has anything to dismiss. Disagreement means back leaves the page.
+   */
+  const NARROW = window.matchMedia('(max-width: 70rem)');
+  const MENU = window.matchMedia('(max-width: 60rem)');
+
+  /**
+   * What is open OVER the page, held as session history.
+   *
+   * Two things can cover what is behind them: the nav drawer, and, once the
+   * split has stacked, a record's editor. On Android the back gesture is how
+   * both get dismissed, and a plain CSS class would take the reader out of the
+   * dashboard rather than out of the thing they opened.
+   *
+   * So each is a real history entry, and `applyOverlays` is the ONLY function
+   * that touches the classes. It runs from `popstate`, or from the push that
+   * created the entry, so the DOM and the history stack cannot drift apart.
+   * Every close route (the Close button, the backdrop, Escape, a tab switch)
+   * unwinds through history rather than clearing a class directly.
+   *
+   * The stack is only ever `[]`, `['menu']`, `['detail']` or `['detail','menu']`:
+   * the backdrop covers the whole viewport, so no row can be tapped while the
+   * drawer is open. That is why `popOverlay` can assume the thing it is asked to
+   * close is the top entry.
+   */
+  let overlays = [];
+  // Set while a popstate is being applied, so the select* call that closes a
+  // pane does not try to unwind the very entry that is already unwinding.
+  let unwinding = false;
+
+  const CLOSE_DETAIL = {
+    locations: () => selectLocation(null),
+    tags: () => selectTag(null),
+    queue: () => selectSubmission(null),
+  };
+
+  function applyOverlays(next) {
+    const was = overlays;
+    overlays = next;
+
+    const menu = next.includes('menu');
+    const detail = next.includes('detail');
+
+    document.body.classList.toggle('menu-open', menu);
+    document.body.classList.toggle('detail-open', detail);
+    $('#nav-toggle').setAttribute('aria-expanded', String(menu));
+    $('#nav-backdrop').hidden = !menu;
+    $('#detail-back').hidden = !detail;
+
+    // The entry went, so the pane it stood for goes with it.
+    if (was.includes('detail') && !detail) {
+      unwinding = true;
+      CLOSE_DETAIL[state.detailTab]?.();
+      state.detailTab = null;
+      unwinding = false;
+    }
+  }
+
+  function pushOverlay(kind) {
+    if (overlays.includes(kind)) return;
+    const next = [...overlays, kind];
+    history.pushState({ ncz: next }, '');
+    applyOverlays(next);
+  }
+
+  const popOverlay = (kind) => { if (overlays.includes(kind)) history.back(); };
+
+  /** One `go`, so the whole stack unwinds in a single popstate. */
+  const closeOverlays = () => { if (overlays.length) history.go(-overlays.length); };
+
+  const toggleMenu = () => (overlays.includes('menu') ? popOverlay('menu') : pushOverlay('menu'));
+
+  /**
+   * A record was opened.
+   *
+   * Below 70rem that is a navigation: the editor replaces the list, so there has
+   * to be something to come back to. Above it the editor fills a pane that is
+   * already on screen, and nothing is pushed, because selecting a row on a
+   * desktop is not a place anyone should be able to press Back out of.
+   */
+  function openDetail(tab) {
+    state.detailTab = tab;
+    if (unwinding || !NARROW.matches) return;
+    pushOverlay('detail');
+  }
+
+  function closeDetail() {
+    if (unwinding) return;
+    state.detailTab = null;
+    popOverlay('detail');
+  }
+
+  /**
+   * The number on the closed menu button.
+   *
+   * Summed from the tab badges already rendered, not recomputed from state. Two
+   * independent counts of the same thing is how #823 happened, and this has no
+   * reason to be a second consumer of anything.
+   */
+  function syncNavBadge() {
+    const total = ['#queue-count', '#candidates-count', '#alerts-count']
+      .reduce((n, sel) => n + (Number($(sel).textContent) || 0), 0);
+    $('#nav-count').textContent = total ? String(total) : '';
+  }
+
   // ---------------------------------------------------------------- tabs --
 
   const TABS = ['overview', 'locations', 'queue', 'candidates', 'tags', 'alerts', 'audit'];
 
   function switchTab(name) {
+    // A tab is a different place, so nothing opened over the old one survives
+    // the move. Without this, opening the drawer over an open record and tapping
+    // Queue lands on a queue showing its review pane with nothing selected.
+    closeOverlays();
     for (const btn of document.querySelectorAll('nav.tabs button')) {
       btn.setAttribute('aria-selected', String(btn.dataset.tab === name));
     }
@@ -2479,6 +2770,31 @@
     for (const btn of document.querySelectorAll('nav.tabs button')) {
       btn.onclick = () => switchTab(btn.dataset.tab);
     }
+
+    // The overlay layer. `popstate` is the only applier; everything else either
+    // pushes an entry or asks history to unwind one. See the note on `overlays`.
+    window.addEventListener('popstate', (e) => applyOverlays(
+      Array.isArray(e.state?.ncz) ? e.state.ncz : [],
+    ));
+    $('#nav-toggle').onclick = toggleMenu;
+    $('#nav-backdrop').onclick = () => popOverlay('menu');
+    $('#detail-back').onclick = () => popOverlay('detail');
+    document.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && overlays.length) history.back();
+    });
+    // A rotation can cross the split breakpoint with a record already open.
+    // Wide to narrow leaves the editor covering the screen with no entry behind
+    // it, so back would leave the dashboard; push one. Narrow to wide leaves an
+    // entry for a pane that covers nothing, which is harmless: back deselects.
+    NARROW.addEventListener('change', (e) => {
+      if (e.matches && state.detailTab && !overlays.includes('detail')) pushOverlay('detail');
+    });
+    MENU.addEventListener('change', (e) => { if (!e.matches) popOverlay('menu'); });
+    // The header gives its wordmark back once the page has moved. A threshold
+    // rather than any scroll at all, so a touch bounce does not flicker it.
+    window.addEventListener('scroll', () => {
+      document.body.classList.toggle('scrolled', window.scrollY > 24);
+    }, { passive: true });
     // The inputs write into the filter state rather than being read from it,
     // so the Overview tiles and the controls cannot disagree about what the
     // list is showing.

--- a/admin/index.html
+++ b/admin/index.html
@@ -35,30 +35,63 @@
 </main>
 
 <header class="topbar">
+  <!--
+    The menu button, and the drawer it opens, exist only below the nav
+    breakpoint. Above it the drawer is `display: contents` and its children lay
+    out in this bar exactly as they would have without it, so there is one set
+    of controls and one set of ids at every width.
+
+    The badge is the total of the three tab counts below. It is what the closed
+    menu still says: eight tabs folded behind a button, with nothing on the
+    button, is a dashboard that has stopped reporting that there is work waiting.
+  -->
+  <button type="button" class="nav-toggle" id="nav-toggle"
+          aria-expanded="false" aria-controls="tablist" aria-label="Menu">
+    <span class="nav-toggle-bars" aria-hidden="true"></span>
+    <span class="tab-count" id="nav-count"></span>
+  </button>
+
   <h1>NC Zoning Board</h1>
-  <nav class="tabs" role="tablist">
-    <button type="button" role="tab" data-tab="overview" aria-selected="true">Overview</button>
-    <button type="button" role="tab" data-tab="locations" aria-selected="false">Locations</button>
-    <!-- The count is filled in from the rows already fetched, not from a
-         server aggregate. See the note on the Overview panel. -->
-    <button type="button" role="tab" data-tab="queue" aria-selected="false">Queue<span class="tab-count" id="queue-count"></span></button>
-    <button type="button" role="tab" data-tab="candidates" aria-selected="false">Candidates<span class="tab-count" id="candidates-count"></span></button>
-    <button type="button" role="tab" data-tab="tags" aria-selected="false">Tags</button>
-    <!-- Unacknowledged only. An alert that someone has already dealt with is
-         history, not a thing to badge. -->
-    <button type="button" role="tab" data-tab="alerts" aria-selected="false">Alerts<span class="tab-count" id="alerts-count"></span></button>
-    <button type="button" role="tab" data-tab="audit" aria-selected="false">Audit</button>
-  </nav>
-  <span class="spacer"></span>
+
   <!-- What the map is actually serving right now, and how old it is. Staging
        has no cron, so without this the read path can sit hours stale with
-       nothing to show for it. -->
+       nothing to show for it. Stays in the bar at every width: it is the one
+       indicator that is worth nothing if it has to be gone looking for. -->
   <span class="freshness" id="freshness" title="Age of the dataset the public API is serving"></span>
-  <button type="button" class="btn secondary" id="rebuild" title="Rebuild the served dataset from the current source">Rebuild</button>
-  <span class="muted">Signed in as <span class="who" id="whoami"></span></span>
-  <span class="muted" id="api-label"></span>
-  <button type="button" class="btn secondary" id="signout">Sign out</button>
+
+  <div class="topbar-drawer" id="topbar-drawer">
+    <nav class="tabs" role="tablist" id="tablist">
+      <button type="button" role="tab" data-tab="overview" aria-selected="true">Overview</button>
+      <button type="button" role="tab" data-tab="locations" aria-selected="false">Locations</button>
+      <!-- The count is filled in from the rows already fetched, not from a
+           server aggregate. See the note on the Overview panel. -->
+      <button type="button" role="tab" data-tab="queue" aria-selected="false">Queue<span class="tab-count" id="queue-count"></span></button>
+      <button type="button" role="tab" data-tab="candidates" aria-selected="false">Candidates<span class="tab-count" id="candidates-count"></span></button>
+      <button type="button" role="tab" data-tab="tags" aria-selected="false">Tags</button>
+      <!-- Unacknowledged only. An alert that someone has already dealt with is
+           history, not a thing to badge. -->
+      <button type="button" role="tab" data-tab="alerts" aria-selected="false">Alerts<span class="tab-count" id="alerts-count"></span></button>
+      <button type="button" role="tab" data-tab="audit" aria-selected="false">Audit</button>
+    </nav>
+
+    <div class="topbar-meta">
+      <button type="button" class="btn secondary" id="rebuild" title="Rebuild the served dataset from the registry">Rebuild</button>
+      <span class="muted">Signed in as <span class="who" id="whoami"></span></span>
+      <span class="muted" id="api-label"></span>
+      <button type="button" class="btn secondary" id="signout">Sign out</button>
+    </div>
+  </div>
+
+  <!-- Below the split breakpoint the editor replaces the list rather than
+       sitting beside it, so there has to be a way back that is not the
+       browser's. Rendered here, once, rather than into each of the three
+       editor panes, all of which replace their own contents wholesale. -->
+  <button type="button" class="detail-back" id="detail-back" hidden>Back to the list</button>
 </header>
+
+<!-- Catches the tap that closes the drawer. A real element rather than a
+     ::backdrop so it can also stop the page behind it being scrolled. -->
+<div class="nav-backdrop" id="nav-backdrop" hidden></div>
 
 <main>
   <div id="banner"></div>


### PR DESCRIPTION
Draft until someone opens it on a real phone. `admin/` has no automated coverage, and this has shipped visibly broken twice before off a narrow desktop window.

## 1. "D1" is not a word for users

Seven sites, not the six an audit of the labels finds. `/admin/refresh` returns `source: 'd1'` (`worker/src/admin.js:171`) and the rebuild banner printed it verbatim: "Rebuilt from d1". One `DATASET_SOURCE_LABEL` map now serves both the banner and the `dataset.refresh` audit sentence, so they cannot drift, and an unmapped token renders as itself rather than as a blank.

The stored audit `target` is untouched. The log is append-only and the stored value is what was true, so the mapping lives in the renderer.

The registry/served distinction is kept, not flattened: `in the registry` / `published in the registry` / `served to the map` are still three numbers, which is how a stale dataset gets spotted.

## 2. Audit log, plain language

`granted_by: "apply"` was never produced by `auditSentence`. It leaked from the raw JSON in the `<details>` block, so fixing the sentence renderer would not have touched what was actually seen.

- `FIELD_LABEL` maps every column that can appear in a `before`/`after` to a phrase. Deliberately incomplete: an unmapped field renders as its own name, because a label map that silently drops unknown fields would make the log lie by omission.
- `VALUE_LABEL` maps the closed-set fields only (`granted_by`, `status`, `kind`). Names, notes and reasons are prose already and are shown exactly as recorded.
- Absent, `null` and `''` now read as three different things rather than as one `JSON.stringify` output.
- The verbatim record sits one fold deeper under **Show exactly what was recorded**. The `.audit-head .action` comment says the raw action stays visible so the sentence can be trusted; the same argument applies to the expanded record, so nothing is hidden, only folded.
- `renderDiff` is shared with the queue's review pane (`admin.js:1271,1279`), so a reviewer reads the same English.
- `changedFields` feeds the sentence's `(admin_notes, name, status, tags)` and now uses the same labels as the diff below it.

## 3. The responsive pass

Two breakpoints, deliberately different numbers, and `admin.js` reads both back:

- **70rem** is where `.split` stacks. Below it the editor was not hidden, it was below the table and off-screen, and selecting a row did nothing visible. It now replaces the list.
- **60rem** is where eight uppercase tabs stop fitting (they measure ~55rem alone). The nav folds into a drawer, keeping `role="tablist"` and `aria-selected`. The badge on the closed button sums the three tab counts, read off the badges already rendered rather than recomputed from state.

Back gestures were decided before the nav was built, as the kickoff required. The drawer and the stacked editor are real `pushState` entries. `applyOverlays` is the only function that writes the classes and it runs from `popstate`, so every close route (Close button, backdrop, Escape, tab switch) unwinds through history and the DOM cannot disagree with the stack. Above 70rem nothing is pushed: selecting a row on a desktop is not a place anyone should be able to press Back out of.

Also: header collapses its wordmark on scroll (keeping the badge and the freshness pill, which are the two things in the bar that report anything), 46px rows, and the four detail columns hidden below 50rem so the list fits without a sideways scroll.

### One trap worth recording

`backdrop-filter` on `.topbar` makes it the containing block for its `position: fixed` descendants, so the drawer resolved `bottom: 0` against the header and rendered as a sliver. The bar goes solid below the nav breakpoint instead.

## Verification

Chrome at 390, 1080 and 1440. No console errors. Checked: drawer open/close, tab switch from the drawer with a record open, list→detail→back on all three split tabs (locations, tags, queue), Escape, scroll collapse, Leaflet mini-map in the stacked review pane, zero horizontal page overflow.

Not checked on a real phone. That is the gate on taking this out of draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
