### PR TITLE
feat(api)!: drop the recently_updated bool; consumers own the clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- The API no longer serves a per-record `recently_updated` bool (API surface `0.6.0`). `updated_at` and the envelope's `recently_updated_days` stay; every consumer now has a clock and computes recency itself.
+- Installs still on an older NCZoningCore lose the in-game recency badge until they update. No error, no crash.
+
 ## [2.9.1] - 2026-08-06
 
 ### Fixed

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2409,11 +2409,11 @@ async function initMap() {
     // site and the Worker can deploy in either order during the migration.
     const tagsDict = NCZ.normaliseTags(tagsPayload);
     const { mods, nexusThumbs } = apiResult;
-    // The API owns the recency window (it computes each mod's recently_updated
-    // bool against it). Adopt it so the tooltip text matches; fall back to the
-    // local constant if an older API omits it.
+    // The API owns the recency window; NCZ.isRecentlyUpdated applies it here.
+    // Adopt it so the badge and its tooltip agree, falling back to the local
+    // constant when the envelope omits it.
     NCZ.recentlyUpdatedDays = apiResult.recentlyUpdatedDays ?? NCZ.RECENTLY_UPDATED_DAYS;
-    console.log(`Data source: /v1 API — ${mods.length} mods`);
+    console.log(`Data source: /v1 API: ${mods.length} mods`);
 
     modCountEl.textContent = `(${mods.length})`;
 

--- a/assets/js/constants.js
+++ b/assets/js/constants.js
@@ -80,7 +80,7 @@ NCZ.CATEGORY_STYLES = {
 // The Nexus auto-discovery merge that once ran client-side now lives entirely in
 // the API (worker/); the browser makes no Nexus calls.
 //
-// EVERY origin reads PRODUCTION by default — dev.nczoning.net, *.pages.dev
+// EVERY origin reads PRODUCTION by default: dev.nczoning.net, *.pages.dev
 // previews and localhost included. The old hostname split sent them to the
 // staging API on the premise that it "reflects staging data", but there has
 // never been a deliberate dev dataset: dev differs from main only when merged
@@ -123,7 +123,7 @@ NCZ.DATASET_POLL_MS = 60 * 1000;
 
 // The tag registry now comes from /v1/tags alongside the locations: one origin,
 // one contract, rather than a same-origin fetch of data/tags.json, which was
-// fine while the file was the source of truth — from Phase 4 the D1 `tags`
+// fine while the file was the source of truth; from Phase 4 the D1 `tags`
 // table is, edited in the dashboard rather than by pull request.
 //
 // Kept only as the fallback if /v1/tags cannot be reached, so a tag-registry
@@ -212,10 +212,10 @@ NCZ.CET_UNITS_PER_METER = 1;
 // LocalStorage cache keys & TTLs
 NCZ.THEME_PREFERENCE_KEY = "nc_theme_id";
 NCZ.SHOWCASE_OPTIONS_KEY = "nc_showcase_options";
-// Default recency window (days). The API owns this rule: it computes each mod's
-// `recently_updated` bool and publishes the window as `recently_updated_days` on
-// the response envelope, which the app adopts into NCZ.recentlyUpdatedDays. This
-// constant is only the safety default for an older API deploy that omits the field.
+// Default recency window (days). The API owns the rule and publishes it as
+// `recently_updated_days` on the response envelope, which the app adopts into
+// NCZ.recentlyUpdatedDays; the site applies it itself in NCZ.isRecentlyUpdated.
+// This constant is only the safety default for when the envelope omits it.
 NCZ.RECENTLY_UPDATED_DAYS = 7;
 NCZ.UPDATED_LABEL = "RECENTLY UPDATED";
 

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -188,12 +188,11 @@ NCZ.pickDirectionAndPosition = function (anchorPoint, size, mapSize, config) {
 };
 
 // Returns true when a mod was updated on Nexus within the recent window.
-// The API computes this server-side (so the clockless in-game consumer can read
-// it too) and ships it as `recently_updated` on every record; trust that when
-// present. The timestamp fallback below only runs for an older API deploy that
-// omits the bool, computing it from the raw `_updatedAt` and effective window.
+// Computed here, from the raw `_updatedAt` and the window the API publishes on
+// its envelope (`NCZ.recentlyUpdatedDays`). The API serves no recency bool: it
+// would be the only time-dependent field in the payload, which forces the cron
+// to rewrite KV on every tick.
 NCZ.isRecentlyUpdated = function (mod) {
-  if (typeof mod.recently_updated === "boolean") return mod.recently_updated;
   if (!mod._updatedAt) return false;
   const days = NCZ.recentlyUpdatedDays ?? NCZ.RECENTLY_UPDATED_DAYS;
   return new Date(mod._updatedAt).getTime() > Date.now() - days * 86400000;
@@ -254,7 +253,7 @@ NCZ.pointInPolygon = function (point, ring) {
  *
  * TRANSITIONAL: accepts BOTH the array-of-records shape (D1-backed, current)
  * and the legacy { slug: description } dictionary. Not defensive coding for its
- * own sake — the site and the Worker deploy independently, and the dev site
+ * own sake: the site and the Worker deploy independently, and the dev site
  * reads the PRODUCTION API by default, so during the migration a new site can
  * legitimately be talking to an API still serving the pre-0.4.0 shape. Tolerating
  * both means the two can ship in either order with no flag day.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -32,11 +32,15 @@ Every response is wrapped:
 `dataset_version` is a content hash of the whole dataset. It's also the
 `ETag`, so it's how you detect changes (see [Caching](#caching)).
 
-`recently_updated_days` is the recency window in days: a location's
-`recently_updated` bool is `true` when its Nexus update falls within this many
-days. It's published so consumers (and UI text) read the rule instead of
-hardcoding it, though a clockless in-game consumer doesn't need it: it just
-reads each record's `recently_updated` bool directly.
+`recently_updated_days` is the recency window in days: a location counts as
+recently updated when its `updated_at` falls within this many days of now. The
+API publishes the rule and does not apply it. **There is no per-record
+`recently_updated` bool** (removed in 0.6.0): compute it yourself as
+`updated_at > now - recently_updated_days * 86400`.
+
+The window is a constant, so it costs the ETag nothing. A per-record bool would
+be the only field in the payload that depends on what time it is, which forces a
+KV rewrite on every cron tick.
 
 ## Contract rules (why the JSON looks the way it does)
 
@@ -55,9 +59,9 @@ parser:
   `nexus-<nexus_id>`. Safe to bookmark.
 - **`district` is never null**: anywhere outside every district polygon is
   Badlands (the game's own default). `subdistrict` may be null.
-- **Additive versioning:** new fields may appear within `/v1/`; breaking
-  changes would ship as `/v2/`. Which additive changes have landed is readable
-  from `/v1/health`'s `version`. See [Versioning](#versioning).
+- **Versioning:** while the surface is on `0.x`, **both** additive and breaking
+  changes stay on `/v1/` and are readable only from `/v1/health`'s `version`.
+  Pin to a shape you have read, not to the path. See [Versioning](#versioning).
 
 ## Routes
 
@@ -90,22 +94,28 @@ A location record:
   "authors": ["ellios2normandie"],
   "district": "City Center",
   "subdistrict": "Corpo Plaza",
-  "recently_updated": true,
   "description": "…",
   "credits": "Optional team name",
   "thumbnail_url": "https://…",
   "picture_url": "https://…",
-  "updated_at": "2026-07-02T12:00:00.000Z",
+  "updated_at": "2026-07-02T12:00:00Z",
   "archives": ["Atari AIO.archive"]
 }
 ```
 
-- `recently_updated` is server-computed: `true` when `updated_at` is within
-  `recently_updated_days` (on the envelope). It's the answer a clockless in-game
-  consumer can't compute for itself, so the server provides it.
+- **`updated_at` is served as exactly `YYYY-MM-DDTHH:MM:SSZ`**: 20 characters,
+  UTC, no offset, no fractional seconds. This is a hard contract, not a
+  formatting preference. NCZoningCore's redscript parser is length-locked to that
+  shape and returns `0.0` for anything else rather than guessing at a wrong
+  instant, so an offset or a millisecond field would make every record read as
+  not-recently-updated with no error and no log line anywhere. If the format ever
+  has to change, the mod ships first.
+- **Recency is yours to compute**, from `updated_at` and the envelope's
+  `recently_updated_days`. The server no longer ships a `recently_updated` bool
+  (see [Versioning](#versioning), 0.6.0).
 - `credits` appears only when set; `thumbnail_url` / `picture_url` / `updated_at`
-  are `null` when unknown (e.g. WIP/Dummy entries with no Nexus page, which are
-  also never `recently_updated`).
+  are `null` when unknown (e.g. WIP/Dummy entries with no Nexus page, which
+  therefore can never read as recently updated).
 - `archives` is the list of the mod's install files as shipped: `.archive` load
   files and `.xl` (ArchiveXL) manifests, both of which live in `archive/pc/mod/`.
   **Match these against the player's `archive/pc/mod/` folder to detect which
@@ -163,7 +173,7 @@ From `1.0.0` onward:
 So a consumer can read `/v1/health` once and know whether the field it wants
 exists yet, without probing for it.
 
-Every shape change the surface has taken, in order. The last two are breaking,
+Every shape change the surface has taken, in order. Three of them are breaking,
 which on a 1.x line would each have cost a MAJOR plus a path move:
 
 | Shape change | Under the 1.x numbering | Now |
@@ -174,10 +184,11 @@ which on a 1.x line would each have cost a MAJOR plus a path move:
 | `last_refresh_at`, `refresh_age_seconds` on `/v1/health` | 1.3.0 | 0.3.0 |
 | **breaking:** `/v1/tags` becomes an array of records | would be 2.0.0 | 0.4.0 |
 | **breaking:** `source` and the synthetic `nczoning` tag leave every location record | would be 3.0.0 | 0.5.0 |
-| `/v1/meta.skipped` lists every open candidate | 3.0.1 | **0.5.1** *(current)* |
+| `/v1/meta.skipped` lists every open candidate | 3.0.1 | 0.5.1 |
+| **breaking:** `recently_updated` leaves every location record | would be 4.0.0 | **0.6.0** *(current)* |
 
 The rollback was mechanical: the MINOR digit was preserved and the MAJOR dropped,
-so the three additive changes already made survived as `0.3.0`. The two breaking
+so the three additive changes already made survived as `0.3.0`. The breaking
 changes since then each cost a MINOR, which is the whole point of taking them
 before `1.0.0`.
 
@@ -188,7 +199,7 @@ policy backfilled it to `1.3.0`, which shipped in 1.7.0, and it was rolled back 
 `0.3.0` in 1.7.2. The middle column above is a reconstruction (what each
 deploy *should* have served); the right-hand column is what the API serves today.
 
-⚠️ **`0.5.1` is numerically lower than the `1.3.0` some earlier deploys served.**
+⚠️ **`0.6.0` is numerically lower than the `1.3.0` some earlier deploys served.**
 Nothing compares this field numerically (verified before the rollback), but a
 consumer that starts doing so must not read the decrease as a downgrade.
 
@@ -247,7 +258,8 @@ public class NCZLocation {
   let category: String;
   let district: String;
   let subdistrict: String;
-  let recently_updated: Bool;      // server-computed; no client clock needed
+  let updated_at: String;          // 20-char UTC; parse it, then compare against
+                                   // the envelope's recently_updated_days
 }
 
 public class NCZExample extends ScriptableSystem {
@@ -305,7 +317,8 @@ re-downloading unchanged data.
   preview for 24 hours after the mod's `updated_at` rather than recording the
   empty result, so a mod caught mid-publication does not freeze as `[]` until
   its next release.
-- `recently_updated` rides the content hash: because it depends on the clock,
-  a location crossing the `recently_updated_days` boundary changes
-  `dataset_version` (and the `ETag`) even when nothing on Nexus changed, so a
-  conditional GET correctly sees the flip rather than a stale `304`.
+- **Every served field is a pure function of the stored data.** Nothing in the
+  payload depends on what time it is, so `dataset_version` (and the `ETag`) moves
+  only when the data moves, and an idle cron tick rewrites nothing. This is why
+  recency is the consumer's job: a per-record bool would flip on the clock alone,
+  forcing a rewrite every tick to keep conditional GETs honest.

--- a/docs/nczoning-auto-discovery.md
+++ b/docs/nczoning-auto-discovery.md
@@ -42,7 +42,7 @@ Independent of the tag, for every mod that has a pin:
 | Nexus field | Used as |
 | --- | --- |
 | `thumbnailUrl` | The image on the pin popup and sidebar entry |
-| `updatedAt` | The `UPDATED` badge, within the API's `recently_updated_days` window |
+| `updatedAt` | Served as `updated_at`; the `UPDATED` badge when it falls within the API's `recently_updated_days` window |
 
 Your mod's **description is no longer read at all**. Nothing is parsed out of it.
 

--- a/docs/nexus-api-reference.md
+++ b/docs/nexus-api-reference.md
@@ -163,7 +163,7 @@ The Nexus API does not document pagination for the `mods` query, but it supports
 1. A tagged mod that already has a location contributes nothing further here: its images and `updatedAt` reach the record through `nexus_cache` like every other record's
 2. A tagged mod that is neither a location nor dismissed is a **candidate**, offered in the submit form's picker and the dashboard
 3. `name`, `summary` (truncated to 500 characters) and `uploader.name` prefill the submit form when a candidate is selected. All three stay editable
-4. `updatedAt` drives the server-computed `recently_updated` bool, which shows an `UPDATED` badge in the popup, sidebar and cluster flyout
+4. `updatedAt` is served as each record's `updated_at`, from which every consumer computes recency itself: the site shows an `UPDATED` badge in the popup, sidebar and cluster flyout
 
 > **Retired at 2.0.0.** `node.description` used to be parsed for an `[NCZoning]`
 > metadata block, and a valid block published a pin with no human step. The

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -40,7 +40,7 @@ if submitted on a location.
 | Tag | Applied by | Description |
 | --- | --- | --- |
 | `nczoning` | Auto-discovery (server-side, `worker/src/nexus.js`) | Applied to every mod sourced automatically from Nexus Mods. Appears as a filter tag and as a badge on the popup and sidebar entry. |
-| `updated` | `app.js` filter setup | A virtual filter that surfaces any recently updated mod, matched via `isRecentlyUpdated()`, which reads the API's server-computed `recently_updated` bool (or, for an older API deploy that omits the bool, computes from `updatedAt` vs the recency window). Not a stored tag. |
+| `updated` | `app.js` filter setup | A virtual filter that surfaces any recently updated mod, matched via `isRecentlyUpdated()`, which computes recency here from the record's `updated_at` and the window the API publishes as `recently_updated_days`. Not a stored tag. |
 
 ---
 

--- a/docs/three-js-scene.md
+++ b/docs/three-js-scene.md
@@ -455,7 +455,7 @@ All in `utils.js`. Both views call these: nothing view-specific lives here.
 
 | Function | Description |
 |----------|-------------|
-| `NCZ.isRecentlyUpdated(mod)` | True if mod was recently updated on Nexus. Reads the API's server-computed `recently_updated` bool; on the API-down fallback path, computes from `_updatedAt` vs the effective window (`NCZ.recentlyUpdatedDays`, default `NCZ.RECENTLY_UPDATED_DAYS`) |
+| `NCZ.isRecentlyUpdated(mod)` | True if mod was recently updated on Nexus. Computed here from `_updatedAt` vs the effective window (`NCZ.recentlyUpdatedDays`, default `NCZ.RECENTLY_UPDATED_DAYS`); the API serves no recency bool |
 | `NCZ.cetToThree(cetX, cetY, cetZ)` | CET → Three.js `[x, y, z]` |
 | `NCZ.buildPopupHtml(mod, catStyle, nexusThumbs, tagsDict)` | Full popup HTML string, used by both views |
 | `NCZ.prepareModRenderData(mod, nexusThumbs, tagsDict)` | Returns `{ catStyle, popupHtml, thumbSrc, fullSrc, nexusUrl, nexusLabel }` |

--- a/worker/README.md
+++ b/worker/README.md
@@ -172,9 +172,9 @@ node scripts/parity-check.mjs                                   # the gate
 ```
 
 `parity-check.mjs` rebuilds `/v1/locations` from D1 via `src/materialize.js` and
-diffs it **byte-for-byte** against what the live API is serving. All 18 served
-fields are rebuilt: 11 from `locations`, 4 from `nexus_cache`, and
-`district`/`subdistrict`/`recently_updated` recomputed from D1's own data. It
+diffs it **byte-for-byte** against what the live API is serving. All 16 served
+fields are rebuilt: 10 from `locations`, 4 from `nexus_cache`, and
+`district`/`subdistrict` recomputed from D1's own coordinates. It
 **fails on any served field it neither rebuilds nor feeds in**, so a new `/v1`
 field cannot slip past as "not compared".
 

--- a/worker/api-version.lock.json
+++ b/worker/api-version.lock.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.5.1",
-  "shape_hash": "sha256:86e819ec351ce40a4978ef1964f779db8355cb66eadeeb52aa2fa0d6580e8614"
+  "version": "0.6.0",
+  "shape_hash": "sha256:977773b38442a487218c53aa5d99810c58e9dc3056d60bad07656ce0eec0dc3e"
 }

--- a/worker/openapi.json
+++ b/worker/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "NC Zoning Data API",
-    "version": "0.5.1",
+    "version": "0.6.0",
     "description": "Read-only API serving the NC Zoning Board mod registry (Cyberpunk 2077 location mods) to in-game mods and the website. Every response is wrapped in a versioned envelope. Coordinates are raw CET world values [X, Y, Z], usable in-game with no transform. The JSON stays DTO-mappable for the in-game RedData parser: no arrays-of-arrays, property names are case-sensitive. See https://github.com/nczoning/nc-zoning-board for the project.",
     "contact": { "name": "NC Zoning Board", "url": "https://nczoning.net" }
   },
@@ -34,7 +34,7 @@
     "/v1/locations": {
       "get": {
         "summary": "All locations",
-        "description": "The workhorse: every location as a full record (all fields incl. description, credits, Nexus image URLs, and the recently_updated bool) in one array. There is a single representation; ?full=1 is accepted as a no-op alias for older consumers. Consumers derive any aggregate (district/category counts, recency counts) by grouping these records. Supports conditional GET: send If-None-Match with the last dataset_version to get a 304.",
+        "description": "The workhorse: every location as a full record (all fields incl. description, credits, Nexus image URLs and updated_at) in one array. There is a single representation; ?full=1 is accepted as a no-op alias for older consumers. Consumers derive any aggregate (district/category counts, recency counts) by grouping these records. Supports conditional GET: send If-None-Match with the last dataset_version to get a 304.",
         "parameters": [
           { "name": "full", "in": "query", "required": false, "schema": { "type": "string", "enum": ["1"] }, "description": "Accepted as a no-op alias (the response is always the full record). Retained so existing consumers that pass full=1 keep working." },
           { "$ref": "#/components/parameters/IfNoneMatch" }
@@ -164,7 +164,7 @@
           "schema": { "type": "integer", "const": 1, "description": "Envelope schema version." },
           "generated_at": { "type": ["string", "null"], "format": "date-time", "description": "When the dataset was last built." },
           "dataset_version": { "type": ["string", "null"], "description": "Content hash; the ETag value." },
-          "recently_updated_days": { "type": "integer", "description": "The recency window in days: a location's recently_updated bool is true when its Nexus update is within this many days. Published so clock-having consumers (and UI text) read the rule instead of hardcoding it." },
+          "recently_updated_days": { "type": "integer", "description": "The recency window in days: a location counts as recently updated when its updated_at is within this many days of now. The API publishes the rule and does not apply it, because the answer depends on the clock and every consumer has one. It is a constant, so it costs the ETag nothing." },
           "data": { "description": "Route-specific payload." }
         }
       },
@@ -189,13 +189,12 @@
         "description": "The single location representation served by /v1/locations and /v1/locations/{id}.",
         "allOf": [
           { "$ref": "#/components/schemas/Location" },
-          { "type": "object", "required": ["recently_updated"], "properties": {
-            "recently_updated": { "type": "boolean", "description": "Server-computed: true when updated_at is within recently_updated_days (see envelope). Polyfill for the clockless in-game consumer; the website reads it too." },
+          { "type": "object", "properties": {
             "description": { "type": "string" },
             "credits": { "type": "string" },
             "thumbnail_url": { "type": ["string", "null"], "description": "Nexus thumbnail image URL, or null (unknown / WIP / Dummy)." },
             "picture_url": { "type": ["string", "null"], "description": "Nexus full-size image URL, or null." },
-            "updated_at": { "type": ["string", "null"], "format": "date-time", "description": "Nexus last-updated timestamp, or null." },
+            "updated_at": { "type": ["string", "null"], "format": "date-time", "description": "Nexus last-updated timestamp, or null. CONTRACT: exactly YYYY-MM-DDTHH:MM:SSZ, 20 characters, UTC, no offset and no fractional seconds. NCZoningCore's redscript parser is length-locked to that shape and returns 0.0 for anything else rather than guessing at a wrong instant, so an offset or a millisecond field makes every record read as not recently updated with no error anywhere. Consumers derive recency from this field and the envelope's recently_updated_days." },
             "archives": { "type": "array", "items": { "type": "string" }, "description": "The mod's install files as shipped: .archive load files AND .xl (ArchiveXL) manifests, both of which land in archive/pc/mod/. Bare filenames, not paths. FILTER TO .archive FOR AN INSTALL CHECK: an .xl is a manifest rather than a mounted archive, so a lookup over ResourceDepot's Mod-scope archive groups (what CET's ModArchiveExists and NCZoningCore both walk) never matches one. A record whose only names are .xl is therefore undetectable and must read as unknown, not as not-installed. Excludes CET/AMM .json files (they load into CET's sandboxed folder and are not readable by other mods). Empty means not determinable (an AMM-only mod, a WIP/Dummy entry with no Nexus page, a mod whose Nexus file preview has stayed unavailable for a day past its upload, or not yet fetched by the cron), never 'ships nothing'.", "example": ["Atari Canyon AIO.archive", "atari_aio.xl"] }
           } }
         ]

--- a/worker/package.json
+++ b/worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nczoning-api",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "description": "NC Zoning Data API worker (api.nczoning.net)",
   "type": "module",

--- a/worker/scripts/parity-check.mjs
+++ b/worker/scripts/parity-check.mjs
@@ -20,9 +20,6 @@
  *   RECOMPUTED           district, subdistrict   (from D1's OWN x/y/z, which is
  *                                                 what catches a mangled
  *                                                 coordinate)
- *                        recently_updated        (from nexus_cache.updated_at
- *                                                 against the envelope's
- *                                                 generated_at clock)
  *
  * A field in NEITHER set fails the run (see assertKeyCoverage). That is what
  * stops a newly added /v1 field from silently slipping past the gate as
@@ -51,7 +48,7 @@ const ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID || 'b9937d8d595fad7de8d1549
 
 const REBUILT_KEYS = new Set([
   'id', 'name', 'nexus_id', 'coordinates', 'yaw', 'category', 'tags', 'authors',
-  'description', 'credits', 'district', 'subdistrict', 'recently_updated',
+  'description', 'credits', 'district', 'subdistrict',
   'thumbnail_url', 'picture_url', 'updated_at', 'archives',
 ]);
 // Empty on purpose, and kept rather than deleted: it is the list of fields this
@@ -142,7 +139,7 @@ function assertKeyCoverage(records) {
   }
 }
 
-function buildFromRows(rows, dismissedIds, tagsDict, districts, nexusIndex, nowMs, locationTags) {
+function buildFromRows(rows, dismissedIds, tagsDict, districts, nexusIndex, locationTags) {
   const { full } = materializeFromD1({
     rows,
     dismissed: dismissedIds,
@@ -154,7 +151,6 @@ function buildFromRows(rows, dismissedIds, tagsDict, districts, nexusIndex, nowM
     // locations.tags column, so the gate would pass while testing the path
     // production no longer takes.
     locationTags,
-    nowMs,
   });
   // Appended last, in the position the cron appends it, because the comparison
   // below is on bytes and JSON.stringify emits insertion order.
@@ -174,8 +170,6 @@ async function main() {
     getJson(`${SITE}/data/tags.json`),
   ]);
   const liveRecords = envelope.data;
-  const nowMs = Date.parse(envelope.generated_at);
-  if (!Number.isFinite(nowMs)) fail('envelope.generated_at is not a date -- cannot reproduce recently_updated');
 
   assertKeyCoverage(liveRecords);
 
@@ -213,7 +207,7 @@ async function main() {
   }
 
   const nexusIndex = indexFromRows(nexusRows);
-  const candidate = buildFromRows(rows, dismissedIds, tagsDict, subdistricts.districts, nexusIndex, nowMs, locationTags);
+  const candidate = buildFromRows(rows, dismissedIds, tagsDict, subdistricts.districts, nexusIndex, locationTags);
 
   // --- ID assertion (the deep-link contract) ----------------------------
   const liveIds = new Set(liveRecords.map((r) => r.id));
@@ -293,7 +287,7 @@ async function main() {
     const mutatedTags = mutateTags ? mutateTags(locationTags) : locationTags;
     let differs;
     try {
-      const out = buildFromRows(mutatedRows, dismissedIds, tagsDict, subdistricts.districts, mutatedIndex, nowMs, mutatedTags);
+      const out = buildFromRows(mutatedRows, dismissedIds, tagsDict, subdistricts.districts, mutatedIndex, mutatedTags);
       differs = !compare(out, liveRecords);
     } catch {
       differs = true; // a throw is also a detection

--- a/worker/src/config.js
+++ b/worker/src/config.js
@@ -1,21 +1,24 @@
 /**
- * Shared dataset config. Single source of truth for values that must agree
- * across the merge (which computes the recency bool) and the request handler
- * (which publishes the window on the envelope).
+ * Shared dataset config. Single source of truth for values the request handler
+ * and the cron must agree on.
  */
 
-// "Recently updated" window, in days. A location's recently_updated bool is
-// computed against this in merge.js; the value is published on every response
-// envelope as recently_updated_days so clock-having consumers (and humans)
-// read the rule rather than hardcoding it. The website's own constant is only
-// a fallback for when the API is unavailable.
+// "Recently updated" window, in days. Published on every response envelope as
+// recently_updated_days, and applied by nobody here: the API states the rule
+// and each consumer answers it against its own clock, from the record's
+// updated_at. The website's NCZ.RECENTLY_UPDATED_DAYS is only a fallback for
+// when the envelope is unavailable.
+//
+// A constant, so it costs the content hash nothing. The per-record bool this
+// used to feed was removed once every consumer had a clock; see
+// wiki/learnings/time-relative-field-cannot-ride-a-content-hash-gated-write.
 export const RECENTLY_UPDATED_DAYS = 7;
 
 // Minimum gap between liveness-heartbeat writes on an UNCHANGED cron tick.
 //
 // The cron rebuilds every 5 min but writes KV only when the content hash moves
 // (see refresh.js). The #849 heartbeat deliberately bypassed that gate to prove
-// scheduled() is still running — which reintroduced exactly the per-tick write
+// scheduled() is still running, which reintroduced exactly the per-tick write
 // cost the hash gate existed to remove: 288 writes/day/env against a free-tier
 // cap of 1,000 per ACCOUNT. Rate-limiting the heartbeat keeps the liveness
 // signal while cutting idle writes to ~96/day.

--- a/worker/src/index.js
+++ b/worker/src/index.js
@@ -48,9 +48,10 @@ const DATA_CACHE = 'public, max-age=300, stale-while-revalidate=3600';
 
 /**
  * Wrap payload data in the versioned envelope (version/time from meta).
- * recently_updated_days publishes the recency window so clock-having consumers
- * (and the website's tooltip text) read the rule rather than hardcoding it; the
- * clockless in-game consumer instead reads each record's recently_updated bool.
+ * recently_updated_days publishes the recency window so every consumer (the
+ * website, NCZoningCore, and the tooltip text) reads the rule rather than
+ * hardcoding it, and answers it against its own clock from each record's
+ * updated_at. It is a constant, so it never moves the ETag.
  */
 function envelope(data, meta) {
   return {

--- a/worker/src/materialize.js
+++ b/worker/src/materialize.js
@@ -17,7 +17,6 @@
  */
 
 import { assignDistrict } from './districts.js';
-import { RECENTLY_UPDATED_DAYS } from './config.js';
 
 /**
  * Decode one D1 row into the intermediate entry shape.
@@ -51,16 +50,13 @@ export function rowToEntry(row, locationTags) {
  * Tags for one record.
  *
  * `locationTags` is REQUIRED, and a missing map throws rather than defaulting.
- * There used to be a fallback to the legacy `locations.tags` JSON column, kept
- * while migration 0002 held both in sync so the switch could be proven
- * byte-for-byte. That column is gone, and a silent default here would serve
- * every record untagged while looking like it worked, which is the failure this
- * whole area keeps producing.
+ * Tags come only from the join; the legacy `locations.tags` JSON column no
+ * longer exists. A silent default would serve every record untagged while
+ * looking like it worked.
  *
- * The synthetic `nczoning` marker is NOT added. It used to be prepended for
- * auto-sourced records, which made it a visible filter for a tag `/v1/tags` does
- * not list. Nothing auto-publishes any more, so the marker described nothing a
- * consumer could act on.
+ * The synthetic `nczoning` marker is NOT added. Nothing auto-publishes, so the
+ * marker would be a visible filter for a tag `/v1/tags` does not list and that
+ * describes nothing a consumer can act on.
  */
 function resolveTags(row, locationTags) {
   if (!locationTags) {
@@ -79,12 +75,18 @@ function resolveTags(row, locationTags) {
  *   keyed by nexus_id. One lookup, not two: under D1 the tagged nodes and the
  *   modsByUid backfill have both already been folded into `nexus_cache` by the
  *   sweep, so a second in-memory channel would only be a way for them to disagree.
- * @param {number} [input.nowMs]       clock the recently_updated bool is computed against
  * @returns {{full: Object<string, object>, meta: object}}
+ *
+ * NO CLOCK. Every field here is a pure function of the stored data, which is
+ * what lets the cron's content-hash gate suppress an unchanged tick's KV write.
+ * Recency is not answered here: both consumers own a clock and derive it
+ * themselves from `updated_at` and the envelope's `recently_updated_days`.
+ * A time-derived field added here re-breaks the write gate; see
+ * wiki/learnings/time-relative-field-cannot-ride-a-content-hash-gated-write.
  */
 export function materializeFromD1({
   rows, dismissed, nexusNodes, districts, nexusIndex = new Map(),
-  locationTags = null, nowMs = Date.now(), withheld = new Set(),
+  locationTags = null, withheld = new Set(),
 }) {
   const dismissedIds = dismissed instanceof Set ? dismissed : new Set(dismissed || []);
   const withheldIds = withheld instanceof Set ? withheld : new Set(withheld || []);
@@ -132,7 +134,6 @@ export function materializeFromD1({
     .map((row) => rowToEntry(row, locationTags))
     .sort((a, b) => a.name.localeCompare(b.name));
 
-  const cutoffMs = nowMs - RECENTLY_UPDATED_DAYS * 86400000;
   const full = {};
 
   for (const entry of all) {
@@ -143,10 +144,6 @@ export function materializeFromD1({
       picture_url: t?.pictureUrl ?? null,
       updated_at: t?.updatedAt ?? null,
     };
-    const recently_updated = thumbs.updated_at
-      ? Date.parse(thumbs.updated_at) > cutoffMs
-      : false;
-
     full[entry.id] = {
       id: entry.id,
       name: entry.name,
@@ -158,7 +155,6 @@ export function materializeFromD1({
       authors: entry.authors,
       district,
       subdistrict,
-      recently_updated,
       description: entry.description ?? '',
       ...(entry.credits ? { credits: entry.credits } : {}),
       ...thumbs,

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -421,7 +421,7 @@ async function fillArchives(env, fetchImpl, full, index, nowIso) {
  * sweep needs both before this runs, and the tagged query is one of the two
  * expensive calls in the tick.
  */
-async function sourceAndBuild(env, fetchImpl, origin, nowMs, { nexusNodes, nexusIndex }) {
+async function sourceAndBuild(env, fetchImpl, origin, { nexusNodes, nexusIndex }) {
   const subdistricts = await fetchJson(fetchImpl, origin, '/data/subdistricts.json');
   const districts = subdistricts.districts;
 
@@ -455,7 +455,7 @@ async function sourceAndBuild(env, fetchImpl, origin, nowMs, { nexusNodes, nexus
   // record's images into nexus_cache, including the auto-discovered ones,
   // which are rows like any other.
   const built = materializeFromD1({
-    rows, dismissed, nexusNodes, districts, nexusIndex, locationTags, nowMs,
+    rows, dismissed, nexusNodes, districts, nexusIndex, locationTags,
     withheld: withhold,
   });
   if (built.meta.withheld.length) {
@@ -501,7 +501,7 @@ export async function runRefresh(env, fetchImpl = fetch) {
     // A D1 read failure, by contrast, throws and lands in the catch below --
     // last-known-good, discovery_stale, alert. Never an empty map.
     const { full, meta, tagsList, districts } = await sourceAndBuild(
-      env, fetchImpl, origin, Date.parse(generatedAt), { nexusNodes, nexusIndex },
+      env, fetchImpl, origin, { nexusNodes, nexusIndex },
     );
     const districtsOut = districtsPayload(districts);
 
@@ -509,11 +509,12 @@ export async function runRefresh(env, fetchImpl = fetch) {
     await fillArchives(env, fetchImpl, full, nexusIndex, generatedAt);
 
     // Hash the content that actually varies (not generated_at). Tags are
-    // included so a tags.json edit propagates through the ETag. `full` carries
-    // the recently_updated bool, so its clock-driven flips move the ETag;
-    // that is deliberate (a location aging past the window must invalidate
-    // caches even though nothing on Nexus changed). This is why the cron
-    // rebuilds every tick against a fresh clock, with no Nexus short-circuit.
+    // included so a tags.json edit propagates through the ETag.
+    //
+    // `full` is a pure function of the stored data: no field in it depends on
+    // what time it is. So an idle tick reproduces the same hash and writes
+    // nothing, and the ETag moves only when the data does. Adding a
+    // time-derived field back would make every tick a write.
     const version = await contentHash(
       JSON.stringify({ full, districts: districtsOut, tags: tagsList }),
     );

--- a/worker/test/index.test.js
+++ b/worker/test/index.test.js
@@ -21,11 +21,11 @@ const META = {
   skipped: [], discovery_stale: false, last_refresh_at: '2026-07-04T00:05:00.000Z',
 };
 // The single representation: full records keyed by id (what /v1/locations serves
-// the values of, and /v1/locations/{id} reads directly). Each carries the
-// server-computed recently_updated bool.
+// the values of, and /v1/locations/{id} reads directly). Recency is not among
+// the fields: consumers derive it from updated_at and the envelope's window.
 const FULL = {
-  m1: { id: 'm1', name: 'Manual', nexus_id: '1', coordinates: [1, 2, 3], category: 'other', tags: [], authors: ['A'], district: 'Watson', subdistrict: 'Kabuki', recently_updated: false, description: 'a manual mod' },
-  'nexus-2': { id: 'nexus-2', name: 'Auto', nexus_id: '2', coordinates: [4, 5, 6], category: 'new-location', tags: [], authors: ['B'], district: 'Watson', subdistrict: null, recently_updated: true, description: 'an auto mod' },
+  m1: { id: 'm1', name: 'Manual', nexus_id: '1', coordinates: [1, 2, 3], category: 'other', tags: [], authors: ['A'], district: 'Watson', subdistrict: 'Kabuki', description: 'a manual mod', updated_at: '2026-07-01T00:00:00Z' },
+  'nexus-2': { id: 'nexus-2', name: 'Auto', nexus_id: '2', coordinates: [4, 5, 6], category: 'new-location', tags: [], authors: ['B'], district: 'Watson', subdistrict: null, description: 'an auto mod', updated_at: '2026-07-03T00:00:00Z' },
 };
 const DISTRICTS = [{ id: 'watson', name: 'Watson', boundary: [0, 0, 10, 0, 10, 10], centroid: { x: 5, y: 5 }, subdistricts: [] }];
 const TAGS = { apartment: 'a place', corpo: 'suits' };
@@ -65,7 +65,7 @@ test('GET /v1/health before the first cron: alive, heartbeat null (not 503)', as
   assert.equal(body.data.refresh_age_seconds, null);
 });
 
-test('GET /v1/locations returns the full records with recently_updated + envelope window', async () => {
+test('GET /v1/locations returns the full records, with the recency window on the envelope', async () => {
   const res = await worker.fetch(GET('/v1/locations'), seededEnv());
   assert.equal(res.status, 200);
   assert.equal(res.headers.get('ETag'), '"abc123"');
@@ -77,7 +77,9 @@ test('GET /v1/locations returns the full records with recently_updated + envelop
   assert.equal(body.recently_updated_days, 7); // window published on the envelope
   assert.equal(body.data.length, 2);
   assert.equal(body.data[0].description, 'a manual mod');     // single full representation
-  assert.equal(typeof body.data[0].recently_updated, 'boolean');
+  // The window is published; the per-record answer is not. Consumers compute it.
+  assert.equal('recently_updated' in body.data[0], false);
+  assert.equal(body.data[0].updated_at, '2026-07-01T00:00:00Z');
 });
 
 test('GET /v1/locations?full=1 is a no-op alias: same body, same ETag', async () => {
@@ -127,7 +129,7 @@ test('GET /v1/locations/{id} returns the full entry', async () => {
   assert.equal(res.status, 200);
   const body = await res.json();
   assert.equal(body.data.description, 'an auto mod');
-  assert.equal(body.data.recently_updated, true);
+  assert.equal(body.data.updated_at, '2026-07-03T00:00:00Z');
 });
 
 test('GET /v1/locations/{unknown} → 404', async () => {

--- a/worker/test/materialize.test.js
+++ b/worker/test/materialize.test.js
@@ -41,7 +41,6 @@ const build = (rows, over = {}) => materializeFromD1({
   nexusNodes: [],
   districts: DISTRICTS,
   locationTags: new Map(rows.map((r) => [r.id, ['apartment']])),
-  nowMs: Date.parse('2026-01-10T00:00:00Z'),
   ...over,
 });
 
@@ -74,9 +73,24 @@ test('key order matches merge.js, because the gate compares bytes', () => {
   const { full } = build([row()]);
   assert.deepEqual(Object.keys(full['aaaa-1111']), [
     'id', 'name', 'nexus_id', 'coordinates', 'yaw', 'category', 'tags', 'authors',
-    'district', 'subdistrict', 'recently_updated', 'description', 'credits',
+    'district', 'subdistrict', 'description', 'credits',
     'thumbnail_url', 'picture_url', 'updated_at',
   ]);
+});
+
+test('no field in a record depends on the clock', () => {
+  // The content hash gates the cron KV write, so a time-derived field would
+  // make every tick a write. Two builds an hour apart must be byte-identical.
+  const rows = [row()];
+  const nexusIndex = index({ 12345: { updatedAt: new Date().toISOString() } });
+  const a = JSON.stringify(build(rows, { nexusIndex }));
+  const realNow = Date.now;
+  Date.now = () => realNow() + 3600_000;
+  try {
+    assert.equal(JSON.stringify(build(rows, { nexusIndex })), a);
+  } finally {
+    Date.now = realNow;
+  }
 });
 
 test('only published rows are served; hidden and draft are withheld', () => {
@@ -141,8 +155,7 @@ test('an existing record suppresses its own re-creation, and is imaged from the 
   assert.equal(Object.keys(full).length, 1);
   assert.equal(full['aaaa-1111'].thumbnail_url, 'thumb');
   assert.equal(full['aaaa-1111'].picture_url, 'pic');
-  // 2026-01-08 is 2 days before the 2026-01-10 clock, inside the 7-day window.
-  assert.equal(full['aaaa-1111'].recently_updated, true);
+  assert.equal(full['aaaa-1111'].updated_at, '2026-01-08T00:00:00Z');
 });
 
 test('a tagged node cannot image a record on its own', () => {
@@ -156,12 +169,20 @@ test('a tagged node cannot image a record on its own', () => {
   assert.equal(full['aaaa-1111'].thumbnail_url, null);
 });
 
-test('recently_updated is false outside the window and for an unknown date', () => {
+test('updated_at is served raw, and is null when the index has no entry', () => {
+  // Recency is the consumer's answer to compute; the API ships only the fact it
+  // is computed from, in the exact shape NCZoningCore's parser is locked to.
   const stale = index({ 12345: { updatedAt: '2025-01-01T00:00:00Z' } });
-  assert.equal(build([row()], { nexusIndex: stale }).full['aaaa-1111'].recently_updated, false);
-  // No index entry at all: updated_at null, so the bool is false rather than
-  // NaN-ish.
-  assert.equal(build([row()]).full['aaaa-1111'].recently_updated, false);
+  const served = build([row()], { nexusIndex: stale }).full['aaaa-1111'].updated_at;
+  assert.equal(served, '2025-01-01T00:00:00Z');
+  assert.match(served, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  assert.equal(build([row()]).full['aaaa-1111'].updated_at, null);
+});
+
+test('no record carries a recently_updated key', () => {
+  const fresh = index({ 12345: { updatedAt: new Date().toISOString() } });
+  const record = build([row()], { nexusIndex: fresh }).full['aaaa-1111'];
+  assert.equal('recently_updated' in record, false);
 });
 
 test('a WIP record stays image-less rather than borrowing another mod images', () => {

--- a/worker/test/refresh.test.js
+++ b/worker/test/refresh.test.js
@@ -152,7 +152,7 @@ test('first run writes the full dataset (changed=true)', async () => {
   const locs = Object.values(full);
   assert.equal(locs.length, 2); // 1 manual + 1 auto (777 excluded)
   assert.ok(locs.every((l) => l.district));
-  assert.ok(locs.every((l) => typeof l.recently_updated === 'boolean'));
+  assert.ok(locs.every((l) => !('recently_updated' in l)));
   const meta = await env.DATASET.get(KEYS.meta, 'json');
   assert.equal(meta.discovery_stale, false);
   assert.ok(!('counts' in meta)); // aggregates removed; consumers derive their own
@@ -188,7 +188,7 @@ test('unchanged content on the second run skips the content write (changed=false
   const before = (await env.DATASET.get(KEYS.meta, 'json')).generated_at;
   const r2 = await runRefresh(env, fakeFetch());
   assert.equal(r2.changed, false);
-  // generated_at (content time) is preserved — the dataset wasn't rewritten. Only
+  // generated_at (content time) is preserved: the dataset wasn't rewritten. Only
   // the last_refresh_at heartbeat moves on an unchanged cycle (see next test).
   assert.equal((await env.DATASET.get(KEYS.meta, 'json')).generated_at, before);
 });
@@ -201,7 +201,7 @@ test('an unchanged cycle advances the heartbeat once the interval has elapsed', 
 
   // Pin the heartbeat far enough in the past to be due, then run an UNCHANGED
   // cycle: the content hash matches, so nothing is rewritten EXCEPT the
-  // heartbeat, which must advance — proving the cron ran. generated_at (content
+  // heartbeat, which must advance, proving the cron ran. generated_at (content
   // time) must NOT move. This is the #849 liveness signal: a running-but-idle
   // cron still proves life.
   await env.DATASET.put(KEYS.meta, JSON.stringify({ ...m1, last_refresh_at: '2000-01-01T00:00:00.000Z' }));
@@ -233,7 +233,7 @@ test('an unchanged cycle inside the heartbeat interval writes NOTHING', async ()
 
 test('a missing last_refresh_at is treated as due (no permanent suppression)', async () => {
   // Meta written before #849 has no heartbeat field. Date.parse(undefined) is
-  // NaN, and every comparison against NaN is false — so a naive `elapsed >= X`
+  // NaN, and every comparison against NaN is false, so a naive `elapsed >= X`
   // guard would suppress the heartbeat forever and the monitor would read the
   // Worker as wedged. It must fall through to "write it".
   const env = newEnv();
@@ -287,8 +287,8 @@ test('Nexus failure keeps last-known-good, flags stale, and records the alert', 
 });
 
 test('the third consecutive failure is the one that reaches Discord', async () => {
-  // The threshold is the whole point of routing this alert: below it a person
-  // is not told, at it they are. Asserting only the quiet case would pass on a
+  // The threshold decides who is told: below it a person is not notified, at
+  // it they are. Asserting only the quiet case would pass on a
   // build that never notifies at all.
   const env = newEnv({ NCZ_ALERTS_DISCORD_WEBHOOK_URL: 'https://discord/webhook' });
   const discordSink = [];

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -46,7 +46,7 @@
 		// package.json, then run `npm run version:lock` —
 		// test/api-version.test.js enforces all four. There is no monotonicity
 		// check, so a decrease passes provided all four move together.
-		"API_VERSION": "0.5.1",
+		"API_VERSION": "0.6.0",
 		// Origin the cron pulls subdistricts from. Locations and tags are in D1;
 		// this is the last thing served as a static file.
 		"SITE_ORIGIN": "https://nczoning.net",
@@ -150,7 +150,7 @@
 			],
 			"vars": {
 				// Pre-1.0 window — see the production block above.
-				"API_VERSION": "0.5.1",
+				"API_VERSION": "0.6.0",
 				"SITE_ORIGIN": "https://dev.nczoning.net",
 				// STAGING IS THE D1 CANARY: it runs the D1 path while production
 				// stays on mods.json, so the binding, the reads and the whole


### PR DESCRIPTION
## What

Removes the per-record `recently_updated` boolean from `/v1`. API surface **`0.5.1` → `0.6.0`**.

`updated_at` stays. `recently_updated_days` stays on the envelope. Only the *answer* goes; the *rule* is still published.

## Why now

`recently_updated` only ever existed because redscript had no clock, so the server had to do the comparison and ship the result. That stopped being true:

- **RedFunctions** (Nexus 32312) gives redscript `RedFunc.RealTimestamp()`.
- **NCZoningCore 1.1.0** takes it as a **hard dependency**. Verified live on Nexus before opening this: mod 32277, `version: "1.1.0"`, `status: published`, updated 2026-08-07.
- The mod parses `updated_at` into Unix seconds at ingest (`NCZ_Iso8601ToEpoch`) and re-answers recency in `SetStore()` — the one place both the cache load and the network swap pass through — against the envelope's window rather than a hardcoded 7.

**The two implementations were run against each other in game.** Across all 294 dated records, on both a cache read and a fresh fetch:

```
recency recomputed against the clock: window=7d, 0 record(s) differed from the API
```

Zero disagreement is what makes this a shape change rather than a behaviour change.

## What it actually buys: writes, not bytes

`recently_updated` was **the only field in the payload that depended on what time it is**. A mod can age past the 7-day window with nothing upstream having changed, so the cron had to rebuild and rewrite KV every tick forever to keep the ETag honest. That constraint is written up in [`learnings/time-relative-field-cannot-ride-a-content-hash-gated-write`].

The payload is a pure function of the stored data again, so the content-hash gate in `refresh.js` can actually suppress an idle tick's write. `materialize.test.js` now asserts this directly: two builds an hour apart are byte-identical.

**Not a quota emergency.** The original decision recorded this cost as bounded and well inside free-tier limits, and that was accurate. This is a cleanliness win.

No separate "source unchanged → skip rebuild" short-circuit was added. The write gate was always the expensive part and it now works; skipping the rebuild too would save only D1 reads and CPU. Worth a separate look, not this PR.

## Versioning: breaking, and it stays on `/v1`

Removing a field is breaking. The surface is **pre-1.0**, where the published rule is **breaking → MINOR, additive → PATCH, path stays `/v1`**. So `0.6.0`, no `/v2`, and **no exception is being carved** — this is the documented behaviour of the `0.x` line.

The kickoff for this work assumed a `/v1` exception would need recording. It does not; the 1.x-era wiki page just reads that way, so it now carries a superseded banner pointing at the live rules.

## Blast radius

- ~127 unique installs of Core, 125 of District Guide (Nexus, 2026-08-06).
- Anyone still on an older Core sees the "recently updated" badge quietly stop appearing. `GetKeyBool("recently_updated")` returns false and the badge is not drawn.
- **No crash, no error, no log line.** Self-heals on mod update.
- Exactly one live record has a null `updated_at`, so it loses recency permanently. That is the entire remaining cost.

## Also in here

The `updated_at` format is now documented as a **contract** in `openapi.json`, not left to `format: date-time`: exactly `YYYY-MM-DDTHH:MM:SSZ`, 20 characters, UTC, no offset, no fractional seconds. The mod parser is length-locked to it and returns `0.0` for anything else rather than guessing at a wrong instant, so a format change would silently make every record read as not-recently-updated.

`docs/api-reference.md`'s own example violated this (`...T12:00:00.000Z`) and is corrected.

## Testing

- `worker`: **410/410 pass**
- root: **81/81 pass**
- `npm run version:lock` regenerated; the four `API_VERSION` declaration sites agree.
- New: a record carries no `recently_updated` key (materialize, index, refresh); the build is clock-independent; `updated_at` is asserted against the 20-char shape.

## Open question, not blocking

`1.0.0` was to return "the day the first in-game mod ships". **That has happened** and the number was not taken. Whether to declare `1.0.0` — and put the next breaking change behind a real `/v2` — is your call. Recorded in the wiki as open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)