### PR TITLE
feat(admin): see a location mod's install files, and why the list is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- The dashboard shows a location's install files: the `.archive` and `.xl` names a player's mod folder is matched against.
+- It says which of three things an empty list means, where the API can only say "unknown": never read, read against an older upload, or genuinely none.
+
 ## [2.8.0] - 2026-08-03
 
 ### Added

--- a/admin/admin.css
+++ b/admin/admin.css
@@ -602,6 +602,22 @@ button.breakdown-row:hover .k { color: var(--secondary); }
 }
 .detail dd.empty { color: var(--text-dim); font-style: italic; }
 
+/* The mod's .archive / .xl names. A list rather than a comma-joined line
+   because a filename can contain both spaces and commas, so joined text is
+   genuinely ambiguous about where one file ends and the next begins, and these
+   are matched character for character against a folder listing. */
+.archive-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: var(--space-2xs);
+}
+
+.archive-list .mono { font-family: ui-monospace, monospace; font-size: var(--fs-code); }
+
+.archive-note { margin: var(--space-2xs) 0 0; font-size: var(--fs-label); }
+
 /* A count with a proportional bar. The bar is decoration on top of the number,
    never a replacement for it: a reader must be able to get the exact value. */
 .breakdown { display: grid; gap: var(--space-2xs); }

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -875,6 +875,42 @@
    * opened a live form would make every browse a potential edit: one stray
    * keystroke in a focused field marks a record dirty that was only being read.
    */
