### PR TITLE
fix: an unpinned mod is not a recovered mod, and a dismissal reads as English

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Dealing with a flagged mod no longer announces that the mod is back on Nexus. Repointing a pin at a successor, or deleting the pin outright, stops the registry tracking that mod: it does not mean the mod recovered, and saying so was false.
+- The audit log reads as English for a dismissal, and no longer reports a mod hidden on Nexus as "off the map" one line above saying its pin is still up.
+
 ## [2.5.0] - 2026-08-02
 
 A mod that leaves Nexus no longer leaves its pin behind. Nexus states a

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -2259,6 +2259,24 @@
     reason: 'Reason',
     dismissed_by: 'Dismissed by',
     owner_id: 'Owner',
+
+    // A nexus_mod_status row. `status` is deliberately absent: it collides with
+    // the location column of the same name and is disambiguated per action, in
+    // ACTION_VALUE_LABEL and ACTION_FIELD_LABEL.
+    mod_name: 'Mod name',
+    streak: 'Consecutive sweeps',
+    first_seen_at: 'First seen',
+    last_seen_at: 'Last seen',
+    flagged_at: 'Flagged',
+    dismissed_at: 'Dismissed',
+    withheld: 'Pin withheld',
+    locations: 'Pins',
+  };
+
+  /** Field labels that only make sense for one action. Same reason as ACTION_VALUE_LABEL. */
+  const ACTION_FIELD_LABEL = {
+    'nexus_status.dismiss': { status: 'Status on Nexus' },
+    'nexus_status.restore': { status: 'Status on Nexus' },
   };
 
   const fieldLabel = (key) => FIELD_LABEL[key] ?? key;
@@ -2282,6 +2300,25 @@
    * Only for fields whose values are a closed set. A name, a note or a reason is
    * already prose and must be shown exactly as recorded, never "tidied".
    */
+  /**
+   * What Nexus says about a mod, in a word.
+   *
+   * Lives with the other label maps rather than with the panel that renders
+   * them, because the audit log's per-action overrides read it at module init
+   * and a `const` declared further down is still in its temporal dead zone.
+   *
+   * The three read differently on purpose. "Deleted" has already changed the
+   * map; "hidden" has changed nothing and needs a person to go and read why;
+   * "no answer" is the weak signal and says so.
+   */
+  const MOD_STATUS_LABEL = {
+    wastebinned: 'Deleted',
+    hidden: 'Hidden',
+    absent: 'No answer',
+  };
+
+  const modStatusLabel = (s) => MOD_STATUS_LABEL[s] ?? s;
+
   const VALUE_LABEL = {
     granted_by: {
       apply: 'applied to the existing record',
@@ -2315,8 +2352,23 @@
     if (v === undefined) return 'not recorded';
     if (v === null) return 'not set';
     if (typeof v === 'boolean') return v ? 'yes' : 'no';
-    if (Array.isArray(v)) return v.length ? v.join(', ') : 'none';
+    // An array of records, not of strings: a bare join renders every element as
+    // `[object Object]`, which is how the pins on a mod-status row read. Prefer
+    // the element's own name where it has one, and never lose the value.
+    if (Array.isArray(v)) {
+      return v.length
+        ? v.map((el) => (el && typeof el === 'object'
+          ? (el.name ?? JSON.stringify(el))
+          : String(el))).join(', ')
+        : 'none';
+    }
     if (typeof v === 'object') return JSON.stringify(v);
+    // A stored timestamp, rendered the way every other time on this page is.
+    // Matched on the column-name convention rather than by sniffing the value,
+    // so a name or a note that happens to parse as a date is left alone.
+    if (typeof v === 'string' && /_at$/.test(key) && Number.isFinite(Date.parse(v))) {
+      return formatTime(v);
+    }
     return VALUE_LABEL[key]?.[String(v)] ?? (v === '' ? 'empty' : String(v));
   }
 
@@ -2338,7 +2390,33 @@
       h('pre', { text: JSON.stringify(payload, null, 2) }));
   }
 
