### PR TITLE
Release 2.8.0: filtering the audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- The audit log filters by who, what and which record, combinable. The filter reads the entries already loaded, so it answers instantly and asks the API for nothing extra.
+- Filtering by a location finds both halves of an approval, including the submission row that names it only in its recorded values.
+
 ## [2.7.0] - 2026-08-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.8.0] - 2026-08-03
 
 ### Added
 
 - The audit log filters by who, what and which record, combinable. The filter reads the entries already loaded, so it answers instantly and asks the API for nothing extra.
 - Filtering by a location finds both halves of an approval, including the submission row that names it only in its recorded values.
+- The action filter reads as English, with the stored action beside each label so it still matches what the entry shows.
 
 ## [2.7.0] - 2026-08-03
 

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -74,6 +74,12 @@
     // "3 open" when it merely fetched 3 of them.
     alerts: [],
     alertsUnacknowledged: 0,
+    // What the Audit tab last fetched, held so a filter change re-renders
+    // instead of re-fetching. The filter is applied to these rows and nowhere
+    // else: `decisions/api-per-location-records` derives rather than asking the
+    // server for a narrower answer, and at 14 rows the whole log is one fetch.
+    audit: [],
+    auditFilter: { actor: '', action: '', target: '' },
     // Pinned mods Nexus no longer calls published, with the pins that point at
     // them. Server state, not derived from the locations list: how many
     // consecutive sweeps have said so is a fact about a run of cron ticks, and
@@ -2634,6 +2640,99 @@
     }
   }
 
