### PR TITLE
release: 2.5.0 — a deleted mod no longer keeps its pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- A pin whose Nexus mod has been deleted drops off the map on its own again, three sweeps after Nexus reports it. The location record is not edited, so the pin returns by itself if Nexus changes its mind.
+- A pin whose mod is hidden on Nexus is flagged for review and left on the map: only the reason the author gave says whether that is temporary, and the API does not expose it.
+- The dashboard's Overview lists both, with the pins each one affects and a control to dismiss the flag or put a withheld pin back.
+
 ## [2.4.1] - 2026-08-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.5.0] - 2026-08-02
+
+A mod that leaves Nexus no longer leaves its pin behind. Nexus states a
+mod's status outright and the sweep now asks for it, so a deletion is a
+fact rather than an inference. Deleted pulls the pin by itself; hidden
+never does, because the API will not say whether an author is mid-upload
+or a moderator is holding the page, and only the reason on the mod page
+answers that. Nothing changes a location's status but a person.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A pin whose Nexus mod has been deleted drops off the map on its own again, three sweeps after Nexus reports it. The location record is not edited, so the pin returns by itself if Nexus changes its mind.
 - A pin whose mod is hidden on Nexus is flagged for review and left on the map: only the reason the author gave says whether that is temporary, and the API does not expose it.
 - The dashboard's Overview lists both, with the pins each one affects and a control to dismiss the flag or put a withheld pin back.
+- A mod published on Nexus again restores its own pin and says so. If someone had hidden the record by hand meanwhile, the alert names it: that stays hidden until a person republishes it.
+- Alerts link to the mod they are about, in the dashboard and in Discord.
 
 ## [2.4.1] - 2026-08-02
 

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -1292,6 +1292,24 @@ button.breakdown-row:hover .k { color: var(--secondary); }
 
 #overview-alerts .btn { margin-top: var(--space-xs); }
 
+/* A mod-status card's foot carries one control per pin plus the dismissal,
+   where an alert's has only ever had one. Scoped to the panel so the Alerts tab
+   keeps the layout it was reviewed with. */
+#overview-mod-status .alert-foot {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+}
+
+/* "Pin withheld" sits in the card head, where .chip's uppercase label reads as
+   a state rather than as another filter. Amber, not cyan: it is the one thing
+   in this panel that has already changed what visitors see. */
+#overview-mod-status .alert-head .chip {
+    border-color: var(--tertiary);
+    background: transparent;
+    color: var(--tertiary);
+}
+
 /* The diff renders field names and enum values in English, so it is prose and
    set in the body face. The verbatim record below it is JSON, and is the only
    part here that takes the monospace. */

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -74,6 +74,18 @@
     // "3 open" when it merely fetched 3 of them.
     alerts: [],
     alertsUnacknowledged: 0,
+    // Pinned mods Nexus no longer calls published, with the pins that point at
+    // them. Server state, not derived from the locations list: how many
+    // consecutive sweeps have said so is a fact about a run of cron ticks, and
+    // nothing in the browser can see it.
+    nexusMods: [],
+    // Set when this page has done something that changes what the map serves
+    // and the rebuild is still in flight. Only the mod-status dismissal does:
+    // it is the one control here whose effect lands in KV a moment after the
+    // response comes back, so for that moment the registry and the origin
+    // disagree BY DESIGN. Without this the drift row calls that a fault and
+    // tells the reader to rebuild, which is exactly what is already happening.
+    awaitingRebuild: false,
     selectedLocation: null,   // id, or '' for a new record
     selectedTag: null,        // slug, or '' for a new tag
     selectedSubmission: null, // submission id
@@ -1840,7 +1852,7 @@
    */
   async function refreshAll() {
     const results = await Promise.all([
-      loadTags(), loadLocations(), loadQueue(), loadCandidates(),
+      loadTags(), loadLocations(), loadQueue(), loadCandidates(), loadNexusStatus(),
     ]);
 
     // A record open in the detail pane can have gone away in the meantime.
@@ -2026,6 +2038,7 @@
         state.alertsUnacknowledged ? 'warn' : null));
 
     renderOverviewAlerts();
+    renderNexusStatus();
 
     replace($('#stat-category'),
       breakdown(countBy(records, (r) => r.category), records.length, (name) => ({ category: name })));
@@ -2090,13 +2103,36 @@
     // Two independent counts of the same thing. The pair is the point: what the
     // registry holds against what the public API hands the map. Renaming them
     // must not collapse them into one number.
+    // Published records whose Nexus mod is confirmed deleted are withheld from
+    // the dataset on purpose (#900), so they are NOT drift. Counted from the
+    // pins the status list names, because a count would not survive a record
+    // being deleted between the two reads. Without this the drift row reports a
+    // deliberate withdrawal as a fault and tells the reader to rebuild, which
+    // would not fix it: a spurious drift alarm trains people to ignore the row.
+    const withheldPins = new Set(
+      state.nexusMods.filter((m) => m.withheld).flatMap((m) => m.locations.map((l) => l.id)),
+    );
+    const expected = published.filter((r) => !withheldPins.has(r.id)).length;
+
     rows.push(kvRow('in the registry', String(records.length)));
     rows.push(kvRow('published in the registry', String(published.length)));
+    if (withheldPins.size) {
+      rows.push(kvRow('withheld (mod deleted on Nexus)', String(withheldPins.size)));
+    }
+    const agrees = servedCount === expected;
+    if (agrees) state.awaitingRebuild = false;
+
     rows.push(kvRow('served to the map', servedCount === null ? 'unknown' : String(servedCount),
-      servedCount === null ? null : servedCount === published.length ? 'ok' : 'bad'));
-    if (servedCount !== null && servedCount !== published.length) {
-      rows.push(kvRow('drift',
-        `${published.length - servedCount} record(s) not on the map. Rebuild.`, 'bad'));
+      // Neutral, not red, while a rebuild this page started is still in flight:
+      // the number is correct for the moment, it is just about to change.
+      servedCount === null || (!agrees && state.awaitingRebuild) ? null : agrees ? 'ok' : 'bad'));
+    if (servedCount !== null && !agrees) {
+      // A rebuild this page started is not drift, and must not be reported as
+      // one: telling the reader to do the thing already in progress is how a
+      // real drift alarm gets trained out of them.
+      rows.push(state.awaitingRebuild
+        ? kvRow('map', 'rebuilding after your change; this settles within a minute')
+        : kvRow('drift', `${expected - servedCount} record(s) not on the map. Rebuild.`, 'bad'));
     }
     rows.push(kvRow('api host', API.replace('https://', ''), 'mono'));
 
@@ -2504,20 +2540,65 @@
     return loadAlerts();
   }
 
