### PR TITLE
fix(api): a failed refresh reports itself, and names what broke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- A refresh that fails now says so on `/v1/health` instead of reporting the API as healthy. Three consecutive failures did the opposite: they alerted Discord every five minutes while the freshness pill and the wedged-cron monitor stayed quiet.
+- A refresh alert names the fetch that broke, with its URL, status, content type and the start of the body. "Unexpected token '<'" could have been either of two upstreams and said which of them neither.
+
 ## [2.5.1] - 2026-08-02
 
 ### Fixed

--- a/worker/src/json.js
+++ b/worker/src/json.js
@@ -1,0 +1,61 @@
+/**
+ * Parsing a response body as JSON, with an error that says what actually
+ * arrived.
+ *
+ * ## Why this exists
+ *
+ * `res.ok && await res.json()` is the obvious shape and it fails uselessly. An
+ * upstream that answers **200 with an HTML body** passes the `ok` check and
+ * dies in the parser, and the thrown error is:
+ *
+ *     SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
+ *
+ * No URL, no status, no content-type. On 2026-08-02 that alert fired on four
+ * consecutive production cron ticks and could not be attributed to either of
+ * the two fetches capable of producing it, because both produce exactly the
+ * same string. A cron whose failure path serves last-known-good is quiet by
+ * design, so the alert text is the only diagnostic anyone gets.
+ *
+ * The 200-with-HTML case is not exotic. A Cloudflare challenge, a WAF
+ * interstitial, an origin error page and a Pages SPA fallback all do it.
+ *
+ * ## Why the body is read from a clone
+ *
+ * `res.json()` consumes the body, so the text is unavailable afterwards to
+ * describe what went wrong. Cloning first costs nothing on the success path and
+ * is the only way to quote the body on the failure path.
+ *
+ * A response without `clone()` still gets the URL, the status and the
+ * content-type: the injected fakes throughout `worker/test/` are plain objects,
+ * and this must not force every one of them to grow a method to keep working.
+ */
+
+/** Enough of the body to recognise what it is, on one line. */
+const SNIPPET = 100;
+
+/**
+ * @param {Response} res  an already-checked response (call sites test `res.ok`)
+ * @param {string} url    what was requested, for the error message
+ * @returns {Promise<any>} the parsed body
+ * @throws {Error} naming the URL, status, content-type and the body's opening
+ */
+export async function jsonOrThrow(res, url) {
+  const copy = typeof res?.clone === 'function' ? res.clone() : null;
+  try {
+    return await res.json();
+  } catch (err) {
+    const type = res?.headers?.get?.('content-type') || 'no content-type';
+    let head = '';
+    if (copy) {
+      try {
+        head = (await copy.text()).trim().replace(/\s+/g, ' ').slice(0, SNIPPET);
+      } catch {
+        // The clone is a convenience. Losing it costs the snippet, not the error.
+      }
+    }
+    throw new Error(
+      `GET ${url} -> HTTP ${res?.status ?? '?'} ${type}, not JSON`
+      + `${head ? `: "${head}"` : ` (${String(err).slice(0, 80)})`}`,
+    );
+  }
+}

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -9,6 +9,8 @@
  * dataset".
  */
 
+import { jsonOrThrow } from './json.js';
+
 export const NEXUS_GQL_ENDPOINT = 'https://api.nexusmods.com/v2/graphql';
 // Newer public router endpoint that exposes modFiles (the V2 endpoint above
 // does not). Both are unauthenticated; see docs/nexus-api-reference.md.
@@ -83,7 +85,11 @@ export async function fetchTaggedModNodes(fetchImpl = fetch) {
     });
     if (!res.ok) throw new Error(`Nexus GraphQL HTTP ${res.status}`);
 