+  /**
+   * The mod's install-file fingerprint: the `.archive` / `.xl` names a consumer
+   * matches against the player's `archive/pc/mod/` to decide whether the mod is
+   * installed. Cron-owned and read-only here.
+   *
+   * Worth a row of its own because `/v1` collapses two different situations
+   * into the same empty array on purpose: an unread listing and a mod that
+   * ships no archive at all both serve `[]`, and a consumer is told to treat
+   * both as unknown. This is the one screen that separates them, which is what
+   * makes "why is this pin's file list empty?" answerable.
+   */
+  function archivesCell(loc) {
+    // WIP and Dummy are valid nexus_ids with no mod page behind them, so there
+    // is nothing to read and never will be. Saying "not read yet" there would
+    // promise a fetch that is never going to happen.
+    if (!isRealNexusId(loc.nexus_id)) {
+      return h('span', { class: 'muted', text: 'no Nexus page to read files from' });
+    }
+    const names = loc.archives || [];
+    const state = loc.archives_state || 'unknown';
+    if (state === 'unknown') {
+      return h('span', { class: 'muted', text: 'not read yet; a cron tick will fetch it' });
+    }
+    if (!names.length) {
+      return h('span', { class: 'muted', text: 'none: this mod ships no .archive or .xl' });
+    }
+    return h('div', {},
+      h('ul', { class: 'archive-list' }, names.map((n) => h('li', { class: 'mono', text: n }))),
+      state === 'stale'
+        ? h('p', {
+          class: 'muted archive-note',
+          text: 'Read against an earlier upload. The mod has re-uploaded since, so a refetch is pending.',
+        })
+        : null);
+  }
+
   function renderLocationDetail(loc) {
     const row = (label, value, cls) => [
       h('dt', { text: label }),
@@ -906,6 +942,7 @@
         row('Added', timeEl(loc.added_at)),
         row('Modified', timeEl(loc.modified_at)),
         row('Updated on Nexus', loc.nexus_updated_at ? timeEl(loc.nexus_updated_at) : null),
+        row('Install files', archivesCell(loc)),
       )),
       h('div', { class: 'editor-actions' },
         h('button', {

--- a/worker/README.md
+++ b/worker/README.md
@@ -343,6 +343,16 @@ exercise auth. Test on `dev.nczoning.net`. These are deliberately absent from
 | `/admin/locations` | GET | every location, all statuses, including `admin_notes` |
 | `/admin/locations` | POST | 201; `id` is server-generated and refused from input |
 | `/admin/locations/{id}` | GET / PATCH / DELETE | PATCH is partial; DELETE keeps the full record in the audit row |
+
+Both read routes above add `archives` and `archives_state` from `nexus_cache`.
+`archives_state` is the three-way answer `/v1` cannot give, because there the
+empty array covers both ends: `unknown` (the listing has never been read),
+`stale` (read against an earlier upload, refetch pending) and `known` (read
+against the current upload, so an empty list means the mod ships no
+`.archive`/`.xl`). The predicate mirrors `refreshArchives`' own due-rule, so
+"pending" names exactly the mods the next cron tick will fetch. The write
+routes deliberately omit both fields: their bodies are the audit record, and
+archives are cron-owned data no editor can change.
 | `/admin/tags` | GET | the registry, each row with `usage_count` |
 | `/admin/tags` | POST | 201; 409 `tag_exists` on a duplicate slug |
 | `/admin/tags/{slug}` | GET / PATCH / DELETE | see the two rules below |

--- a/worker/src/admin.js
+++ b/worker/src/admin.js
@@ -22,7 +22,7 @@ import {
 import { introspectDatasets, introspectType, readQuota } from './quota.js';
 import {
   getRow, rowToAdmin, loadAdminRecord, materializeAfterWrite, insertLocation, patchLocation,
-  readNexusUpdatedMap,
+  readNexusModMap, archivesView,
 } from './registry.js';
 import { handleReview } from './review.js';
 
@@ -242,11 +242,20 @@ export async function handleAdmin(request, env, ctx) {
     const { results } = await env.DB.prepare('SELECT * FROM locations ORDER BY name').all();
     const rows = results ?? [];
     const tagMap = await readTagsForLocations(env, rows.map((r) => r.id));
-    const nexusMap = await readNexusUpdatedMap(env);
+    const nexusMap = await readNexusModMap(env);
+    // Archives ride the list rather than a per-record fetch because the detail
+    // pane reads the record straight out of the loaded list -- see
+    // selectLocation in admin/admin.js. Attached here rather than inside
+    // rowToAdmin so the audit log keeps carrying only editable fields.
     return json(request, {
-      locations: rows.map((r) => rowToAdmin(
-        r, tagMap.get(r.id) ?? [], nexusMap.get(String(r.nexus_id)) ?? null,
-      )),
+      locations: rows.map((r) => {
+        const nexus = nexusMap.get(String(r.nexus_id)) ?? null;
+        return {
+          ...rowToAdmin(r, tagMap.get(r.id) ?? [], nexus?.updated_at ?? null),
+          archives: nexus?.archives ?? [],
+          archives_state: nexus?.archives_state ?? 'unknown',
+        };
+      }),
     });
   }
 
@@ -270,7 +279,16 @@ export async function handleAdmin(request, env, ctx) {
   if (oneMatch && method === 'GET') {
     const row = await getRow(env, decodeURIComponent(oneMatch[1]));
     if (!row) return json(request, { error: 'not_found' }, 404);
-    return json(request, { location: await loadAdminRecord(env, row) });
+    // Same two fields the list carries, so a single-record read is not a
+    // narrower view than the list it came from. The write routes deliberately
+    // do NOT: their bodies are the audit record.
+    const nexus = await env.DB.prepare(
+      'SELECT updated_at, archives, archives_at FROM nexus_cache WHERE nexus_id = ?',
+    ).bind(String(row.nexus_id)).first();
+    const { archives, archives_state } = archivesView(nexus);
+    return json(request, {
+      location: { ...await loadAdminRecord(env, row), archives, archives_state },
+    });
   }
 
   // ---- update ------------------------------------------------------------

--- a/worker/src/registry.js
+++ b/worker/src/registry.js
@@ -61,17 +61,66 @@ export function rowToAdmin(row, tags = [], nexusUpdatedAt = null) {
 }
 
 /**
- * `nexus_id` -> the mod's Nexus update time, for every cached mod.
+ * A `nexus_cache` row -> the Nexus-derived view the dashboard shows.
+ *
+ * `archives_state` is the three-way answer the served `archives: []` cannot
+ * give, because /v1 collapses "unknown" and "ships none" into the same empty
+ * array on purpose (docs/api-reference.md). Here they are worth separating:
+ *
+ * - `unknown`  the listing has never been read. `archives` column is NULL.
+ * - `stale`    read, but against an older upload -- the mod has re-uploaded
+ *              since and the refetch has not come round yet.
+ * - `known`    read against the current upload. An empty list here is a real
+ *              answer: a loose-file mod ships no `.archive`/`.xl` at all.
+ *
+ * The predicate mirrors refreshArchives' own due-rule (nexus-cache.js) exactly,
+ * `archives != null && archives_at === updated_at`, so the panel says "pending"
+ * for precisely the mods the next cron tick will go and fetch. Do not switch
+ * the freshness test to `archives_at != null`: a mod whose Nexus `updated_at`
+ * is itself null stores a null `archives_at` on a perfectly good fetch.
+ */
+export function archivesView(row) {
+  if (!row) return { archives: [], archives_state: 'unknown', archives_at: null };
+  let names = [];
+  try {
+    const parsed = JSON.parse(row.archives ?? '[]');
+    if (Array.isArray(parsed)) names = parsed.filter((n) => typeof n === 'string');
+  } catch {
+    // A malformed cell reads as unknown rather than as an error: one mod's file
+    // list is not worth failing an admin page load over, and the cron rewrites
+    // it on the next re-upload anyway.
+    return { archives: [], archives_state: 'unknown', archives_at: null };
+  }
+  const at = row.archives_at ?? null;
+  const known = row.archives != null;
+  return {
+    archives: names,
+    archives_state: !known ? 'unknown' : at === (row.updated_at ?? null) ? 'known' : 'stale',
+    archives_at: at,
+  };
+}
+
+/**
+ * `nexus_id` -> `{ updated_at, ...archivesView }`, for every cached mod.
  *
  * One query for the whole list rather than a lookup per record: the admin list
  * route already reads tags in bulk for the same reason.
+ *
+ * Deliberately NOT folded into rowToAdmin. That function's output is what the
+ * audit log stores as a write's `before` and `after`, and archives are
+ * cron-owned data no editor can change; a file list in an edit diff is noise at
+ * best, and a phantom change nobody made if a sweep lands between the two
+ * reads. `nexus_updated_at` is in there for historical reasons and is not a
+ * precedent to extend.
  */
-export async function readNexusUpdatedMap(env) {
+export async function readNexusModMap(env) {
   const { results } = await env.DB.prepare(
-    'SELECT nexus_id, updated_at FROM nexus_cache',
+    'SELECT nexus_id, updated_at, archives, archives_at FROM nexus_cache',
   ).all();
   const map = new Map();
-  for (const r of results ?? []) map.set(String(r.nexus_id), r.updated_at ?? null);
+  for (const r of results ?? []) {
+    map.set(String(r.nexus_id), { updated_at: r.updated_at ?? null, ...archivesView(r) });
+  }
   return map;
 }
 

--- a/worker/test/admin.test.js
+++ b/worker/test/admin.test.js
@@ -90,14 +90,14 @@ const FRESH_USER = (collab = 1) => ({
 
 function envFor({
   collab = 1, locations = [ROW],
-  locationTags = [['loc-1', 'apartment']], checkedAt, nexusModStatus,
+  locationTags = [['loc-1', 'apartment']], checkedAt, nexusModStatus, nexusCache,
 } = {}) {
   const user = FRESH_USER(collab);
   if (checkedAt) user.checked_at = checkedAt;
   return {
     SESSION_SECRET: SECRET,
     DATASET: fakeKv(),
-    DB: sqliteD1({ locations, locationTags, users: [user], nexusModStatus }),
+    DB: sqliteD1({ locations, locationTags, users: [user], nexusModStatus, nexusCache }),
   };
 }
 
@@ -269,6 +269,115 @@ test('the single-record route still uses a targeted lookup', async () => {
   const res = await hit(env, 'GET', '/admin/locations/loc-1');
   assert.equal(res.status, 200);
   assert.deepEqual((await res.json()).location.tags, ['apartment']);
+});
+
+// ------------------------------------------------------ archives on a read ---
+
+/** A `nexus_cache` row for the fixture's mod. `fetched_at` is NOT NULL. */
+const cacheRow = (over = {}) => ({
+  nexus_id: '12345', updated_at: '2026-01-02T00:00:00Z',
+  archives: null, archives_at: null, fetched_at: '2026-01-02T00:00:00Z', ...over,
+});
+
+const firstLocation = async (env) => (await (await hit(env, 'GET', '/admin/locations')).json()).locations[0];
+
+test('the list carries the mod archives, marked as read against the current upload', async () => {
+  const env = envFor({
+    nexusCache: [cacheRow({
+      archives: JSON.stringify(['Loft.archive', 'Loft.xl']),
+      archives_at: '2026-01-02T00:00:00Z',
+    })],
+  });
+  const loc = await firstLocation(env);
+  assert.deepEqual(loc.archives, ['Loft.archive', 'Loft.xl']);
+  assert.equal(loc.archives_state, 'known');
+});
+
+test('a listing read against an older upload is stale, not current', async () => {
+  // The mod re-uploaded (updated_at moved) and the refetch has not run. The
+  // names on file are the previous upload's, so presenting them as the current
+  // fingerprint would send a consumer looking for files that may be gone.
+  const env = envFor({
+    nexusCache: [cacheRow({
+      updated_at: '2026-03-01T00:00:00Z',
+      archives: JSON.stringify(['Loft.archive']),
+      archives_at: '2026-01-02T00:00:00Z',
+    })],
+  });
+  const loc = await firstLocation(env);
+  assert.deepEqual(loc.archives, ['Loft.archive']);
+  assert.equal(loc.archives_state, 'stale');
+});
+
+test('an empty listing read against the current upload is a real answer, not unknown', async () => {
+  // The distinction /v1 cannot make: out there both serve `archives: []` and
+  // the consumer is told to read that as unknown. A loose-file mod genuinely
+  // ships nothing, and this screen has to be able to say so.
+  const env = envFor({
+    nexusCache: [cacheRow({ archives: '[]', archives_at: '2026-01-02T00:00:00Z' })],
+  });
+  const loc = await firstLocation(env);
+  assert.deepEqual(loc.archives, []);
+  assert.equal(loc.archives_state, 'known');
+});
+
+test('a never-read listing is unknown, whether the cache row is empty or absent', async () => {
+  for (const nexusCache of [[cacheRow()], []]) {
+    const loc = await firstLocation(envFor({ nexusCache }));
+    assert.deepEqual(loc.archives, []);
+    assert.equal(loc.archives_state, 'unknown');
+  }
+});
+
+test('a null Nexus updated_at still reads as known once the listing is fetched', async () => {
+  // refreshArchives stores `archives_at = updated_at`, so a mod Nexus reports
+  // no update time for stores null on a perfectly good fetch. Testing freshness
+  // as `archives_at != null` would call that one permanently stale and refetch
+  // it every tick.
+  const env = envFor({
+    nexusCache: [cacheRow({ updated_at: null, archives: JSON.stringify(['Loft.archive']) })],
+  });
+  assert.equal((await firstLocation(env)).archives_state, 'known');
+});
+
+test('a malformed archives cell reads as unknown rather than failing the page', async () => {
+  const env = envFor({
+    nexusCache: [cacheRow({ archives: 'not json', archives_at: '2026-01-02T00:00:00Z' })],
+  });
+  const res = await hit(env, 'GET', '/admin/locations');
+  assert.equal(res.status, 200);
+  const loc = (await res.json()).locations[0];
+  assert.deepEqual(loc.archives, []);
+  assert.equal(loc.archives_state, 'unknown');
+});
+
+test('the single-record read carries archives too, so it is not a narrower view than the list', async () => {
+  const env = envFor({
+    nexusCache: [cacheRow({
+      archives: JSON.stringify(['Loft.archive']), archives_at: '2026-01-02T00:00:00Z',
+    })],
+  });
+  const { location } = await (await hit(env, 'GET', '/admin/locations/loc-1')).json();
+  assert.deepEqual(location.archives, ['Loft.archive']);
+  assert.equal(location.archives_state, 'known');
+});
+
+test('archives stay OUT of the audit record, being cron-owned rather than edited', async () => {
+  // The audit row is the record of who changed what. A file list nobody on this
+  // screen can change does not belong in it, and a sweep landing between the
+  // `before` and `after` reads would write a diff for a change nobody made.
+  const env = envFor({
+    nexusCache: [cacheRow({
+      archives: JSON.stringify(['Loft.archive']), archives_at: '2026-01-02T00:00:00Z',
+    })],
+  });
+  assert.equal((await hit(env, 'PATCH', '/admin/locations/loc-1', { name: 'Renamed' })).status, 200);
+  const [entry] = auditRows(env);
+  for (const side of ['before', 'after']) {
+    const rec = JSON.parse(entry[side]);
+    assert.ok(!('archives' in rec), `${side} must not carry archives`);
+    assert.ok(!('archives_state' in rec), `${side} must not carry archives_state`);
+  }
 });
 
 // ------------------------------------------------- tags on the write path ---


### PR DESCRIPTION
## What

The location detail pane gains an **Install files** row: the `.archive` / `.xl`
names a consumer matches against a player's `archive/pc/mod/` folder.

## Why this was a blind spot

Archives are fetched, cached and served. `nexus.js` reads them, `nexus_cache`
stores them, `/v1/locations` ships them. But the admin dashboard reads the
`locations` table, archives live in `nexus_cache`, and the only admin route
that joined that table is `/admin/nexus-status`, which selects publish status.

The split is a materialization artefact: `nexus_cache` is cron-owned derived
data, `locations` is human-owned truth, and admin was built as an editor for
the second.

## The three-way state

`/v1` collapses two situations into the same empty array on purpose, and tells
consumers to read `[]` as "unknown". That is correct out there and unhelpful
here, so `archives_state` separates them:

| state | means | column condition |
| --- | --- | --- |
| `unknown` | never read | `archives IS NULL` |
| `stale` | read against an earlier upload; refetch pending | `archives_at != updated_at` |
| `known` | read against the current upload | `archives_at == updated_at` |

`known` with an empty list is a real answer: a loose-file mod ships no
`.archive` at all.

The predicate mirrors `refreshArchives`' own due-rule in `nexus-cache.js`
(`archivesKnown && archivesAt === updatedAt`), so the panel says "pending" for
precisely the mods the next cron tick will go and fetch.

**Not** `archives_at != null`: a mod whose Nexus `updated_at` is itself null
stores a null `archives_at` on a perfectly good fetch, and testing that way
would call it permanently stale. Covered by a test.

## Where it is attached

At the route boundary in `admin.js`, not inside `rowToAdmin`. `rowToAdmin`'s
output is what the audit log stores as a write's `before` and `after`, and
archives are cron-owned data no editor can change: a file list in an edit diff
is noise, and a phantom change nobody made if a sweep lands between the two
reads. A test asserts both sides stay clean.

Both read routes carry it (list and single-record) so a `curl` of one record is
not a narrower view than the list it came from. The write routes do not.

`WIP`/`Dummy` ids render "no Nexus page to read files from" rather than "not
read yet", which would promise a fetch that never happens.

## Tests

8 new in `worker/test/admin.test.js`, all against the real SQLite migrations.
Full suite: 403 passing.

## Not verified in a live browser

The server side is fully covered. The rendered cell is not: admin auth needs a
real GitHub collaborator session, and `*.pages.dev` previews are not on the
allowed-origin list, so this wants a look on `dev.nczoning.net` after merge.

## Follow-up, not in this PR

The locations search haystack (`admin.js`) does not include archive names.
"Which pin owns `Atari AIO.archive`?" would be a near-free addition on top of
this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