-  function renderDiff(before, after, rawLabel = 'Show the raw values') {
+  /**
+   * Records from different tables share field NAMES that do not share meaning.
+   *
+   * `status` is the worst of them: on a location it is the map vocabulary
+   * (`published` reads as "on the map"), and on a `nexus_mod_status` row it is
+   * what Nexus says about the mod. Rendering a mod's `hidden` as "off the map"
+   * is not an unfriendly label, it is a false statement, and it sat one line
+   * above `withheld: no` contradicting it.
+   *
+   * Scoped by the action that wrote the row, which is the only thing that knows
+   * which table the record came from. Anything not listed here falls through to
+   * the shared maps exactly as before.
+   */
+  const ACTION_VALUE_LABEL = {
+    'nexus_status.dismiss': { status: MOD_STATUS_LABEL },
+    'nexus_status.restore': { status: MOD_STATUS_LABEL },
+  };
+
+  function renderDiff(before, after, rawLabel = 'Show the raw values', action = null) {
+    const scoped = ACTION_VALUE_LABEL[action] ?? null;
+    const scopedField = ACTION_FIELD_LABEL[action] ?? null;
+    const label = (key) => scopedField?.[key] ?? fieldLabel(key);
+    const value = (key, v) => {
+      const override = scoped?.[key];
+      if (override && typeof v === 'string' && override[v]) return override[v];
+      return humanValue(key, v);
+    };
     const keys = [...new Set([...Object.keys(before || {}), ...Object.keys(after || {})])].sort();
     const rows = [];
     for (const key of keys) {
@@ -2349,10 +2427,10 @@
       if (key === 'modified_at') continue;
       if (sameValue(from, to)) continue;
       rows.push(h('div', {},
-        h('span', { class: 'k', text: `${fieldLabel(key)}: ` }),
-        before ? h('span', { class: 'from', text: humanValue(key, from) }) : null,
+        h('span', { class: 'k', text: `${label(key)}: ` }),
+        before ? h('span', { class: 'from', text: value(key, from) }) : null,
         before && after ? ' → ' : null,
-        after ? h('span', { class: 'to', text: humanValue(key, to) }) : null));
+        after ? h('span', { class: 'to', text: value(key, to) }) : null));
     }
     return h('div', { class: 'diff-block' },
       rows.length
@@ -2477,6 +2555,23 @@
       case 'candidate.restore':
         return ['put mod ', nexusLink(target), ' back in the candidates list'];
 
+      // The dismissal means two different things depending on what Nexus said,
+      // and the difference is whether a pin moved. Reading `after.status` rather
+      // than assuming: the row records what the mod's state was at the time.
+      case 'nexus_status.dismiss': {
+        const name = after.mod_name;
+        const wasDeleted = after.status === 'wastebinned';
+        return [
+          wasDeleted ? 'put the pin back for deleted mod ' : 'cleared the flag on ',
+          nexusLink(target), name ? [' ', quoted(name)] : '',
+          wasDeleted ? '' : `, ${modStatusLabel(after.status).toLowerCase()} on Nexus`,
+        ];
+      }
+      case 'nexus_status.restore':
+        return ['re-flagged mod ', nexusLink(target),
+          after.mod_name ? [' ', quoted(after.mod_name)] : '',
+          after.withheld ? ', taking its pin back off the map' : ''];
+
       // An action this page has not been taught. Say what is known rather than
       // rendering a blank line: a new server action must not vanish from view
       // just because the dashboard is behind.
@@ -2503,7 +2598,7 @@
           // always be checked against what was actually recorded.
           h('code', { class: 'action', title: `recorded as ${e.action} on ${e.target ?? 'nothing'}`, text: e.action })),
         h('details', {}, h('summary', { text: 'The full record' }),
-          renderDiff(e.before, e.after, 'Show exactly what was recorded'))))
+          renderDiff(e.before, e.after, 'Show exactly what was recorded', e.action))))
       : h('p', { class: 'muted', text: 'No entries yet.' }));
   }
 
