### PR TITLE
fix(admin): let the locations search box accept spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The admin locations search box accepts spaces. It trimmed on every keystroke and echoed the result back into the input, so a space was deleted before the next character could be typed and no multi-word query was possible.
+
 ## [2.10.1] - 2026-08-09
 
 ### Fixed

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -433,13 +433,19 @@
     if (f.district && state.districtById.get(loc.id) !== f.district) return false;
     if (f.special === 'untagged' && (loc.tags || []).length) return false;
     if (f.special === 'wip' && /^\d+$/.test(String(loc.nexus_id))) return false;
-    if (!f.q) return true;
+    // Trimmed here rather than on input: `q` is echoed back into the search box
+    // by setFilter, so trimming on the way in deletes the space the moment it is
+    // typed and no multi-word query can ever be entered.
+    const q = f.q.trim().toLowerCase();
+    if (!q) return true;
     const hay = [loc.name, loc.nexus_id, ...(loc.authors || []), ...(loc.tags || [])]
       .join(' ').toLowerCase();
-    return hay.includes(f.q.toLowerCase());
+    return hay.includes(q);
   }
 
-  const activeFilters = () => Object.entries(state.filter).filter(([, v]) => v !== '');
+  // Trimmed: `q` now holds the raw box contents, so a lone space is "no filter"
+  // rather than a chip with nothing visible in it.
+  const activeFilters = () => Object.entries(state.filter).filter(([, v]) => String(v).trim() !== '');
 
   /**
    * Apply a filter and show the result.
@@ -3377,7 +3383,7 @@
     // The inputs write into the filter state rather than being read from it,
     // so the Overview tiles and the controls cannot disagree about what the
     // list is showing.
-    $('#loc-search').addEventListener('input', (e) => setFilter({ q: e.target.value.trim() }));
+    $('#loc-search').addEventListener('input', (e) => setFilter({ q: e.target.value }));
     $('#loc-status').addEventListener('change', (e) => setFilter({ status: e.target.value }));
     $('#loc-category').addEventListener('change', (e) => setFilter({ category: e.target.value }));
 


### PR DESCRIPTION
## The bug

You cannot type a space in the admin locations search box, so no multi-word query is reachable.

Two lines conspire:

```js
// admin.js — input handler
$('#loc-search').addEventListener('input', (e) => setFilter({ q: e.target.value.trim() }));

// admin.js — setFilter(), "the selects are a second view of the same state, so they follow it"
$('#loc-search').value = state.filter.q;
```

Type `watson`, then a space. The handler trims it away, `setFilter` writes the trimmed string **back into the input**, and the space is gone before the next character arrives. The echo is deliberate and worth keeping (it is what stops the Overview tiles and the controls disagreeing); the trim is what makes it destructive.

## The fix

`q` holds the raw box contents. The trim moves to `locationMatches`, which is the only place it was ever needed:

```js
const q = f.q.trim().toLowerCase();
if (!q) return true;
```

`activeFilters` now treats a whitespace-only value as inactive, so a lone space does not render a chip with nothing visible in it.

## Verification

No client-side test harness exists for `admin/admin.js` (all 19 test files are Worker-side), and the page requires a GitHub session. Verified instead by replaying per-character `input` events against both versions of the handler in a browser:

| Version | Typing `watson tattoo` yields |
| --- | --- |
| before | `watsontattoo` |
| after | `watson tattoo` |

Search results are unchanged for single-word queries, and leading/trailing whitespace still matches as before because the trim survives at the comparison point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