+  /** Who did it, in the words the entry itself uses. */
+  const actorLabel = (actor) => (actor === 'anonymous' ? 'a visitor' : actor);
+
+  /**
+   * Every id this entry is ABOUT, not just the one in its `target` column.
+   *
+   * One approval writes two rows and they do not share a target: the
+   * `location.update` names the location UUID, and the `submission.approve`
+   * beside it names the submission number, carrying the UUID in its recorded
+   * values. Matching the column alone answers "what has been done to this
+   * location" with half of what happened to it, which is worse than answering
+   * nothing, because it looks complete.
+   *
+   * A bounded list of id fields rather than a scan of the whole record:
+   * `before`/`after` also hold prose (a name, a reason, an admin note), and
+   * searching those turns an id lookup into a text search that happens to match
+   * ids as well.
+   */
+  const AUDIT_ID_FIELDS = ['id', 'location_id', 'nexus_id', 'slug'];
+
+  function auditIdentifiers(e) {
+    const parts = [e.target];
+    for (const snapshot of [e.before, e.after]) {
+      if (!snapshot || typeof snapshot !== 'object') continue;
+      for (const key of AUDIT_ID_FIELDS) parts.push(snapshot[key]);
+      // A mod-status row is about the pins it lists, not about one target.
+      if (Array.isArray(snapshot.locations)) parts.push(...snapshot.locations.map((l) => l?.id));
+    }
+    return parts.filter((v) => v !== null && v !== undefined).join(' ').toLowerCase();
+  }
+
+  /** `filter.target` arrives already trimmed and lowercased; see the wiring in main(). */
+  function auditMatches(e, filter) {
+    if (filter.actor && e.actor !== filter.actor) return false;
+    if (filter.action && e.action !== filter.action) return false;
+    if (filter.target && !auditIdentifiers(e).includes(filter.target)) return false;
+    return true;
+  }
+
+  /**
+   * Fill a filter select from the values that actually occur in the fetched
+   * rows, never from a list written here. A hard-coded list silently drops an
+   * action a later Worker change adds, which is the same failure `FIELD_LABEL`
+   * avoids by falling back to the raw key.
+   *
+   * The current selection stays an option even when no fetched row carries it,
+   * so narrowing the limit cannot quietly reset the filter to "anyone" while
+   * the list below is showing nothing.
+   */
+  function fillAuditSelect(select, anyLabel, values, selected, label = (v) => v) {
+    const present = [...new Set(values)].sort();
+    if (selected && !present.includes(selected)) present.push(selected);
+    replace(select,
+      h('option', { value: '', text: anyLabel }),
+      present.map((v) => h('option', { value: v, text: label(v) })));
+    select.value = selected;
+  }
+
+  function renderAudit() {
+    const filter = state.auditFilter;
+    const filtering = Boolean(filter.actor || filter.action || filter.target);
+    const shown = filtering ? state.audit.filter((e) => auditMatches(e, filter)) : state.audit;
+
+    fillAuditSelect($('#audit-actor'), 'Anyone', state.audit.map((e) => e.actor), filter.actor, actorLabel);
+    fillAuditSelect($('#audit-action'), 'Any action', state.audit.map((e) => e.action), filter.action);
+    $('#audit-clear').disabled = !filtering;
+
+    replace($('#audit-list'), shown.length
+      ? shown.map((e) => h('div', { class: 'audit-entry' },
+        h('div', { class: 'audit-head' },
+          timeEl(e.at),
+          h('span', { class: 'who', text: actorLabel(e.actor) }),
+          h('span', { class: 'sentence' }, describeAudit(e).flat()),
+          // The machine-readable pair, kept visible so the sentence above can
+          // always be checked against what was actually recorded. It is also
+          // what makes the action filter discoverable: nothing else on the row
+          // says the words the select is offering.
+          h('code', { class: 'action', title: `recorded as ${e.action} on ${e.target ?? 'nothing'}`, text: e.action })),
+        h('details', {}, h('summary', { text: 'The full record' }),
+          renderDiff(e.before, e.after, 'Show exactly what was recorded', e.action))))
+      // An empty log and an empty filter result are different facts, and only
+      // one of them means nothing has happened.
+      : h('p', {
+        class: 'muted',
+        text: state.audit.length ? 'No entries match this filter.' : 'No entries yet.',
+      }));
+
+    $('#audit-summary').textContent = state.audit.length === 0 ? ''
+      : filtering
+        ? `${shown.length} shown of ${state.audit.length} loaded.`
+        : `${state.audit.length} entries, most recent first.`;
+  }
+
   async function loadAudit() {
     const limit = $('#audit-limit').value;
     const res = await api(`/admin/audit?limit=${encodeURIComponent(limit)}`);
@@ -2641,19 +2740,8 @@
       const [kind, message] = describeFailure(res);
       return banner(kind, message);
     }
-    const entries = res.body.entries || [];
-    replace($('#audit-list'), entries.length
-      ? entries.map((e) => h('div', { class: 'audit-entry' },
-        h('div', { class: 'audit-head' },
-          timeEl(e.at),
-          h('span', { class: 'who', text: e.actor === 'anonymous' ? 'a visitor' : e.actor }),
-          h('span', { class: 'sentence' }, describeAudit(e).flat()),
-          // The machine-readable pair, kept visible so the sentence above can
-          // always be checked against what was actually recorded.
-          h('code', { class: 'action', title: `recorded as ${e.action} on ${e.target ?? 'nothing'}`, text: e.action })),
-        h('details', {}, h('summary', { text: 'The full record' }),
-          renderDiff(e.before, e.after, 'Show exactly what was recorded', e.action))))
-      : h('p', { class: 'muted', text: 'No entries yet.' }));
+    state.audit = res.body.entries || [];
+    return renderAudit();
   }
 
   // -------------------------------------------------------------- alerts --
@@ -3233,6 +3321,26 @@
     $('#tag-new').onclick = () => selectTag('');
     $('#audit-refresh').onclick = loadAudit;
     $('#audit-limit').onchange = loadAudit;