@@ -2689,20 +2784,6 @@
 
   // ------------------------------------ mods not published on Nexus --
 
-  /**
-   * What each status means here, and what the reader is being asked to do.
-   *
-   * Three separate stories on purpose. "Deleted" has already changed the map
-   * and needs confirming; "hidden" has changed nothing and needs a person to go
-   * and read why; "no longer returned" is the weak signal and says so. Rendering
-   * them identically would flatten the one distinction the panel exists for.
-   */
-  const MOD_STATUS_LABEL = {
-    wastebinned: 'Deleted',
-    hidden: 'Hidden',
-    absent: 'No answer',
-  };
-
   const MOD_STATUS_NOTE = {
     wastebinned: 'Nexus reports this mod as deleted, so its pin is off the map. '
       + 'The record itself has not been edited. Dismiss to put the pin back.',
@@ -2713,7 +2794,6 @@
       + 'same as reporting it deleted. The pin is still up.',
   };
 
-  const modStatusLabel = (s) => MOD_STATUS_LABEL[s] ?? s;
   const modStatusNote = (s) => MOD_STATUS_NOTE[s]
     ?? `Nexus reports this mod as "${s}", which this dashboard has not been taught. `
       + 'The pin is still up.';

--- a/worker/src/nexus-cache.js
+++ b/worker/src/nexus-cache.js
@@ -417,9 +417,17 @@ export async function refreshNexusCache(env, { fetchImpl = fetch, nowIso, tagged
   const { results: locRows } = await env.DB.prepare(
     'SELECT DISTINCT nexus_id FROM locations WHERE nexus_id IS NOT NULL',
   ).all();
-  const needBackfill = (locRows ?? [])
-    .map((r) => String(r.nexus_id))
-    .filter((id) => isRealNexusId(id) && !incoming.has(id));
+  const pinnedIds = (locRows ?? []).map((r) => String(r.nexus_id)).filter(isRealNexusId);
+  const needBackfill = pinnedIds.filter((id) => !incoming.has(id));
+
+  // Every pinned mod this sweep has an answer about: the ones asked via
+  // modsByUid, and the ones the tagged query already returned (which is proof
+  // of `published`, since that query serves published mods only).
+  //
+  // Load-bearing for the recovery report, NOT for the counting. A tracked mod
+  // that has dropped out of this set is one nothing points at any more, which
+  // is a different fact from the mod being fixed. See recordSweep.
+  const considered = new Set(pinnedIds);
 
   // What this sweep learned about each pinned mod that is not published:
   // nexus_id -> status, where `absent` means the response did not mention it.
@@ -475,7 +483,7 @@ export async function refreshNexusCache(env, { fetchImpl = fetch, nowIso, tagged
   const writes = diffRows([...incoming.values()], existing);
   summary.written = await writeRows(env, writes, stamp);
   summary.modStatus = await trackModStatus(
-    env, { unavailable, missingIds, needBackfill, summary, stamp },
+    env, { unavailable, considered, missingIds, needBackfill, summary, stamp },
   );
   return summary;
 }
@@ -507,7 +515,9 @@ export async function refreshNexusCache(env, { fetchImpl = fetch, nowIso, tagged
  * that really is gone keeps the count it has earned and picks up again on the
  * next sweep worth believing.
  */
-async function trackModStatus(env, { unavailable, missingIds, needBackfill, summary, stamp }) {
+async function trackModStatus(
+  env, { unavailable, considered, missingIds, needBackfill, summary, stamp },
+) {
   if (summary.stale) return { skipped: 'stale', flagged: [] };
   if (sweepLooksUnreliable({ missing: missingIds.length, requested: needBackfill.length })) {
     console.warn(
@@ -519,7 +529,7 @@ async function trackModStatus(env, { unavailable, missingIds, needBackfill, summ
   // Absence is folded in only now, so the guards above judge it first.
   for (const id of missingIds) unavailable.set(id, ABSENT);
   try {
-    return await recordSweep(env, { unavailable, nowIso: stamp });
+    return await recordSweep(env, { unavailable, considered, nowIso: stamp });
   } catch (err) {
     console.warn('nexus_mod_status tracking failed (non-fatal):', String(err).slice(0, 200));
     return { skipped: 'error', flagged: [], error: String(err).slice(0, 200) };

--- a/worker/src/nexus-status.js
+++ b/worker/src/nexus-status.js
@@ -149,6 +149,10 @@ function crossesThreshold(row, nowMs) {
  *   pinned mod this sweep did NOT get a published answer for. `absent` is this
  *   module's own value; everything else is Nexus's own string, stored verbatim
  *   so an unrecognised vocabulary is recorded rather than discarded.
+ * @param {Set<string>} opts.considered  every pinned mod id this sweep had an
+ *   answer about. A tracked row inside this set and outside `unavailable` is
+ *   published again; a tracked row OUTSIDE it is simply no longer pinned, which
+ *   is not the same fact and must not be reported as the same one.
  * @param {string} opts.nowIso
  * @returns {Promise<{tracked:number, cleared:number, flagged:string[]}>}
  *   `flagged` is the ids that crossed on THIS sweep, which is what the caller
@@ -157,7 +161,7 @@ function crossesThreshold(row, nowMs) {
  * NOT called on a sweep the caller does not trust: this prunes every row it was
  * not told about, so a failed sweep passed through here would clear the table.
  */
-export async function recordSweep(env, { unavailable = new Map(), nowIso }) {
+export async function recordSweep(env, { unavailable = new Map(), considered = null, nowIso }) {
   const stamp = nowIso ?? new Date().toISOString();
   const nowMs = Date.parse(stamp);
   const existing = await readRows(env);
@@ -201,11 +205,10 @@ export async function recordSweep(env, { unavailable = new Map(), nowIso }) {
     ));
   }
 
-  // Every row this sweep did not name: Nexus called it published, or it is no
-  // longer pinned. Both are a delete rather than a reset, so an untracked mod
-  // costs no write at all in the steady state. A dismissal goes with the row,
-  // which is right: the admin dismissed a mod that was in trouble, and this one
-  // is not.
+  // Every row this sweep did not name is deleted, whatever the reason, so an
+  // untracked mod costs no write at all in the steady state. A dismissal goes
+  // with the row, which is right: the admin dismissed a mod that was in
+  // trouble, and this one no longer is.
   let cleared = 0;
   for (const id of existing.keys()) {
     if (unavailable.has(id)) continue;
@@ -214,17 +217,41 @@ export async function recordSweep(env, { unavailable = new Map(), nowIso }) {
   }
 
   // The up edge, captured BEFORE the delete, because the row is the only record
-  // that anything was ever wrong. Only rows that were FLAGGED: a mod that
-  // looked odd for one sweep and was fine on the next is not a recovery, it is
-  // noise, and announcing it would teach people to skip the recovery alerts
-  // that matter.
+  // that anything was ever wrong.
+  //
+  // A row can stop being named for two unrelated reasons, and only ONE of them
+  // is a recovery:
+  //
+  //   * the mod is in `considered` and not in `unavailable` -- this sweep asked
+  //     Nexus about it and got `published`. That is the mod coming back.
+  //   * the mod is not in `considered` at all -- nothing points at it any more.
+  //     The pin was repointed at a successor mod, or the location was deleted.
+  //     THE MOD IS EXACTLY AS BROKEN AS IT WAS; the registry simply stopped
+  //     caring. Reporting that as "back on Nexus" states something false about
+  //     the outside world, which is worse than saying nothing.
+  //
+  // Both were reported as recoveries until 2026-08-02, and both fired in
+  // production the first time an admin dealt with a flagged mod: repointing
+  // Jig Jig Revolution at its successor announced that mod 28736 was back, and
+  // deleting the Silicon Mirage Villa pin announced the same for a mod whose
+  // author had deleted their account.
+  //
+  // A null `considered` means the caller did not say, and nothing is treated as
+  // a recovery. Silence is the safe default here: a missed recovery costs an
+  // alert, an invented one costs the reader's trust in the whole channel.
+  //
+  // FLAGGED rows only. A mod that looked odd for one sweep and was fine on the
+  // next is noise, and announcing it teaches people to skip the alerts that
+  // matter.
   //
   // The pins go with it. Withholding reverses itself, but an admin who HID the
   // record while the mod was down has made a write that no sweep will undo, and
   // the only moment anyone can be told is this one.
-  const recovering = [...existing.values()].filter(
-    (r) => !unavailable.has(String(r.nexus_id)) && r.flagged_at,
-  );
+  const recovering = [...existing.values()].filter((r) => {
+    const id = String(r.nexus_id);
+    if (unavailable.has(id) || !r.flagged_at) return false;
+    return considered instanceof Set && considered.has(id);
+  });
   const pins = recovering.length ? await readPinsForTracked(env) : new Map();
   const recovered = recovering.map((r) => ({
     nexus_id: String(r.nexus_id),

--- a/worker/test/nexus-status.test.js
+++ b/worker/test/nexus-status.test.js
@@ -4,7 +4,7 @@ import { sqliteD1 } from '../test-support/d1-sqlite.mjs';
 import { refreshNexusCache } from '../src/nexus-cache.js';
 import { materializeFromD1 } from '../src/materialize.js';
 import {
-  sweepLooksUnreliable, isPublished, readModStatuses, readWithheld, setDismissed,
+  sweepLooksUnreliable, isPublished, readModStatuses, readWithheld, setDismissed, recordSweep,
   CONFIRM_SWEEPS, ABSENT_STREAK, SWEEP_MIN_SUSPECT, MAX_WITHHELD,
   WASTEBINNED, ABSENT,
 } from '../src/nexus-status.js';
@@ -208,6 +208,53 @@ test('a mod that was dismissed reports no withholding to undo', async () => {
   const back = await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: 2 * HOUR });
   assert.equal(back.modStatus.recovered[0].wasWithheld, false,
     'the admin already put the pin back by hand; there is nothing to restore');
+});
+
+// Both of these fired in production on 2026-08-02, the first time an admin dealt
+// with a flagged mod. A row stops being named for two unrelated reasons and only
+// one of them is the mod being fixed; reporting the other says something false
+// about the outside world.
+
+test('repointing a pin at a successor mod is not the old mod recovering', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+  assert.ok(one(env, '200').flagged_at, 'precondition: flagged');
+
+  // What an admin does when the author says "use this other mod instead".
+  env.DB._db.prepare('UPDATE locations SET nexus_id = ? WHERE id = ?').run('300', 'l2');
+
+  const after = await sweeps(env, {
+    states: { ...ALL_OK, 300: 'published' }, count: 1, gap: 5 * MIN, from: HOUR,
+  });
+  assert.deepEqual(after.modStatus.recovered, [],
+    'mod 200 is exactly as hidden as it was; nothing points at it any more');
+  assert.equal(one(env, '200'), null, 'the row still clears, silently');
+  assert.equal(one(env, '300'), null, 'and the successor is healthy, so it is not tracked');
+});
+
+test('deleting the pin is not the mod recovering', async () => {
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+
+  // The author deleted their account, so the mod is gone for good and the
+  // record should never have outlived it.
+  env.DB._db.prepare('DELETE FROM locations WHERE id = ?').run('l2');
+
+  const after = await sweeps(env, { states: ALL_OK, count: 1, gap: 5 * MIN, from: HOUR });
+  assert.deepEqual(after.modStatus.recovered, [],
+    'announcing "back on Nexus" for a mod whose author deleted their account is a lie');
+  assert.equal(one(env, '200'), null);
+});
+
+test('a caller that does not say what it considered reports no recoveries', async () => {
+  // Silence is the safe default: a missed recovery costs an alert, an invented
+  // one costs the reader's trust in the channel.
+  const env = envWith();
+  await sweeps(env, { states: { ...ALL_OK, 200: 'hidden' }, count: CONFIRM_SWEEPS, gap: 5 * MIN });
+
+  const r = await recordSweep(env, { unavailable: new Map(), nowIso: at(HOUR) });
+  assert.deepEqual(r.recovered, []);
+  assert.equal(r.cleared, 1, 'the row still clears');
 });
 
 test('a one-sweep blink is not a recovery', async () => {


### PR DESCRIPTION
Follow-up to #926 / #927. Refs #900. Found by the user within an hour of 2.5.0 going live, by doing the two most obvious things an admin does with a flagged mod.

## 1. Dealing with a flagged mod announced that the mod had recovered

Both of these fired a `recovery` alert saying the mod was **back on Nexus**, and neither mod was:

- **Repointing a pin at its successor.** Jig Jig Revolution's author hid mod 28736 as obsolete and named a replacement. Editing the record to point at the replacement announced that 28736 was back. It is still hidden.
- **Deleting a pin.** Silicon Mirage Villa's author deleted their Nexus account on 2 Aug, taking the mod with it. Deleting the now-pointless location announced that the mod had returned. It is gone permanently.

One wrong assumption, written down in my own comment:

> Every row this sweep did not name: Nexus called it published, or it is no longer pinned. **Both are proof the mod is fine.**

The second half is false. A tracked row stops being named for two unrelated reasons:

| | means | is it a recovery? |
|---|---|---|
| in `considered`, not in `unavailable` | the sweep asked Nexus and got `published` | **yes** |
| not in `considered` at all | nothing points at the mod any more | **no** — the mod is exactly as broken as it was |

The sweep now passes `considered`: the pinned ids it had an answer about. Only the first case reports. A null `considered` reports nothing at all — a missed recovery costs one alert, an invented one costs the reader's trust in the whole channel.

Worth noting for the record: **an author deleting their account presents as `hidden`, not `wastebinned`.** So there is a permanent-loss case that never reaches the deleted branch, and the pin stays up until a person deals with it. That is the correct outcome under the policy in [[deleted-withholds-hidden-waits]], but it is not obvious from the status alone.

## 2. The audit entry was unreadable, and one line of it was false

Raw: `nexus_status.dismiss on 26929`. Expanded, worse:

```
Status: off the map          ← the mod is `hidden` ON NEXUS
locations: [object Object]
withheld: no                 ← two lines below, contradicting the first
```

`VALUE_LABEL.status` is the **location** vocabulary and was being applied to any field named `status`. A `nexus_mod_status` row uses that name for what Nexus says about the mod, so the log told a reader the pin was off the map, and then that it wasn't.

Labels are now scoped by the action that wrote the row — the only thing that knows which table the record came from. Anything unlisted falls through to the shared maps, and a location edit still reads `on the map → off the map`.

Three smaller ones, fixed generally rather than as special cases:

- an array of records joined as if it were an array of strings → prefer each element's own name
- `*_at` strings rendered as raw ISO → the same local format as every other time on the page
- `streak`, `withheld`, `mod_name` and friends had no labels at all

After:

```
cleared the flag on 26929 “NCPD Precinct (World Builder)”, hidden on Nexus
  Dismissed: 02 Aug 2026, 17:03 GMT+10      Pins: NCPD Precinct
  Status on Nexus: Hidden                   Consecutive sweeps: 5
  Pin withheld: no
```

A dismissal on a *deleted* mod reads differently, because it does something different: **"put the pin back for deleted mod 17513 …"**.

## Verification

- 365 → **368 tests**, all passing. Site: 81, unchanged.
- **Two mutations**, both killed: treating an unpinned row as recovered (the production bug — 3 tests catch it), and passing no `considered` set (6 tests).
- Browser pass over the audit tab with the exact production record: all four problems gone, no console errors, and a location edit confirmed unaffected. Also confirms the module-init crash fixed along the way — `MOD_STATUS_LABEL` was in its temporal dead zone when the new per-action map read it.

## Note on scope

This is a correctness fix on a released feature, so it wants its own PR rather than going straight to `dev`. It should ship as **2.5.1** once merged.