+  /**
+   * An alert title, with a trailing Nexus mod id made clickable.
+   *
+   * Matched on shape rather than on a field, because the alerts table stores a
+   * title and a body and nothing else: adding a `link` column would mean a
+   * migration, a change to the /internal/alerts contract and a second thing for
+   * the GitHub Actions producers to fill in. The pattern is anchored tightly so
+   * it cannot catch a number that is not a mod id (`Quota 80%: KV writes`), and
+   * a title it does not recognise renders as plain text, which is what every
+   * alert did before this existed.
+   */
+  const MOD_ID_TITLE = /^(.*\bmod\b.*: )(\d+)$/i;
+
+  function alertTitleNodes(title) {
+    const m = MOD_ID_TITLE.exec(String(title ?? ''));
+    if (!m) return [String(title ?? '')];
+    return [m[1], nexusLink(m[2])];
+  }
+
+  /**
+   * Alert bodies are plain text assembled by the producers, and some of them
+   * carry a URL. Rendering it as a live link is the difference between "go and
+   * read the author's reason" and making someone copy a line out of an embed.
+   *
+   * Generic over every source rather than special-cased to one: the text is
+   * split and inserted as text nodes, so nothing here can turn a body into
+   * markup.
+   */
+  const URL_IN_TEXT = /https?:\/\/[^\s<>"')]+/g;
+
+  function bodyNodes(body) {
+    const text = String(body ?? '');
+    const out = [];
+    let last = 0;
+    for (const m of text.matchAll(URL_IN_TEXT)) {
+      if (m.index > last) out.push(text.slice(last, m.index));
+      out.push(h('a', {
+        href: m[0], target: '_blank', rel: 'noopener noreferrer', text: m[0],
+      }));
+      last = m.index + m[0].length;
+    }
+    if (last < text.length) out.push(text.slice(last));
+    return out;
+  }
+
   function alertCard(a) {
     const severity = SEVERITY_LABEL[a.severity] ? a.severity : 'info';
     const acknowledged = Boolean(a.acknowledged_at);
     return h('div', { class: `alert-entry sev-${severity}${acknowledged ? ' acknowledged' : ''}` },
       h('div', { class: 'alert-head' },
         h('span', { class: 'alert-sev', text: SEVERITY_LABEL[severity] }),
-        h('strong', { class: 'alert-title', text: a.title }),
+        h('strong', { class: 'alert-title' }, alertTitleNodes(a.title)),
         h('span', { class: 'spacer', style: 'flex:1' }),
         h('span', { class: 'muted', text: SOURCE_LABEL[a.source] ?? a.source }),
         timeEl(a.at)),
       // Pre-wrap: the body is plain text assembled with newlines by the
-      // producers, not markup, and it is inserted as text so a Discord-flavoured
-      // body can never become HTML here.
-      a.body ? h('p', { class: 'alert-body', text: a.body }) : null,
+      // producers, not markup. Split into text nodes and anchors, never
+      // innerHTML, so a Discord-flavoured body still cannot become markup here.
+      a.body ? h('p', { class: 'alert-body' }, bodyNodes(a.body)) : null,
       h('div', { class: 'alert-foot' },
         acknowledged
           ? h('span', { class: 'muted' },
@@ -2595,7 +2676,7 @@
     replace(box,
       sorted.slice(0, SHOWN).map((a) => h('div', { class: `overview-alert sev-${SEVERITY_LABEL[a.severity] ? a.severity : 'info'}` },
         h('span', { class: 'alert-sev', text: SEVERITY_LABEL[a.severity] ?? 'Info' }),
-        h('span', { class: 'overview-alert-title', text: a.title }),
+        h('span', { class: 'overview-alert-title' }, alertTitleNodes(a.title)),
         h('span', { class: 'muted', text: SOURCE_LABEL[a.source] ?? a.source }),
         timeEl(a.at))),
       // Says what is NOT on screen. A panel capped at four that does not admit
@@ -2604,6 +2685,174 @@
         class: 'btn secondary', type: 'button',
         onclick: () => switchTab('alerts'),
       }, total > SHOWN ? `See all ${total} open alerts` : 'Open the Alerts tab'));
+  }
+
+  // ------------------------------------ mods not published on Nexus --
+
+  /**
+   * What each status means here, and what the reader is being asked to do.
+   *
+   * Three separate stories on purpose. "Deleted" has already changed the map
+   * and needs confirming; "hidden" has changed nothing and needs a person to go
+   * and read why; "no longer returned" is the weak signal and says so. Rendering
+   * them identically would flatten the one distinction the panel exists for.
+   */
+  const MOD_STATUS_LABEL = {
+    wastebinned: 'Deleted',
+    hidden: 'Hidden',
+    absent: 'No answer',
+  };
+
+  const MOD_STATUS_NOTE = {
+    wastebinned: 'Nexus reports this mod as deleted, so its pin is off the map. '
+      + 'The record itself has not been edited. Dismiss to put the pin back.',
+    hidden: 'The pin is still up and nothing here will take it down. Hidden covers '
+      + 'an author mid-upload and a moderation hold equally, and only the reason on '
+      + 'the mod page says which.',
+    absent: 'Nexus has stopped answering about this mod at all, which is not the '
+      + 'same as reporting it deleted. The pin is still up.',
+  };
+
+  const modStatusLabel = (s) => MOD_STATUS_LABEL[s] ?? s;
+  const modStatusNote = (s) => MOD_STATUS_NOTE[s]
+    ?? `Nexus reports this mod as "${s}", which this dashboard has not been taught. `
+      + 'The pin is still up.';
+
+  /**
+   * Pinned mods Nexus no longer calls published (#900).
+   *
+   * Server state, unlike every other number on the Overview: how many
+   * consecutive sweeps have said so is a fact about a run of cron ticks, and
+   * nothing in the browser can derive it from the locations list.
+   *
+   * The list is served whole, confirmed rows and not, and this decides what to
+   * show. A mod that has looked odd for one sweep is not news; the panel would
+   * cry wolf every time Nexus hiccupped if the API had already called it one.
+   */
+  async function loadNexusStatus() {
+    const res = await api('/admin/nexus-status');
+    if (!res.ok) {
+      const [kind, message] = describeFailure(res);
+      banner(kind, message);
+      return false;
+    }
+    state.nexusMods = res.body.mods || [];
+    renderNexusStatus();
+    // The health panel's drift row subtracts the withheld pins, so it has to be
+    // redrawn when this list moves. Only when it is on screen: renderOverview
+    // re-reads the public endpoints, which is not free.
+    if (!$('#tab-overview').hidden) renderOverview();
+    return true;
+  }
+
+  /** Whole days since a timestamp, floored at one: never "0 days". */
+  function daysSince(iso) {
+    const ms = Date.now() - Date.parse(iso);
+    return Number.isFinite(ms) ? Math.max(1, Math.round(ms / 86400000)) : 1;
+  }
+
+  /**
+   * One confirmed mod. Borrows the Alerts tab's card rather than defining a
+   * second one: same severity stripe, same head/body/foot, and the two panels
+   * report the same kind of thing.
+   */
+  function modStatusEntry(r) {
+    const days = daysSince(r.first_seen_at);
+    // The stripe carries the difference the reader has to see first: a pin that
+    // is already down is a stronger statement than one that needs a decision.
+    const severity = r.withheld ? 'error' : 'warn';
+    return h('div', { class: `alert-entry sev-${severity}` },
+      h('div', { class: 'alert-head' },
+        h('span', { class: 'alert-sev', text: modStatusLabel(r.status) }),
+        h('strong', { class: 'alert-title', text: r.mod_name || 'Name unknown' }),
+        nexusLink(r.nexus_id),
+        r.withheld ? h('span', { class: 'chip', text: 'pin withheld' }) : null,
+        h('span', { class: 'spacer', style: 'flex:1' }),
+        h('span', { class: 'muted', text: `${r.streak} sweeps` }),
+        timeEl(r.first_seen_at)),
+      h('p', {
+        class: 'alert-body',
+        text: `${days} day${days === 1 ? '' : 's'}. ${modStatusNote(r.status)}`,
+      }),
+      h('div', { class: 'alert-foot' },
+        // The pin, not the mod, is the thing that can be changed, so the buttons
+        // go to the record rather than to Nexus. One per pin: a mod can supply
+        // two locations, and a decision about one says nothing about the other.
+        r.locations.map((l) => h('button', {
+          type: 'button',
+          class: 'btn secondary',
+          onclick: () => { switchTab('locations'); selectLocation(l.id); },
+        }, `Open ${l.name}`)),
+        h('button', {
+          type: 'button',
+          class: 'btn secondary',
+          title: r.withheld
+            ? 'Put the pin back and stop showing this. The mod stays flagged underneath.'
+            : 'Stop showing this. The mod stays flagged underneath, and the pin is untouched.',
+          onclick: (e) => dismissModStatus(r.nexus_id, e.currentTarget),
+        }, r.withheld ? 'Keep the pin' : 'Dismiss')));
+  }
+
+  /**
+   * The panel. Collapses to one muted line on a quiet day, like the alerts
+   * panel above it, and says what it is NOT showing rather than implying the
+   * confirmed rows are everything being tracked.
+   */
+  function renderNexusStatus() {
+    const box = $('#overview-mod-status');
+    if (!box) return;
+
+    const rows = state.nexusMods;
+    const open = rows.filter((r) => r.flagged_at && !r.dismissed_at);
+    const dismissed = rows.filter((r) => r.dismissed_at).length;
+    const watching = rows.filter((r) => !r.flagged_at).length;
+    const aside = [
+      watching ? `${watching} seen once, not confirmed` : null,
+      dismissed ? `${dismissed} dismissed` : null,
+    ].filter(Boolean).join(', ');
+
+    if (!open.length) {
+      replace(box, h('p', {
+        class: 'muted',
+        text: `Every pin points at a mod Nexus still publishes${aside ? ` (${aside})` : ''}.`,
+      }));
+      return;
+    }
+
+    // Deleted first: those pins are already off the map, and the rest are
+    // asking for a decision that has not been made yet.
+    const RANK = { wastebinned: 0, hidden: 1, absent: 2 };
+    const sorted = [...open].sort(
+      (a, b) => (RANK[a.status] ?? 9) - (RANK[b.status] ?? 9)
+        || String(a.first_seen_at).localeCompare(String(b.first_seen_at)),
+    );
+
+    replace(box,
+      sorted.map(modStatusEntry),
+      aside ? h('p', { class: 'muted', text: `Also tracked: ${aside}.` }) : null);
+  }
+
+  /**
+   * Dismiss one flag. The row and its count stay; the panel stops showing it.
+   * For a deleted mod it also puts the pin back, and the button says so.
+   */
+  async function dismissModStatus(nexusId, button) {
+    button.disabled = true;
+    const res = await api(`/admin/nexus-status/${encodeURIComponent(nexusId)}`, {
+      method: 'PATCH',
+      body: { dismissed: true },
+    });
+    if (!res.ok) {
+      button.disabled = false;
+      const [kind, message] = describeFailure(res);
+      return banner(kind, message);
+    }
+    clearBanner();
+    // The Worker rebuilds the dataset for this, in the background. Until that
+    // lands the origin still serves what it served a second ago; see the note
+    // on state.awaitingRebuild.
+    if (res.body?.mod?.status === 'wastebinned') state.awaitingRebuild = true;
+    return loadNexusStatus();
   }
 
   // -------------------------------------------------- narrow-screen nav --
@@ -2845,7 +3094,7 @@
     // Both feed counts the Overview and the tab badges derive from, so they
     // load at boot rather than on first visit to their tab. A badge that only
     // appears once you have already gone looking is not a notification.
-    await Promise.all([loadQueue(), loadCandidates(), loadAlerts()]);
+    await Promise.all([loadQueue(), loadCandidates(), loadAlerts(), loadNexusStatus()]);
     await refreshFreshness();
     // Overview is the landing tab, and its numbers come from what was just
     // loaded, so it is rendered after both rather than on its own fetch.

--- a/admin/index.html
+++ b/admin/index.html
@@ -119,6 +119,16 @@
       <div id="overview-alerts"></div>
     </div>
 
+    <!-- Pins whose mod Nexus no longer publishes. Beside the alerts, because it is
+         the other thing on this page asking for a decision rather than
+         reporting a number, and collapses to one muted line the same way. The
+         cron only ever flags: nothing here has been hidden, and nothing here
+         will be until someone says so. -->
+    <div class="panel" style="grid-column: 1 / -1">
+      <h2>Not published on Nexus</h2>
+      <div id="overview-mod-status"></div>
+    </div>
+
     <div class="panel">
       <h2>Registry</h2>
       <div id="stat-registry" class="stat-grid"></div>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,6 +150,11 @@ The 3D scene ships on `main`. These are the other five files:
 - **Validation** happens on the write path in the Worker, so a bad value is refused at submission rather than caught in CI afterwards.
 - **The registry is not in git.** `data/locations/*.json`, `mods.json` and `build_mods.js` were deleted at Phase 6. The backup is the nightly export to the `data-snapshots` branch, plus D1 Time Travel's 30 days.
 - A frozen copy of 297 records lives at `worker/test/fixtures/locations-corpus.json`. It is a **test fixture**, not a backup: it does not track the registry and is not restored from.
+- **A pin whose mod stops being published on Nexus is acted on by status, not by absence.** `modsByUid` returns deleted and hidden mods like any other node, carrying a `status`; only the tag-search query filters. `nexus_mod_status` records how many consecutive sweeps have seen each non-published status (#900).
+  - `wastebinned` (deleted), confirmed over 3 sweeps: the pin is **withheld from the built dataset**. `locations.status` is never written, so a reversal on Nexus restores the pin with nobody involved, and no sweep may withhold more than 5 pins at once.
+  - `hidden`, confirmed over 3 sweeps: **review list only**. It covers an author mid-upload and a moderation hold equally and the API will not say which, so a person reads the reason on the mod page and decides.
+  - absent from the response, 6 sweeps and 24 hours: review list only. The weakest signal, because a failed `modsByUid` chunk manufactures it.
+  - Only a person writes `locations.status`. The dashboard's drift row subtracts the withheld pins, so a deliberate withdrawal is not reported as a fault.
 
 ### Styling (`style.css`)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,6 +155,7 @@ The 3D scene ships on `main`. These are the other five files:
   - `hidden`, confirmed over 3 sweeps: **review list only**. It covers an author mid-upload and a moderation hold equally and the API will not say which, so a person reads the reason on the mod page and decides.
   - absent from the response, 6 sweeps and 24 hours: review list only. The weakest signal, because a failed `modsByUid` chunk manufactures it.
   - Only a person writes `locations.status`. The dashboard's drift row subtracts the withheld pins, so a deliberate withdrawal is not reported as a fault.
+  - **The up edge is reported too.** A mod returning to `published` clears its row and restores any withheld pin automatically, and raises a `recovery` alert. The alert exists for the asymmetric half: withholding reverses itself, but a record an admin hid by hand does not, and this is the only moment anyone is told it can be republished. A status that was never confirmed does not produce a recovery.
 
 ### Styling (`style.css`)
 

--- a/docs/nexus-api-reference.md
+++ b/docs/nexus-api-reference.md
@@ -35,6 +35,8 @@ query modsByUid($uids: [ID!]!, $count: Int!) {
   modsByUid(uids: $uids, count: $count) {
     nodes {
       modId
+      name
+      status
       pictureUrl
       thumbnailUrl
       updatedAt
@@ -42,6 +44,24 @@ query modsByUid($uids: [ID!]!, $count: Int!) {
   }
 }
 ```
+
+**⚠️ `modsByUid` does NOT filter by status; the `mods` search query does.**
+
+Measured against the live API on 2026-08-02. A deleted or hidden mod comes back from `modsByUid` looking like any other node, and only `status` says otherwise. The tag-search query returns published mods only, which is why an auto-discovered mod used to drop off the map by itself while a manually pinned one never does.
+
+| `status` | Means | Where it comes from |
+| --- | --- | --- |
+| `published` | On the site | The normal case |
+| `hidden` | Not visible to visitors. Author-hidden **or** staff-hidden, and the API does not distinguish them | Only the reason on the mod page says which |
+| `wastebinned` | Deleted | Mod 17513 (Starfield) is a live example; its `name` also carries " - DELETED" |
+
+`status` is a `String`, not an enum, so the values above are observed rather than exhaustive. Treat anything that is not `published` as not-published, and treat **null as published**: a missing field must never be read as evidence.
+
+**The reason a mod is hidden is not reachable.** `Mod` has no moderation field, `moderationWarnings` requires a login ("You must be logged in to retrieve moderation warnings"), and the mod page returns 403 to a non-browser. `moderationReasons()` is readable anonymously but is only the catalogue (7 entries, including "Under review" and "DMCA investigation"), not any given mod's record.
+
+**`updatedAt` is not "when it went away".** For a deleted mod it is the deletion; for a hidden one it can be the last real file update months earlier. `nexus_mod_status.first_seen_at` records when the sweep first saw the status, which is the only timestamp that means one thing.
+
+Consumed by `worker/src/nexus-status.js`; see [`architecture.md`](architecture.md).
 
 **Input Variables:**
 - `uids`: Array of composite Nexus UIDs (see UID Construction below)

--- a/worker/migrations/0009_nexus_mod_status.sql
+++ b/worker/migrations/0009_nexus_mod_status.sql
@@ -1,0 +1,70 @@
+-- What Nexus says about a pinned mod, when it stops saying "published".
+--
+-- WHY. A location whose mod is deleted or hidden on Nexus keeps its pin: with
+-- D1 as the registry it is a row, and rows persist. Before D1 an
+-- auto-discovered mod that vanished simply stopped appearing in the tag query
+-- and fell off the map on its own. Nothing replaced that (#900).
+--
+-- NEXUS ANSWERS THIS DIRECTLY, and we were not asking. The `Mod` type carries a
+-- `status` field. Measured 2026-08-02 against the live API:
+--
+--   * `modsByUid` returns deleted and hidden mods like any other. Mod 17513
+--     (Starfield) comes back with `status: "wastebinned"`; two mods pinned on
+--     our own map come back `hidden` today.
+--   * The `mods` SEARCH query returns only published mods. That asymmetry is
+--     exactly why auto-discovery used to self-heal and the by-uid backfill does
+--     not: the tag query silently dropped a pulled mod, the uid lookup keeps
+--     handing it back.
+--
+-- So absence is the WEAK signal and the rare one. The strong signal is a status
+-- string, and this table records how long we have been seeing it.
+--
+-- THREE STATES, THREE RULES, because they are not the same event:
+--
+--   * `wastebinned` -- deleted. Unambiguous, so the pin is withheld from the
+--     served dataset after a few sweeps confirm it. The ROW IS NOT TOUCHED:
+--     the materializer stops building it, `locations.status` still says
+--     whatever the admin last set, and a reversal on Nexus restores it with no
+--     human involved.
+--   * `hidden` -- could be an author mid-upload, could be a DMCA
+--     investigation, and THE API WILL NOT SAY WHICH. `Mod` has no moderation
+--     field, `moderationWarnings` needs a login, and the mod page 403s. Only a
+--     person reading the author's stated reason can decide, so this never
+--     changes what is served. It goes on the review list and waits.
+--   * absent -- the mod is not in the response at all. Weakest of the three:
+--     `fetchModsByUidThumbs` returns {} on failure and cannot distinguish
+--     "purged" from "Nexus is down", so this one needs a streak AND a day
+--     before it counts as anything.
+--
+-- NO ROW MEANS FINE. A sweep that sees the mod published again deletes the row
+-- rather than zeroing it, so the table holds only the mods currently in
+-- trouble. Same for a mod that stops being pinned. That is also why there is no
+-- index: a full scan of a table this size costs less than maintaining one.
+--
+-- `first_seen_at` IS THE START OF THE CURRENT RUN, not the first time the mod
+-- was ever seen this way, and NOT Nexus's own `updatedAt`. That field means
+-- different things per status (for 17513 it is the deletion; for a hidden mod
+-- it can be the last real file update, months earlier), so the only honest
+-- answer to "how long has this been wrong" is when we first saw it.
+--
+-- `status` CHANGING RESETS THE RUN. hidden -> wastebinned is a new fact about
+-- the mod, and inheriting the hidden run's clock would let it act on a
+-- confirmation it never got.
+
+CREATE TABLE nexus_mod_status (
+  nexus_id      TEXT PRIMARY KEY,
+  status        TEXT NOT NULL,     -- hidden | wastebinned | absent | any future non-published string
+  streak        INTEGER NOT NULL,  -- consecutive sweeps that saw THIS status
+  first_seen_at TEXT NOT NULL,     -- first sweep of the current run
+  last_seen_at  TEXT NOT NULL,     -- most recent sweep of the current run
+  flagged_at    TEXT,              -- crossed its threshold; NULL = still counting
+  dismissed_by  TEXT,              -- admin who said "I know, leave it"
+  dismissed_at  TEXT
+);
+
+-- The status as of the last successful fetch, so the materializer and the
+-- dashboard read one value rather than re-deriving it. NULL means never
+-- resolved, which is the state of every row until the next sweep runs, and it
+-- MUST read as published: a pin may never come down because a field was
+-- missing.
+ALTER TABLE nexus_cache ADD COLUMN status TEXT;

--- a/worker/src/admin.js
+++ b/worker/src/admin.js
@@ -13,6 +13,7 @@ import { adminCors } from './auth.js';
 import { validateLocationInput } from './validate.js';
 import { writeAudit, readAudit } from './audit.js';
 import { readAlerts, countUnacknowledged, acknowledgeAlert } from './alerts.js';
+import { readModStatuses, setDismissed } from './nexus-status.js';
 import { runRefresh } from './refresh.js';
 import {
   validateTagInput, readTagSlugs, readTagsWithUsage, readTagUsers, readTag,
@@ -100,6 +101,51 @@ export async function handleAdmin(request, env, ctx) {
     return json(request, { alert });
   }
   if (alertMatch) return json(request, { error: 'method_not_allowed' }, 405);
+
+  // ---- pinned mods Nexus no longer calls published (#900) ------------------
+  //
+  // Read plus a dismissal, and deliberately nothing else. The cron owns every
+  // other column: an admin who decides a flagged mod is gone for good edits the
+  // LOCATION, through the existing hidden/published control and the existing
+  // audit trail. Nothing here writes `locations.status`.
+  //
+  // Its own route rather than a field on the location PATCH, because the flag
+  // is per MOD and a mod can carry two pins (23896 supplies two tattoo shops).
+  // Dismissing it from one of them would have to mean dismissing it for both,
+  // which is a location endpoint quietly writing something that is not a
+  // location.
+  if (url.pathname === '/admin/nexus-status' && method === 'GET') {
+    return json(request, { mods: await readModStatuses(env) });
+  }
+
+  const modStatusMatch = url.pathname.match(/^\/admin\/nexus-status\/([^/]+)$/);
+  if (modStatusMatch && method === 'PATCH') {
+    const nexusId = decodeURIComponent(modStatusMatch[1]);
+    let payload;
+    try { payload = await request.json(); } catch { return json(request, { error: 'invalid_json' }, 400); }
+    if (typeof payload?.dismissed !== 'boolean') {
+      return json(request, { error: 'validation_failed', errors: ['dismissed must be a boolean'] }, 422);
+    }
+
+    const record = await setDismissed(env, nexusId, { actor, dismissed: payload.dismissed });
+    if (!record) return json(request, { error: 'not_found' }, 404);
+
+    // Audited, unlike an alert acknowledgement. For a deleted mod this decides
+    // whether a pin is on the public map, and even for a hidden one it records
+    // that a person looked at the author's reason and made a call.
+    await writeAudit(env, {
+      actor,
+      action: payload.dismissed ? 'nexus_status.dismiss' : 'nexus_status.restore',
+      target: nexusId,
+      after: record,
+    });
+    // Dismissing a DELETED mod puts its pin back, so the served dataset has to
+    // be rebuilt for that to be true anywhere but this response. Same
+    // fire-and-forget as every other write on this surface.
+    materializeAfterWrite(env, ctx);
+    return json(request, { mod: record });
+  }
+  if (modStatusMatch) return json(request, { error: 'method_not_allowed' }, 405);
 
   // ---- quota: dataset introspection --------------------------------------
   //

--- a/worker/src/materialize.js
+++ b/worker/src/materialize.js
@@ -84,13 +84,25 @@ function resolveTags(row, locationTags) {
  */
 export function materializeFromD1({
   rows, dismissed, nexusNodes, districts, nexusIndex = new Map(),
-  locationTags = null, nowMs = Date.now(),
+  locationTags = null, nowMs = Date.now(), withheld = new Set(),
 }) {
   const dismissedIds = dismissed instanceof Set ? dismissed : new Set(dismissed || []);
+  const withheldIds = withheld instanceof Set ? withheld : new Set(withheld || []);
 
   // Only published records reach the map. `hidden` keeps the row but pulls the
-  // pin (the Nexus-deletion case); `draft` has never been published.
-  const published = rows.filter((r) => r.status === 'published');
+  // pin; `draft` has never been published.
+  const publishedRows = rows.filter((r) => r.status === 'published');
+
+  // Records whose Nexus mod has been confirmed deleted (`wastebinned` on
+  // consecutive sweeps; see nexus-status.js). Withheld HERE rather than by
+  // writing `locations.status`, so the row keeps whatever the admin last set
+  // and a reversal on Nexus restores the pin with nobody involved. Reported on
+  // /v1/meta, because a record that is published and not served is otherwise a
+  // silent disagreement between the dashboard and the map.
+  const withdrawn = publishedRows.filter((r) => withheldIds.has(String(r.nexus_id)));
+  const published = withdrawn.length
+    ? publishedRows.filter((r) => !withheldIds.has(String(r.nexus_id)))
+    : publishedRows;
 
   // Every record's nexus_id, not just the manual ones -- the auto-discovered
   // records are rows now, so they suppress their own re-creation for free.
@@ -153,7 +165,16 @@ export function materializeFromD1({
     };
   }
 
-  return { full, meta: { skipped } };
+  return {
+    full,
+    meta: {
+      skipped,
+      // Published in the registry, deliberately not on the map. Named, not
+      // counted: "3 records withheld" is a number nobody can check, and the
+      // dashboard's drift row has to subtract exactly these.
+      withheld: withdrawn.map((r) => ({ id: r.id, nexus_id: String(r.nexus_id) })),
+    },
+  };
 }
 
 /**

--- a/worker/src/nexus-cache.js
+++ b/worker/src/nexus-cache.js
@@ -71,11 +71,14 @@
 
 import { fetchTaggedModNodes, fetchModsByUidThumbs, fetchModArchiveNames } from './nexus.js';
 import { readArchives } from './store.js';
+import {
+  recordSweep, sweepLooksUnreliable, isPublished, ABSENT, PUBLISHED,
+} from './nexus-status.js';
 
 /** Columns compared to decide whether a row needs writing. */
 const TRACKED = [
   'name', 'summary', 'uploader', 'updated_at', 'thumbnail_url', 'picture_url',
-  'archives', 'archives_at', 'nczoning_tagged',
+  'archives', 'archives_at', 'nczoning_tagged', 'status',
 ];
 
 // Per-tick archive budgets, carried over from refresh.js unchanged. Archives are
@@ -101,6 +104,10 @@ function nodeToRow(node, tagged) {
   return {
     nexus_id: String(node.modId),
     name: node.name ?? null,
+    // The tagged query returns published mods only (measured against the live
+    // API), so a node arriving from it is published by construction. Stated
+    // rather than read off the node, which does not carry the field.
+    status: tagged ? PUBLISHED : (node.status ?? null),
     // The two fields merge.js builds an auto-discovered record's description
     // and first author from, kept so the submit form can prefill the same way.
     summary: node.summary ?? null,
@@ -116,7 +123,7 @@ function nodeToRow(node, tagged) {
 export async function readNexusCache(env) {
   const { results } = await env.DB.prepare(
     `SELECT nexus_id, name, summary, uploader, updated_at, thumbnail_url,
-            picture_url, archives, archives_at, nczoning_tagged, fetched_at
+            picture_url, archives, archives_at, nczoning_tagged, status, fetched_at
        FROM nexus_cache`,
   ).all();
   const map = new Map();
@@ -240,8 +247,8 @@ async function writeRows(env, rows, nowIso) {
   const stmt = env.DB.prepare(
     `INSERT INTO nexus_cache
        (nexus_id, name, summary, uploader, updated_at, thumbnail_url, picture_url,
-        archives, archives_at, nczoning_tagged, fetched_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        archives, archives_at, nczoning_tagged, status, fetched_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(nexus_id) DO UPDATE SET
        name            = COALESCE(excluded.name, nexus_cache.name),
        summary         = COALESCE(excluded.summary, nexus_cache.summary),
@@ -252,6 +259,7 @@ async function writeRows(env, rows, nowIso) {
        archives        = COALESCE(excluded.archives, nexus_cache.archives),
        archives_at     = COALESCE(excluded.archives_at, nexus_cache.archives_at),
        nczoning_tagged = excluded.nczoning_tagged,
+       status          = COALESCE(excluded.status, nexus_cache.status),
        fetched_at      = excluded.fetched_at`,
   );
   await env.DB.batch(rows.map((r) => stmt.bind(
@@ -265,6 +273,7 @@ async function writeRows(env, rows, nowIso) {
     r.archives ?? null,
     r.archives_at ?? null,
     r.nczoning_tagged ?? 0,
+    r.status ?? null,
     nowIso,
   )));
   return rows.length;
@@ -412,16 +421,31 @@ export async function refreshNexusCache(env, { fetchImpl = fetch, nowIso, tagged
     .map((r) => String(r.nexus_id))
     .filter((id) => isRealNexusId(id) && !incoming.has(id));
 
+  // What this sweep learned about each pinned mod that is not published:
+  // nexus_id -> status, where `absent` means the response did not mention it.
+  // Folded into nexus_mod_status at the end, once it is known whether the sweep
+  // can be trusted at all.
+  const unavailable = new Map();
+  let missingIds = [];
+
   if (needBackfill.length) {
     // Do not wrap this in a try/catch: fetchModsByUidThumbs never throws, it
     // returns {} on failure because images are cosmetic. That empty object is
     // indistinguishable from a successful call that found nothing, so the only
     // usable signal is the count against what was requested.
     const thumbs = await fetchModsByUidThumbs(fetchImpl, needBackfill);
+    const returned = new Set(Object.keys(thumbs ?? {}).map(String));
+    missingIds = needBackfill.filter((id) => !returned.has(id));
     for (const [id, t] of Object.entries(thumbs ?? {})) {
+      // A deleted or hidden mod is RETURNED by modsByUid, unlike the tagged
+      // query, which filters. Its images and name are cached like any other
+      // (they are what the review list shows); `status` is what says the pin
+      // needs looking at.
+      if (!isPublished(t.status)) unavailable.set(String(id), String(t.status));
       incoming.set(String(id), {
         nexus_id: String(id),
         name: t.name ?? null,
+        status: t.status ?? null,
         updated_at: t.updatedAt ?? null,
         thumbnail_url: t.thumbnailUrl ?? null,
         picture_url: t.pictureUrl ?? null,
@@ -450,5 +474,54 @@ export async function refreshNexusCache(env, { fetchImpl = fetch, nowIso, tagged
 
   const writes = diffRows([...incoming.values()], existing);
   summary.written = await writeRows(env, writes, stamp);
+  summary.modStatus = await trackModStatus(
+    env, { unavailable, missingIds, needBackfill, summary, stamp },
+  );
   return summary;
+}
+
+/**
+ * Fold this sweep's verdicts into `nexus_mod_status` (#900).
+ *
+ * Runs after the cache write, and never fails the sweep: a mod that vanished
+ * from Nexus is worth telling someone about, and it is not worth costing the
+ * dataset its freshness when the bookkeeping for it hits a D1 error. Same
+ * posture as archives.
+ *
+ * Two reasons to skip a sweep entirely, and both are the difference between a
+ * useful flag and one Nexus outage condemning the whole registry:
+ *
+ *   * `summary.stale` -- the all-or-nothing case detected above. Asked for
+ *     some, got none: that is Nexus, not the mods.
+ *   * `sweepLooksUnreliable` -- the partial case the stale flag cannot see.
+ *     modsByUid is chunked and a chunk that fails after its retry returns {}
+ *     for its whole share, which looks like a simultaneous mass deletion.
+ *
+ * Both guards are about ABSENCE, which is the only one of the three states a
+ * Nexus failure can manufacture: a failed chunk returns no node, never a node
+ * saying `wastebinned`. They still gate the whole step, because a sweep that
+ * cannot be trusted about half its ids should not be recording verdicts on the
+ * other half either.
+ *
+ * Skipping leaves the stored runs untouched rather than resetting them: a mod
+ * that really is gone keeps the count it has earned and picks up again on the
+ * next sweep worth believing.
+ */
+async function trackModStatus(env, { unavailable, missingIds, needBackfill, summary, stamp }) {
+  if (summary.stale) return { skipped: 'stale', flagged: [] };
+  if (sweepLooksUnreliable({ missing: missingIds.length, requested: needBackfill.length })) {
+    console.warn(
+      `nexus_mod_status: ignoring sweep, ${missingIds.length} of ${needBackfill.length} `
+      + 'ids came back empty (reads as a Nexus failure, not a deletion)',
+    );
+    return { skipped: 'unreliable', flagged: [] };
+  }
+  // Absence is folded in only now, so the guards above judge it first.
+  for (const id of missingIds) unavailable.set(id, ABSENT);
+  try {
+    return await recordSweep(env, { unavailable, nowIso: stamp });
+  } catch (err) {
+    console.warn('nexus_mod_status tracking failed (non-fatal):', String(err).slice(0, 200));
+    return { skipped: 'error', flagged: [], error: String(err).slice(0, 200) };
+  }
 }

--- a/worker/src/nexus-status.js
+++ b/worker/src/nexus-status.js
@@ -213,8 +213,52 @@ export async function recordSweep(env, { unavailable = new Map(), nowIso }) {
     cleared += 1;
   }
 
+  // The up edge, captured BEFORE the delete, because the row is the only record
+  // that anything was ever wrong. Only rows that were FLAGGED: a mod that
+  // looked odd for one sweep and was fine on the next is not a recovery, it is
+  // noise, and announcing it would teach people to skip the recovery alerts
+  // that matter.
+  //
+  // The pins go with it. Withholding reverses itself, but an admin who HID the
+  // record while the mod was down has made a write that no sweep will undo, and
+  // the only moment anyone can be told is this one.
+  const recovering = [...existing.values()].filter(
+    (r) => !unavailable.has(String(r.nexus_id)) && r.flagged_at,
+  );
+  const pins = recovering.length ? await readPinsForTracked(env) : new Map();
+  const recovered = recovering.map((r) => ({
+    nexus_id: String(r.nexus_id),
+    was: r.status,
+    // Dismissed means the admin already put the pin back by hand, so there is
+    // nothing for this to restore.
+    wasWithheld: r.status === WASTEBINNED && !r.dismissed_at,
+    locations: pins.get(String(r.nexus_id)) ?? [],
+  }));
+
   if (statements.length) await env.DB.batch(statements);
-  return { tracked: unavailable.size, cleared, flagged };
+  return { tracked: unavailable.size, cleared, flagged, recovered };
+}
+
+/**
+ * Pins for every currently tracked mod, keyed by nexus_id.
+ *
+ * `IN (SELECT ...)` rather than an id list, for the reason readCandidates uses
+ * it: no bound parameter per mod, no 100-parameter ceiling to grow into. Read
+ * only when something is recovering, which is rare.
+ */
+async function readPinsForTracked(env) {
+  const { results } = await env.DB.prepare(
+    `SELECT id, name, status, nexus_id FROM locations
+      WHERE nexus_id IN (SELECT nexus_id FROM nexus_mod_status)
+      ORDER BY name`,
+  ).all();
+  const byMod = new Map();
+  for (const l of results ?? []) {
+    const key = String(l.nexus_id);
+    if (!byMod.has(key)) byMod.set(key, []);
+    byMod.get(key).push({ id: l.id, name: l.name, status: l.status });
+  }
+  return byMod;
 }
 
 /**

--- a/worker/src/nexus-status.js
+++ b/worker/src/nexus-status.js
@@ -1,0 +1,338 @@
+/**
+ * nexus_mod_status: pinned mods Nexus no longer calls published.
+ *
+ * A location whose mod is deleted or hidden on Nexus keeps its pin, because
+ * with D1 as the registry it is a row and rows persist (#900). This module
+ * decides how long a bad answer has to persist before it counts, and what each
+ * kind of bad answer is allowed to do.
+ *
+ * ## Nexus says it outright
+ *
+ * The `Mod` type carries `status`, and `modsByUid` does NOT filter on it: a
+ * deleted mod comes back looking like any other node. So the primary signal is
+ * a string, not an absence, and it is available on the first sweep.
+ *
+ * That inverts what the issue assumed. Absence is the weak, rare case:
+ * `fetchModsByUidThumbs` returns {} on failure, so an id that is simply not in
+ * the response cannot be told apart from a Nexus outage, and only persistence
+ * can settle it. A `status` of `wastebinned` needs no such argument.
+ *
+ * ## Three states, three rules
+ *
+ * | status        | confirmed after | what it does                    |
+ * |---------------|-----------------|---------------------------------|
+ * | `wastebinned` | 3 sweeps        | pin withheld from the dataset   |
+ * | `hidden`      | 3 sweeps        | review list only, map untouched |
+ * | `absent`      | 6 sweeps + 24h  | review list only, map untouched |
+ *
+ * **`hidden` never changes what is served.** It covers an author mid-upload and
+ * a DMCA investigation equally, and the API will not say which: `Mod` has no
+ * moderation field, `moderationWarnings` requires a login, and the mod page
+ * refuses a machine. Only a person reading the author's stated reason can
+ * decide, and the two decisions are opposite ones.
+ *
+ * **`wastebinned` does**, because deleted is deleted. It withholds the record
+ * at build time rather than writing `locations.status`: the row stays exactly
+ * as the admin left it, and if Nexus ever says published again the pin returns
+ * with nobody involved. Writing the column would need a human to undo.
+ *
+ * ## Nothing here fails closed
+ *
+ * A null or unrecognised `status` reads as published. A pin must never come
+ * down because a field went missing from a response, and Nexus changing the
+ * vocabulary is a thing that can happen without warning on an API they
+ * describe as unsupported.
+ */
+
+/** The one value that means "still on the site". Everything else is tracked. */
+export const PUBLISHED = 'published';
+
+/** Nexus's word for deleted. The only status allowed to change what is served. */
+export const WASTEBINNED = 'wastebinned';
+
+/** Local marker for "not in the response at all". Never a value Nexus sends. */
+export const ABSENT = 'absent';
+
+/**
+ * Sweeps a status must repeat before it is acted on.
+ *
+ * Three, and it is confirmation rather than patience: one anomalous response
+ * must not be able to pull a pin off the public map. It is deliberately NOT a
+ * grace period for an author to finish an upload. A mod hidden for twenty
+ * minutes and a mod hidden for a month both need a person to read the reason,
+ * and waiting only delays the ones that matter.
+ */
+export const CONFIRM_SWEEPS = 3;
+
+/**
+ * Absence is held to the older, stricter rule, because it is the only one of
+ * the three that a Nexus outage can manufacture.
+ */
+export const ABSENT_STREAK = 6;
+export const ABSENT_MIN_AGE_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The partial-outage guard for ABSENCE. A sweep is not believed when this many
+ * ids came back empty AND they are this large a share of what was asked for:
+ * `modsByUid` is chunked, and a chunk that fails after its retry returns {} for
+ * its whole share, which looks exactly like a mass deletion.
+ *
+ * The floor matters as much as the ratio: with three pinned mods, one genuine
+ * deletion is 33% and must still count.
+ */
+export const SWEEP_MIN_SUSPECT = 5;
+export const SWEEP_MAX_RATIO = 0.25;
+
+/**
+ * The second guard, and the one that protects the MAP rather than the alert:
+ * no sweep may withhold more than this many pins.
+ *
+ * A status-driven mass withdrawal has no innocent explanation the way an absent
+ * batch does, which is exactly why it should stop and ask instead of acting.
+ * Five is above any plausible real event and far below anything that would
+ * empty the map.
+ */
+export const MAX_WITHHELD = 5;
+
+/**
+ * Does this sweep's absent set look like Nexus failing rather than mods going
+ * away? Pure, and exported, because it decides whether a whole sweep is thrown
+ * away and is worth testing directly.
+ */
+export function sweepLooksUnreliable({ missing, requested }) {
+  if (missing < SWEEP_MIN_SUSPECT) return false;
+  return missing >= requested * SWEEP_MAX_RATIO;
+}
+
+/**
+ * Is this what Nexus says about a mod that is still on the site?
+ *
+ * Null included, and that is the point: an absent field is not evidence of
+ * anything, and treating it as evidence would pull pins the first time the
+ * schema moved.
+ */
+export const isPublished = (status) => status == null || String(status) === PUBLISHED;
+
+/** Every tracked row, keyed by nexus_id. One query, no bound parameters. */
+async function readRows(env) {
+  const { results } = await env.DB.prepare(
+    `SELECT nexus_id, status, streak, first_seen_at, last_seen_at, flagged_at,
+            dismissed_by, dismissed_at
+       FROM nexus_mod_status`,
+  ).all();
+  const map = new Map();
+  for (const r of results ?? []) map.set(String(r.nexus_id), r);
+  return map;
+}
+
+/**
+ * Has this row repeated its status long enough to act on, and not been acted on
+ * already? `flagged_at` set means the alert went out and the review list has
+ * it, whether or not anyone has looked.
+ */
+function crossesThreshold(row, nowMs) {
+  if (row.flagged_at) return false;
+  if (row.status !== ABSENT) return row.streak >= CONFIRM_SWEEPS;
+
+  if (row.streak < ABSENT_STREAK) return false;
+  const since = Date.parse(row.first_seen_at);
+  if (!Number.isFinite(since)) return false;
+  return nowMs - since >= ABSENT_MIN_AGE_MS;
+}
+
+/**
+ * Fold one sweep's verdicts into the table.
+ *
+ * @param {object} env
+ * @param {object} opts
+ * @param {Map<string,string>} opts.unavailable  nexus_id -> status, for every
+ *   pinned mod this sweep did NOT get a published answer for. `absent` is this
+ *   module's own value; everything else is Nexus's own string, stored verbatim
+ *   so an unrecognised vocabulary is recorded rather than discarded.
+ * @param {string} opts.nowIso
+ * @returns {Promise<{tracked:number, cleared:number, flagged:string[]}>}
+ *   `flagged` is the ids that crossed on THIS sweep, which is what the caller
+ *   alerts on. Already-flagged ids are not repeated.
+ *
+ * NOT called on a sweep the caller does not trust: this prunes every row it was
+ * not told about, so a failed sweep passed through here would clear the table.
+ */
+export async function recordSweep(env, { unavailable = new Map(), nowIso }) {
+  const stamp = nowIso ?? new Date().toISOString();
+  const nowMs = Date.parse(stamp);
+  const existing = await readRows(env);
+
+  const upsert = env.DB.prepare(
+    `INSERT INTO nexus_mod_status
+       (nexus_id, status, streak, first_seen_at, last_seen_at, flagged_at)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(nexus_id) DO UPDATE SET
+       status        = excluded.status,
+       streak        = excluded.streak,
+       first_seen_at = excluded.first_seen_at,
+       last_seen_at  = excluded.last_seen_at,
+       flagged_at    = excluded.flagged_at`,
+  );
+  const remove = env.DB.prepare('DELETE FROM nexus_mod_status WHERE nexus_id = ?');
+
+  const statements = [];
+  const flagged = [];
+
+  for (const [rawId, status] of unavailable) {
+    const id = String(rawId);
+    const prev = existing.get(id);
+    // A different status is a different fact, so the run restarts. Carrying the
+    // clock from a `hidden` run into a `wastebinned` one would let a deletion
+    // act on a confirmation it never got, and withholding a pin is the one
+    // thing here a visitor can see.
+    const continues = prev?.status === status;
+    const row = {
+      status,
+      streak: continues ? prev.streak + 1 : 1,
+      first_seen_at: continues ? prev.first_seen_at : stamp,
+      flagged_at: continues ? (prev.flagged_at ?? null) : null,
+    };
+    if (crossesThreshold(row, nowMs)) {
+      row.flagged_at = stamp;
+      flagged.push(id);
+    }
+    statements.push(upsert.bind(
+      id, row.status, row.streak, row.first_seen_at, stamp, row.flagged_at,
+    ));
+  }
+
+  // Every row this sweep did not name: Nexus called it published, or it is no
+  // longer pinned. Both are a delete rather than a reset, so an untracked mod
+  // costs no write at all in the steady state. A dismissal goes with the row,
+  // which is right: the admin dismissed a mod that was in trouble, and this one
+  // is not.
+  let cleared = 0;
+  for (const id of existing.keys()) {
+    if (unavailable.has(id)) continue;
+    statements.push(remove.bind(id));
+    cleared += 1;
+  }
+
+  if (statements.length) await env.DB.batch(statements);
+  return { tracked: unavailable.size, cleared, flagged };
+}
+
+/**
+ * The nexus_ids whose pins the dataset must NOT be built from: confirmed
+ * deleted, and not dismissed by an admin who decided otherwise.
+ *
+ * Capped. A status-driven mass withdrawal has no innocent explanation, so past
+ * the cap this withholds NOTHING and reports the count instead: a gutted map is
+ * a worse outcome than a stale pin, and both are worse than being told.
+ *
+ * @returns {Promise<{withhold:Set<string>, refused:number}>}
+ */
+export async function readWithheld(env) {
+  const { results } = await env.DB.prepare(
+    `SELECT nexus_id FROM nexus_mod_status
+      WHERE status = ? AND flagged_at IS NOT NULL AND dismissed_at IS NULL`,
+  ).bind(WASTEBINNED).all();
+  const ids = (results ?? []).map((r) => String(r.nexus_id));
+  if (ids.length > MAX_WITHHELD) return { withhold: new Set(), refused: ids.length };
+  return { withhold: new Set(ids), refused: 0 };
+}
+
+/**
+ * The review list: every tracked mod, with the pins that point at it.
+ *
+ * Serves the unflagged rows too. The dashboard shows the confirmed ones and
+ * counts the rest, which is the house rule that a display derives rather than
+ * asking the API to have already decided.
+ *
+ * The locations query is an `IN (SELECT ...)` rather than an id list from the
+ * caller, for the same reason readCandidates is: no bound parameter per mod, no
+ * 100-parameter ceiling to grow into.
+ */
+export async function readModStatuses(env) {
+  const { results } = await env.DB.prepare(
+    `SELECT m.nexus_id, m.status, m.streak, m.first_seen_at, m.last_seen_at,
+            m.flagged_at, m.dismissed_by, m.dismissed_at, c.name AS mod_name
+       FROM nexus_mod_status m
+       LEFT JOIN nexus_cache c ON c.nexus_id = m.nexus_id
+      ORDER BY m.first_seen_at`,
+  ).all();
+  const rows = results ?? [];
+  if (!rows.length) return [];
+
+  const { results: locs } = await env.DB.prepare(
+    `SELECT id, name, status, nexus_id FROM locations
+      WHERE nexus_id IN (SELECT nexus_id FROM nexus_mod_status)
+      ORDER BY name`,
+  ).all();
+  const byMod = new Map();
+  for (const l of locs ?? []) {
+    const key = String(l.nexus_id);
+    if (!byMod.has(key)) byMod.set(key, []);
+    byMod.get(key).push({ id: l.id, name: l.name, status: l.status });
+  }
+
+  const { refused } = await readWithheld(env);
+
+  return rows.map((r) => ({
+    nexus_id: String(r.nexus_id),
+    mod_name: r.mod_name ?? null,
+    status: r.status,
+    streak: Number(r.streak ?? 0),
+    first_seen_at: r.first_seen_at,
+    last_seen_at: r.last_seen_at,
+    flagged_at: r.flagged_at ?? null,
+    dismissed_by: r.dismissed_by ?? null,
+    dismissed_at: r.dismissed_at ?? null,
+    // Says outright whether this pin is off the map, rather than leaving three
+    // consumers to re-derive it from status + flagged_at + dismissed_at and one
+    // of them to get it wrong. False while the cap is refusing to act, which is
+    // the honest answer: the pin IS still being served.
+    withheld: !refused && r.status === WASTEBINNED
+      && Boolean(r.flagged_at) && !r.dismissed_at,
+    // A tracked mod with no locations is possible and is not an error: the pin
+    // can be deleted between one sweep and the next, and the row survives until
+    // that next sweep prunes it.
+    locations: byMod.get(String(r.nexus_id)) ?? [],
+  }));
+}
+
+/**
+ * One tracked mod, or null. Used by the dismiss route so it can 404 rather than
+ * report success for an id nothing is tracking.
+ */
+export async function readModStatusOne(env, nexusId) {
+  const all = await readModStatuses(env);
+  return all.find((r) => r.nexus_id === String(nexusId)) ?? null;
+}
+
+/**
+ * Dismiss a flagged mod, or undo that.
+ *
+ * Dismissing does NOT delete the row and does not reset the streak. The mod is
+ * still in trouble; the admin has said they know. Deleting would hand the next
+ * sweep a clean slate and re-flag it, which is the behaviour that teaches
+ * people to ignore the panel.
+ *
+ * For a `wastebinned` mod it also PUTS THE PIN BACK, because withholding is
+ * gated on the dismissal. That is the intended escape hatch: an admin who
+ * thinks Nexus is wrong, or who wants the pin up while they point it at a
+ * successor mod, needs a way to say so that is not editing the record into a
+ * state they then have to remember to undo.
+ *
+ * Returns the updated record, or null when the id is not tracked.
+ */
+export async function setDismissed(env, nexusId, { actor, dismissed = true, nowIso } = {}) {
+  const id = String(nexusId);
+  const existing = await readRows(env);
+  if (!existing.has(id)) return null;
+
+  const stamp = nowIso ?? new Date().toISOString();
+  await env.DB.prepare(
+    'UPDATE nexus_mod_status SET dismissed_by = ?, dismissed_at = ? WHERE nexus_id = ?',
+  ).bind(
+    dismissed ? (actor ?? null) : null,
+    dismissed ? stamp : null,
+    id,
+  ).run();
+  return readModStatusOne(env, id);
+}

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -20,6 +20,16 @@ export const FILE_METADATA_BASE = 'https://file-metadata.nexusmods.com/file/nexu
 export const FILE_MANIFEST_BASE = 'https://file-manifests.nexusmods.com';
 export const NEXUS_GAME_ID = 3333; // Cyberpunk 2077
 export const NEXUS_BATCH_SIZE = 50;
+
+/**
+ * A mod's public page. Alerts carry it: an alert that says "go and read the
+ * author's reason" and then makes the reader retype a six-digit id into a
+ * browser is an alert that gets skipped.
+ *
+ * Resolves for a hidden or deleted mod too. It answers 404 or a "not
+ * available" page to a visitor, which IS the thing being reported.
+ */
+export const modPageUrl = (modId) => `https://www.nexusmods.com/cyberpunk2077/mods/${modId}`;
 const ARCHIVE_UA = 'nczoning-data-api (+https://nczoning.net)';
 
 const QUERY = `
@@ -107,6 +117,7 @@ const THUMBS_QUERY = `query modsByUid($uids: [ID!]!, $count: Int!) {
     nodes {
       modId
       name
+      status
       pictureUrl
       thumbnailUrl
       updatedAt
@@ -149,6 +160,12 @@ export async function fetchModsByUidThumbs(fetchImpl = fetch, numericIds = []) {
       for (const node of nodes) {
         map[String(node.modId)] = {
           name: node.name || null,
+          // Nexus's own word for whether the mod is still on the site.
+          // `modsByUid` does NOT filter by it (the `mods` search query does), so
+          // a deleted or hidden mod arrives here looking like any other and
+          // this field is the only thing that says otherwise. Null when the
+          // field is absent, which must read as published: see nexus-status.js.
+          status: node.status || null,
           pictureUrl: node.pictureUrl || null,
           thumbnailUrl: node.thumbnailUrl || null,
           updatedAt: node.updatedAt || null,

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -13,9 +13,12 @@
  * unit-testable with a fake KV + fake fetch.
  */
 
-import { fetchTaggedModNodes } from './nexus.js';
+import { fetchTaggedModNodes, modPageUrl } from './nexus.js';
 import { materializeFromD1, attachArchives } from './materialize.js';
 import { refreshNexusCache, refreshArchives, readNexusIndex } from './nexus-cache.js';
+import {
+  readModStatuses, readWithheld, WASTEBINNED, ABSENT, MAX_WITHHELD,
+} from './nexus-status.js';
 import {
   readLocationRows, readDismissedIds, readTags, readLocationTags,
 } from './d1.js';
@@ -24,7 +27,7 @@ import { HEARTBEAT_MIN_INTERVAL_MS } from './config.js';
 import {
   KEYS, contentHash, readMeta, writeDataset, writeMeta,
 } from './store.js';
-import { raiseAlert } from './alerts.js';
+import { raiseAlert, alertedSinceUtcMidnight } from './alerts.js';
 import { checkQuotaThresholds } from './quota.js';
 
 const SCHEMA_VERSION = 1;
@@ -71,6 +74,117 @@ async function alertRefreshRecovered(env, fetchImpl) {
 }
 
 /**
+ * Beyond this many mods flagged on one sweep, say it once instead of once each.
+ *
+ * Twenty separate embeds is a channel nobody reads afterwards, and a flag this
+ * broad is a different story anyway: mods do not go under in batches, so the
+ * batch itself is the thing worth looking at.
+ */
+const STATUS_ALERT_MAX = 5;
+
+/** "Deleted Mod (12345)", or just the id when Nexus never supplied a name. */
+const describeMod = (row, id) => (row?.mod_name ? `${row.mod_name} (${id})` : `mod ${id}`);
+
+/** "Cliffside Abode, Kabuki Ripper" -- the pins pointing at the mod. */
+const describePins = (row) => (row?.locations?.length
+  ? row.locations.map((l) => l.name).join(', ')
+  : 'no pins (the location was removed since it was flagged)');
+
+/**
+ * What each status means, and what has already happened about it.
+ *
+ * The three read differently on purpose. A reviewer opening the channel needs
+ * to know within one line whether the map has already changed, because that
+ * decides whether this is urgent or merely due.
+ */
+const STATUS_STORY = {
+  [WASTEBINNED]: {
+    headline: 'deleted from Nexus',
+    detail: 'Nexus reports this mod as deleted. Its pin has been WITHHELD from '
+      + 'the map automatically, and the record itself is untouched: nothing has '
+      + 'edited the location, so nothing needs undoing if this turns out to be '
+      + 'wrong. Dismissing the flag in the dashboard puts the pin back.',
+  },
+  [ABSENT]: {
+    headline: 'no longer returned by Nexus',
+    detail: 'Nexus has stopped answering about this mod at all, for a day of '
+      + 'consecutive sweeps. That is not the same as a deletion, which Nexus '
+      + 'states outright, so nothing has changed on the map. It usually means '
+      + 'the mod was purged rather than binned.',
+  },
+  default: {
+    headline: 'hidden on Nexus',
+    detail: 'The pin is still on the map and nothing here will take it down. '
+      + 'Hidden covers an author mid-upload and a moderation hold equally, and '
+      + 'the API does not say which: only the reason the author left on the mod '
+      + 'page does. Read it, then either hide the record, point it at a '
+      + 'successor mod, or dismiss the flag and leave it up.',
+  },
+};
+
+const storyFor = (status) => STATUS_STORY[status] ?? STATUS_STORY.default;
+
+/**
+ * Pinned mods Nexus no longer calls published (#900).
+ *
+ * Raised here rather than in the sweep for the reason every other alert is:
+ * nexus-cache.js does D1 and Nexus, this file does the fan-out. The sweep hands
+ * back the ids that crossed their threshold ON THIS TICK, so a mod alerts once
+ * and then lives in the dashboard's review list until a person deals with it.
+ *
+ * `alertedSinceUtcMidnight` is still checked on top of that. The stored
+ * `flagged_at` already makes this once-per-run, but two overlapping cron runs
+ * would each see the same crossing before either had written, and the alerts
+ * table is the only thing that can see across them.
+ *
+ * Never throws: an alert about a deleted mod must not cost the dataset a cycle.
+ */
+async function alertModStatus(env, fetchImpl, flagged, nowMs) {
+  const tracked = await readModStatuses(env);
+  const byId = new Map(tracked.map((r) => [r.nexus_id, r]));
+
+  if (flagged.length > STATUS_ALERT_MAX) {
+    const title = `${flagged.length} pinned mods are no longer published on Nexus`;
+    if (await alertedSinceUtcMidnight(env, { source: 'refresh', title }, nowMs)) return;
+    await raiseAlert(env, {
+      source: 'refresh',
+      severity: 'warn',
+      title,
+      body: `${flagged.map((id) => {
+        const row = byId.get(id);
+        return `${describeMod(row, id)}: ${storyFor(row?.status).headline}\n${modPageUrl(id)}`;
+      }).join('\n\n')}\n\n`
+        + `A batch this size is more likely a Nexus change than ${flagged.length} `
+        + `separate events, so no more than ${MAX_WITHHELD} pins are ever withheld `
+        + 'at once: past that the map is left exactly as it is and this alert is '
+        + 'the whole of the response. Check the dashboard.',
+    }, { fetchImpl, nowMs });
+    return;
+  }
+
+  for (const id of flagged) {
+    const row = byId.get(id);
+    const story = storyFor(row?.status);
+    // The title is the dedup key, so it carries the id and the status and
+    // nothing that moves between sweeps. The streak belongs in the body:
+    // putting it in the title would make every tick a new alert.
+    const title = `Pinned mod ${story.headline}: ${id}`;
+    if (await alertedSinceUtcMidnight(env, { source: 'refresh', title }, nowMs)) continue;
+    await raiseAlert(env, {
+      source: 'refresh',
+      // `warn` throughout: the dataset is being served either way. A withheld
+      // pin is a correct outcome, not a failure, and `error` is for not serving.
+      severity: 'warn',
+      title,
+      body: `${describeMod(row, id)} has been ${story.headline} since `
+        + `${row?.first_seen_at ?? 'this sweep'} (${row?.streak ?? 1} consecutive sweeps).\n\n`
+        + `${modPageUrl(id)}\n\n`
+        + `Pins affected: ${describePins(row)}.\n\n${story.detail}`,
+    }, { fetchImpl, nowMs });
+  }
+}
+
+/**
  * Sweep `nexus_cache` and return the index the dataset is built against.
  *
  * The sweep never throws (a Nexus outage must leave last-known-good in place),
@@ -86,6 +200,20 @@ async function sweepNexusCache(env, fetchImpl, nexusNodes, nowIso) {
         `nexus_cache: ${sweep.written} rows written (${sweep.tagged} tagged, `
         + `${sweep.backfilled} backfilled, ${sweep.untagged} untagged)`,
       );
+    }
+    if (sweep.modStatus?.flagged?.length) {
+      // Its own try/catch, INSIDE the one that rethrows: a D1 failure reading
+      // the cache must keep last-known-good, and a Discord failure telling
+      // someone about a deleted mod must not. Different severities, so they
+      // cannot share a catch.
+      try {
+        const nowMs = Date.parse(nowIso);
+        await alertModStatus(
+          env, fetchImpl, sweep.modStatus.flagged, Number.isFinite(nowMs) ? nowMs : Date.now(),
+        );
+      } catch (err) {
+        console.warn('mod-status alert failed (non-fatal):', String(err).slice(0, 200));
+      }
     }
     return await readNexusIndex(env);
   } catch (err) {
@@ -156,12 +284,31 @@ async function sourceAndBuild(env, fetchImpl, origin, nowMs, { nexusNodes, nexus
   if (nexusIndex.size === 0) {
     throw new Error('nexus_cache is empty -- refusing to serve a dataset with no images');
   }
+  // Pins whose mod Nexus has confirmed deleted. Read here rather than inside
+  // the materializer, which is pure: it is handed the verdict, it does not go
+  // and ask. `refused` is the cap having declined to act on an implausible
+  // batch, which is a thing to say out loud rather than a quiet no-op.
+  const { withhold, refused } = await readWithheld(env);
+  if (refused) {
+    console.warn(
+      `nexus_mod_status: ${refused} pins are flagged as deleted, above the cap of `
+      + `${MAX_WITHHELD}. Withholding none of them; the map is unchanged.`,
+    );
+  }
+
   // No modsByUid call here: the sweep has already resolved every published
   // record's images into nexus_cache, including the auto-discovered ones,
   // which are rows like any other.
   const built = materializeFromD1({
     rows, dismissed, nexusNodes, districts, nexusIndex, locationTags, nowMs,
+    withheld: withhold,
   });
+  if (built.meta.withheld.length) {
+    console.log(
+      `withheld ${built.meta.withheld.length} pin(s) whose mod is deleted on Nexus: `
+      + built.meta.withheld.map((w) => `${w.id} (mod ${w.nexus_id})`).join(', '),
+    );
+  }
   return { ...built, tagsList, districts };
 }
 

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -185,6 +185,65 @@ async function alertModStatus(env, fetchImpl, flagged, nowMs) {
 }
 
 /**
+ * A pinned mod is published on Nexus again (#900).
+ *
+ * The down edge is handled, the up edge was not, and the two are not
+ * symmetrical. Withholding reverses itself: the row goes, `readWithheld` stops
+ * naming the mod, and the next build serves the pin again with nobody involved.
+ * A HIDDEN RECORD DOES NOT. If an admin set `status: hidden` on the location
+ * while the mod was down, that is a human write, no sweep will undo it, and
+ * this alert is the only moment anyone finds out it can be undone.
+ *
+ * So the body is written around what is left to do, which is nothing at all in
+ * the common case and one edit in the case that would otherwise go unnoticed
+ * for as long as nobody happened to look.
+ *
+ * Mirrors alertRefreshRecovered: same `recovery` severity, same fires-once-on-
+ * the-edge shape. Never throws.
+ */
+async function alertModRecovered(env, fetchImpl, recovered, nowMs) {
+  if (recovered.length > STATUS_ALERT_MAX) {
+    const title = `${recovered.length} pinned mods are published on Nexus again`;
+    if (await alertedSinceUtcMidnight(env, { source: 'refresh', title }, nowMs)) return;
+    await raiseAlert(env, {
+      source: 'refresh',
+      severity: 'recovery',
+      title,
+      body: `${recovered.map((r) => `${r.nexus_id}: was ${r.was}`).join('\n')}\n\n`
+        + 'Any withheld pins are served again from this build. Records that were '
+        + 'hidden by hand stay hidden: the registry does not un-hide anything on '
+        + 'its own. Check the dashboard.',
+    }, { fetchImpl, nowMs });
+    return;
+  }
+
+  for (const r of recovered) {
+    const title = `Pinned mod is back on Nexus: ${r.nexus_id}`;
+    if (await alertedSinceUtcMidnight(env, { source: 'refresh', title }, nowMs)) continue;
+
+    // The pins a person still has to deal with. `published` needs nothing; a
+    // record someone hid while the mod was down is the whole reason this alert
+    // exists, and naming it is the difference between a notification and a task.
+    const needsAHand = (r.locations ?? []).filter((l) => l.status !== 'published');
+    const todo = needsAHand.length
+      ? `Still hidden in the registry: ${needsAHand.map((l) => `${l.name} (${l.status})`).join(', ')}.\n`
+        + 'Nothing here changes a location\'s status, so that stays as it is until '
+        + 'someone republishes the record in the dashboard.'
+      : 'Nothing to do. The pin is served again from this build.';
+
+    await raiseAlert(env, {
+      source: 'refresh',
+      severity: 'recovery',
+      title,
+      body: `Nexus reports mod ${r.nexus_id} as published again, after `
+        + `${storyFor(r.was).headline}.\n\n${modPageUrl(r.nexus_id)}\n\n`
+        + `${r.wasWithheld ? 'Its pin was withheld and is restored automatically. ' : ''}`
+        + todo,
+    }, { fetchImpl, nowMs });
+  }
+}
+
+/**
  * Sweep `nexus_cache` and return the index the dataset is built against.
  *
  * The sweep never throws (a Nexus outage must leave last-known-good in place),
@@ -201,16 +260,20 @@ async function sweepNexusCache(env, fetchImpl, nexusNodes, nowIso) {
         + `${sweep.backfilled} backfilled, ${sweep.untagged} untagged)`,
       );
     }
-    if (sweep.modStatus?.flagged?.length) {
-      // Its own try/catch, INSIDE the one that rethrows: a D1 failure reading
-      // the cache must keep last-known-good, and a Discord failure telling
-      // someone about a deleted mod must not. Different severities, so they
-      // cannot share a catch.
+    // Its own try/catch, INSIDE the one that rethrows: a D1 failure reading the
+    // cache must keep last-known-good, and a Discord failure telling someone
+    // about a deleted mod must not. Different severities, so they cannot share
+    // a catch.
+    if (sweep.modStatus?.flagged?.length || sweep.modStatus?.recovered?.length) {
+      const parsed = Date.parse(nowIso);
+      const nowMs = Number.isFinite(parsed) ? parsed : Date.now();
       try {
-        const nowMs = Date.parse(nowIso);
-        await alertModStatus(
-          env, fetchImpl, sweep.modStatus.flagged, Number.isFinite(nowMs) ? nowMs : Date.now(),
-        );
+        if (sweep.modStatus.flagged?.length) {
+          await alertModStatus(env, fetchImpl, sweep.modStatus.flagged, nowMs);
+        }
+        if (sweep.modStatus.recovered?.length) {
+          await alertModRecovered(env, fetchImpl, sweep.modStatus.recovered, nowMs);
+        }
       } catch (err) {
         console.warn('mod-status alert failed (non-fatal):', String(err).slice(0, 200));
       }

--- a/worker/test-support/d1-sqlite.mjs
+++ b/worker/test-support/d1-sqlite.mjs
@@ -87,6 +87,7 @@ function statement(db, sql, args = []) {
  * @param {Array}  [seed.submissions]    raw `submissions` rows
  * @param {Array}  [seed.nexusCache]     raw `nexus_cache` rows
  * @param {Array}  [seed.dismissed]      raw `dismissed_candidates` rows
+ * @param {Array}  [seed.nexusModStatus] raw `nexus_mod_status` rows
  */
 export function sqliteD1(seed = {}) {
   const db = new DatabaseSync(':memory:');
@@ -133,6 +134,7 @@ export function sqliteD1(seed = {}) {
   insertRows('submissions', seed.submissions);
   insertRows('nexus_cache', seed.nexusCache);
   insertRows('dismissed_candidates', seed.dismissed);
+  insertRows('nexus_mod_status', seed.nexusModStatus);
 
   return {
     _db: db,

--- a/worker/test/admin.test.js
+++ b/worker/test/admin.test.js
@@ -90,14 +90,14 @@ const FRESH_USER = (collab = 1) => ({
 
 function envFor({
   collab = 1, locations = [ROW],
-  locationTags = [['loc-1', 'apartment']], checkedAt,
+  locationTags = [['loc-1', 'apartment']], checkedAt, nexusModStatus,
 } = {}) {
   const user = FRESH_USER(collab);
   if (checkedAt) user.checked_at = checkedAt;
   return {
     SESSION_SECRET: SECRET,
     DATASET: fakeKv(),
-    DB: sqliteD1({ locations, locationTags, users: [user] }),
+    DB: sqliteD1({ locations, locationTags, users: [user], nexusModStatus }),
   };
 }
 
@@ -143,6 +143,7 @@ test('every admin route is refused without a session', async () => {
     ['GET', '/admin/tags'], ['POST', '/admin/tags'],
     ['GET', '/admin/tags/corpo'], ['PATCH', '/admin/tags/corpo'],
     ['DELETE', '/admin/tags/corpo'], ['POST', '/admin/refresh'],
+    ['GET', '/admin/nexus-status'], ['PATCH', '/admin/nexus-status/12345'],
   ]) {
     const res = await worker.fetch(
       new Request(`https://api.nczoning.net${path}`, { method }), env, {},
@@ -643,4 +644,73 @@ test('a tag write rebuilds the read path too, since /v1/tags serves it', async (
     { waitUntil: (p) => waited.push(p) });
   assert.equal(waited.length, 1);
   await waited[0];
+});
+
+// -------------------------------------- mods no longer published on Nexus ---
+// The review surface for #900. Read plus a dismissal and nothing else: the cron
+// owns every other column, and an admin who decides the mod is gone for good
+// edits the LOCATION, through the existing status control and audit trail.
+
+const DELETED_ROW = {
+  nexus_id: '12345', status: 'wastebinned', streak: 300,
+  first_seen_at: '2026-07-01T00:00:00Z', last_seen_at: '2026-07-02T00:00:00Z',
+  flagged_at: '2026-07-02T00:00:00Z',
+};
+
+test('the review list comes back with the pins that point at the mod', async () => {
+  const env = envFor({ nexusModStatus: [DELETED_ROW] });
+  const res = await hit(env, 'GET', '/admin/nexus-status');
+  assert.equal(res.status, 200);
+  const { mods } = await res.json();
+  assert.equal(mods.length, 1);
+  assert.equal(mods[0].nexus_id, '12345');
+  assert.equal(mods[0].status, 'wastebinned');
+  assert.equal(mods[0].streak, 300);
+  assert.equal(mods[0].withheld, true, 'a confirmed deletion is already off the map');
+  assert.deepEqual(mods[0].locations, [{ id: 'loc-1', name: 'Existing Loft', status: 'published' }],
+    'the pin is the thing the admin has to decide about');
+});
+
+test('dismissing records who did it, is audited, and puts the pin back', async () => {
+  const env = envFor({ nexusModStatus: [DELETED_ROW] });
+  const res = await hit(env, 'PATCH', '/admin/nexus-status/12345', { dismissed: true });
+  assert.equal(res.status, 200);
+  const { mod } = await res.json();
+  assert.equal(mod.dismissed_by, 'spuddeh');
+  assert.equal(mod.withheld, false, 'dismissing a deletion is how a pin goes back up');
+
+  const row = env.DB.one('SELECT * FROM nexus_mod_status WHERE nexus_id = ?', '12345');
+  assert.equal(row.dismissed_by, 'spuddeh');
+  assert.ok(row.dismissed_at);
+  assert.equal(row.streak, 300, 'dismissing is not forgetting: the mod is still deleted');
+
+  const audit = auditRows(env);
+  assert.equal(audit.length, 1);
+  assert.equal(audit[0].action, 'nexus_status.dismiss');
+  assert.equal(audit[0].target, '12345');
+});
+
+test('dismissing never writes the location', async () => {
+  const env = envFor({ nexusModStatus: [DELETED_ROW] });
+  await hit(env, 'PATCH', '/admin/nexus-status/12345', { dismissed: true });
+  assert.equal(env.DB.one('SELECT status FROM locations WHERE id = ?', 'loc-1').status, 'published',
+    'the pin moves on and off the map without the record ever changing');
+});
+
+test('a dismissal rebuilds the read path, since it changes what is served', async () => {
+  const env = envFor({ nexusModStatus: [DELETED_ROW] });
+  const waited = [];
+  await hit(env, 'PATCH', '/admin/nexus-status/12345', { dismissed: true },
+    { waitUntil: (p) => waited.push(p) });
+  assert.equal(waited.length, 1, 'without this the pin only returns at the next cron tick');
+  await waited[0];
+});
+
+test('an untracked mod is 404, and a bad body is 422', async () => {
+  const env = envFor({ nexusModStatus: [DELETED_ROW] });
+  assert.equal((await hit(env, 'PATCH', '/admin/nexus-status/99999', { dismissed: true })).status, 404);
+  assert.equal((await hit(env, 'PATCH', '/admin/nexus-status/12345', { note: 'x' })).status, 422);
+  assert.equal((await hit(env, 'DELETE', '/admin/nexus-status/12345')).status, 405,
+    "the row is the cron's to delete, not an admin's");
+  assert.equal(auditRows(env).length, 0, 'a refused call is not audited');
 });

--- a/worker/test/nexus-status.test.js
+++ b/worker/test/nexus-status.test.js
@@ -1,0 +1,373 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sqliteD1 } from '../test-support/d1-sqlite.mjs';
+import { refreshNexusCache } from '../src/nexus-cache.js';
+import { materializeFromD1 } from '../src/materialize.js';
+import {
+  sweepLooksUnreliable, isPublished, readModStatuses, readWithheld, setDismissed,
+  CONFIRM_SWEEPS, ABSENT_STREAK, SWEEP_MIN_SUSPECT, MAX_WITHHELD,
+  WASTEBINNED, ABSENT,
+} from '../src/nexus-status.js';
+
+// A pin whose mod is no longer published on Nexus (#900).
+//
+// Real SQLite on the real migrations, driven through the actual sweep rather
+// than by calling recordSweep directly, because the interesting part is not the
+// counter: it is which sweeps are allowed to move it, and what each verdict is
+// permitted to do to the map.
+//
+// The premise, measured against the live API on 2026-08-02: `modsByUid` returns
+// deleted and hidden mods like any other node, carrying a `status` that says
+// so. The `mods` SEARCH query returns published mods only. So a deleted mod is
+// PRESENT in the response, and absence is the weak, rare third case.
+
+const T0 = Date.parse('2026-07-27T00:00:00.000Z');
+const at = (ms) => new Date(T0 + ms).toISOString();
+const HOUR = 3600_000;
+const MIN = 60_000;
+
+/**
+ * A fetch answering the tagged query, then modsByUid from a per-id status map.
+ * An id absent from `states` is absent from the response, which is the third
+ * case; an id present with a status is RETURNED carrying it.
+ */
+function fakeNexus({ tagged = [], states = {} } = {}) {
+  return async (_url, init) => {
+    const body = JSON.parse(init.body);
+    if (body.query.includes('NCZoningMods')) {
+      return { ok: true, async json() { return { data: { mods: { nodes: tagged, totalCount: tagged.length } } }; } };
+    }
+    // The composite uid is (gameId << 32) + modId; recover the modId so the
+    // stub can answer per-id rather than by count.
+    const asked = body.variables.uids.map((uid) => String(BigInt(uid) & 0xffffffffn));
+    const nodes = asked.filter((id) => id in states).map((id) => ({
+      modId: id,
+      name: `Mod ${id}`,
+      status: states[id],
+      pictureUrl: `p${id}`,
+      thumbnailUrl: `t${id}`,
+      updatedAt: '2026-07-01T00:00:00.000Z',
+    }));
+    return { ok: true, async json() { return { data: { modsByUid: { nodes } } }; } };
+  };
+}
+
+const location = (id, nexusId) => ({
+  id, name: `Loc ${id}`, nexus_id: nexusId, category: 'new-location',
+  x: 0, y: 0, z: 0, authors: '["a"]', description: '',
+  status: 'published', added_at: at(0), modified_at: at(0),
+});
+
+const envWith = (pins = [['l1', '100'], ['l2', '200']]) => (
+  { DB: sqliteD1({ locations: pins.map(([id, nx]) => location(id, nx)) }) }
+);
+
+/** Both pinned mods published: the healthy baseline for every test. */
+const ALL_OK = { 100: 'published', 200: 'published' };
+
+const tracked = (env) => env.DB.rows('SELECT * FROM nexus_mod_status ORDER BY nexus_id');
+const one = (env, id) => env.DB.one('SELECT * FROM nexus_mod_status WHERE nexus_id = ?', id);
+
+/** Run n sweeps `gap` apart against the same states, starting at `from`. */
+async function sweeps(env, { states, count, gap, from = 0 }) {
+  let last;
+  for (let i = 0; i < count; i += 1) {
+    last = await refreshNexusCache(env, {
+      fetchImpl: fakeNexus({ states }), nowIso: at(from + i * gap),
+    });
+  }
+  return last;
+}
+
+// --------------------------------------------------------- reading a status ---
+
+test('a null or unknown status reads as published, so no missing field can pull a pin', () => {
+  assert.equal(isPublished('published'), true);
+  assert.equal(isPublished(null), true, 'an absent field is not evidence of anything');
+  assert.equal(isPublished(undefined), true);
+  assert.equal(isPublished('hidden'), false);
+  assert.equal(isPublished(WASTEBINNED), false);
+  assert.equal(isPublished('some_new_word'), false,
+    'an unrecognised status is tracked, not ignored');
+});
+
+test('a status Nexus has never sent before is stored verbatim', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'under_moderation' }, count: 1, gap: HOUR });
+  assert.equal(one(env, '200').status, 'under_moderation',
+    'flattening it to "hidden" would hide a vocabulary change from the one person who can act on it');
+});
+
+// ------------------------------------------------------------------ hidden ---
+
+test('a hidden mod is flagged after three sweeps and the pin stays up', async () => {
+  const env = envWith();
+  const early = await sweeps(env, {
+    states: { ...ALL_OK, 200: 'hidden' }, count: CONFIRM_SWEEPS - 1, gap: 5 * MIN,
+  });
+  assert.deepEqual(early.modStatus.flagged, [], 'one odd response is not a verdict');
+
+  const crossing = await sweeps(env, {
+    states: { ...ALL_OK, 200: 'hidden' }, count: 1, gap: 5 * MIN,
+    from: (CONFIRM_SWEEPS - 1) * 5 * MIN,
+  });
+  assert.deepEqual(crossing.modStatus.flagged, ['200']);
+  assert.equal(one(env, '200').status, 'hidden');
+
+  const { withhold } = await readWithheld(env);
+  assert.equal(withhold.size, 0,
+    'hidden covers an author mid-upload and a moderation hold, and the API will not say which');
+});
+
+test('hidden never reaches the map, however long it lasts', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: 20, gap: 6 * HOUR });
+  const { withhold } = await readWithheld(env);
+  assert.equal(withhold.size, 0, 'five days hidden is still a decision for a person');
+  assert.equal(env.DB.one('SELECT status FROM locations WHERE id = ?', 'l2').status, 'published',
+    'and the record is never written either');
+});
+
+// ------------------------------------------------------------- wastebinned ---
+
+test('a deleted mod is confirmed in three sweeps and its pin is withheld', async () => {
+  const env = envWith();
+  const early = await sweeps(env, {
+    states: { ...ALL_OK, 200: WASTEBINNED }, count: CONFIRM_SWEEPS - 1, gap: 5 * MIN,
+  });
+  assert.deepEqual(early.modStatus.flagged, []);
+  assert.equal((await readWithheld(env)).withhold.size, 0, 'not confirmed yet, so the pin stays');
+
+  await sweeps(env, {
+    states: { ...ALL_OK, 200: WASTEBINNED }, count: 1, gap: 5 * MIN,
+    from: (CONFIRM_SWEEPS - 1) * 5 * MIN,
+  });
+  assert.deepEqual([...(await readWithheld(env)).withhold], ['200']);
+});
+
+test('the withheld pin is absent from the built dataset, and the row is untouched', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: WASTEBINNED }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  const { withhold } = await readWithheld(env);
+
+  const rows = env.DB.rows('SELECT * FROM locations');
+  const built = materializeFromD1({
+    rows, dismissed: [], nexusNodes: [], districts: [], withheld: withhold,
+    locationTags: new Map(),
+  });
+
+  assert.deepEqual(Object.keys(built.full), ['l1'], "the deleted mod's pin is not served");
+  assert.deepEqual(built.meta.withheld, [{ id: 'l2', nexus_id: '200' }],
+    'and the build says which, so the dashboard can subtract exactly these');
+  assert.equal(env.DB.one('SELECT status FROM locations WHERE id = ?', 'l2').status, 'published',
+    'withheld at build time, NOT by writing the record: a reversal needs no human');
+});
+
+test('the pin comes back on its own if Nexus publishes the mod again', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: WASTEBINNED }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  assert.equal((await readWithheld(env)).withhold.size, 1);
+
+  await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: HOUR });
+  assert.equal(one(env, '200'), null, 'no row means fine');
+  assert.equal((await readWithheld(env)).withhold.size, 0);
+});
+
+test('a hidden mod that is then deleted starts its run again', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: 5, gap: 5 * MIN });
+  assert.equal(one(env, '200').streak, 5);
+  assert.ok(one(env, '200').flagged_at, 'precondition: the hidden run was flagged');
+
+  const turn = await sweeps(env, {
+    states: { ...ALL_OK, 200: WASTEBINNED }, count: 1, gap: 5 * MIN, from: HOUR,
+  });
+  const row = one(env, '200');
+  assert.equal(row.status, WASTEBINNED);
+  assert.equal(row.streak, 1, 'a different status is a different fact');
+  assert.equal(row.flagged_at, null, 'and it has not been confirmed as deleted yet');
+  assert.deepEqual(turn.modStatus.flagged, []);
+  assert.equal((await readWithheld(env)).withhold.size, 0,
+    'inheriting the hidden run would withhold a pin on a confirmation it never got');
+});
+
+test('no sweep may withhold more than the cap, and it withholds nothing rather than some', async () => {
+  const pins = Array.from({ length: MAX_WITHHELD + 3 }, (_, i) => [`l${i}`, String(100 + i)]);
+  const env = envWith(pins);
+  const states = {};
+  for (const [, nx] of pins) states[nx] = WASTEBINNED;
+
+  await sweeps(env, { states, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  assert.equal(tracked(env).length, pins.length, 'all of them are flagged');
+
+  const { withhold, refused } = await readWithheld(env);
+  assert.equal(withhold.size, 0, 'a gutted map is worse than a stale pin');
+  assert.equal(refused, pins.length, 'and the refusal is reported, not silent');
+
+  const list = await readModStatuses(env);
+  assert.ok(list.every((r) => r.withheld === false),
+    'the review list must not claim pins are down while the cap is refusing to take them down');
+});
+
+// ------------------------------------------------------------------ absent ---
+// The only one of the three a Nexus failure can manufacture, so it keeps the
+// stricter rule: a streak AND a day.
+
+test('an absent mod needs a day of sweeps, not three', async () => {
+  const env = envWith();
+  const short = await sweeps(env, {
+    states: { 100: 'published' }, count: ABSENT_STREAK + 4, gap: 5 * MIN,
+  });
+  assert.deepEqual(short.modStatus.flagged, [], 'an hour of silence is not a deletion');
+  assert.equal(one(env, '200').status, ABSENT);
+  assert.equal(one(env, '200').flagged_at, null);
+
+  const env2 = envWith();
+  await sweeps(env2, { states: { 100: 'published' }, count: ABSENT_STREAK, gap: 5 * HOUR });
+  assert.ok(one(env2, '200').flagged_at, 'a day of consecutive silence is');
+  assert.equal((await readWithheld(env2)).withhold.size, 0, 'and it still does not touch the map');
+});
+
+test('two sweeps a day apart are not an absence verdict', async () => {
+  const env = envWith();
+  const r = await sweeps(env, { states: { 100: 'published' }, count: 2, gap: 25 * HOUR });
+  assert.deepEqual(r.modStatus.flagged, [], 'a cron that ran twice has demonstrated nothing');
+  assert.equal(one(env, '200').flagged_at, null);
+});
+
+// --------------------------------------------------------- untrusted sweeps ---
+
+test('sweepLooksUnreliable: a small absent set is believed, a chunk-shaped one is not', () => {
+  assert.equal(sweepLooksUnreliable({ missing: 1, requested: 3 }), false,
+    'one deletion out of three pinned mods is 33% and must still count');
+  assert.equal(sweepLooksUnreliable({ missing: SWEEP_MIN_SUSPECT - 1, requested: 5 }), false,
+    'below the floor is always believed, whatever the ratio');
+  assert.equal(sweepLooksUnreliable({ missing: 50, requested: 200 }), true,
+    'a whole failed chunk is not fifty deletions');
+});
+
+test('a sweep where Nexus returned nothing at all records nothing', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: 2, gap: 5 * MIN });
+  assert.equal(one(env, '200').streak, 2);
+
+  const r = await refreshNexusCache(env, { fetchImpl: fakeNexus({ states: {} }), nowIso: at(HOUR) });
+  assert.equal(r.stale, true, 'precondition: asked for two, got none');
+  assert.equal(r.modStatus.skipped, 'stale');
+  assert.equal(one(env, '200').streak, 2, 'a failed sweep must not advance a run');
+  assert.equal(one(env, '100'), null, 'and must not invent one for the healthy mod');
+});
+
+test('a sweep that reads as a failed chunk records nothing, and keeps the runs it has', async () => {
+  const pins = Array.from({ length: 12 }, (_, i) => [`l${i}`, String(100 + i)]);
+  const env = envWith(pins);
+  const good = {};
+  for (const [, nx] of pins) good[nx] = 'published';
+  good['111'] = WASTEBINNED;
+
+  await sweeps(env, { states: good, count: 2, gap: 5 * MIN });
+  assert.equal(one(env, '111').streak, 2);
+
+  // Nine of twelve ids simply absent: 75% of the request, so a Nexus problem.
+  const partial = { 100: 'published', 101: 'published', 102: 'published' };
+  const r = await refreshNexusCache(env, {
+    fetchImpl: fakeNexus({ states: partial }), nowIso: at(HOUR),
+  });
+  assert.equal(r.stale, false, 'three came back, so the all-or-nothing guard does not fire');
+  assert.equal(r.modStatus.skipped, 'unreliable');
+  assert.equal(tracked(env).length, 1, 'nine mods did not vanish at once');
+  assert.equal(one(env, '111').streak, 2, 'the real run is frozen, not reset');
+
+  const back = await sweeps(env, { states: good, count: 1, gap: 5 * MIN, from: 2 * HOUR });
+  assert.equal(back.modStatus.tracked, 1, 'and it picks up on the next believable sweep');
+  assert.equal(one(env, '111').streak, 3);
+});
+
+// ---------------------------------------------------------- the review list ---
+
+test('the review list names the pins, including two pins on one mod', async () => {
+  const env = envWith([['l1', '100'], ['l2', '200'], ['l3', '200']]);
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: 2, gap: 5 * MIN });
+
+  const list = await readModStatuses(env);
+  assert.equal(list.length, 1);
+  assert.equal(list[0].nexus_id, '200');
+  assert.equal(list[0].mod_name, 'Mod 200', 'the cache keeps the name of a mod that went under');
+  assert.deepEqual(list[0].locations.map((l) => l.name).sort(), ['Loc l2', 'Loc l3'],
+    'one mod can supply two pins, and both are what the admin has to decide about');
+});
+
+test('the review list says outright whether the pin is down', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: WASTEBINNED }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  const gone = (await readModStatuses(env)).find((r) => r.nexus_id === '200');
+  assert.equal(gone.withheld, true);
+
+  const env2 = envWith();
+  await sweeps(env2, { states: { ...ALL_OK, 200: 'hidden' }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  const up = (await readModStatuses(env2)).find((r) => r.nexus_id === '200');
+  assert.equal(up.withheld, false, 'hidden is flagged, and flagged is not withheld');
+});
+
+// -------------------------------------------------------------- dismissal ---
+
+test('dismissing a deleted mod puts its pin back', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: WASTEBINNED }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  assert.equal((await readWithheld(env)).withhold.size, 1, 'precondition: the pin is down');
+
+  const after = await setDismissed(env, '200', { actor: 'spuddeh', nowIso: at(HOUR) });
+  assert.equal(after.dismissed_by, 'spuddeh');
+  assert.equal(after.withheld, false);
+  assert.equal((await readWithheld(env)).withhold.size, 0,
+    'the escape hatch for an admin who thinks Nexus is wrong, or wants the pin up while redirecting it');
+});
+
+test('dismissing survives later sweeps and does not stop the count', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: WASTEBINNED }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  await setDismissed(env, '200', { actor: 'spuddeh', nowIso: at(HOUR) });
+
+  await sweeps(env, { states: { ...ALL_OK, 200: WASTEBINNED }, count: 1, gap: 5 * MIN, from: 2 * HOUR });
+  const row = one(env, '200');
+  assert.equal(row.dismissed_by, 'spuddeh', 'the sweep must not clear a decision a person made');
+  assert.equal(row.streak, CONFIRM_SWEEPS + 1, 'and the count keeps running underneath it');
+  assert.equal((await readWithheld(env)).withhold.size, 0, 'the pin stays up');
+});
+
+test('dismissing an untracked mod is a miss, not a silent success', async () => {
+  const env = envWith();
+  assert.equal(await setDismissed(env, '999', { actor: 'spuddeh' }), null);
+});
+
+test('undismissing takes the pin down again', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: WASTEBINNED }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  await setDismissed(env, '200', { actor: 'spuddeh', nowIso: at(HOUR) });
+
+  const back = await setDismissed(env, '200', { actor: 'spuddeh', dismissed: false });
+  assert.equal(back.dismissed_at, null);
+  assert.equal(back.withheld, true);
+  assert.deepEqual([...(await readWithheld(env)).withhold], ['200']);
+});
+
+// -------------------------------------------------------------- the cache ---
+
+test('the status is cached, so the dashboard and the build read one value', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: 1, gap: 5 * MIN });
+  assert.equal(env.DB.one('SELECT status FROM nexus_cache WHERE nexus_id = ?', '200').status, 'hidden');
+  assert.equal(env.DB.one('SELECT status FROM nexus_cache WHERE nexus_id = ?', '100').status, 'published');
+});
+
+test('a status change is a write, and an unchanged sweep still costs nothing', async () => {
+  const env = envWith();
+  await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN });
+  const quiet = await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: 5 * MIN });
+  assert.equal(quiet.written, 0, 'the write gate still holds: 288 ticks a day against a 100k cap');
+
+  const changed = await sweeps(env, {
+    states: { ...ALL_OK, 200: 'hidden' }, count: 1, gap: 5 * MIN, from: 10 * MIN,
+  });
+  assert.equal(changed.written, 1, 'a mod going hidden must reach the cache');
+});

