### PR TITLE
feat(api): report a pinned mod returning to published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A pin whose Nexus mod has been deleted drops off the map on its own again, three sweeps after Nexus reports it. The location record is not edited, so the pin returns by itself if Nexus changes its mind.
 - A pin whose mod is hidden on Nexus is flagged for review and left on the map: only the reason the author gave says whether that is temporary, and the API does not expose it.
 - The dashboard's Overview lists both, with the pins each one affects and a control to dismiss the flag or put a withheld pin back.
+- A mod published on Nexus again restores its own pin and says so. If someone had hidden the record by hand meanwhile, the alert names it: that stays hidden until a person republishes it.
+- Alerts link to the mod they are about, in the dashboard and in Discord.
 
 ## [2.4.1] - 2026-08-02
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,6 +155,7 @@ The 3D scene ships on `main`. These are the other five files:
   - `hidden`, confirmed over 3 sweeps: **review list only**. It covers an author mid-upload and a moderation hold equally and the API will not say which, so a person reads the reason on the mod page and decides.
   - absent from the response, 6 sweeps and 24 hours: review list only. The weakest signal, because a failed `modsByUid` chunk manufactures it.
   - Only a person writes `locations.status`. The dashboard's drift row subtracts the withheld pins, so a deliberate withdrawal is not reported as a fault.
+  - **The up edge is reported too.** A mod returning to `published` clears its row and restores any withheld pin automatically, and raises a `recovery` alert. The alert exists for the asymmetric half: withholding reverses itself, but a record an admin hid by hand does not, and this is the only moment anyone is told it can be republished. A status that was never confirmed does not produce a recovery.
 
 ### Styling (`style.css`)
 

--- a/worker/src/nexus-status.js
+++ b/worker/src/nexus-status.js
@@ -213,8 +213,52 @@ export async function recordSweep(env, { unavailable = new Map(), nowIso }) {
     cleared += 1;
   }
 
+  // The up edge, captured BEFORE the delete, because the row is the only record
+  // that anything was ever wrong. Only rows that were FLAGGED: a mod that
+  // looked odd for one sweep and was fine on the next is not a recovery, it is
+  // noise, and announcing it would teach people to skip the recovery alerts
+  // that matter.
+  //
+  // The pins go with it. Withholding reverses itself, but an admin who HID the
+  // record while the mod was down has made a write that no sweep will undo, and
+  // the only moment anyone can be told is this one.
+  const recovering = [...existing.values()].filter(
+    (r) => !unavailable.has(String(r.nexus_id)) && r.flagged_at,
+  );
+  const pins = recovering.length ? await readPinsForTracked(env) : new Map();
+  const recovered = recovering.map((r) => ({
+    nexus_id: String(r.nexus_id),
+    was: r.status,
+    // Dismissed means the admin already put the pin back by hand, so there is
+    // nothing for this to restore.
+    wasWithheld: r.status === WASTEBINNED && !r.dismissed_at,
+    locations: pins.get(String(r.nexus_id)) ?? [],
+  }));
+
   if (statements.length) await env.DB.batch(statements);