+    $('#audit-actor').onchange = (e) => {
+      state.auditFilter.actor = e.target.value;
+      renderAudit();
+    };
+    $('#audit-action').onchange = (e) => {
+      state.auditFilter.action = e.target.value;
+      renderAudit();
+    };
+    // Normalised once, here, so the match is a plain `includes` on values that
+    // are already lowercase. A reviewer pastes part of a UUID out of a URL or a
+    // Discord message and it arrives with whatever case and spacing it had.
+    $('#audit-target').oninput = (e) => {
+      state.auditFilter.target = e.target.value.trim().toLowerCase();
+      renderAudit();
+    };
+    $('#audit-clear').onclick = () => {
+      state.auditFilter = { actor: '', action: '', target: '' };
+      $('#audit-target').value = '';
+      renderAudit();
+    };
     $('#alerts-refresh').onclick = loadAlerts;
     $('#alerts-limit').onchange = loadAlerts;
     $('#alerts-unack-only').onchange = loadAlerts;

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -2644,6 +2644,49 @@
   const actorLabel = (actor) => (actor === 'anonymous' ? 'a visitor' : actor);
 
   /**
+   * What was done, in words, for the filter select.
+   *
+   * `submission.*` splits two ways that read alike and are not alike: three of
+   * them are what the public asked for, three are what a reviewer decided. The
+   * labels say which, because "submission.remove" beside "submission.reject"
+   * gives no clue that one is a request and the other an answer.
+   *
+   * Same fallback rule as `FIELD_LABEL`: an action this page has not been
+   * taught shows as itself rather than being dropped from the list.
+   */
+  const ACTION_LABEL = {
+    'dataset.refresh': 'Dataset rebuilt',
+    'location.create': 'Location created',
+    'location.update': 'Location changed',
+    'location.delete': 'Location deleted',
+    'tag.create': 'Tag created',
+    'tag.update': 'Tag changed',
+    'tag.rename': 'Tag renamed',
+    'tag.delete': 'Tag deleted',
+    'submission.create': 'Asked for: a new pin',
+    'submission.edit': 'Asked for: an edit',
+    'submission.remove': 'Asked for: a pin off the map',
+    'submission.approve': 'Submission approved',
+    'submission.reject': 'Submission rejected',
+    'submission.hold': 'Submission put on hold',
+    'candidate.dismiss': 'Candidate dismissed',
+    'candidate.restore': 'Candidate restored',
+    'nexus_status.dismiss': 'Nexus flag dealt with',
+    'nexus_status.restore': 'Nexus flag raised again',
+  };
+
+  /**
+   * The raw action stays IN the label, never replaced by it.
+   *
+   * Each entry shows its action as a `<code>`, and that chip is the only thing
+   * on the row saying the words this select offers. A select that spoke only
+   * English would be a second vocabulary with nothing connecting it to the
+   * first, and the log would go back to being unfilterable by anything the
+   * reader can see.
+   */
+  const actionLabel = (action) => (ACTION_LABEL[action] ? `${ACTION_LABEL[action]} (${action})` : action);
+
+  /**
    * Every id this entry is ABOUT, not just the one in its `target` column.
    *
    * One approval writes two rows and they do not share a target: the
@@ -2690,11 +2733,17 @@
    * the list below is showing nothing.
    */
   function fillAuditSelect(select, anyLabel, values, selected, label = (v) => v) {
-    const present = [...new Set(values)].sort();
+    const present = [...new Set(values)];
     if (selected && !present.includes(selected)) present.push(selected);
+    // Ordered by what is READ, not by the stored value. Sorting on the raw
+    // action interleaves the three requests with the three decisions, because
+    // they share the `submission.` prefix and nothing else.
+    const options = present
+      .map((v) => ({ value: v, text: label(v) }))
+      .sort((a, b) => a.text.localeCompare(b.text));
     replace(select,
       h('option', { value: '', text: anyLabel }),
-      present.map((v) => h('option', { value: v, text: label(v) })));
+      options.map((o) => h('option', { value: o.value, text: o.text })));
     select.value = selected;
   }
 