--- a/worker/test/nexus-status.test.js
+++ b/worker/test/nexus-status.test.js
@@ -173,6 +173,68 @@ test('the pin comes back on its own if Nexus publishes the mod again', async () 
   assert.equal((await readWithheld(env)).withhold.size, 0);
 });
 
+// ---------------------------------------------------------- the up edge ---
+// Withholding reverses itself; a record an admin hid does not. The recovery
+// report is the only moment anyone learns the second one can be undone.
+
+test('a mod returning to published is reported, with the pins it affects', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+
+  const back = await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: HOUR });
+  assert.equal(back.modStatus.recovered.length, 1);
+  assert.equal(back.modStatus.recovered[0].nexus_id, '200');
+  assert.equal(back.modStatus.recovered[0].was, 'hidden');
+  assert.equal(back.modStatus.recovered[0].wasWithheld, false, 'hidden never withheld it');
+  assert.deepEqual(back.modStatus.recovered[0].locations.map((l) => l.name), ['Loc l2'],
+    'captured before the row is deleted, or there is nothing left to name');
+});
+
+test('a deleted mod returning says its pin was withheld', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: WASTEBINNED }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  assert.equal((await readWithheld(env)).withhold.size, 1, 'precondition: the pin is down');
+
+  const back = await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: HOUR });
+  assert.equal(back.modStatus.recovered[0].wasWithheld, true);
+  assert.equal((await readWithheld(env)).withhold.size, 0, 'and it is already restored');
+});
+
+test('a mod that was dismissed reports no withholding to undo', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: WASTEBINNED }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  await setDismissed(env, '200', { actor: 'spuddeh', nowIso: at(HOUR) });
+
+  const back = await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: 2 * HOUR });
+  assert.equal(back.modStatus.recovered[0].wasWithheld, false,
+    'the admin already put the pin back by hand; there is nothing to restore');
+});
+
+test('a one-sweep blink is not a recovery', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: 1, gap: 5 * MIN });
+  assert.equal(one(env, '200').flagged_at, null, 'precondition: never confirmed');
+
+  const back = await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: 10 * MIN });
+  assert.deepEqual(back.modStatus.recovered, [],
+    'announcing noise is how the recoveries that matter get skipped');
+  assert.equal(one(env, '200'), null, 'the row still clears');
+});
+
+test('the recovery carries the pin an admin hid, so it can be put back', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  // What an admin does about a mod that has gone: pull the pin by hand.
+  env.DB._db.prepare('UPDATE locations SET status = ? WHERE id = ?').run('hidden', 'l2');
+
+  const back = await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: HOUR });
+  assert.deepEqual(back.modStatus.recovered[0].locations, [
+    { id: 'l2', name: 'Loc l2', status: 'hidden' },
+  ], 'no sweep will un-hide this, so the report has to say it is still hidden');
+  assert.equal(env.DB.one('SELECT status FROM locations WHERE id = ?', 'l2').status, 'hidden',
+    'and the recovery must not un-hide it either: that write was a decision');
+});
+
 test('a hidden mod that is then deleted starts its run again', async () => {
   const env = envWith();
   await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: 5, gap: 5 * MIN });

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -68,14 +68,34 @@ function uidFetch(responses) {
   };
 }
 const uidNode = (i) => ({
-  modId: i, name: `n${i}`, pictureUrl: `p${i}`, thumbnailUrl: `t${i}`, updatedAt: `u${i}`,
+  modId: i, name: `n${i}`, status: 'published',
+  pictureUrl: `p${i}`, thumbnailUrl: `t${i}`, updatedAt: `u${i}`,
 });
 
 test('modsByUid: returns a thumb map keyed by modId', async () => {
   const impl = uidFetch([{ json: { data: { modsByUid: { nodes: [uidNode(1), uidNode(2)] } } } }]);
   const map = await fetchModsByUidThumbs(impl, ['1', '2']);
-  assert.deepEqual(map['1'], { name: 'n1', pictureUrl: 'p1', thumbnailUrl: 't1', updatedAt: 'u1' });
-  assert.deepEqual(map['2'], { name: 'n2', pictureUrl: 'p2', thumbnailUrl: 't2', updatedAt: 'u2' });
+  assert.deepEqual(map['1'], { name: 'n1', status: 'published', pictureUrl: 'p1', thumbnailUrl: 't1', updatedAt: 'u1' });
+  assert.deepEqual(map['2'], { name: 'n2', status: 'published', pictureUrl: 'p2', thumbnailUrl: 't2', updatedAt: 'u2' });
+});
+
+test('modsByUid: a deleted mod is RETURNED, carrying the status that says so', async () => {
+  // The premise of #900's detection, and the opposite of what the issue
+  // assumed. Measured against the live API: mod 17513 comes back with
+  // `wastebinned`. Only the `mods` SEARCH query filters by status.
+  const impl = uidFetch([{ json: { data: { modsByUid: { nodes: [
+    { modId: 1, name: 'Gone - DELETED', status: 'wastebinned', updatedAt: 'u1' },
+  ] } } } }]);
+  const map = await fetchModsByUidThumbs(impl, ['1']);
+  assert.equal(map['1'].status, 'wastebinned',
+    'dropping this field is what made a deleted mod indistinguishable from a live one');
+});
+
+test('modsByUid: a node with no status yields null, which reads as published', async () => {
+  const impl = uidFetch([{ json: { data: { modsByUid: { nodes: [{ modId: 1, pictureUrl: 'p1' }] } } } }]);
+  const map = await fetchModsByUidThumbs(impl, ['1']);
+  assert.equal(map['1'].status, null,
+    'a pin must never come down because a field went missing from a response');
 });
 
 test('modsByUid: a mod with no name yields null rather than dropping the key', async () => {

--- a/worker/test/refresh-d1.test.js
+++ b/worker/test/refresh-d1.test.js
@@ -82,8 +82,11 @@ const NEXUS_PAGE = {
  * @param {object} opts
  * @param {boolean} opts.nexusKnowsNothing  Nexus answers both queries with an
  *   empty node list, so nothing lands in nexus_cache.
+ * @param {object} opts.nexusStatus  extra modsByUid nodes, `{modId: status}`.
+ *   A deleted or hidden mod is RETURNED by modsByUid carrying its status, not
+ *   omitted, which is the whole basis of the #900 detection.
  */
-function fakeFetch({ nexusKnowsNothing = false } = {}) {
+function fakeFetch({ nexusKnowsNothing = false, nexusStatus = {} } = {}) {
   return async (url, init) => {
     if (url.includes('/subdistricts.json')) return { ok: true, json: async () => SUBDISTRICTS };
     if (url.includes('api-router.nexusmods.com')) return { ok: false, status: 503 };
@@ -92,7 +95,14 @@ function fakeFetch({ nexusKnowsNothing = false } = {}) {
       if (JSON.parse(init.body).query.includes('modsByUid')) {
         return { ok: true, json: async () => ({
           data: { modsByUid: { nodes: nexusKnowsNothing ? [] : [
-            { modId: 12345, pictureUrl: 'pm', thumbnailUrl: 'tm', updatedAt: '2026-07-08' },
+            {
+              modId: 12345, status: 'published',
+              pictureUrl: 'pm', thumbnailUrl: 'tm', updatedAt: '2026-07-08',
+            },
+            ...Object.entries(nexusStatus).map(([modId, status]) => ({
+              modId: Number(modId), name: `Mod ${modId}`, status,
+              pictureUrl: 'px', thumbnailUrl: 'tx', updatedAt: '2026-07-08',
+            })),
           ] } },
         }) };
       }
@@ -213,6 +223,77 @@ test('a failed nexus_cache sweep is reported as itself, not as an empty cache', 
   assert.equal(r.stale, true);
   assert.match(r.error, /nexus_cache write refused/);
   assert.doesNotMatch(r.error, /nexus_cache is empty/, 'the symptom must not replace the cause');
+});
+
+test('a pin whose mod Nexus calls deleted is withheld, alerted once, and never hidden', async () => {
+  // The end of #900, through the real cron. `nexusStatus` makes modsByUid
+  // answer for 99999 with `wastebinned`, which is what the live API does for a
+  // deleted mod: it returns the node, it does not omit it.
+  const gone = { ...ROWS[0], id: 'm2', name: 'Deleted Mod Pin', nexus_id: '99999' };
+  const db = fakeD1({ rows: [...ROWS, gone] });
+  // Two sweeps' worth of history, so the third confirms it. Written directly
+  // because the point under test is the cron's response to a confirmation, not
+  // the counting, which nexus-status.test.js covers.
+  db._db.prepare(
+    `INSERT INTO nexus_mod_status (nexus_id, status, streak, first_seen_at, last_seen_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run('99999', 'wastebinned', 2, new Date(Date.now() - 900_000).toISOString(),
+    new Date(Date.now() - 300_000).toISOString());
+
+  const env = { DATASET: fakeKV(), DB: db, SITE_ORIGIN: 'https://x' };
+  const r = await runRefresh(env, fakeFetch({ nexusStatus: { 99999: 'wastebinned' } }));
+  assert.equal(r.stale, false, 'one mod being deleted is not a broken refresh');
+
+  const full = await env.DATASET.get(KEYS.full, 'json');
+  assert.deepEqual(Object.keys(full).sort(), ['m1', 'nexus-888'], 'the pin is off the map');
+  assert.equal(db.one('SELECT status FROM locations WHERE id = ?', 'm2').status, 'published',
+    'and the record is untouched, so Nexus reversing itself needs no human');
+
+  const alerts = db.rows('SELECT * FROM alerts');
+  assert.equal(alerts.length, 1, 'one alert for one deletion');
+  assert.equal(alerts[0].source, 'refresh');
+  assert.equal(alerts[0].severity, 'warn');
+  assert.match(alerts[0].title, /99999/);
+  assert.match(alerts[0].body, /Deleted Mod Pin/, 'the body names the pin, not just the mod id');
+  assert.match(alerts[0].body, /WITHHELD/, 'and says the map has already changed');
+  assert.match(alerts[0].body, /https:\/\/www\.nexusmods\.com\/cyberpunk2077\/mods\/99999/,
+    'an alert that asks someone to go and look has to link to the thing');
+
+  // Second tick, same day: the flag is already raised, so nothing is said again.
+  await runRefresh(env, fakeFetch({ nexusStatus: { 99999: 'wastebinned' } }));
+  assert.equal(db.rows('SELECT * FROM alerts').length, 1,
+    'alerting every five minutes is how a channel gets muted');
+
+  // And with the stored flag taken away, which is what two overlapping cron
+  // runs look like (each crossing before the other has written), the alerts
+  // table is the only thing left that can see the duplicate.
+  db._db.prepare('UPDATE nexus_mod_status SET flagged_at = NULL WHERE nexus_id = ?').run('99999');
+  await runRefresh(env, fakeFetch({ nexusStatus: { 99999: 'wastebinned' } }));
+  assert.equal(db.rows('SELECT * FROM alerts').length, 1,
+    'alertedSinceUtcMidnight is the backstop when the flag itself cannot dedup');
+});
+
+test('a hidden mod is alerted about and its pin stays up', async () => {
+  const hiddenPin = { ...ROWS[0], id: 'm2', name: 'Hidden Mod Pin', nexus_id: '99999' };
+  const db = fakeD1({ rows: [...ROWS, hiddenPin] });
+  db._db.prepare(
+    `INSERT INTO nexus_mod_status (nexus_id, status, streak, first_seen_at, last_seen_at)
+     VALUES (?, ?, ?, ?, ?)`,
+  ).run('99999', 'hidden', 2, new Date(Date.now() - 900_000).toISOString(),
+    new Date(Date.now() - 300_000).toISOString());
+
+  const env = { DATASET: fakeKV(), DB: db, SITE_ORIGIN: 'https://x' };
+  await runRefresh(env, fakeFetch({ nexusStatus: { 99999: 'hidden' } }));
+
+  const full = await env.DATASET.get(KEYS.full, 'json');
+  assert.ok(full.m2, 'hidden is a decision for a person, so the pin is still served');
+  const alerts = db.rows('SELECT * FROM alerts');
+  assert.equal(alerts.length, 1);
+  assert.match(alerts[0].title, /hidden on Nexus/);
+  assert.match(alerts[0].body, /reason the author left/,
+    'the alert has to send the reader to the only place the reason exists');
+  assert.match(alerts[0].body, /https:\/\/www\.nexusmods\.com\/cyberpunk2077\/mods\/99999/,
+    'and it has to be one click away, or nobody makes the trip');
 });
 
 test('a truncated result set fails the refresh rather than shrinking the map', async () => {

--- a/worker/test/refresh-d1.test.js
+++ b/worker/test/refresh-d1.test.js
@@ -296,6 +296,62 @@ test('a hidden mod is alerted about and its pin stays up', async () => {
     'and it has to be one click away, or nobody makes the trip');
 });
 
+test('a mod coming back raises a recovery alert and restores its pin', async () => {
+  const gone = { ...ROWS[0], id: 'm2', name: 'Back From The Dead', nexus_id: '99999' };
+  const db = fakeD1({ rows: [...ROWS, gone] });
+  // Already confirmed deleted and flagged, which is the state the up edge has
+  // to fire from.
+  db._db.prepare(
+    `INSERT INTO nexus_mod_status (nexus_id, status, streak, first_seen_at, last_seen_at, flagged_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run('99999', 'wastebinned', 9, new Date(Date.now() - 3600_000).toISOString(),
+    new Date(Date.now() - 300_000).toISOString(), new Date(Date.now() - 1800_000).toISOString());
+
+  const env = { DATASET: fakeKV(), DB: db, SITE_ORIGIN: 'https://x' };
+  // Withheld first, so the restoration is a change and not a starting state.
+  await runRefresh(env, fakeFetch({ nexusStatus: { 99999: 'wastebinned' } }));
+  let full = await env.DATASET.get(KEYS.full, 'json');
+  assert.equal(full.m2, undefined, 'precondition: the pin is withheld');
+
+  // Nexus publishes it again.
+  await runRefresh(env, fakeFetch({ nexusStatus: { 99999: 'published' } }));
+  full = await env.DATASET.get(KEYS.full, 'json');
+  assert.ok(full.m2, 'the pin is served again, with nobody involved');
+  assert.equal(db.one('SELECT nexus_id FROM nexus_mod_status WHERE nexus_id = ?', '99999'), null);
+
+  const recovery = db.rows("SELECT * FROM alerts WHERE severity = 'recovery'");
+  assert.equal(recovery.length, 1, 'a silent recovery is how a hidden record stays hidden forever');
+  assert.match(recovery[0].title, /back on Nexus: 99999/);
+  assert.match(recovery[0].body, /withheld and is restored automatically/);
+  assert.match(recovery[0].body, /https:\/\/www\.nexusmods\.com\/cyberpunk2077\/mods\/99999/);
+
+  // Third tick, still published: the edge has passed and stays quiet.
+  await runRefresh(env, fakeFetch({ nexusStatus: { 99999: 'published' } }));
+  assert.equal(db.rows("SELECT * FROM alerts WHERE severity = 'recovery'").length, 1);
+});
+
+test('a recovery names a record the admin hid, because no sweep will un-hide it', async () => {
+  const hiddenRecord = {
+    ...ROWS[0], id: 'm2', name: 'Pulled By Hand', nexus_id: '99999', status: 'hidden',
+  };
+  const db = fakeD1({ rows: [...ROWS, hiddenRecord] });
+  db._db.prepare(
+    `INSERT INTO nexus_mod_status (nexus_id, status, streak, first_seen_at, last_seen_at, flagged_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run('99999', 'hidden', 9, new Date(Date.now() - 3600_000).toISOString(),
+    new Date(Date.now() - 300_000).toISOString(), new Date(Date.now() - 1800_000).toISOString());
+
+  const env = { DATASET: fakeKV(), DB: db, SITE_ORIGIN: 'https://x' };
+  await runRefresh(env, fakeFetch({ nexusStatus: { 99999: 'published' } }));
+
+  const recovery = db.rows("SELECT * FROM alerts WHERE severity = 'recovery'");
+  assert.equal(recovery.length, 1);
+  assert.match(recovery[0].body, /Still hidden in the registry: Pulled By Hand \(hidden\)/,
+    'the one thing left to do is the one thing the alert has to say');
+  assert.equal(db.one('SELECT status FROM locations WHERE id = ?', 'm2').status, 'hidden',
+    'and it is still a human decision to reverse');
+});
+
 test('a truncated result set fails the refresh rather than shrinking the map', async () => {
   const env = {
     DATASET: fakeKV(),


### PR DESCRIPTION
Release **2.5.0**. Brings #926 and #927 to production, closing #900.

## What changes for a visitor

A pin whose mod has been deleted from Nexus disappears from the map on its own, three sweeps after Nexus reports it. Before D1 that happened by accident (a pulled mod dropped out of the tag query); since the cutover it stopped happening at all, because a location is a row and rows persist.

Nothing else about the map changes.

## What changes for an admin

Three mods pinned on the map are `hidden` on Nexus right now: **28736 Jig Jig Revolution**, **26929 NCPD Precinct**, **30702 Silicon Mirage Villa**. Within about fifteen minutes of this deploying, all three will appear on the dashboard's Overview and fire one `warn` alert each into map-alerts.

**No pin will move.** `hidden` never withholds; it asks a person to read the reason the author left and decide. Jig Jig Revolution is the worked example: hidden on 11 May 2026 because it is obsolete and superseded by "Jig Jig Unleashed - REVOLUTION", which no rule could have inferred and which calls for repointing the pin rather than pulling it.

## The mechanism, briefly

The `Mod` type carries `status`, and `modsByUid` does **not** filter by it: a deleted mod comes back looking like any other node. Only the `mods` search query filters. So the signal is a string, available on the first sweep, and absence is the weak third case.

| Nexus says | Confirmed after | The map |
|---|---|---|
| `wastebinned` | 3 sweeps | pin withheld from the dataset |
| `hidden` | 3 sweeps | unchanged |
| absent from the response | 6 sweeps + 24h | unchanged |
| null / unrecognised | never | unchanged |

Withholding happens at build time, never by writing `locations.status`: the record stays as the admin left it, and a reversal on Nexus restores the pin with nobody involved. The up edge raises a `recovery` alert, which exists mainly for the case that does *not* self-heal — a record someone hid by hand while the mod was down.

Two caps: a sweep whose absent set looks like a failed `modsByUid` chunk is discarded, and no sweep may withhold more than 5 pins (past that it withholds none and says so).

## Already done

- **Migration `0009_nexus_mod_status.sql` is applied to production D1** (and to staging). Verified: `nexus_mod_status` exists, `nexus_cache.status` present, 297 locations intact, `/v1/health` green throughout.
- Staging has been running this since 05:27 UTC. It flagged all three hidden mods on the third sweep, fired three alerts, and moved no pins. It also caught Silicon Mirage Villa going hidden live, ninety minutes after a scan had found it published.

## Verification

- worker: 327 → **365 tests**, all passing. Site: 81, unchanged.
- **18 mutations** across the two PRs, each killed by the test that should have killed it.
- The dashboard was driven in a browser at 1440px and 390px: every status including an unrecognised one, both quiet states, a dismissal round trip, and the drift row proven to still report *real* drift while ignoring deliberate withholding.
- API version stays 0.5.1: no `/v1` route or payload shape changed, and the version guard agrees.

## Rollback

Revert the merge. The migration can stay: the previous build names its columns explicitly and never reads `nexus_mod_status`, so an unused table and a nullable column cost nothing.