-  return { tracked: unavailable.size, cleared, flagged };
+  return { tracked: unavailable.size, cleared, flagged, recovered };
+}
+
+/**
+ * Pins for every currently tracked mod, keyed by nexus_id.
+ *
+ * `IN (SELECT ...)` rather than an id list, for the reason readCandidates uses
+ * it: no bound parameter per mod, no 100-parameter ceiling to grow into. Read
+ * only when something is recovering, which is rare.
+ */
+async function readPinsForTracked(env) {
+  const { results } = await env.DB.prepare(
+    `SELECT id, name, status, nexus_id FROM locations
+      WHERE nexus_id IN (SELECT nexus_id FROM nexus_mod_status)
+      ORDER BY name`,
+  ).all();
+  const byMod = new Map();
+  for (const l of results ?? []) {
+    const key = String(l.nexus_id);
+    if (!byMod.has(key)) byMod.set(key, []);
+    byMod.get(key).push({ id: l.id, name: l.name, status: l.status });
+  }
+  return byMod;
 }
 
 /**

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -185,6 +185,65 @@ async function alertModStatus(env, fetchImpl, flagged, nowMs) {
 }
 
 /**
+ * A pinned mod is published on Nexus again (#900).
+ *
+ * The down edge is handled, the up edge was not, and the two are not
+ * symmetrical. Withholding reverses itself: the row goes, `readWithheld` stops
+ * naming the mod, and the next build serves the pin again with nobody involved.
+ * A HIDDEN RECORD DOES NOT. If an admin set `status: hidden` on the location
+ * while the mod was down, that is a human write, no sweep will undo it, and
+ * this alert is the only moment anyone finds out it can be undone.
+ *
+ * So the body is written around what is left to do, which is nothing at all in
+ * the common case and one edit in the case that would otherwise go unnoticed
+ * for as long as nobody happened to look.
+ *
+ * Mirrors alertRefreshRecovered: same `recovery` severity, same fires-once-on-
+ * the-edge shape. Never throws.
+ */
+async function alertModRecovered(env, fetchImpl, recovered, nowMs) {
+  if (recovered.length > STATUS_ALERT_MAX) {
+    const title = `${recovered.length} pinned mods are published on Nexus again`;
+    if (await alertedSinceUtcMidnight(env, { source: 'refresh', title }, nowMs)) return;
+    await raiseAlert(env, {
+      source: 'refresh',
+      severity: 'recovery',
+      title,
+      body: `${recovered.map((r) => `${r.nexus_id}: was ${r.was}`).join('\n')}\n\n`
+        + 'Any withheld pins are served again from this build. Records that were '
+        + 'hidden by hand stay hidden: the registry does not un-hide anything on '
+        + 'its own. Check the dashboard.',
+    }, { fetchImpl, nowMs });
+    return;
+  }
+
+  for (const r of recovered) {
+    const title = `Pinned mod is back on Nexus: ${r.nexus_id}`;
+    if (await alertedSinceUtcMidnight(env, { source: 'refresh', title }, nowMs)) continue;
+
+    // The pins a person still has to deal with. `published` needs nothing; a
+    // record someone hid while the mod was down is the whole reason this alert
+    // exists, and naming it is the difference between a notification and a task.
+    const needsAHand = (r.locations ?? []).filter((l) => l.status !== 'published');
+    const todo = needsAHand.length
+      ? `Still hidden in the registry: ${needsAHand.map((l) => `${l.name} (${l.status})`).join(', ')}.\n`
+        + 'Nothing here changes a location\'s status, so that stays as it is until '
+        + 'someone republishes the record in the dashboard.'
+      : 'Nothing to do. The pin is served again from this build.';
+
+    await raiseAlert(env, {
+      source: 'refresh',
+      severity: 'recovery',
+      title,
+      body: `Nexus reports mod ${r.nexus_id} as published again, after `
+        + `${storyFor(r.was).headline}.\n\n${modPageUrl(r.nexus_id)}\n\n`
+        + `${r.wasWithheld ? 'Its pin was withheld and is restored automatically. ' : ''}`
+        + todo,
+    }, { fetchImpl, nowMs });
+  }
+}
+
+/**
  * Sweep `nexus_cache` and return the index the dataset is built against.
  *
  * The sweep never throws (a Nexus outage must leave last-known-good in place),
@@ -201,16 +260,20 @@ async function sweepNexusCache(env, fetchImpl, nexusNodes, nowIso) {
         + `${sweep.backfilled} backfilled, ${sweep.untagged} untagged)`,
       );
     }
-    if (sweep.modStatus?.flagged?.length) {
-      // Its own try/catch, INSIDE the one that rethrows: a D1 failure reading
-      // the cache must keep last-known-good, and a Discord failure telling
-      // someone about a deleted mod must not. Different severities, so they
-      // cannot share a catch.
+    // Its own try/catch, INSIDE the one that rethrows: a D1 failure reading the
+    // cache must keep last-known-good, and a Discord failure telling someone
+    // about a deleted mod must not. Different severities, so they cannot share
+    // a catch.
+    if (sweep.modStatus?.flagged?.length || sweep.modStatus?.recovered?.length) {
+      const parsed = Date.parse(nowIso);
+      const nowMs = Number.isFinite(parsed) ? parsed : Date.now();
       try {
-        const nowMs = Date.parse(nowIso);
-        await alertModStatus(
-          env, fetchImpl, sweep.modStatus.flagged, Number.isFinite(nowMs) ? nowMs : Date.now(),
-        );
+        if (sweep.modStatus.flagged?.length) {
+          await alertModStatus(env, fetchImpl, sweep.modStatus.flagged, nowMs);
+        }
+        if (sweep.modStatus.recovered?.length) {
+          await alertModRecovered(env, fetchImpl, sweep.modStatus.recovered, nowMs);
+        }
       } catch (err) {
         console.warn('mod-status alert failed (non-fatal):', String(err).slice(0, 200));
       }

--- a/worker/test/nexus-status.test.js
+++ b/worker/test/nexus-status.test.js
@@ -173,6 +173,68 @@ test('the pin comes back on its own if Nexus publishes the mod again', async () 
   assert.equal((await readWithheld(env)).withhold.size, 0);
 });
 
+// ---------------------------------------------------------- the up edge ---
+// Withholding reverses itself; a record an admin hid does not. The recovery
+// report is the only moment anyone learns the second one can be undone.
+
+test('a mod returning to published is reported, with the pins it affects', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+
+  const back = await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: HOUR });
+  assert.equal(back.modStatus.recovered.length, 1);
+  assert.equal(back.modStatus.recovered[0].nexus_id, '200');
+  assert.equal(back.modStatus.recovered[0].was, 'hidden');
+  assert.equal(back.modStatus.recovered[0].wasWithheld, false, 'hidden never withheld it');
+  assert.deepEqual(back.modStatus.recovered[0].locations.map((l) => l.name), ['Loc l2'],
+    'captured before the row is deleted, or there is nothing left to name');
+});
+
+test('a deleted mod returning says its pin was withheld', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: WASTEBINNED }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  assert.equal((await readWithheld(env)).withhold.size, 1, 'precondition: the pin is down');
+
+  const back = await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: HOUR });
+  assert.equal(back.modStatus.recovered[0].wasWithheld, true);
+  assert.equal((await readWithheld(env)).withhold.size, 0, 'and it is already restored');
+});
+
+test('a mod that was dismissed reports no withholding to undo', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: WASTEBINNED }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  await setDismissed(env, '200', { actor: 'spuddeh', nowIso: at(HOUR) });
+
+  const back = await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: 2 * HOUR });
+  assert.equal(back.modStatus.recovered[0].wasWithheld, false,
+    'the admin already put the pin back by hand; there is nothing to restore');
+});
+
+test('a one-sweep blink is not a recovery', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: 1, gap: 5 * MIN });
+  assert.equal(one(env, '200').flagged_at, null, 'precondition: never confirmed');
+
+  const back = await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: 10 * MIN });
+  assert.deepEqual(back.modStatus.recovered, [],
+    'announcing noise is how the recoveries that matter get skipped');
+  assert.equal(one(env, '200'), null, 'the row still clears');
+});
+
+test('the recovery carries the pin an admin hid, so it can be put back', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  // What an admin does about a mod that has gone: pull the pin by hand.
+  env.DB._db.prepare('UPDATE locations SET status = ? WHERE id = ?').run('hidden', 'l2');
+
+  const back = await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: HOUR });
+  assert.deepEqual(back.modStatus.recovered[0].locations, [
+    { id: 'l2', name: 'Loc l2', status: 'hidden' },
+  ], 'no sweep will un-hide this, so the report has to say it is still hidden');
+  assert.equal(env.DB.one('SELECT status FROM locations WHERE id = ?', 'l2').status, 'hidden',
+    'and the recovery must not un-hide it either: that write was a decision');
+});
+
 test('a hidden mod that is then deleted starts its run again', async () => {
   const env = envWith();
   await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: 5, gap: 5 * MIN });

--- a/worker/test/refresh-d1.test.js
+++ b/worker/test/refresh-d1.test.js
@@ -296,6 +296,62 @@ test('a hidden mod is alerted about and its pin stays up', async () => {
     'and it has to be one click away, or nobody makes the trip');
 });
 
+test('a mod coming back raises a recovery alert and restores its pin', async () => {
+  const gone = { ...ROWS[0], id: 'm2', name: 'Back From The Dead', nexus_id: '99999' };
+  const db = fakeD1({ rows: [...ROWS, gone] });
+  // Already confirmed deleted and flagged, which is the state the up edge has
+  // to fire from.
+  db._db.prepare(
+    `INSERT INTO nexus_mod_status (nexus_id, status, streak, first_seen_at, last_seen_at, flagged_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run('99999', 'wastebinned', 9, new Date(Date.now() - 3600_000).toISOString(),
+    new Date(Date.now() - 300_000).toISOString(), new Date(Date.now() - 1800_000).toISOString());
+
+  const env = { DATASET: fakeKV(), DB: db, SITE_ORIGIN: 'https://x' };
+  // Withheld first, so the restoration is a change and not a starting state.
+  await runRefresh(env, fakeFetch({ nexusStatus: { 99999: 'wastebinned' } }));
+  let full = await env.DATASET.get(KEYS.full, 'json');
+  assert.equal(full.m2, undefined, 'precondition: the pin is withheld');
+
+  // Nexus publishes it again.
+  await runRefresh(env, fakeFetch({ nexusStatus: { 99999: 'published' } }));
+  full = await env.DATASET.get(KEYS.full, 'json');
+  assert.ok(full.m2, 'the pin is served again, with nobody involved');
+  assert.equal(db.one('SELECT nexus_id FROM nexus_mod_status WHERE nexus_id = ?', '99999'), null);
+
+  const recovery = db.rows("SELECT * FROM alerts WHERE severity = 'recovery'");
+  assert.equal(recovery.length, 1, 'a silent recovery is how a hidden record stays hidden forever');
+  assert.match(recovery[0].title, /back on Nexus: 99999/);
+  assert.match(recovery[0].body, /withheld and is restored automatically/);
+  assert.match(recovery[0].body, /https:\/\/www\.nexusmods\.com\/cyberpunk2077\/mods\/99999/);
+
+  // Third tick, still published: the edge has passed and stays quiet.
+  await runRefresh(env, fakeFetch({ nexusStatus: { 99999: 'published' } }));
+  assert.equal(db.rows("SELECT * FROM alerts WHERE severity = 'recovery'").length, 1);
+});
+
+test('a recovery names a record the admin hid, because no sweep will un-hide it', async () => {
+  const hiddenRecord = {
+    ...ROWS[0], id: 'm2', name: 'Pulled By Hand', nexus_id: '99999', status: 'hidden',
+  };
+  const db = fakeD1({ rows: [...ROWS, hiddenRecord] });
+  db._db.prepare(
+    `INSERT INTO nexus_mod_status (nexus_id, status, streak, first_seen_at, last_seen_at, flagged_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run('99999', 'hidden', 9, new Date(Date.now() - 3600_000).toISOString(),
+    new Date(Date.now() - 300_000).toISOString(), new Date(Date.now() - 1800_000).toISOString());
+
+  const env = { DATASET: fakeKV(), DB: db, SITE_ORIGIN: 'https://x' };
+  await runRefresh(env, fakeFetch({ nexusStatus: { 99999: 'published' } }));
+
+  const recovery = db.rows("SELECT * FROM alerts WHERE severity = 'recovery'");
+  assert.equal(recovery.length, 1);
+  assert.match(recovery[0].body, /Still hidden in the registry: Pulled By Hand \(hidden\)/,
+    'the one thing left to do is the one thing the alert has to say');
+  assert.equal(db.one('SELECT status FROM locations WHERE id = ?', 'm2').status, 'hidden',
+    'and it is still a human decision to reverse');
+});
+
 test('a truncated result set fails the refresh rather than shrinking the map', async () => {
   const env = {
     DATASET: fakeKV(),


### PR DESCRIPTION
Follow-up to #926. Refs #900.

## The two edges are not symmetrical

`wastebinned` → the pin is withheld. Nexus publishes it again → the row clears, `readWithheld` stops naming the mod, and the next build serves the pin. That already worked and #926 has a test for it. What it did **not** do was say so.

`hidden` → an admin looks at the author's reason, decides the mod is gone for good, and sets `status: hidden` on the location. Nexus publishes it again → **nothing happens**. That was a human write and no sweep will undo it. The row is deleted, the flag disappears from the review list, and the record stays hidden until somebody happens to notice, which is the same silence #900 was opened about, arrived at from the other direction.

So the recovery report exists mostly for the second case, and the alert body is written around what is left to do:

- pin was withheld → "Its pin was withheld and is restored automatically. Nothing to do."
- a record is still hidden → "Still hidden in the registry: Pulled By Hand (hidden). Nothing here changes a location's status, so that stays as it is until someone republishes the record in the dashboard."

Both carry the mod link, like the down-edge alerts now do.

## Two details worth naming

**Captured before the delete.** The row is the only record that anything was ever wrong, and the pins' *current* statuses are what decide whether a person is still needed. Reading them after the batch would return a clean slate and an alert with nothing in it.

**Only confirmed rows recover.** A mod that looked odd for one sweep and was fine on the next never reached the review list, so announcing its "recovery" would be announcing noise — and that is how the recoveries that matter get skipped. Unflagged rows still clear silently.

Severity `recovery`, matching `alertRefreshRecovered`: same edge-triggered shape, same green embed, and `alertedSinceUtcMidnight` on top for the overlapping-cron case.

## Verification

- 358 → **365 tests**, all passing.
- **Mutation-checked, 5 behaviours**, each killed by the right test: unflagged blinks counting as recoveries, the pins being lost, every recovery claiming a pin was withheld, no alert being raised at all, and the alert omitting what is still hidden.
- No dashboard change, so nothing here needs a browser pass. The recovery shows up in the Alerts tab through the existing card, with its id and body URL already clickable from #926.

## Not in scope

Nothing auto-republishes a hidden record. That stays a human decision, for the same reason the `hidden` flag never withheld a pin: the registry does not know why someone pulled it down.