-    const json = await res.json();
+    // Not `res.json()`: Nexus answering 200 with a challenge or error PAGE is a
+    // thing that happens, and a bare SyntaxError names neither this endpoint nor
+    // the body, which makes it indistinguishable from the other JSON parse in
+    // the cron's fatal path. See json.js.
+    const json = await jsonOrThrow(res, `${NEXUS_GQL_ENDPOINT} (tagged query, offset ${offset})`);
     const page = json?.data?.mods;
     if (!page) {
       throw new Error(

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -28,15 +28,24 @@ import {
   KEYS, contentHash, readMeta, writeDataset, writeMeta,
 } from './store.js';
 import { raiseAlert, alertedSinceUtcMidnight } from './alerts.js';
+import { jsonOrThrow } from './json.js';
 import { checkQuotaThresholds } from './quota.js';
 
 const SCHEMA_VERSION = 1;
 
-/** Fetch a JSON file from the site origin; throws on non-200. */
+/**
+ * Fetch a JSON file from the site origin; throws on non-200, and throws
+ * something diagnosable when a 200 turns out not to be JSON.
+ *
+ * The origin is a Cloudflare Pages site, so "200 with an HTML body" is a real
+ * answer it can give: a fallback for a missing asset, or a challenge page. See
+ * jsonOrThrow.
+ */
 async function fetchJson(fetchImpl, origin, path) {
-  const res = await fetchImpl(`${origin}${path}`);
-  if (!res.ok) throw new Error(`GET ${path} → HTTP ${res.status}`);
-  return res.json();
+  const url = `${origin}${path}`;
+  const res = await fetchImpl(url);
+  if (!res.ok) throw new Error(`GET ${url} -> HTTP ${res.status}`);
+  return jsonOrThrow(res, url);
 }
 
 /**
@@ -466,18 +475,52 @@ export async function runRefresh(env, fetchImpl = fetch) {
     return { changed: true, version, stale: false, recovered };
   } catch (err) {
     // Keep last-known-good; flag stale; alert. Never wipe the dataset.
-    const prev = await readMeta(env);
-    if (prev) {
+    //
+    // Logged as well as alerted. A cycle that fails here is invisible in
+    // `wrangler tail` otherwise: runRefresh does not rethrow, so the scheduled
+    // handler reports the tick as Ok and Discord is the only place the failure
+    // appears. That is the wrong way round for anything being debugged.
+    console.error('refresh failed, serving last-known-good:', String(err).slice(0, 300));
+
+    let prev = null;
+    try {
+      prev = await readMeta(env);
+    } catch (readErr) {
+      console.error('could not read meta:', String(readErr).slice(0, 200));
+    }
+
+    // `prev` is null before the first successful cron, and ALSO whenever the
+    // KV read comes back empty or unparseable (`get(key, 'json')` answers null
+    // for both). Skipping the write in that case is what let three consecutive
+    // failures on 2026-08-02 leave `discovery_stale: false` and a frozen
+    // `last_refresh_at` behind them: the API reported itself healthy while
+    // alerting every five minutes, so the freshness pill and the wedged-cron
+    // monitor both stayed quiet. A failure has to be recorded even when there
+    // is nothing to merge it into.
+    const base = prev ?? {
+      schema: SCHEMA_VERSION,
+      generated_at: null,
+      dataset_version: null,
+      skipped: [],
+    };
+
+    // Its own try/catch, and BEFORE the alert stays after it: a KV write that
+    // throws here must not be able to swallow the notification. The alert is
+    // the last line of defence and nothing may run ahead of it that can fail.
+    try {
       await writeMeta(env, {
-        ...prev,
+        ...base,
         discovery_stale: true,
         last_error: String(err).slice(0, 300),
         last_error_at: generatedAt,
-        // The cron still RAN (Nexus just didn't answer), so advance the heartbeat
-        // so this reads as "stale data" (discovery_stale), not "wedged cron".
+        // The cron still RAN (an upstream just did not answer), so advance the
+        // heartbeat: this reads as "stale data", not as "wedged cron".
         last_refresh_at: generatedAt,
       });
+    } catch (metaErr) {
+      console.error('could not record the failure in meta:', String(metaErr).slice(0, 200));
     }
+
     await alertRefreshFailed(env, fetchImpl, err);
     return {
       changed: false,

--- a/worker/test/json.test.js
+++ b/worker/test/json.test.js
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { jsonOrThrow } from '../src/json.js';
+
+// A 200 carrying an HTML body is what a Cloudflare challenge, a WAF
+// interstitial, an origin error page and a Pages fallback all look like. The
+// bare `SyntaxError: Unexpected token '<'` it used to produce named neither the
+// URL nor the body, and both JSON parses in the cron's fatal path produced the
+// same string, so a real production failure could not be attributed to either.
+
+const HTML = '<!DOCTYPE html>\n<html><head><title>Just a moment...</title></head>\n<body>checking</body></html>';
+
+/** A real-ish Response: clonable, with headers and a body read once. */
+function response(body, { status = 200, type = 'text/html' } = {}) {
+  const make = () => ({
+    status,
+    ok: status >= 200 && status < 300,
+    headers: { get: (k) => (k.toLowerCase() === 'content-type' ? type : null) },
+    async json() { return JSON.parse(body); },
+    async text() { return body; },
+    clone: () => make(),
+  });
+  return make();
+}
+
+test('a JSON body parses and nothing is disturbed', async () => {
+  const res = response('{"districts":[1,2]}', { type: 'application/json' });
+  assert.deepEqual(await jsonOrThrow(res, 'https://x/data.json'), { districts: [1, 2] });
+});
+
+test('an HTML body names the URL, the status, the content-type and the body', async () => {
+  const res = response(HTML);
+  await assert.rejects(
+    () => jsonOrThrow(res, 'https://nczoning.net/data/subdistricts.json'),
+    (err) => {
+      assert.match(err.message, /https:\/\/nczoning\.net\/data\/subdistricts\.json/, 'the URL');
+      assert.match(err.message, /200/, 'the status');
+      assert.match(err.message, /text\/html/, 'the content-type');
+      assert.match(err.message, /<!DOCTYPE html>/, 'the body, so it can be recognised');
+      return true;
+    },
+  );
+});
+
+test('the snippet is one line and bounded', async () => {
+  const res = response(`${HTML}\n${'x'.repeat(5000)}`);
+  await assert.rejects(() => jsonOrThrow(res, 'https://x/y.json'), (err) => {
+    assert.ok(err.message.length < 300, `message was ${err.message.length} chars`);
+    assert.doesNotMatch(err.message, /\n/, 'a Discord embed and a log line both want one line');
+    return true;
+  });
+});
+
+test('a response with no clone() still reports the URL and status', async () => {
+  // Every injected fake in worker/test/ is a plain object. Requiring clone()
+  // would break all of them to gain a body snippet in tests that do not need it.
+  const bare = {
+    status: 200,
+    ok: true,
+    async json() { throw new SyntaxError("Unexpected token '<'"); },
+  };
+  await assert.rejects(() => jsonOrThrow(bare, 'https://x/y.json'), (err) => {
+    assert.match(err.message, /https:\/\/x\/y\.json/);
+    assert.match(err.message, /200/);
+    assert.match(err.message, /no content-type/);
+    return true;
+  });
+});
+
+test('a body that cannot be re-read still produces a named error', async () => {
+  const res = {
+    status: 502,
+    ok: false,
+    headers: { get: () => 'text/html' },
+    async json() { throw new SyntaxError('bad'); },
+    clone: () => ({ async text() { throw new Error('body already used'); } }),
+  };
+  await assert.rejects(() => jsonOrThrow(res, 'https://x/y.json'), (err) => {
+    assert.match(err.message, /https:\/\/x\/y\.json/);
+    assert.match(err.message, /502/);
+    return true;
+  });
+});

--- a/worker/test/refresh-d1.test.js
+++ b/worker/test/refresh-d1.test.js
@@ -352,6 +352,68 @@ test('a recovery names a record the admin hid, because no sweep will un-hide it'
     'and it is still a human decision to reverse');
 });
 