@@ -2704,7 +2753,7 @@
     const shown = filtering ? state.audit.filter((e) => auditMatches(e, filter)) : state.audit;
 
     fillAuditSelect($('#audit-actor'), 'Anyone', state.audit.map((e) => e.actor), filter.actor, actorLabel);
-    fillAuditSelect($('#audit-action'), 'Any action', state.audit.map((e) => e.action), filter.action);
+    fillAuditSelect($('#audit-action'), 'Any action', state.audit.map((e) => e.action), filter.action, actionLabel);
     $('#audit-clear').disabled = !filtering;
 
     replace($('#audit-list'), shown.length

--- a/admin/index.html
+++ b/admin/index.html
@@ -337,7 +337,27 @@
         </select>
         <button type="button" class="btn secondary" id="audit-refresh">Refresh</button>
       </div>
+      <!--
+        Filters over the entries already fetched, not new query params. The two
+        selects are filled from the rows that came back rather than from a list
+        written here, so an action added to the Worker later shows up on its own.
+      -->
+      <div class="toolbar">
+        <select id="audit-actor" aria-label="Filter by who did it">
+          <option value="">Anyone</option>
+        </select>
+        <select id="audit-action" aria-label="Filter by what was done">
+          <option value="">Any action</option>
+        </select>
+        <input type="search" id="audit-target" placeholder="Location, submission, mod or tag id…"
+               aria-label="Filter by what it was done to">
+        <span class="spacer" style="flex:1"></span>
+        <button type="button" class="btn secondary" id="audit-clear">Clear filters</button>
+      </div>
       <div id="audit-list"></div>
+      <!-- What the list is showing, and whether a filter is why. A filtered log
+           that looks unfiltered reads as "nothing happened". -->
+      <p class="muted" id="audit-summary"></p>
     </div>
   </section>
 </main>


### PR DESCRIPTION
Releases `dev` to `main`. One feature, dashboard only.

## What ships

The Audit tab filters by actor, action and target, combinable. The audit log is what replaced `git log` for data changes, and unfiltered it only answered "what happened recently".

- Two selects and a free-text target box, with a count under the list: `14 entries, most recent first.` unfiltered, `8 shown of 14 loaded.` when it is not. An empty result says "No entries match this filter", which is a different fact from "No entries yet".
- The selects are built from the rows that came back, so an action a later Worker change adds appears on its own. Action labels read as English with the stored value beside them, because each entry shows its raw action as a `<code>` chip and that chip is the only thing on the row saying the words the select offers.
- Target matches a bounded set of id fields across `before`/`after` as well as the `target` column. An approval writes two rows that do not share a target: the `location.update` names the location UUID, the `submission.approve` names the submission number and carries the UUID in `after.location_id`. Matching the column alone returned half of what happened to a location while looking complete.

No new API surface and no new query params: production has 14 audit rows, so the whole log is one fetch. Server-side filtering stays deferred until it outgrows one.

## Commits

- `f65bbf0` feat(audit): filter the log by who, what and which record (#937)
- `383fe79` feat(audit): the action filter reads as English, with the stored value beside it
- `512b815` docs(changelog): cut 2.8.0

## Deploy

**No Worker change, so no `wrangler deploy`.** API stays at 0.5.1: no `/v1` route or payload shape moved and there was no migration. `admin/` reaches production through Cloudflare Pages wired to `main`, so merging this is the deploy.

## Verification

`admin/` has no automated tests, so this was driven in a browser twice: locally against a stubbed `fetch` with 20 rows covering every action prefix, an `anonymous` actor and two approval pairs, and then on `dev.nczoning.net` against the real 14 rows.

Checked: partial and mixed-case UUID both match; filters combine; an impossible combination reports `0 shown of N loaded.` rather than a blank panel; a selection that no longer occurs in a narrower window stays selected instead of silently resetting; an action the page has not been taught still appears, as itself.

Site tests: 81 pass. Worker untouched.

Closes #902.