### PR TITLE
Discord gets what needs a person, the dashboard gets everything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Discord only gets alerts a person has to act on. Every alert is still recorded and readable in the dashboard, marked "log only" when it was not posted.
+- A failed refresh posts on the third consecutive failure rather than the first, then every three hours while it lasts. Recoveries and a wedged cron that self-heal has already redeployed for are recorded only.
+- A mod returning to Nexus posts only when a record was hidden by hand and needs republishing; otherwise nothing was left to do.
+
 ## [2.5.2] - 2026-08-02
 
 ### Fixed

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -1254,6 +1254,11 @@ button.breakdown-row:hover .k { color: var(--secondary); }
 .sev-error .alert-sev { color: var(--status-critical); }
 .sev-recovery .alert-sev { color: var(--status-ok); }
 
+/* "log only" reuses .badge: neutral and outlined, which is what it needs to be.
+   It qualifies an alert rather than ranking it, and the .sev-* colours above
+   are the ranking, so a second coloured treatment here would compete with
+   them. */
+
 /* Producers assemble the body as plain text with newlines, so the line breaks
    they wrote are the ones shown. */
 .alert-body {

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -2680,14 +2680,28 @@
     return out;
   }
 
+  // `notify = 0` means the producer decided this one needed recording but not
+  // interrupting. Marked rather than hidden: this tab is where a log-only alert
+  // is meant to be readable, and an unmarked one would read as a Discord post
+  // somebody missed.
+  const isLogOnly = (a) => a.notify === 0 || a.notify === false;
+
   function alertCard(a) {
     const severity = SEVERITY_LABEL[a.severity] ? a.severity : 'info';
     const acknowledged = Boolean(a.acknowledged_at);
+    const logOnly = isLogOnly(a);
     return h('div', { class: `alert-entry sev-${severity}${acknowledged ? ' acknowledged' : ''}` },
       h('div', { class: 'alert-head' },
         h('span', { class: 'alert-sev', text: SEVERITY_LABEL[severity] }),
         h('strong', { class: 'alert-title' }, alertTitleNodes(a.title)),
         h('span', { class: 'spacer', style: 'flex:1' }),
+        logOnly
+          ? h('span', {
+            class: 'badge',
+            title: 'Recorded here only. Nothing was posted to Discord, because nothing here needs a person.',
+            text: 'log only',
+          })
+          : null,
         h('span', { class: 'muted', text: SOURCE_LABEL[a.source] ?? a.source }),
         timeEl(a.at)),
       // Pre-wrap: the body is plain text assembled with newlines by the
@@ -2695,17 +2709,22 @@
       // innerHTML, so a Discord-flavoured body still cannot become markup here.
       a.body ? h('p', { class: 'alert-body' }, bodyNodes(a.body)) : null,
       h('div', { class: 'alert-foot' },
+        // No Acknowledge on a log-only alert. Acknowledging clears something
+        // from the open count, and a log-only alert was never in it, so the
+        // button would be a control that visibly does nothing.
         acknowledged
           ? h('span', { class: 'muted' },
             'Acknowledged by ',
             h('span', { class: 'who', text: a.acknowledged_by || 'someone' }),
             ' ',
             timeEl(a.acknowledged_at))
-          : h('button', {
-            type: 'button',
-            class: 'btn secondary',
-            onclick: (e) => acknowledgeAlert(a.id, e.currentTarget),
-          }, 'Acknowledge')));
+          : logOnly
+            ? h('span', { class: 'muted', text: 'Nothing to acknowledge.' })
+            : h('button', {
+              type: 'button',
+              class: 'btn secondary',
+              onclick: (e) => acknowledgeAlert(a.id, e.currentTarget),
+            }, 'Acknowledge')));
   }
 
   async function loadAlerts() {
@@ -2754,7 +2773,10 @@
     const box = $('#overview-alerts');
     if (!box) return;
 
-    const open = state.alerts.filter((a) => !a.acknowledged_at);
+    // Log-only alerts are excluded, matching `total`, which the server counts
+    // the same way. A panel listing rows the count beside it does not include
+    // reads as a broken number.
+    const open = state.alerts.filter((a) => !a.acknowledged_at && !isLogOnly(a));
     const total = state.alertsUnacknowledged;
 
     if (!total) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -201,7 +201,7 @@ Alerts come from five sources, and the `source` column names them:
 | Source | Raised by | When |
 | --- | --- | --- |
 | `api-health` | `monitor-api-health.yml`, every 15 min | The Data API (`/v1`) is not serving, **or** its refresh cron has wedged (a frozen `/v1/health.last_refresh_at` heartbeat older than 45 min; the API can serve stale data silently, see #849). On a wedged cron it also **self-heals**: it dispatches `deploy-api.yml` to redeploy the affected Worker (re-registers the Cron Trigger), capped at 2 redeploys/env/hour before escalating for a human |
-| `refresh` | `worker/src/refresh.js`, on the 5-minute cron | A dataset rebuild failed (amber: last-known-good is still served), and the matching all-clear when one later succeeds |
+| `refresh` | `worker/src/refresh.js`, on the 5-minute cron | A dataset rebuild failed (amber: last-known-good is still served), and the matching all-clear when one later succeeds. Both are recorded every time; see [what reaches Discord](#what-reaches-discord) for which of them are posted |
 | `submissions` | `worker/src/submissions.js` | A submission reached the review queue. A plain "one is waiting" post linking to the dashboard, deliberately not the old edit-in-place embed |
 | `quota` | `worker/src/quota.js`, hourly on the cron | A free-tier cap passed 80% for the UTC day. Checked on one tick an hour, and suppressed to once per cap per UTC day |
 | `export` | `export-d1-snapshot.yml`, nightly | The registry backup to the `data-snapshots` branch did not complete. Its own source rather than folded into `refresh`: the 5-minute dataset cron and the nightly git mirror fail for unrelated reasons and are fixed in different places. See [`infrastructure-map.md`](infrastructure-map.md) |
@@ -209,6 +209,34 @@ Alerts come from five sources, and the `source` column names them:
 **In-Worker producers call `raiseAlert()` directly** rather than making an HTTP
 request to their own Worker. `/internal/alerts` is the remote entry point to the
 same function, and exists because a GitHub Action cannot hold a session.
+
+#### What reaches Discord
+
+Every alert is recorded. The `notify` flag on the alert decides whether it is
+also posted, so the channel carries only what a person has to act on and the
+dashboard keeps everything (log-only rows are marked "log only", and are left
+out of the unacknowledged badge because nothing can clear them).
+
+| Posted | Log-only |
+| --- | --- |
+| The API is not serving | A wedged cron that self-heal has already dispatched a redeploy for |
+| Self-heal exhausted, so a human must redeploy | Every all-clear: refresh recovered, API recovered |
+| A refresh failing for 3 consecutive cycles, then once every 3 hours | The first two consecutive refresh failures |
+| A pinned mod hidden or deleted on Nexus | A mod returning to Nexus with nothing left to do |
+| A mod returning to Nexus while a record is still hidden by hand | `discovery_stale` reported as context by the health monitor |
+| A quota cap past 80%, once per cap per UTC day | |
+| A submission waiting in the queue | |
+
+Two rules keep this from going wrong:
+
+- **The producer decides.** Routing on severity or on a title match would put the
+  decision where it cannot see the context: a `recovery` is silent unless a
+  record was hidden by hand, and a wedged cron is silent only because a redeploy
+  was actually dispatched. `notify` is part of the `/internal/alerts` payload for
+  the same reason, so the remote producer keeps the same say as the local ones.
+- **The default is to notify.** Omitting `notify` means true, so a producer that
+  has not considered routing is noisy rather than silent. Silence is the
+  expensive failure.
 
 **Why `/internal/` and not `/admin/`.** Every `/admin/*` route is gated on GitHub
 collaborator status, and `index.js` states that as an invariant. The machine

--- a/scripts/monitor_api_health.js
+++ b/scripts/monitor_api_health.js
@@ -47,6 +47,10 @@
  *          map-alerts channel, so the dashboard keeps a history of everything
  *          this monitor has said. Prints a preview instead of sending if the
  *          secret is unset. NCZ_API_BASE defaults to https://api.nczoning.net.
+ *          Every run's alert is recorded; the `notify` flag on the payload
+ *          decides whether it also reaches Discord. An outage and an exhausted
+ *          self-heal do; a wedged cron whose redeploy was dispatched, an
+ *          all-clear and a soft signal do not. See postHealthAlert.
  * Self-heal env: API_HEALTH_SELF_HEAL=true + GH_TOKEN (+ GITHUB_REPOSITORY,
  *          GITHUB_API_URL — set by Actions). Absent → alert only.
  * Exit:    0 when every target is serving fresh data; 1 on any outage, a wedged
@@ -331,13 +335,21 @@ async function postHealthAlert(results, { recovered = false, selfHeal: heal = nu
   // wedged but auto-heal dispatched, page ORANGE), recovery (all-clear edge),
   // warning (soft). Outage wins if anything is down; recovery only applies when
   // this run is fully clean (no outage AND no staleness).
-  let title, description, color;
+  //
+  // `notify` decides Discord; every branch is recorded in the dashboard either
+  // way. The line it draws is whether a person changes anything by reading it.
+  // An outage and an exhausted self-heal need someone. A wedged cron that a
+  // redeploy was just dispatched for does not: that loop closes by itself in
+  // one tick, and its own failure mode (the redeploy not clearing it) already
+  // has the louder alert two branches up.
+  let title, description, color, notify;
   if (down.length) {
     title = `🔴 Data API outage — ${down.length} environment${down.length === 1 ? "" : "s"} not serving`;
     description =
       "The API is not usable by consumers (in-game mods have no fallback). " +
       "The website may look fine via its client-side fallback — this is that hidden failure surfacing.";
     color = 15158332; /* red */
+    notify = true;
   } else if (frozen.length && escalatedAny) {
     const n = heal.escalated.length;
     title = `🔴 Data API stale — self-heal exhausted on ${n} environment${n === 1 ? "" : "s"}`;
@@ -345,6 +357,7 @@ async function postHealthAlert(results, { recovered = false, selfHeal: heal = nu
       "The refresh cron is wedged and automatic redeploys have not cleared it — " +
       "manual intervention is needed (see below). Consumers are being served a frozen snapshot.";
     color = 15158332; /* red */
+    notify = true;
   } else if (frozen.length) {
     title = `🟠 Data API stale — refresh cron wedged on ${frozen.length} environment${frozen.length === 1 ? "" : "s"}`;
     description =
@@ -352,16 +365,25 @@ async function postHealthAlert(results, { recovered = false, selfHeal: heal = nu
       "so consumers (in-game mods have no fallback) are getting a frozen snapshot. See issue #849." +
       (heal ? "" : " Interim fix: redeploy the Worker to revive the cron.");
     color = 16753920; /* orange */
+    // Silent only when a redeploy was actually dispatched for every stale
+    // target. Self-heal switched off, unmapped, or partly failed leaves nothing
+    // working the problem, and then this alert IS the response.
+    notify = (heal?.healed || []).length < frozen.length;
   } else if (recovered) {
     title = `✅ Data API recovered — serving normally again`;
     description =
       "The earlier outage has cleared: every target is serving again." +
       (anyWarning ? " One soft signal is still active (see below)." : "");
     color = 3066993; /* green */
+    // An all-clear asks nothing of anyone. The run going green says it too.
+    notify = false;
   } else {
     title = `🟠 Data API warning`;
     description = "The API is serving but a soft signal fired (see below).";
     color = 15105570; /* amber */
+    // discovery_stale is the only soft signal, and the cron raises its own
+    // alert about it with its own escalation. Repeating it here is duplication.
+    notify = false;
   }
 
   // Fold the self-heal outcome into the alert body (one post per run).
@@ -380,6 +402,7 @@ async function postHealthAlert(results, { recovered = false, selfHeal: heal = nu
     // repeated here; the emoji in `title` above is stripped for the same reason.
     title: title.replace(/^[^\p{L}\d]+/u, "").trim(),
     body: detail ? `${description}\n\n${detail}` : description,
+    notify,
   });
 }
 
@@ -396,10 +419,10 @@ async function postHealthAlert(results, { recovered = false, selfHeal: heal = nu
  * the other end. Same name, two separate stores, and setting one does not set
  * the other. See learnings/discord-webhook-two-secret-stores.
  */
-async function sendAlert({ severity, title, body }) {
+async function sendAlert({ severity, title, body, notify = true }) {
   const base = process.env.NCZ_API_BASE || "https://api.nczoning.net";
   const secret = process.env.ALERTS_INGEST_SECRET;
-  const payload = { source: "api-health", severity, title, body };
+  const payload = { source: "api-health", severity, title, body, notify };
 
   if (!secret) {
     console.log("\n--- ALERTS_INGEST_SECRET not set — preview of the alert that would be sent ---");
@@ -415,11 +438,15 @@ async function sendAlert({ severity, title, body }) {
   });
   if (!res.ok) throw new Error(`Alert ingest HTTP ${res.status}: ${await res.text()}`);
 
-  // The endpoint reports the two halves separately. A recorded-but-not-forwarded
-  // alert is in the dashboard and not in Discord, which is worth saying out loud
-  // in the job log rather than reading as a clean run.
+  // The endpoint reports the halves separately, and the two ways an alert can
+  // fail to reach Discord are different problems. Not notifying is this run's
+  // own routing decision; notifying and not being forwarded is the webhook
+  // being broken, which is worth saying out loud rather than reading as a clean
+  // run.
   const result = await res.json().catch(() => ({}));
-  if (result.forwarded === false) {
+  if (result.notified === false) {
+    console.log("Alert recorded (log-only: nothing here needs a human).");
+  } else if (result.forwarded === false) {
     console.log("Alert recorded, but Discord did not accept it (check the Worker's webhook secret).");
   } else {
     console.log("Alert recorded and forwarded.");

--- a/worker/migrations/0010_alert_notify.sql
+++ b/worker/migrations/0010_alert_notify.sql
@@ -1,0 +1,19 @@
+-- Alert routing: record everything, notify a human only when there is something
+-- for them to do.
+--
+-- `notify` is the ROUTING DECISION, not the outcome. It answers "was this meant
+-- for a human", which is a property of the alert; whether Discord actually
+-- accepted the post is a property of that hop, is already reported by
+-- `raiseAlert`'s return value, and must NOT feed back into this column. If it
+-- did, a Discord outage would quietly drop real alerts out of the dashboard's
+-- unacknowledged count -- the exact failure the alerts table was built to
+-- survive.
+--
+-- Backfilled to 1 because every row that predates this column was written under
+-- the old always-forward rule, so 1 is what actually happened to it.
+ALTER TABLE alerts ADD COLUMN notify INTEGER NOT NULL DEFAULT 1;
+
+-- The dashboard badge counts open alerts that were meant for a human, and the
+-- Alerts tab reads the same rows. Both are `notify = 1 AND acknowledged_at IS
+-- NULL`, which is now the most-run query against this table.
+CREATE INDEX idx_alerts_open ON alerts (notify, acknowledged_at);

--- a/worker/src/alerts.js
+++ b/worker/src/alerts.js
@@ -25,6 +25,27 @@
  *
  * So `raiseAlert()` never throws. An alert about a failure must not become a
  * second failure, and it must never mask the one it is reporting.
+ *
+ * ## Record everything, notify selectively
+ *
+ * Every alert is recorded. Only the ones a person can act on are forwarded, via
+ * the `notify` flag each producer sets. The channel had drifted into carrying
+ * both halves of every automatic recovery loop -- "the cron wedged", "the cron
+ * recovered", five minutes apart, with the self-heal doing the work in between
+ * -- and a channel that mostly reports things already handled stops being read,
+ * which costs the alerts that do need someone.
+ *
+ * Two rules make this safe to have:
+ *
+ * - **The producer decides, not this module.** Routing on severity or on a
+ *   title match would put the decision somewhere that cannot see the context it
+ *   depends on: a `recovery` is silent unless a record was hidden by hand, and a
+ *   wedged cron is silent only because a redeploy was actually dispatched. Only
+ *   the code raising the alert knows which case it is in.
+ * - **The default is to notify.** `notify` omitted means true, so a new producer
+ *   that has not thought about routing is noisy rather than silent, and every
+ *   row written before this existed reads correctly. Silence is the expensive
+ *   failure here; noise is the cheap one.
  */
 
 /**
@@ -86,19 +107,32 @@ export function validateAlertInput(input) {
   }
   if (!title) errors.push('title is required');
   if (title.length > 200) errors.push('title must be 200 characters or fewer');
+  // Strict, and only when present. A truthy string ("false", "0", "no") coerced
+  // by JavaScript's rules would silently route the opposite way to what the
+  // caller wrote, and a routing bug is invisible: the alert simply does not
+  // arrive. Omitting it is fine and means "notify" (see the module comment).
+  if (input?.notify != null && typeof input.notify !== 'boolean') {
+    errors.push('notify must be a boolean when present');
+  }
 
   if (errors.length) return { ok: false, errors };
-  return { ok: true, alert: { source, severity, title, body } };
+  return {
+    ok: true, alert: { source, severity, title, body, notify: input?.notify !== false },
+  };
 }
 
 /**
  * Insert the alert and return its id. Throws on a D1 failure; the caller
  * decides whether that is fatal (it is not, for `raiseAlert`).
  */
-export async function recordAlert(env, { source, severity, title, body = null }, nowMs = Date.now()) {
+export async function recordAlert(
+  env, { source, severity, title, body = null, notify = true }, nowMs = Date.now(),
+) {
   const { meta } = await env.DB.prepare(
-    'INSERT INTO alerts (at, source, severity, title, body) VALUES (?, ?, ?, ?, ?)',
-  ).bind(new Date(nowMs).toISOString(), source, severity, title, body).run();
+    'INSERT INTO alerts (at, source, severity, title, body, notify) VALUES (?, ?, ?, ?, ?, ?)',
+  ).bind(
+    new Date(nowMs).toISOString(), source, severity, title, body, notify === false ? 0 : 1,
+  ).run();
   return meta?.last_row_id ?? null;
 }
 
@@ -145,11 +179,16 @@ function toEmbed({ source, severity, title, body }) {
  * happened, so a caller that cares (the tests, and `/internal/alerts`) can tell
  * a fully successful fan-out from a half-successful one.
  *
- * @returns {Promise<{id: number|null, recorded: boolean, forwarded: boolean}>}
+ * `notified` is reported separately from `forwarded` so those two cases stay
+ * distinguishable: `notified:false` is this alert being log-only by design,
+ * `notified:true, forwarded:false` is Discord having refused a real one.
+ *
+ * @returns {Promise<{id: number|null, recorded: boolean, notified: boolean, forwarded: boolean}>}
  */
 export async function raiseAlert(env, alert, { fetchImpl = fetch, nowMs = Date.now() } = {}) {
   let id = null;
   let recorded = false;
+  const notified = alert?.notify !== false;
 
   if (env.DB) {
     try {
@@ -161,8 +200,11 @@ export async function raiseAlert(env, alert, { fetchImpl = fetch, nowMs = Date.n
     }
   }
 
-  const forwarded = await forwardToDiscord(env, alert, fetchImpl);
-  return { id, recorded, forwarded };
+  // Recording happens either way; only the Discord hop is conditional. A
+  // log-only alert is in the dashboard and in `wrangler tail`, which is the
+  // whole claim being made about it -- it is quieter, not lost.
+  const forwarded = notified ? await forwardToDiscord(env, alert, fetchImpl) : false;
+  return { id, recorded, notified, forwarded };
 }
 
 /**
@@ -189,14 +231,47 @@ export async function alertedSinceUtcMidnight(env, { source, title }, nowMs = Da
 }
 
 /**
+ * How many times `title` has been raised since the last `resetTitle` for the
+ * same source -- a down-edge count since the last up-edge.
+ *
+ * Exists so a repeating alert can be routed on how long it has been repeating
+ * rather than on the single occurrence, which is the difference between "a
+ * refresh blipped" and "the refresh has been failing all afternoon". The
+ * `alerts` table is the only durable counter available: KV meta holds
+ * `last_error_at` but not a count, and a Worker isolate holds nothing across
+ * cron ticks.
+ *
+ * Excludes the row for the alert being raised, because it is called before that
+ * row is written -- so a caller wanting "counting this one" adds 1 itself.
+ *
+ * Throws on a D1 failure. Callers routing on this MUST treat a throw as
+ * "notify": an unanswerable question about whether to speak up is answered by
+ * speaking up.
+ */
+export async function alertStreak(env, { source, title, resetTitle }) {
+  const row = await env.DB.prepare(
+    `SELECT COUNT(*) AS n FROM alerts
+      WHERE source = ? AND title = ?
+        AND id > COALESCE(
+          (SELECT MAX(id) FROM alerts WHERE source = ? AND title = ?), 0)`,
+  ).bind(source, title, source, resetTitle).first();
+  return Number(row?.n ?? 0);
+}
+
+/**
  * Most recent first, matching `readAudit`. `unacknowledged` filters to the ones
  * still needing a human, which is what the dashboard badge counts.
+ *
+ * "Still needing a human" is `notify = 1` as well as unacknowledged: a log-only
+ * alert is never waiting on anybody, so counting one would put a number on the
+ * badge that nothing can clear. The unfiltered list still returns every row --
+ * the dashboard is where the log-only ones are supposed to be readable.
  */
 export async function readAlerts(env, { limit = 100, unacknowledged = false } = {}) {
   const capped = Math.min(Math.max(Number(limit) || 100, 1), 500);
-  const where = unacknowledged ? 'WHERE acknowledged_at IS NULL' : '';
+  const where = unacknowledged ? 'WHERE acknowledged_at IS NULL AND notify = 1' : '';
   const { results } = await env.DB.prepare(
-    `SELECT id, at, source, severity, title, body, acknowledged_by, acknowledged_at
+    `SELECT id, at, source, severity, title, body, notify, acknowledged_by, acknowledged_at
        FROM alerts ${where} ORDER BY id DESC LIMIT ?`,
   ).bind(capped).all();
   return results ?? [];
@@ -205,7 +280,7 @@ export async function readAlerts(env, { limit = 100, unacknowledged = false } = 
 /** How many alerts are still waiting on a human. Drives the tab's badge. */
 export async function countUnacknowledged(env) {
   const row = await env.DB.prepare(
-    'SELECT COUNT(*) AS n FROM alerts WHERE acknowledged_at IS NULL',
+    'SELECT COUNT(*) AS n FROM alerts WHERE acknowledged_at IS NULL AND notify = 1',
   ).first();
   return Number(row?.n ?? 0);
 }
@@ -226,7 +301,7 @@ export async function acknowledgeAlert(env, id, actor, nowMs = Date.now()) {
       WHERE id = ? AND acknowledged_at IS NULL`,
   ).bind(actor, new Date(nowMs).toISOString(), numeric).run();
   return env.DB.prepare(
-    `SELECT id, at, source, severity, title, body, acknowledged_by, acknowledged_at
+    `SELECT id, at, source, severity, title, body, notify, acknowledged_by, acknowledged_at
        FROM alerts WHERE id = ?`,
   ).bind(numeric).first();
 }

--- a/worker/src/quota.js
+++ b/worker/src/quota.js
@@ -244,6 +244,10 @@ export async function checkQuotaThresholds(env, fetchImpl = fetch, nowMs = Date.
           + `${row.projected == null ? '' : `, projecting ${row.projected} by UTC midnight`}.`
           + `\n\nCaps are per ACCOUNT and reset at UTC midnight. Nothing degrades `
           + `until the cap is hit, at which point the cron simply stops.`,
+        // Notifies. Nothing automatic can bring usage back down, and the window
+        // to act is the rest of the UTC day; the once-a-day dedup above is
+        // already what keeps this from being noise.
+        notify: true,
       }, { fetchImpl, nowMs });
       raised.push(title);
     }

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -27,7 +27,7 @@ import { HEARTBEAT_MIN_INTERVAL_MS } from './config.js';
 import {
   KEYS, contentHash, readMeta, writeDataset, writeMeta,
 } from './store.js';
-import { raiseAlert, alertedSinceUtcMidnight } from './alerts.js';
+import { raiseAlert, alertedSinceUtcMidnight, alertStreak } from './alerts.js';
 import { jsonOrThrow } from './json.js';
 import { checkQuotaThresholds } from './quota.js';
 
@@ -48,6 +48,28 @@ async function fetchJson(fetchImpl, origin, path) {
   return jsonOrThrow(res, url);
 }
 
+const REFRESH_FAILED_TITLE = 'Data API refresh failed';
+const REFRESH_RECOVERED_TITLE = 'Data API refresh recovered';
+
+/**
+ * How many consecutive failures before a person is told, and how often after.
+ *
+ * A single failed tick is almost always an upstream blip that the next tick
+ * clears by itself: the dataset never stopped being served, nothing is asked of
+ * anyone, and posting it trained everyone to scroll past the channel. Three
+ * ticks (~15 min) is long enough that it is not a blip.
+ *
+ * The repeat matters as much as the threshold. Notifying ONLY on the third
+ * would mean an outage lasting all afternoon gets one message at the start and
+ * silence after, which reads exactly like a problem that resolved. So it
+ * repeats every 36th failure afterwards -- 3 hours at 5-minute ticks.
+ */
+const REFRESH_FAILURE_NOTIFY_AT = 3;
+const REFRESH_FAILURE_NOTIFY_EVERY = 36;
+
+const notifyOnFailureStreak = (n) => n >= REFRESH_FAILURE_NOTIFY_AT
+  && (n - REFRESH_FAILURE_NOTIFY_AT) % REFRESH_FAILURE_NOTIFY_EVERY === 0;
+
 /**
  * Refresh failed: keep serving last-known-good and say so.
  *
@@ -55,16 +77,35 @@ async function fetchJson(fetchImpl, origin, path) {
  * dashboard gets a history row as well as the channel getting a message. That
  * call never throws, which preserves the rule this function has always had:
  * alerting must never mask the original failure.
+ *
+ * Recorded every time, forwarded to Discord only once the failure has persisted
+ * (see the constants above). The row is written either way, so the dashboard
+ * and `wrangler tail` still show every single failed tick -- what changes is
+ * only whether it interrupts anyone.
  */
 async function alertRefreshFailed(env, fetchImpl, reason) {
+  // +1 counts THIS failure: the streak is read before the row is written.
+  // A D1 failure answering it lands in the catch as `notify: true` -- if the
+  // database cannot say whether this is a blip, it is not a blip.
+  let streak = null;
+  try {
+    streak = await alertStreak(env, {
+      source: 'refresh', title: REFRESH_FAILED_TITLE, resetTitle: REFRESH_RECOVERED_TITLE,
+    }) + 1;
+  } catch {
+    streak = null;
+  }
+
   await raiseAlert(env, {
     source: 'refresh',
     // warn, not error: the dataset is still being served. A failed refresh
     // degrades freshness (discovery_stale=true) and takes nothing down, which
     // is why this embed has always been amber. `error` is for not serving.
     severity: 'warn',
-    title: 'Data API refresh failed',
-    body: `${String(reason).slice(0, 1200)}\n\nServing last-known-good dataset (discovery_stale=true).`,
+    title: REFRESH_FAILED_TITLE,
+    body: `${String(reason).slice(0, 1200)}\n\nServing last-known-good dataset (discovery_stale=true).`
+      + (streak === null ? '' : `\n\nConsecutive failed cycles: ${streak}.`),
+    notify: streak === null || notifyOnFailureStreak(streak),
   }, { fetchImpl });
 }
 
@@ -72,13 +113,19 @@ async function alertRefreshFailed(env, fetchImpl, reason) {
  * The previous cycle marked the dataset discovery_stale and this cycle rebuilt
  * it cleanly, so this is the down to up edge. Fires once (the next successful
  * cycle sees discovery_stale=false and stays quiet).
+ *
+ * Log-only. Nobody is asked to do anything by an all-clear, and the pair of
+ * posts ("failed", then "recovered" five minutes later) was the single largest
+ * source of channel noise that resolved itself before anyone read it. The row
+ * still lands, which is what makes the streak above countable.
  */
 async function alertRefreshRecovered(env, fetchImpl) {
   await raiseAlert(env, {
     source: 'refresh',
     severity: 'recovery',
-    title: 'Data API refresh recovered',
+    title: REFRESH_RECOVERED_TITLE,
     body: 'A refresh succeeded after an earlier failure. The dataset is fresh again (discovery_stale=false).',
+    notify: false,
   }, { fetchImpl });
 }
 
@@ -146,6 +193,11 @@ const storyFor = (status) => STATUS_STORY[status] ?? STATUS_STORY.default;
  * would each see the same crossing before either had written, and the alerts
  * table is the only thing that can see across them.
  *
+ * Notifies. This is the archetype of an alert that needs a person: nothing here
+ * can tell a deletion from a moderation hold from an author mid-upload, only
+ * the reason on the mod page can, and until someone reads it the flag sits in
+ * the dashboard unresolved.
+ *
  * Never throws: an alert about a deleted mod must not cost the dataset a cycle.
  */
 async function alertModStatus(env, fetchImpl, flagged, nowMs) {
@@ -167,6 +219,9 @@ async function alertModStatus(env, fetchImpl, flagged, nowMs) {
         + `separate events, so no more than ${MAX_WITHHELD} pins are ever withheld `
         + 'at once: past that the map is left exactly as it is and this alert is '
         + 'the whole of the response. Check the dashboard.',
+      // The cap declining to act means the response IS this alert. Nothing else
+      // happens until a person looks.
+      notify: true,
     }, { fetchImpl, nowMs });
     return;
   }
@@ -189,6 +244,9 @@ async function alertModStatus(env, fetchImpl, flagged, nowMs) {
         + `${row?.first_seen_at ?? 'this sweep'} (${row?.streak ?? 1} consecutive sweeps).\n\n`
         + `${modPageUrl(id)}\n\n`
         + `Pins affected: ${describePins(row)}.\n\n${story.detail}`,
+      // Only the reason on the mod page distinguishes these three cases, and
+      // the flag stays open until someone reads it.
+      notify: true,
     }, { fetchImpl, nowMs });
   }
 }
@@ -207,13 +265,24 @@ async function alertModStatus(env, fetchImpl, flagged, nowMs) {
  * the common case and one edit in the case that would otherwise go unnoticed
  * for as long as nobody happened to look.
  *
+ * What is left to do also decides the routing, which severity cannot: this is a
+ * `recovery` exactly as `alertRefreshRecovered` is, and sometimes the only
+ * notice anyone gets of a hidden record that can now be republished.
+ * `hiddenByHand` is the test. Nothing left to do is log-only; a record still
+ * hidden notifies, because nothing else raises it again.
+ *
  * Mirrors alertRefreshRecovered: same `recovery` severity, same fires-once-on-
  * the-edge shape. Never throws.
  */
+
+/** Pins a person still has to deal with: hidden by hand while the mod was down. */
+const hiddenByHand = (r) => (r.locations ?? []).filter((l) => l.status !== 'published');
+
 async function alertModRecovered(env, fetchImpl, recovered, nowMs) {
   if (recovered.length > STATUS_ALERT_MAX) {
     const title = `${recovered.length} pinned mods are published on Nexus again`;
     if (await alertedSinceUtcMidnight(env, { source: 'refresh', title }, nowMs)) return;
+    const stillHidden = recovered.filter((r) => hiddenByHand(r).length);
     await raiseAlert(env, {
       source: 'refresh',
       severity: 'recovery',
@@ -221,7 +290,14 @@ async function alertModRecovered(env, fetchImpl, recovered, nowMs) {
       body: `${recovered.map((r) => `${r.nexus_id}: was ${r.was}`).join('\n')}\n\n`
         + 'Any withheld pins are served again from this build. Records that were '
         + 'hidden by hand stay hidden: the registry does not un-hide anything on '
-        + 'its own. Check the dashboard.',
+        + 'its own. Check the dashboard.'
+        + (stillHidden.length
+          ? `\n\n${stillHidden.length} of these still have a record hidden in the `
+            + 'registry that only a person can republish.'
+          : ''),
+      // Same rule as the single case: silent unless a hand-hidden record is
+      // waiting, which in a batch means any one of them.
+      notify: stillHidden.length > 0,
     }, { fetchImpl, nowMs });
     return;
   }
@@ -233,7 +309,7 @@ async function alertModRecovered(env, fetchImpl, recovered, nowMs) {
     // The pins a person still has to deal with. `published` needs nothing; a
     // record someone hid while the mod was down is the whole reason this alert
     // exists, and naming it is the difference between a notification and a task.
-    const needsAHand = (r.locations ?? []).filter((l) => l.status !== 'published');
+    const needsAHand = hiddenByHand(r);
     const todo = needsAHand.length
       ? `Still hidden in the registry: ${needsAHand.map((l) => `${l.name} (${l.status})`).join(', ')}.\n`
         + 'Nothing here changes a location\'s status, so that stays as it is until '
@@ -248,6 +324,8 @@ async function alertModRecovered(env, fetchImpl, recovered, nowMs) {
         + `${storyFor(r.was).headline}.\n\n${modPageUrl(r.nexus_id)}\n\n`
         + `${r.wasWithheld ? 'Its pin was withheld and is restored automatically. ' : ''}`
         + todo,
+      // The withheld pin restored itself; a hand-hidden record does not.
+      notify: needsAHand.length > 0,
     }, { fetchImpl, nowMs });
   }
 }

--- a/worker/src/submissions.js
+++ b/worker/src/submissions.js
@@ -307,6 +307,9 @@ async function create(request, env, { fetchImpl = fetch, nowMs = Date.now() } = 
     // /admin/#queue would silently open on Overview and read as a broken link.
     body: `A ${kind} submission is pending${id === null ? '' : ` (#${id})`}.`
       + `\n\nReview it in the Queue tab at ${env.SITE_ORIGIN ?? 'https://nczoning.net'}/admin/`,
+    // The doorbell. A submission sits in the queue until a human approves or
+    // rejects it, so this is the definition of actionable.
+    notify: true,
   }, { nowMs });
 
   return json({ id, kind, status: 'pending' }, 201);

--- a/worker/test/alerts.test.js
+++ b/worker/test/alerts.test.js
@@ -11,7 +11,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   raiseAlert, recordAlert, readAlerts, countUnacknowledged, acknowledgeAlert,
-  alertedSinceUtcMidnight, validateAlertInput, ALERT_SOURCES,
+  alertedSinceUtcMidnight, validateAlertInput, alertStreak, ALERT_SOURCES,
 } from '../src/alerts.js';
 import { handleInternal } from '../src/internal.js';
 import { sqliteD1 } from '../test-support/d1-sqlite.mjs';
@@ -99,7 +99,9 @@ test('a D1 failure still lets the notification through', async () => {
 test('raiseAlert never throws, whatever fails', async () => {
   const env = { DB: { prepare() { throw new Error('nope'); } }, NCZ_ALERTS_DISCORD_WEBHOOK_URL: WEBHOOK };
   const result = await raiseAlert(env, ALERT, { fetchImpl: fakeDiscord({ throws: true }) });
-  assert.deepEqual(result, { id: null, recorded: false, forwarded: false });
+  assert.deepEqual(result, {
+    id: null, recorded: false, notified: true, forwarded: false,
+  });
 });
 
 test('with no webhook configured the alert is still recorded', async () => {
@@ -127,6 +129,100 @@ test('severity drives the embed colour and icon', async () => {
   assert.equal(embed.title, '✅ Back up');
   assert.equal(embed.color, 0x2ecc71);
   assert.equal(embed.footer.text, 'NC Zoning Board • refresh');
+});
+
+// ------------------------------------------------------------------ routing --
+
+test('a log-only alert is recorded and never reaches Discord', async () => {
+  const env = newEnv();
+  const discord = fakeDiscord();
+
+  const result = await raiseAlert(env, { ...ALERT, notify: false }, { fetchImpl: discord });
+
+  assert.equal(result.recorded, true);
+  assert.equal(result.notified, false);
+  assert.equal(result.forwarded, false);
+  assert.equal(discord.sent.length, 0, 'the webhook must not be called at all');
+  const rows = await readAlerts(env);
+  assert.equal(rows.length, 1, 'the history is the point: quieter, not lost');
+  assert.equal(rows[0].notify, 0);
+});
+
+test('omitting notify means notify, so an unconsidered producer is noisy not silent', async () => {
+  // The default is the safety property. A producer added later that never
+  // thought about routing gets the old behaviour, and every row written before
+  // the column existed reads as what actually happened to it.
+  const env = newEnv();
+  const discord = fakeDiscord();
+  await raiseAlert(env, ALERT, { fetchImpl: discord });
+  assert.equal(discord.sent.length, 1);
+  assert.equal((await readAlerts(env))[0].notify, 1);
+});
+
+test('notified and forwarded are distinguishable, so a broken webhook still shows', async () => {
+  // The failure this separation prevents: a Discord outage reading as "we chose
+  // not to send it". They need different responses, so they need different
+  // fields.
+  const env = newEnv();
+  const result = await raiseAlert(env, ALERT, { fetchImpl: fakeDiscord({ fail: true }) });
+  assert.equal(result.notified, true, 'this alert WAS meant for a human');
+  assert.equal(result.forwarded, false, 'Discord refused it');
+});
+
+test('a log-only alert is not waiting on anyone, so it stays out of the badge', async () => {
+  // Counting one would put a number on the dashboard badge that nothing can
+  // clear: there is no Acknowledge button on a log-only alert.
+  const env = newEnv();
+  await recordAlert(env, { ...ALERT, notify: false });
+  assert.equal(await countUnacknowledged(env), 0);
+  assert.equal((await readAlerts(env, { unacknowledged: true })).length, 0);
+  assert.equal((await readAlerts(env)).length, 1, 'the full list still shows it');
+
+  await recordAlert(env, { ...ALERT, title: 'Needs a person' });
+  assert.equal(await countUnacknowledged(env), 1);
+});
+
+test('notify must be a boolean, because a truthy string would route backwards', async () => {
+  // "false" is truthy. Coercing it would forward an alert the caller asked to
+  // keep quiet, and routing bugs are silent by nature.
+  assert.equal(validateAlertInput({ ...ALERT, notify: 'false' }).ok, false);
+  assert.equal(validateAlertInput({ ...ALERT, notify: 0 }).ok, false);
+  assert.equal(validateAlertInput({ ...ALERT, notify: false }).alert.notify, false);
+  assert.equal(validateAlertInput({ ...ALERT, notify: true }).alert.notify, true);
+  assert.equal(validateAlertInput(ALERT).alert.notify, true, 'omitted means notify');
+});
+
+// ------------------------------------------------------------------ streaks --
+
+test('alertStreak counts since the last reset, not since the beginning of time', async () => {
+  const env = newEnv();
+  const failed = { source: 'refresh', severity: 'warn', title: 'Data API refresh failed' };
+  const recovered = { source: 'refresh', severity: 'recovery', title: 'Data API refresh recovered' };
+  const streak = () => alertStreak(env, {
+    source: 'refresh', title: failed.title, resetTitle: recovered.title,
+  });
+
+  await recordAlert(env, failed);
+  await recordAlert(env, failed);
+  assert.equal(await streak(), 2);
+
+  await recordAlert(env, recovered);
+  assert.equal(await streak(), 0, 'the recovery is the reset');
+
+  await recordAlert(env, failed);
+  assert.equal(await streak(), 1);
+});
+
+test('alertStreak ignores other sources and other titles', async () => {
+  const env = newEnv();
+  await recordAlert(env, { source: 'api-health', severity: 'warn', title: 'Data API refresh failed' });
+  await recordAlert(env, { source: 'refresh', severity: 'warn', title: 'Something else' });
+  assert.equal(
+    await alertStreak(env, {
+      source: 'refresh', title: 'Data API refresh failed', resetTitle: 'Data API refresh recovered',
+    }),
+    0,
+  );
 });
 
 // -------------------------------------------------------------------- dedup --
@@ -247,6 +343,25 @@ test('a correct secret records and forwards', async () => {
   const body = await res.json();
   assert.equal(body.recorded, true);
   assert.equal((await readAlerts(env)).length, 1);
+});
+
+test('the health monitor can post a log-only alert through the ingest', async () => {
+  // The remote producer needs the same routing as the in-Worker ones, or the
+  // wedged-cron alert (which self-heal already handles) keeps paging.
+  const env = ingestEnv();
+  const res = await handleInternal(post({ ...ALERT, source: 'api-health', notify: false }), env);
+  assert.equal(res.status, 202);
+  const body = await res.json();
+  assert.equal(body.notified, false);
+  assert.equal(body.forwarded, false);
+  assert.equal((await readAlerts(env))[0].notify, 0, 'recorded regardless');
+});
+
+test('a non-boolean notify is a 400, not a silently-routed alert', async () => {
+  const env = ingestEnv();
+  const res = await handleInternal(post({ ...ALERT, notify: 'no' }), env);
+  assert.equal(res.status, 400);
+  assert.equal((await readAlerts(env)).length, 0);
 });
 
 test('a wrong secret is refused and writes nothing', async () => {

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -1,6 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { runRefresh } from '../src/refresh.js';
+import { readAlerts } from '../src/alerts.js';
 import { KEYS } from '../src/store.js';
 import { sqliteD1 } from '../test-support/d1-sqlite.mjs';
 
@@ -258,7 +259,7 @@ test('a failed refresh still advances the heartbeat (cron ran; Nexus did not ans
   assert.notEqual(meta.last_refresh_at, '2000-01-01T00:00:00.000Z'); // …but the cron is alive
 });
 
-test('Nexus failure keeps last-known-good and flags stale + alerts Discord', async () => {
+test('Nexus failure keeps last-known-good, flags stale, and records the alert', async () => {
   // Dedicated alerts channel (preferred over the legacy DISCORD_WEBHOOK_URL).
   const env = newEnv({ NCZ_ALERTS_DISCORD_WEBHOOK_URL: 'https://discord/webhook' });
   await runRefresh(env, fakeFetch()); // seed good data
@@ -273,8 +274,54 @@ test('Nexus failure keeps last-known-good and flags stale + alerts Discord', asy
   const meta = await env.DATASET.get(KEYS.meta, 'json');
   assert.equal(meta.discovery_stale, true);
   assert.match(meta.last_error, /503/);
-  assert.equal(discordSink.length, 1);
+
+  // Recorded, and NOT posted. One failed tick is a blip that the next tick
+  // usually clears, and the dataset never stopped being served. The row is what
+  // makes it reviewable; the Discord post is what is being withheld until the
+  // failure has persisted (see the streak test below).
+  const rows = await readAlerts(env);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].title, 'Data API refresh failed');
+  assert.equal(rows[0].notify, 0);
+  assert.equal(discordSink.length, 0);
+});
+
+test('the third consecutive failure is the one that reaches Discord', async () => {
+  // The threshold is the whole point of routing this alert: below it a person
+  // is not told, at it they are. Asserting only the quiet case would pass on a
+  // build that never notifies at all.
+  const env = newEnv({ NCZ_ALERTS_DISCORD_WEBHOOK_URL: 'https://discord/webhook' });
+  const discordSink = [];
+  await runRefresh(env, fakeFetch({ discordSink })); // seed good
+
+  await runRefresh(env, fakeFetch({ failNexus: true, discordSink }));
+  await runRefresh(env, fakeFetch({ failNexus: true, discordSink }));
+  assert.equal(discordSink.length, 0, 'two failures is still a blip');
+
+  await runRefresh(env, fakeFetch({ failNexus: true, discordSink }));
+  assert.equal(discordSink.length, 1, 'the third is not');
   assert.match(discordSink[0].embeds[0].title, /refresh failed/);
+  assert.match(discordSink[0].embeds[0].description, /Consecutive failed cycles: 3/);
+
+  // Every failure is recorded either way, which is what the streak counts.
+  const failures = (await readAlerts(env)).filter((a) => a.title === 'Data API refresh failed');
+  assert.equal(failures.length, 3);
+});
+
+test('a recovery resets the streak, so the next blip is quiet again', async () => {
+  // Without the reset the count would keep climbing across unrelated outages
+  // and the fourth blip of the week would page for no reason.
+  const env = newEnv({ NCZ_ALERTS_DISCORD_WEBHOOK_URL: 'https://discord/webhook' });
+  const discordSink = [];
+  await runRefresh(env, fakeFetch({ discordSink }));
+  for (let i = 0; i < 3; i += 1) {
+    await runRefresh(env, fakeFetch({ failNexus: true, discordSink }));
+  }
+  assert.equal(discordSink.length, 1, 'the third failure posted');
+
+  await runRefresh(env, fakeFetch({ discordSink }));                  // recover
+  await runRefresh(env, fakeFetch({ failNexus: true, discordSink })); // a fresh blip
+  assert.equal(discordSink.length, 1, 'the count restarted at the recovery');
 });
 
 test('failure with no prior dataset returns stale with null version, no crash', async () => {
@@ -380,18 +427,26 @@ test('archive refresh is budgeted per run and cold-fills over multiple runs', as
   assert.equal(run3.length, 0, 'once filled, steady state fetches nothing');
 });
 
-test('recovery posts a recovery alert exactly once (edge, not every cycle)', async () => {
+test('recovery records a recovery alert exactly once (edge, not every cycle)', async () => {
+  // The edge behaviour is unchanged; only the destination is. Both halves of a
+  // blip-and-recover are recorded and neither is posted, so the channel does
+  // not carry a problem and its resolution five minutes apart.
   const env = newEnv({ NCZ_ALERTS_DISCORD_WEBHOOK_URL: 'https://discord/webhook' });
   const discordSink = [];
   await runRefresh(env, fakeFetch({ discordSink }));                  // seed good
   await runRefresh(env, fakeFetch({ failNexus: true, discordSink })); // fail → stale + alert
   const r = await runRefresh(env, fakeFetch({ discordSink }));        // recover → all-clear
   assert.equal(r.recovered, true);
-  const titles = discordSink.map((m) => m.embeds[0].title);
-  assert.deepEqual(titles, ['⚠️ Data API refresh failed', '✅ Data API refresh recovered']);
+
+  const rows = (await readAlerts(env)).map((a) => [a.title, a.notify]);
+  assert.deepEqual(rows, [
+    ['Data API refresh recovered', 0],
+    ['Data API refresh failed', 0],
+  ], 'newest first, both recorded, neither posted');
+  assert.equal(discordSink.length, 0);
 
   // A subsequent healthy cycle must NOT re-announce recovery.
   const r2 = await runRefresh(env, fakeFetch({ discordSink }));
   assert.equal(r2.recovered ?? false, false);
-  assert.equal(discordSink.length, 2); // still just the fail + the one recovery
+  assert.equal((await readAlerts(env)).length, 2); // still just the fail + the one recovery
 });


### PR DESCRIPTION
## Why

The wedged-cron alert fired again on 2026-08-02 (run `30759939806`): heartbeat 50 min old at 17:55Z, self-heal redeployed production 1 second later, next check green at 18:59Z. The channel got the page and then the all-clear an hour later, for a loop that closed itself without anyone reading either.

Root cause of the wedge is unchanged and already documented: free-tier best-effort cron delivery. Ruled out again from this occurrence, from the alerts table rather than by assumption:

- **Not a refresh failure.** Every failure path writes a `Data API refresh failed` row. Zero between 07:04 and 17:55, so `runRefresh` never entered its catch.
- **Not a KV write failure or write-cap exhaustion.** Same evidence: `writeMeta` throwing lands in that catch.
- **Not the CPU cliff.** 295 locations against a ~470 tripwire.
- **Not deploy-correlated.** Last deploy 8.5 hours earlier.

So the alert was correct, the response was automatic, and nothing was left for a person. That is the class of alert this PR stops posting.

## What changed

Every alert is still recorded. A `notify` flag decides whether it is also forwarded.

| Posted | Log-only |
| --- | --- |
| The API is not serving | A wedged cron whose self-heal redeploy was dispatched |
| Self-heal exhausted, so a human must redeploy | Every all-clear: refresh recovered, API recovered |
| A refresh failing 3 cycles, then every 3 hours | The first two consecutive refresh failures |
| A pinned mod hidden or deleted on Nexus | A mod returning to Nexus with nothing left to do |
| A mod back on Nexus while a record is still hidden by hand | `discovery_stale` reported as context |
| A quota cap past 80%, once per cap per UTC day | |
| A submission waiting in the queue | |

### Three decisions worth arguing with

**The producer decides, not a rule in `alerts.js`.** Routing on severity or a title match puts the decision where it cannot see the context it depends on. Two cases prove it: `alertModRecovered` is a `recovery` that must page when a record was hidden by hand, because nothing else will ever raise it again; and the wedged-cron alert is silent only when a redeploy was actually dispatched for *every* stale target. Self-heal switched off, unmapped, or partly failed and it pages, because then nothing is working the problem.

**Omitting `notify` means notify.** A producer added later that never considered routing gets the old behaviour, and a D1 error while counting a failure streak is treated as "notify". Silence is the expensive failure here; noise is the cheap one.

**A failed refresh escalates rather than posting or not posting.** Third consecutive failure, then every 36th (3 hours at 5-min ticks), counted from the `alerts` table since the last recovery. Notifying only on the third would mean an outage lasting all afternoon gets one message at the start and silence after, which reads exactly like a problem that resolved.

## Schema

Migration `0010_alert_notify.sql` adds `notify INTEGER NOT NULL DEFAULT 1` plus an index on `(notify, acknowledged_at)`. `notify` is the routing *decision*, never the outcome: if a failed Discord post wrote back to it, an outage would quietly drop real alerts out of the unacknowledged count, which is the exact failure the alerts table exists to survive.

The unacknowledged badge and the Overview panel both filter to `notify = 1`. A log-only alert is never waiting on anybody, so counting one would put a number on the dashboard that nothing can clear; it shows in the full list marked "log only", with "Nothing to acknowledge." where the button would be.

**Deploy order:** the migration must be applied to both D1 databases *before* the Worker deploys, or every alert insert fails against the old schema. Not fatal (`raiseAlert` swallows a record failure and still forwards), but it would lose the history for as long as it lasted.

## Tests

387 pass. New coverage: log-only records but never calls the webhook; omitted `notify` still forwards; `notified` and `forwarded` stay distinguishable so a broken webhook is not mistaken for a routing decision; a non-boolean `notify` is a 400 rather than a truthy-string route in the wrong direction; the third consecutive failure is the one that posts; a recovery resets the streak.

Two existing tests changed to state the new behaviour rather than the old: the first Nexus failure now asserts recorded-and-not-posted, and the recovery-edge test asserts both rows exist with `notify = 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)