### PR TITLE
Release 2.7.0: what a resubmission changes, and whether to apply it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- The review queue compares a resubmission against the hidden record it matches, field by field, instead of showing one distance in metres.
+- A third outcome on that panel: restore the record **and** apply the submitted values. Restore-as-is is unchanged and stays the default; the audit tells the two apart.
+
 ## [2.6.0] - 2026-08-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.7.0] - 2026-08-03
 
 ### Added
 

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -925,6 +925,14 @@ button.breakdown-row:hover .k { color: var(--secondary); }
 
 .sibling p { margin: var(--space-2xs) 0 0; }
 
+/* The field-by-field comparison against a HIDDEN record, under the row it
+ * belongs to. `.sibling` is a flex row, so it takes a full-width basis rather
+ * than becoming a third column squeezed beside the buttons. */
+.sibling-diff {
+    flex: 1 0 100%;
+    margin-top: var(--space-xs);
+}
+
 .candidate-list { display: grid; gap: var(--space-sm); }
 
 .candidate {

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1343,6 +1343,26 @@
    * two rows for one pin. Restoring puts the curated record back instead, and
    * still resolves the submission as approved, because the request was granted.
    */
+  /**
+   * What the submission would change about the stored record, field by field.
+   *
+   * The same renderer the queue uses for an `edit`, pointed at a pair it was not
+   * built for: (hidden record -> submitted payload). The reviewer is deciding
+   * between two sets of values, and one distance in metres cannot answer "is it
+   * back in the same place, with the same description, by the same author?".
+   *
+   * Only the keys the payload carries. A `create` payload does not mention
+   * `admin_notes` or `status`, and diffing the record's against `undefined`
+   * would report the record's own fields as removals.
+   */
+  function hiddenSiblingDiff(sub, location) {
+    const before = {};
+    for (const key of Object.keys(sub.payload)) before[key] = location[key];
+    return h('div', { class: 'sibling-diff' },
+      h('p', { class: 'muted', text: 'What the submission would change about this record:' }),
+      renderDiff(before, sub.payload, 'Show both records in full'));
+  }
+
   function siblingPanel(sub) {
     const siblings = siblingLocations(sub);
     if (!siblings.length) return null;
@@ -1357,15 +1377,26 @@
           : `${Math.round(metres).toLocaleString()} m from the proposed pin` })),
       h('div', { class: 'candidate-actions' },
         location.status === 'hidden'
-          ? h('button', {
-            class: 'btn', type: 'button', text: 'Restore this instead',
-            title: 'Puts this record back on the map as it stands, and marks the submission approved. The submitted coordinates are not applied.',
-            onclick: (e) => approveByRestoring(sub, location, e.currentTarget),
-          })
+          ? [
+            h('button', {
+              class: 'btn', type: 'button', text: 'Restore this instead',
+              title: 'Puts this record back on the map as it stands, and marks the submission approved. The submitted coordinates are not applied.',
+              onclick: (e) => approveByRestoring(sub, location, e.currentTarget),
+            }),
+            // Second, and `secondary`, on purpose: 34 of 295 names differ from
+            // their Nexus title by curation, so overwriting the stored record
+            // is the deliberate choice and must not be the easy one.
+            h('button', {
+              class: 'btn secondary', type: 'button', text: 'Restore and apply these values',
+              title: 'Puts this record back on the map AND overwrites it with the submitted values. Any curation on the stored record is replaced.',
+              onclick: (e) => approveByRestoring(sub, location, e.currentTarget, { apply: true }),
+            }),
+          ]
           : h('button', {
             class: 'btn secondary', type: 'button', text: 'Open it',
             onclick: () => selectLocation(location.id),
-          }))));
+          })),
+      location.status === 'hidden' ? hiddenSiblingDiff(sub, location) : null));
 
     return h('div', { class: `sibling-panel${hidden.length ? ' has-hidden' : ''}` },
       h('p', { class: 'muted', text: hidden.length
@@ -1374,19 +1405,30 @@
       rows);
   }
 
-  /** Grant a create by putting an existing hidden record back on the map. */
-  async function approveByRestoring(sub, location, button) {
-    const ok = confirm(
-      `Restore "${location.name}" and approve this submission?\n\n`
-      + 'The record goes back on the map exactly as it is stored. The submitted '
-      + 'coordinates and description are NOT applied, and no second record is created.',
-    );
+  /**
+   * Grant a create by putting an existing hidden record back on the map, either
+   * as it stands or overwritten with the submitted values.
+   *
+   * The two confirms say different things because the two outcomes are
+   * different, and only one of them discards anything. The apply confirm names
+   * the record it is about to overwrite: "Restore and apply" reads as additive
+   * until you know it is a replacement.
+   */
+  async function approveByRestoring(sub, location, button, { apply = false } = {}) {
+    const ok = confirm(apply
+      ? `Restore "${location.name}" and OVERWRITE it with the submitted values?\n\n`
+        + 'The record goes back on the map carrying the submitted name, coordinates '
+        + 'and description. Anything curated on the stored record is replaced. No '
+        + 'second record is created.'
+      : `Restore "${location.name}" and approve this submission?\n\n`
+        + 'The record goes back on the map exactly as it is stored. The submitted '
+        + 'coordinates and description are NOT applied, and no second record is created.');
     if (!ok) return;
 
     button.disabled = true;
     const res = await api(`/admin/submissions/${sub.id}/approve`, {
       method: 'POST',
-      body: { restore_location_id: location.id },
+      body: { restore_location_id: location.id, ...(apply ? { apply_payload: true } : {}) },
     });
     button.disabled = false;
 
@@ -1400,7 +1442,11 @@
     await loadLocations();
     await loadQueue();
     selectSubmission(sub.id);
-    banner('ok', `Restored "${res.body.location.name}" and approved the submission. No second record was created.`);
+    // `res.body.applied` rather than what this call asked for: the reviewer is
+    // told whether the stored values survived, and only the server knows.
+    banner('ok', res.body.applied
+      ? `Restored "${res.body.location.name}" and applied the submitted values. No second record was created.`
+      : `Restored "${res.body.location.name}" and approved the submission. No second record was created.`);
   }
 
   /** The coordinates a submission wants, and the ones it moves away from. */
@@ -2323,6 +2369,7 @@
     granted_by: {
       apply: 'applied to the existing record',
       restore: 'put a hidden record back, rather than creating a second one',
+      restore_apply: 'put a hidden record back AND overwrote it with the submitted values',
     },
     status: {
       published: 'on the map',
@@ -2529,6 +2576,13 @@
         if (after.granted_by === 'restore') {
           return ['approved submission #', target, ' by restoring ',
             quoted(name ?? 'a hidden record'), ' rather than creating a second one'];
+        }
+        // The one outcome that discarded something. The location.update entry
+        // beside this one holds what it discarded; this sentence has to say
+        // that there was something, or nobody goes and looks.
+        if (after.granted_by === 'restore_apply') {
+          return ['approved submission #', target, ' by restoring ',
+            quoted(name ?? 'a hidden record'), ' and overwriting it with the submitted values'];
         }
         return ['approved submission #', target, name ? [', applied to ', quoted(name)] : '',
           // The reviewer approved over a record that had moved since the

--- a/worker/src/review.js
+++ b/worker/src/review.js
@@ -166,16 +166,20 @@ function checkNote(value, { required }) {
  * and later someone submits the same mod again. Approving that create normally
  * would leave two rows for one pin, one hidden and one published.
  *
- * It restores the record AS IT STANDS. The submitted coordinates and
+ * By default it restores the record AS IT STANDS. The submitted coordinates and
  * description are NOT applied: the stored record is curated (34 of 295 names
  * differ from their Nexus title deliberately), and quietly overwriting that
- * from an anonymous payload is not a restore. A reviewer who does want the new
- * values makes that edit deliberately afterwards.
+ * from an anonymous payload is not a restore.
+ *
+ * `applyPayload` is the reviewer saying otherwise, in as many words, having read
+ * the diff the queue now renders. It stays opt-in and must never become the
+ * default: the curation it overwrites is invisible in the payload, so a reviewer
+ * who did not choose it cannot see what it cost.
  *
  * Three checks, three distinct refusals, because each one means the reviewer
  * pointed at the wrong record and they are wrong in different ways.
  */
-async function restoreInstead(env, submission, locationId, { actor, nowIso }) {
+async function restoreInstead(env, submission, locationId, { actor, nowIso, applyPayload }) {
   const row = await getRow(env, locationId);
   if (!row) {
     return { error: 'location_missing', detail: 'that location does not exist', status: 409 };
@@ -202,12 +206,48 @@ async function restoreInstead(env, submission, locationId, { actor, nowIso }) {
   }
 
   const before = await loadAdminRecord(env, row);
-  // Unguarded on purpose: publishing a record this approval just restored is
-  // this call's whole job, and there is no competing version to lose.
-  await patchLocation(env, locationId, { status: 'published' }, nowIso);
+
+  if (!applyPayload) {
+    // Unguarded on purpose: publishing a record this approval just restored is
+    // this call's whole job, and there is no competing version to lose.
+    await patchLocation(env, locationId, { status: 'published' }, nowIso);
+    const after = await loadAdminRecordById(env, locationId);
+    await writeAudit(env, { actor, action: 'location.update', target: locationId, before, after });
+    return { location: after, restored: true };
+  }
+
+  // Revalidated against the tag registry AS IT STANDS NOW, for the reason
+  // applyApproval gives: a tag renamed or deleted while the submission sat in
+  // the queue would write a record whose join rows silently go missing. Full
+  // validation rather than partial, because a `create` payload is a whole
+  // record and applying half of one is not what the reviewer asked for.
+  const v = validateLocationInput(payload, { tagNames: await readTagSlugs(env) });
+  if (!v.ok) return { error: 'validation_failed', errors: v.errors, status: 422 };
+
+  // One UPDATE: the payload and `published` land together or not at all. There
+  // is no state in which the record is back on the map still carrying the
+  // values the reviewer chose to replace.
+  //
+  // GUARDED, unlike the restore above, and on the row this function read a
+  // moment ago rather than on anything the submitter saw. Two approvals racing
+  // on one submission both pass the `hidden` check before either writes; the
+  // second one finds `modified_at` moved and writes nothing, instead of
+  // applying the payload twice over a record that is already published.
+  const patched = await patchLocation(
+    env, locationId, { ...payload, status: 'published' }, nowIso,
+    { ifMatch: row.modified_at },
+  );
+  if (patched.conflict) {
+    return {
+      error: 'stale_restore',
+      detail: `"${row.name}" changed while this approval was being applied, so nothing was written`,
+      current: await loadAdminRecordById(env, locationId),
+      status: 409,
+    };
+  }
   const after = await loadAdminRecordById(env, locationId);
   await writeAudit(env, { actor, action: 'location.update', target: locationId, before, after });
-  return { location: after, restored: true };
+  return { location: after, restored: true, applied: true };
 }
 
 /**
@@ -222,14 +262,16 @@ async function restoreInstead(env, submission, locationId, { actor, nowIso }) {
  * submission pending: a submission that could not be applied has not been
  * reviewed, and marking it approved anyway would lose it.
  */
-async function applyApproval(env, submission, { actor, nowIso, restoreLocationId, baseOverride }) {
+async function applyApproval(
+  env, submission, { actor, nowIso, restoreLocationId, applyPayload, baseOverride },
+) {
   const payload = parsePayload(submission.payload);
 
   if (submission.kind === 'create') {
     // The reviewer chose to grant this by restoring an existing record rather
     // than by inserting a new one. Still an approval: the request was granted.
     if (restoreLocationId) {
-      return restoreInstead(env, submission, restoreLocationId, { actor, nowIso });
+      return restoreInstead(env, submission, restoreLocationId, { actor, nowIso, applyPayload });
     }
 
     const v = validateLocationInput(payload, { tagNames: await readTagSlugs(env) });
@@ -312,6 +354,13 @@ async function applyApproval(env, submission, { actor, nowIso, restoreLocationId
   return { location: after };
 }
 
+/** The route by which an approval reached the registry, for the audit log. */
+function grantedBy(applied) {
+  if (!applied) return null;
+  if (!applied.restored) return 'apply';
+  return applied.applied ? 'restore_apply' : 'restore';
+}
+
 /**
  * POST /admin/submissions/:id/(approve|reject|hold)
  *
@@ -344,6 +393,9 @@ async function act(request, env, ctx, { id, action, actor }) {
   if (body.restore_location_id !== undefined && typeof body.restore_location_id !== 'string') {
     errors.push('restore_location_id must be a string');
   }
+  if (body.apply_payload !== undefined && typeof body.apply_payload !== 'boolean') {
+    errors.push('apply_payload must be a boolean');
+  }
   // The version the REVIEWER is approving against, sent only on a second
   // attempt after a `stale_submission` refusal. See applyApproval's edit branch.
   if (body.base_modified_at !== undefined
@@ -362,6 +414,15 @@ async function act(request, env, ctx, { id, action, actor }) {
     return json(request, {
       error: 'invalid_review',
       errors: ['restore_location_id applies only to approving a create'],
+    }, 400);
+  }
+  // `apply_payload` modifies a restore and means nothing without one. Accepting
+  // it alone would read as "apply the submitted values", which is what a plain
+  // approve already does by inserting them, and would quietly do nothing here.
+  if (body.apply_payload && !body.restore_location_id) {
+    return json(request, {
+      error: 'invalid_review',
+      errors: ['apply_payload applies only alongside restore_location_id'],
     }, 400);
   }
   // Same shape of mistake: a create inserts and a removal is unguarded on
@@ -389,6 +450,7 @@ async function act(request, env, ctx, { id, action, actor }) {
       actor,
       nowIso,
       restoreLocationId: body.restore_location_id ?? null,
+      applyPayload: body.apply_payload === true,
       baseOverride: body.base_modified_at ?? null,
     });
     if (applied.error) {
@@ -431,7 +493,12 @@ async function act(request, env, ctx, { id, action, actor }) {
       // How the request was granted, not just that it was. An approval that
       // inserted nothing and an approval that inserted a record are different
       // events, and the log is the only place that distinction survives.
-      granted_by: applied ? (applied.restored ? 'restore' : 'apply') : null,
+      //
+      // Three values, because a restore that kept the curated record and a
+      // restore that overwrote it with the submitted values are the two
+      // outcomes an audit reader most needs to tell apart: only one of them
+      // discarded something, and neither shows up as a create.
+      granted_by: grantedBy(applied),
       // The reviewer approved an edit over a record that had moved since the
       // submission was made. The before/after pair above shows what changed;
       // this says the overwrite was a decision rather than a race.
@@ -446,6 +513,10 @@ async function act(request, env, ctx, { id, action, actor }) {
     submission,
     location: applied?.location ?? null,
     restored: applied?.restored === true,
+    // Reported, not inferred from what the caller sent: the dashboard tells the
+    // reviewer whether the curated values survived, and that has to come from
+    // what the server actually did.
+    applied: applied?.applied === true,
   });
 }
 

--- a/worker/test/review.test.js
+++ b/worker/test/review.test.js
@@ -540,6 +540,170 @@ test('a restore materializes, because a record did change', async () => {
   assert.equal(waited.length, 1);
 });
 
+// ------------------------------------------ restoring AND applying the values ---
+
+// The reviewer has read the diff and decided the submitted values are the ones
+// that should be on the map. Same grant as a restore (one record, not two) and
+// the opposite decision about whose values win.
+
+const APPLY = { restore_location_id: 'loc-hidden', apply_payload: true };
+const tagsFor = (env, id) => env.DB.rows(
+  'SELECT tag_slug FROM location_tags WHERE location_id = ? ORDER BY tag_slug', id,
+).map((r) => r.tag_slug);
+
+test('restore-and-apply puts the record back AND writes the submitted values', async () => {
+  const env = envFor({ locations: [LOCATION, HIDDEN], submissions: [resubmission()] });
+  const res = await hit(env, 'POST', `/admin/submissions/${firstId(env)}/approve`, APPLY);
+  assert.equal(res.status, 200);
+
+  const body = await res.json();
+  assert.equal(body.restored, true);
+  assert.equal(body.applied, true, 'the two restores have to be tellable apart in the response');
+  assert.equal(body.submission.status, 'approved');
+
+  const rows = locRows(env);
+  assert.equal(rows.length, 2, 'still no second record: this is a restore');
+  const row = rows.find((r) => r.id === 'loc-hidden');
+  assert.equal(row.status, 'published');
+  assert.equal(row.name, 'Rooftop Bar', 'the submitted name is the point of this outcome');
+  assert.equal(row.x, 100);
+  assert.equal(row.y, 200);
+  assert.equal(row.z, 30);
+  // The join, not just the column: a record that materializes with no tags is
+  // the failure insertLocation's comment exists for.
+  assert.deepEqual(tagsFor(env, 'loc-hidden'), ['apartment']);
+});
+
+test('restore-and-apply revalidates against the tag registry as it stands NOW', async () => {
+  // The submission carried a tag that was renamed or deleted while it sat in
+  // the queue. Applying it would write a location whose join rows silently go
+  // missing, so it is refused and the submission stays reviewable.
+  const env = envFor({
+    locations: [LOCATION, HIDDEN],
+    submissions: [submission({
+      payload: JSON.stringify({ ...VALID, tags: ['a-tag-that-was-renamed'] }),
+    })],
+  });
+  const res = await hit(env, 'POST', `/admin/submissions/${firstId(env)}/approve`, APPLY);
+  assert.equal(res.status, 422);
+  assert.equal((await res.json()).error, 'validation_failed');
+
+  const row = locRows(env).find((r) => r.id === 'loc-hidden');
+  assert.equal(row.status, 'hidden', 'nothing may be published by a refused apply');
+  assert.equal(row.name, 'Pulled Loft', 'and nothing may be written');
+  assert.equal(subRows(env)[0].status, 'pending', 'a submission that could not be applied is not reviewed');
+});
+
+test('the audit tells restore-and-apply apart from restore-as-is', async () => {
+  // Only one of the two discarded something. An audit that calls both "restore"
+  // cannot answer the question a reader comes to it with.
+  const env = envFor({ locations: [LOCATION, HIDDEN], submissions: [resubmission()] });
+  await hit(env, 'POST', `/admin/submissions/${firstId(env)}/approve`, APPLY);
+
+  const log = auditRows(env);
+  assert.deepEqual(log.map((r) => r.action), ['location.update', 'submission.approve']);
+  const after = JSON.parse(log.at(-1).after);
+  assert.equal(after.granted_by, 'restore_apply');
+  assert.equal(after.location_id, 'loc-hidden');
+
+  // The location entry has to show what the apply overwrote, or the curated
+  // values it replaced are gone with no record that they existed.
+  const update = JSON.parse(log[0].before);
+  assert.equal(update.name, 'Pulled Loft');
+});
+
+test('two approvals racing on one submission apply the payload once', async () => {
+  // Both requests pass the pending check before either writes. Whichever guard
+  // catches the second (the submission resolve, the `hidden` read, or the
+  // conditional update), exactly one write may land.
+  const env = envFor({ locations: [LOCATION, HIDDEN], submissions: [resubmission()] });
+  const path = `/admin/submissions/${firstId(env)}/approve`;
+  const results = await Promise.all([
+    hit(env, 'POST', path, APPLY),
+    hit(env, 'POST', path, APPLY),
+  ]);
+
+  const codes = results.map((r) => r.status).sort();
+  assert.deepEqual(codes, [200, 409], 'one grant, one refusal');
+  assert.equal(
+    actions(env).filter((a) => a === 'location.update').length, 1,
+    'the registry may be written once, whichever request lost',
+  );
+  assert.equal(subRows(env).filter((r) => r.status === 'approved').length, 1);
+});
+
+test('an apply refuses rather than overwriting a record that moved under it', async () => {
+  // The window the conditional write exists for, and the only way to stand in
+  // it deterministically: the record is written in the instant between
+  // restoreInstead reading it and applying to it. Two reviewers resolving two
+  // resubmissions of one mod at once is what puts a person here, and their
+  // payloads are NOT identical, so last-write-wins is not a harmless no-op.
+  const env = envFor({ locations: [LOCATION, HIDDEN], submissions: [resubmission()] });
+  const realPrepare = env.DB.prepare.bind(env.DB);
+  let moved = false;
+  env.DB.prepare = (sql) => {
+    if (!moved && sql.startsWith('UPDATE locations')) {
+      moved = true;
+      env.DB._db.prepare(
+        "UPDATE locations SET name = 'Renamed by someone else', modified_at = '2026-09-09T00:00:00Z' WHERE id = 'loc-hidden'",
+      ).run();
+    }
+    return realPrepare(sql);
+  };
+
+  const res = await hit(env, 'POST', `/admin/submissions/${firstId(env)}/approve`, APPLY);
+  assert.equal(res.status, 409);
+  assert.equal((await res.json()).error, 'stale_restore');
+
+  const row = locRows(env).find((r) => r.id === 'loc-hidden');
+  assert.equal(row.name, 'Renamed by someone else', 'the other write must survive');
+  assert.equal(row.status, 'hidden', 'and this approval must have written nothing');
+  assert.equal(subRows(env)[0].status, 'pending');
+});
+
+test('a resolved submission cannot be approved again, applied or otherwise', async () => {
+  const env = envFor({ locations: [LOCATION, HIDDEN], submissions: [resubmission()] });
+  const path = `/admin/submissions/${firstId(env)}/approve`;
+  assert.equal((await hit(env, 'POST', path, APPLY)).status, 200);
+
+  const again = await hit(env, 'POST', path, APPLY);
+  assert.equal(again.status, 409);
+  assert.equal((await again.json()).error, 'already_resolved');
+  assert.equal(actions(env).filter((a) => a === 'location.update').length, 1);
+});
+
+test('apply_payload is refused without a record to apply it to, and unless boolean', async () => {
+  // Alone it would read as "apply the submitted values", which is what a plain
+  // approve does by inserting them. Here it would quietly do nothing.
+  const env = envFor({ locations: [LOCATION, HIDDEN], submissions: [resubmission()] });
+  const path = `/admin/submissions/${firstId(env)}/approve`;
+
+  const alone = await hit(env, 'POST', path, { apply_payload: true });
+  assert.equal(alone.status, 400);
+
+  const notBool = await hit(env, 'POST', path, { restore_location_id: 'loc-hidden', apply_payload: 'yes' });
+  assert.equal(notBool.status, 400);
+
+  assert.equal(locRows(env).find((r) => r.id === 'loc-hidden').status, 'hidden');
+  assert.equal(subRows(env)[0].status, 'pending');
+});
+
+test('restore-as-is is unchanged: apply_payload false keeps the curated record', async () => {
+  // 34 of 295 names differ from their Nexus title on purpose. Applying must
+  // stay the explicit choice, never what an absent or false flag does.
+  const env = envFor({ locations: [LOCATION, HIDDEN], submissions: [resubmission()] });
+  const res = await hit(env, 'POST', `/admin/submissions/${firstId(env)}/approve`,
+    { restore_location_id: 'loc-hidden', apply_payload: false });
+  assert.equal(res.status, 200);
+  assert.equal((await res.json()).applied, false);
+
+  const row = locRows(env).find((r) => r.id === 'loc-hidden');
+  assert.equal(row.status, 'published');
+  assert.equal(row.name, 'Pulled Loft');
+  assert.equal(row.x, LOCATION.x);
+  assert.equal(JSON.parse(auditRows(env).at(-1).after).granted_by, 'restore');
+});
+
 // ------------------------------------------------- reject / request changes ---
 
 test('a rejection without a reason is refused, and changes nothing', async () => {


### PR DESCRIPTION
Ships #898 (PR #935).

## What changes for a reviewer

A `create` submitted for a mod that already has a **hidden** record is the
resubmission case: a removal was approved, and the mod is back. The queue
detected it and offered two outcomes, but the only comparison it drew was the
straight-line distance in metres to the sibling. That cannot answer the question
the case poses, which is whether the mod is back in the same place, with the
same description, by the same author.

The panel now renders the queue's existing field-by-field diff against the
hidden record, and offers a third outcome: **restore and apply the submitted
values**, in one action, distinguishable in the audit afterwards.

Restore-as-is is unchanged and stays the default. 34 of 295 names differ from
their Nexus title by curation, a payload cannot show what it would overwrite,
so the button that discards is the secondary one and its confirm names the
record it is about to replace.

## Server

`POST /admin/submissions/{id}/approve` takes `apply_payload: true` beside the
existing `restore_location_id`; refused alone, refused non-boolean, and only
reaches the restore path. The apply revalidates against the tag registry as it
stands now, writes the payload and `published` in one conditional UPDATE,
refuses (`stale_restore`, 409) rather than overwriting a record that moved under
it, and records a third `granted_by` value.

No migration. No `/v1` route or payload shape moves, so the API stays 0.5.1.

## Verification

- `worker/test/`: 387 -> 395, all green. Every new behaviour mutation-checked,
  each mutation confirmed to fail the right test. One guard survived its first
  mutation and got a better test rather than a smaller claim; see #935.
- Site tests: 81, unchanged.
- `admin/` has no automated tests, so both buttons, both confirms, both banners
  and both audit sentences were driven by hand in a browser against a stubbed
  API.

## After merge

`admin/` reaches production through Cloudflare Pages on `main`, and the Worker
change ships with `npx wrangler deploy` from `worker/`. Both halves are needed:
the dashboard sends `apply_payload`, and the Worker is what honours it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)