+// A refresh that fails must never leave the API reporting itself healthy. On
+// 2026-08-02 three consecutive production failures alerted Discord every five
+// minutes while `/v1/health` stayed green and `last_refresh_at` sat frozen,
+// because `readMeta` came back null and the meta write was skipped.
+
+test('a 200 that is not JSON says which URL and what arrived', async () => {
+  const html = '<!DOCTYPE html><html><title>Just a moment...</title></html>';
+  const fetchImpl = async (url) => {
+    if (String(url).includes('/subdistricts.json')) {
+      return {
+        ok: true,
+        status: 200,
+        headers: { get: () => 'text/html' },
+        async json() { return JSON.parse(html); },
+        async text() { return html; },
+        clone() { return this; },
+      };
+    }
+    return fakeFetch()(url, { body: '{"query":""}' });
+  };
+
+  const db = fakeD1();
+  const env = { DATASET: fakeKV(), DB: db, SITE_ORIGIN: 'https://x' };
+  const r = await runRefresh(env, fetchImpl);
+
+  assert.equal(r.stale, true);
+  assert.match(r.error, /subdistricts\.json/, 'the alert has to name the fetch that broke');
+  assert.match(r.error, /text\/html/);
+  assert.match(r.error, /DOCTYPE/);
+});
+
+test('a failed cycle records itself even with no previous meta', async () => {
+  const db = fakeD1();
+  const env = { DATASET: fakeKV(), DB: db, SITE_ORIGIN: 'https://x' };
+  // Nothing in KV: the state a first-ever run is in, and the state a null read
+  // is indistinguishable from.
+  const r = await runRefresh(env, fakeFetch({ nexusKnowsNothing: true }));
+  assert.equal(r.stale, true);
+
+  const meta = await env.DATASET.get(KEYS.meta, 'json');
+  assert.ok(meta, 'skipping this write is what made an outage invisible');
+  assert.equal(meta.discovery_stale, true);
+  assert.ok(meta.last_error, 'and the error is kept, not just the flag');
+  assert.ok(meta.last_refresh_at, 'the cron RAN: this must read as stale data, not a wedged cron');
+});
+
+test('a meta write that throws cannot swallow the alert', async () => {
+  const db = fakeD1();
+  const env = {
+    DATASET: {
+      async get() { return null; },
+      async put() { throw new Error('KV unavailable'); },
+    },
+    DB: db,
+    SITE_ORIGIN: 'https://x',
+  };
+  const r = await runRefresh(env, fakeFetch({ nexusKnowsNothing: true }));
+  assert.equal(r.stale, true, 'the failure is still reported to the caller');
+  assert.equal(db.rows("SELECT * FROM alerts WHERE title = 'Data API refresh failed'").length, 1,
+    'the alert is the last line of defence; nothing that can fail may run after it');
+});
+
 test('a truncated result set fails the refresh rather than shrinking the map', async () => {
   const env = {
     DATASET: fakeKV(),


### PR DESCRIPTION
Production has alerted **"Data API refresh failed: SyntaxError: Unexpected token '<', "<!DOCTYPE "…"** on four cron ticks so far. This does not fix the cause — it makes the next occurrence say what the cause is, and stops the outage being invisible to every monitor we have.

## The cause could not be attributed

Exactly two JSON parses can kill a cycle:

- `refresh.js` → `https://nczoning.net/data/subdistricts.json`
- `nexus.js` → the Nexus GraphQL tagged query

Both were `res.ok && await res.json()`, and both produce the **identical** error string, naming neither the URL nor the body. An upstream that answers **200 with an HTML body** sails through the `ok` check and dies in the parser, and that is not exotic: a Cloudflare challenge, a WAF interstitial, an origin error page and a Pages SPA fallback all do it.

`jsonOrThrow` now reports URL, status, content-type and the opening of the body:

```
GET https://nczoning.net/data/subdistricts.json -> HTTP 200 text/html, not JSON: "<!DOCTYPE html><html><title>Just a moment...</title>…"
```

The body is read from a clone taken **before** parsing, because `res.json()` consumes it. A response without `clone()` still gets URL and status — every injected fake in `worker/test/` is a plain object, and requiring `clone()` would have broken all of them to gain a snippet in tests that do not need one.

## The worse half: the failures reported the API as healthy

The catch skipped its meta write whenever `readMeta` returned null — and `get(key, 'json')` answers null **both** before the first successful cron **and** when the read comes back empty or unparseable.

Measured on production during the incident: three consecutive failures left `discovery_stale: false` and `last_refresh_at` frozen at `08:50:47`, while Discord was alerting every five minutes.

- `/v1/health` reported `status: ok` throughout
- the dashboard's freshness pill stayed green
- `monitor_api_health.js`'s wedged-cron detector never fired
- and the **recovery** alert could not fire either, because the up edge needs a stale flag to recover from

So the one channel that knew was the one nobody is watching at 19:00 on a Sunday.

Three changes: a failure is recorded even with nothing to merge into; the write is wrapped so a KV error cannot swallow the notification (the alert is the last line of defence and nothing that can fail may run after it); and the catch calls `console.error`, because `runRefresh` deliberately does not rethrow and so `wrangler tail` reported every failing tick as `Ok` — which is exactly what it did while I was watching it.

## Verification

- 368 → **376 tests**, all passing.
- **Four mutations**, each killed by the right test: skipping the meta write with no previous meta, letting the meta write swallow the alert, degrading `jsonOrThrow` to a bare `res.json()`, and the anchor retry on the guard itself.
- No schema change, no migration, no API surface change. Admin-facing and log-facing only.

## What this does not do

It does not fix the underlying flapping upstream, because I still cannot say which one it is. That is the point: the next occurrence will name it, in the Discord alert and in `wrangler tail`, and then it can be fixed properly.
