### PR TITLE
Release 2.4.1: freshness pill back beside Rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2026-08-02
+
+### Fixed
+
+- The dataset freshness pill sits beside Rebuild again on desktop. Restructuring the top bar for the mobile drawer moved it next to the wordmark, away from the control it exists to prompt.
+
 ## [2.4.0] - 2026-08-02
 
 The admin dashboard works on a phone, and says what it means. Nothing about

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -2811,6 +2811,19 @@
     );
     measure();
     new ResizeObserver(measure).observe(topbar);
+
+    // The freshness pill lives with Rebuild, which is the control it exists to
+    // prompt. That group folds into the drawer below the nav breakpoint, and a
+    // staleness indicator behind a closed menu reports nothing, so the pill (and
+    // only the pill) comes back out into the bar. One element that changes
+    // parent, rather than two that can disagree about the same number.
+    const freshness = $('#freshness');
+    const drawer = $('#topbar-drawer');
+    const placeFreshness = (narrow) => (narrow
+      ? topbar.insertBefore(freshness, drawer)
+      : $('.topbar-meta').prepend(freshness));
+    placeFreshness(MENU.matches);
+    MENU.addEventListener('change', (e) => placeFreshness(e.matches));
     $('#loc-new').onclick = () => selectLocation('');
     $('#tag-new').onclick = () => selectTag('');
     $('#audit-refresh').onclick = loadAudit;

--- a/admin/index.html
+++ b/admin/index.html
@@ -53,12 +53,6 @@
 
   <h1>NC Zoning Board</h1>
 
-  <!-- What the map is actually serving right now, and how old it is. Staging
-       has no cron, so without this the read path can sit hours stale with
-       nothing to show for it. Stays in the bar at every width: it is the one
-       indicator that is worth nothing if it has to be gone looking for. -->
-  <span class="freshness" id="freshness" title="Age of the dataset the public API is serving"></span>
-
   <div class="topbar-drawer" id="topbar-drawer">
     <nav class="tabs" role="tablist" id="tablist">
       <button type="button" role="tab" data-tab="overview" aria-selected="true">Overview</button>
@@ -75,6 +69,16 @@
     </nav>
 
     <div class="topbar-meta">
+      <!-- What the map is actually serving right now, and how old it is. Staging
+           has no cron, so without this the read path can sit hours stale with
+           nothing to show for it. It sits with Rebuild because they are one job:
+           read the age, then act on it.
+
+           admin.js moves this element into the bar below the nav breakpoint,
+           where the rest of this group folds into the drawer. An indicator that
+           has to be gone looking for is worth nothing, and one element that
+           changes parent cannot disagree with itself the way two would. -->
+      <span class="freshness" id="freshness" title="Age of the dataset the public API is serving"></span>
       <button type="button" class="btn secondary" id="rebuild" title="Rebuild the served dataset from the registry">Rebuild</button>
       <span class="muted">Signed in as <span class="who" id="whoami"></span></span>
       <span class="muted" id="api-label"></span>


### PR DESCRIPTION
Patch on 2.4.0. One element, one position. No API change, no data change, the map is untouched.

## The regression

Restructuring the top bar for the mobile drawer in 2.4.0 moved `#freshness` out of the right-hand control cluster and put it next to the wordmark. On desktop that separates the dataset age from Rebuild, which is the control it exists to prompt: read the age, then act on it. Apart, the age reads as decoration.

It was caught on desktop after 2.4.0 shipped, because the whole review pass for that release was done on a phone.

## The fix

The pill is back inside `.topbar-meta`, immediately before Rebuild, so desktop is byte-for-byte the previous layout.

That group folds into the drawer below the nav breakpoint, and a staleness indicator behind a closed menu reports nothing, so `admin.js` moves the pill (and only the pill) back out into the bar there. One element that changes parent, rather than two elements that could disagree about the same number.

## Verification

1440, 1280 and 390, resizing across the 60rem breakpoint in both directions: the pill lands in `.topbar-meta` above it and in `.topbar` below it, adjacent to Rebuild in both senses that matter. With the drawer open at 390, checked with `elementFromPoint` that the pill is in the bar rather than the drawer and that nothing covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
