### PR TITLE
Release 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- The admin locations search box accepts spaces. It trimmed on every keystroke and echoed the result back into the input, so a space was deleted before the next character could be typed and no multi-word query was possible.
+
 ## [2.10.1] - 2026-08-09
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The admin locations search box accepts spaces. It trimmed on every keystroke and echoed the result back into the input, so a space was deleted before the next character could be typed and no multi-word query was possible.
+- Two locations sharing one Nexus page are no longer served each other's `.archive` files, which made both report as installed when the player had either one. Archive listings are now kept per download, and a record on a shared page is mapped to its own download from the dashboard.
+- A record on a shared page with no mapping is served no archives rather than the whole page. A missing install badge is recoverable; a false one is not.
 
 ## [2.10.1] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.11.0] - 2026-08-09
+
+### Added
+
+- Locations sharing a Nexus page can be mapped to the specific download they ship, from a picker in the dashboard. It appears only for a record whose page holds another location.
 
 ### Fixed
 

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -46,6 +46,10 @@
   const WRITABLE = [
     'name', 'authors', 'credits', 'coordinates', 'yaw', 'nexus_id',
     'description', 'category', 'tags', 'status', 'admin_notes',
+    // Only ever sent for a record whose Nexus page holds another location; the
+    // picker that produces it is not rendered otherwise, and readForm leaves
+    // the key off entirely rather than sending null and clearing a mapping.
+    'nexus_files',
   ];
 
   // Reasons the OAuth callback can bounce back with. `check_unavailable` is
@@ -630,6 +634,18 @@
       description: val('description'),
       authors: trimmed('authors').split(',').map((a) => a.trim()).filter(Boolean),
       tags: [...form.querySelectorAll('input[name="tag"]:checked')].map((i) => i.value),
+      // Present only when the download picker was rendered, i.e. only when this
+      // record shares its Nexus page with another. Everywhere else the key is
+      // absent and diffPayload skips it, so the stored mapping is untouched.
+      ...(form.querySelector('[data-field="nexus_files"]')
+        ? (() => {
+          const picked = [...form.querySelectorAll('input[name="nexus_file"]:checked')]
+            .map((i) => i.value);
+          // Nothing ticked is null, not [], matching what the server stores.
+          // Otherwise every save of an unmapped record would look like a change.
+          return { nexus_files: picked.length ? picked : null };
+        })()
+        : {}),
     };
   }
 
@@ -646,6 +662,10 @@
   function diffPayload(current, original) {
     const patch = {};
     for (const key of WRITABLE) {
+      // A key the form did not produce at all is not "changed to undefined".
+      // `nexus_files` is only present when the download picker was rendered,
+      // and a missing picker must leave the stored mapping alone.
+      if (!Object.prototype.hasOwnProperty.call(current, key)) continue;
       if (!sameValue(current[key], original[key])) patch[key] = current[key];
     }
     return patch;
@@ -674,10 +694,59 @@
       }));
   }
 
+  /**
+   * The download picker, for a record that shares its Nexus page with another.
+   *
+   * Rendered only in that case. A page with several downloads and one location
+   * is the normal shape (229 of 294 pages) and needs no mapping: it takes the
+   * whole listing. Asking there would be a question with one right answer on
+   * three quarters of the registry.
+   *
+   * The download list is a live Nexus fact the client does not hold, so it is
+   * fetched per record. That request only ever happens for a contested record,
+   * which today is two of them.
+   */
+  function downloadPicker(loc, others) {
+    const box = h('div', { class: 'tag-picker', 'data-field': 'nexus_files' },
+      h('span', { class: 'muted', text: 'Loading downloads…' }));
+
+    api(`/admin/locations/${encodeURIComponent(loc.id)}`).then((res) => {
+      const downloads = res.body?.page?.downloads ?? [];
+      replace(box);
+      if (!downloads.length) {
+        // No breakdown stored yet: the cron refills it on this mod's next
+        // listing fetch. Say so rather than showing an empty box that looks
+        // like "this page has no downloads".
+        box.append(h('span', {
+          class: 'muted',
+          text: 'No download breakdown cached yet. It appears after the next archive refresh.',
+        }));
+        return;
+      }
+      const selected = loc.nexus_files ?? [];
+      for (const d of downloads) {
+        const cb = h('input', { type: 'checkbox', name: 'nexus_file', value: d.name });
+        cb.checked = selected.includes(d.name);
+        box.append(h('label', {
+          title: (d.files || []).join('\n') || 'no archive files in this download',
+        }, cb, d.name));
+      }
+    }).catch(() => {
+      replace(box);
+      box.append(h('span', { class: 'muted', text: 'Could not load the download list.' }));
+    });
+
+    return field('Which download is this?', box,
+      `This Nexus page is also ${others.length === 1 ? 'used by' : 'used by'} `
+      + `${others.map((o) => o.name).join(', ')}. Tick the download(s) this record ships, `
+      + 'so an installed-mod check cannot match the other record\'s files. '
+      + 'Left blank, this record is served no archives at all.');
+  }
+
   const BLANK_LOCATION = {
     id: '', name: '', nexus_id: '', category: 'new-location', status: 'draft',
     coordinates: ['', '', ''], yaw: null, credits: null,
-    admin_notes: null, description: '', authors: [], tags: [],
+    admin_notes: null, description: '', authors: [], tags: [], nexus_files: null,
   };
 
   function renderLocationEditor(loc) {
@@ -717,6 +786,15 @@
       field('Credits', input('credits', loc.credits ?? '', { placeholder: 'blank for none' })),
       field('Description', h('textarea', { name: 'description', maxlength: '500' }, loc.description || '')),
       field('Tags', tagPicker(loc.tags || [])),
+      // Only when another record already points at this Nexus page. Computed
+      // from the list the dashboard already holds, so the extra request the
+      // picker makes happens for those records and nowhere else.
+      (() => {
+        if (isNew || !isRealNexusId(String(loc.nexus_id))) return null;
+        const others = (state.locations || [])
+          .filter((l) => String(l.nexus_id) === String(loc.nexus_id) && l.id !== loc.id);
+        return others.length ? downloadPicker(loc, others) : null;
+      })(),
       field('Admin notes', h('textarea', { name: 'admin_notes', placeholder: 'internal, never served on /v1' },
         loc.admin_notes || '')),
     );

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -433,13 +433,19 @@
     if (f.district && state.districtById.get(loc.id) !== f.district) return false;
     if (f.special === 'untagged' && (loc.tags || []).length) return false;
     if (f.special === 'wip' && /^\d+$/.test(String(loc.nexus_id))) return false;
-    if (!f.q) return true;
+    // Trimmed here rather than on input: `q` is echoed back into the search box
+    // by setFilter, so trimming on the way in deletes the space the moment it is
+    // typed and no multi-word query can ever be entered.
+    const q = f.q.trim().toLowerCase();
+    if (!q) return true;
     const hay = [loc.name, loc.nexus_id, ...(loc.authors || []), ...(loc.tags || [])]
       .join(' ').toLowerCase();
-    return hay.includes(f.q.toLowerCase());
+    return hay.includes(q);
   }
 
-  const activeFilters = () => Object.entries(state.filter).filter(([, v]) => v !== '');
+  // Trimmed: `q` now holds the raw box contents, so a lone space is "no filter"
+  // rather than a chip with nothing visible in it.
+  const activeFilters = () => Object.entries(state.filter).filter(([, v]) => String(v).trim() !== '');
 
   /**
    * Apply a filter and show the result.
@@ -3377,7 +3383,7 @@
     // The inputs write into the filter state rather than being read from it,
     // so the Overview tiles and the controls cannot disagree about what the
     // list is showing.
-    $('#loc-search').addEventListener('input', (e) => setFilter({ q: e.target.value.trim() }));
+    $('#loc-search').addEventListener('input', (e) => setFilter({ q: e.target.value }));
     $('#loc-status').addEventListener('change', (e) => setFilter({ status: e.target.value }));
     $('#loc-category').addEventListener('change', (e) => setFilter({ category: e.target.value }));
 

--- a/worker/README.md
+++ b/worker/README.md
@@ -105,10 +105,24 @@ are entirely separate stores that answer the same command, which is exactly how
 a "verified" migration ends up missing in production.
 
 ```bash
-export CLOUDFLARE_ACCOUNT_ID=b9937d8d595fad7de8d1549b22390281
 npx wrangler d1 migrations apply nczoning-data --remote
 npx wrangler d1 migrations apply nczoning-data-staging --env staging --remote
 ```
+
+**Do not set `CLOUDFLARE_ACCOUNT_ID`.** This block used to open with
+`export CLOUDFLARE_ACCOUNT_ID=b9937d8d595fad7de8d1549b22390281`, and that line
+is what makes the command fail. The wrangler login is an OAuth token spanning
+two accounts; it resolves the right one from the config on its own, and pinning
+the id makes the API answer
+
+```text
+The given account is not valid or is not authorized to access this service [code: 7403]
+```
+
+which reads as "you are not logged in" and is not. `npx wrangler whoami` will
+show a valid token with `d1 (write)` while the same shell cannot list a
+migration. Unset it and the command works. The same variable also empties the
+Cloudflare MCP's D1 listing.
 
 **`--env staging` is not optional on the second line.** Wrangler resolves
 database names from the top-level config only, so without it the staging

--- a/worker/migrations/0011_archives_by_download.sql
+++ b/worker/migrations/0011_archives_by_download.sql
@@ -1,0 +1,38 @@
+-- Splits a Nexus page's archive listing by download, so two locations sharing
+-- one page can be served different file lists.
+--
+-- The old model was `nexus_cache.archives` keyed by nexus_id alone, attached to
+-- every location with that nexus_id. That encodes "one Nexus page = one mod =
+-- one location". Page 23896 (Watson Tattoo Shops) violates it: two separate
+-- downloads, two registry records, and each record was served all six files
+-- from both. Core reads that list to decide whether a location is installed, so
+-- each record reported INSTALLED whenever the player had either download.
+--
+-- Measured before choosing the trigger: 229 of 294 pages have more than one
+-- download (main plus updates and optional patches, all one location), but
+-- exactly 1 page maps to more than one location. So the split is keyed off
+-- "how many locations point at this page", which the board computes itself,
+-- and NOT off "how many downloads does this page have", which would interrogate
+-- 78% of the registry for no reason.
+
+-- Archive names grouped by the download they came from:
+--   {"Watson Little China Tattoo Shop": ["Watson Little China Tattoo Shop.archive", ...], ...}
+--
+-- `archives` (the flat union) stays and stays authoritative for every page that
+-- maps to a single location, which is all but one of them. This column is the
+-- breakdown that lets a contested page be split, not a replacement.
+ALTER TABLE nexus_cache ADD COLUMN archives_by_file TEXT;
+
+-- Which download(s) on the page this location is. JSON array of Nexus file
+-- NAMES, e.g. ["Watson Little China Tattoo Shop"].
+--
+-- Names, not `uri`s: a uri embeds version and upload timestamp
+-- (`Watson Little China Tattoo Shop-23896-1-2-1757287730.zip`) and changes on
+-- every re-upload, so a stored uri would go stale the first time the author
+-- posts an update. The display name repeats across versions and is what the
+-- author actually names the download.
+--
+-- NULL means "not mapped", which is the correct state for the ~295 locations
+-- that are the only record on their page: they take the whole union and this
+-- column is never consulted.
+ALTER TABLE locations ADD COLUMN nexus_files TEXT;

--- a/worker/src/admin.js
+++ b/worker/src/admin.js
@@ -283,11 +283,38 @@ export async function handleAdmin(request, env, ctx) {
     // narrower view than the list it came from. The write routes deliberately
     // do NOT: their bodies are the audit record.
     const nexus = await env.DB.prepare(
-      'SELECT updated_at, archives, archives_at FROM nexus_cache WHERE nexus_id = ?',
+      `SELECT updated_at, archives, archives_by_file, archives_at
+         FROM nexus_cache WHERE nexus_id = ?`,
     ).bind(String(row.nexus_id)).first();
     const { archives, archives_state } = archivesView(nexus);
+
+    // Everything the download picker needs, and only for a record that needs
+    // one. `contested` is "another location points at this Nexus page", which
+    // is what makes a per-download mapping necessary; a page with several
+    // downloads and a single location does not need one and gets no picker
+    // (229 of 294 pages are that shape). See migration 0011.
+    const sharers = await env.DB.prepare(
+      'SELECT id, name FROM locations WHERE nexus_id = ? AND id != ?',
+    ).bind(String(row.nexus_id), row.id).all();
+    const others = sharers.results ?? [];
+    let downloads = [];
+    try {
+      const parsed = JSON.parse(nexus?.archives_by_file ?? '{}');
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        downloads = Object.entries(parsed).map(([name, files]) => ({ name, files }));
+      }
+    } catch {
+      // No breakdown reads as no picker, same posture as archivesView: one
+      // mod's file listing is not worth failing the page load over.
+    }
+
     return json(request, {
       location: { ...await loadAdminRecord(env, row), archives, archives_state },
+      page: {
+        contested: others.length > 0,
+        shared_with: others.map((o) => ({ id: o.id, name: o.name })),
+        downloads,
+      },
     });
   }
 

--- a/worker/src/admin.js
+++ b/worker/src/admin.js
@@ -25,6 +25,10 @@ import {
   readNexusModMap, archivesView,
 } from './registry.js';
 import { handleReview } from './review.js';
+// The single definition of "what archives is this record served". Shared with
+// the materializer on purpose: a second copy here is how the dashboard came to
+// disagree with /v1 about a split page.
+import { resolveArchives, parseNexusFiles } from './materialize.js';
 
 const json = (request, body, status = 200) => new Response(JSON.stringify(body), {
   status,
@@ -247,12 +251,27 @@ export async function handleAdmin(request, env, ctx) {
     // pane reads the record straight out of the loaded list -- see
     // selectLocation in admin/admin.js. Attached here rather than inside
     // rowToAdmin so the audit log keeps carrying only editable fields.
+    // Which pages more than one PUBLISHED record points at. Same definition the
+    // materializer uses, so the panel shows what /v1 serves rather than what the
+    // Nexus page holds; showing the page's whole listing against a split record
+    // reads as "the download mapping did not work".
+    const perPage = new Map();
+    for (const r of rows) {
+      if (r.status !== 'published') continue;
+      const k = String(r.nexus_id);
+      perPage.set(k, (perPage.get(k) ?? 0) + 1);
+    }
     return json(request, {
       locations: rows.map((r) => {
         const nexus = nexusMap.get(String(r.nexus_id)) ?? null;
         return {
           ...rowToAdmin(r, tagMap.get(r.id) ?? [], nexus?.updated_at ?? null),
-          archives: nexus?.archives ?? [],
+          archives: resolveArchives({
+            pageArchives: nexus?.archives ?? [],
+            archivesByFile: nexus?.archivesByFile ?? {},
+            files: parseNexusFiles(r.nexus_files),
+            contested: (perPage.get(String(r.nexus_id)) ?? 0) > 1,
+          }),
           archives_state: nexus?.archives_state ?? 'unknown',
         };
       }),
@@ -308,8 +327,20 @@ export async function handleAdmin(request, env, ctx) {
       // mod's file listing is not worth failing the page load over.
     }
 
+    // What this record is actually served, not what its page holds. The two
+    // differ only on a shared page, which is exactly the record a reviewer
+    // opens this panel to check.
+    const resolved = resolveArchives({
+      pageArchives: archives,
+      archivesByFile: Object.fromEntries(downloads.map((d) => [d.name, d.files])),
+      files: parseNexusFiles(row.nexus_files),
+      contested: others.length > 0,
+    });
+
     return json(request, {
-      location: { ...await loadAdminRecord(env, row), archives, archives_state },
+      location: {
+        ...await loadAdminRecord(env, row), archives: resolved, archives_state,
+      },
       page: {
         contested: others.length > 0,
         shared_with: others.map((o) => ({ id: o.id, name: o.name })),

--- a/worker/src/admin.js
+++ b/worker/src/admin.js
@@ -311,7 +311,7 @@ export async function handleAdmin(request, env, ctx) {
     // one. `contested` is "another location points at this Nexus page", which
     // is what makes a per-download mapping necessary; a page with several
     // downloads and a single location does not need one and gets no picker
-    // (229 of 294 pages are that shape). See migration 0011.
+    // (229 of 294 pages were that shape when this was measured). See migration 0011.
     const sharers = await env.DB.prepare(
       'SELECT id, name FROM locations WHERE nexus_id = ? AND id != ?',
     ).bind(String(row.nexus_id), row.id).all();

--- a/worker/src/materialize.js
+++ b/worker/src/materialize.js
@@ -232,37 +232,54 @@ export function materializeFromD1({
  * Pure, and shared by the cron and the parity gate so the gate cannot pass
  * against a channel the cron does not use.
  */
+/**
+ * What one record's `archives` should be. The single definition of that answer.
+ *
+ * Exported and shared with the admin dashboard deliberately. The dashboard is
+ * where a reviewer goes to CHECK this mapping, so a second copy of the rule
+ * there is the one place a disagreement would be invisible: it showed the whole
+ * page's listing while /v1 served the split, which reads as "the mapping did
+ * not work".
+ *
+ * @param {object} opts
+ * @param {string[]} [opts.pageArchives]    the page's flat union
+ * @param {object}   [opts.archivesByFile]  that union grouped by download name
+ * @param {string[]|null} [opts.files]      this record's mapped download names
+ * @param {boolean}  [opts.contested]       another record points at this page
+ */
+export function resolveArchives({
+  pageArchives = [], archivesByFile = {}, files = null, contested = false,
+} = {}) {
+  // The ordinary case, and all but two records today: the only record on its
+  // page, so the page's whole listing is its listing.
+  if (!contested) return pageArchives;
+
+  // Two or more records share this page, so the union would hand each of them
+  // the others' files and Core would report every one of them installed as soon
+  // as the player had any one of them.
+  //
+  // Unmapped resolves empty, not to the union: a false "not installed" is a
+  // missing badge, a false "installed" is a lie about the player's game. A
+  // mapping that matched no download resolves empty for the same reason, since
+  // the fallback IS the bug.
+  if (!files) return [];
+  const picked = new Set();
+  for (const fileName of files) {
+    for (const name of archivesByFile[fileName] ?? []) picked.add(name);
+  }
+  return [...picked].sort();
+}
+
 export function attachArchives(full, nexusIndex = new Map(), archivePlan = new Map()) {
   for (const rec of Object.values(full)) {
     const entry = nexusIndex.get(String(rec.nexus_id));
     const plan = archivePlan.get(rec.id);
-
-    // The ordinary case, and all but one record today: the only record on its
-    // page, so the page's whole listing is its listing.
-    if (!plan?.contested) {
-      rec.archives = entry?.archives ?? [];
-      continue;
-    }
-
-    // Two or more records share this page, so the union would hand each of them
-    // the others' files and Core would report every one of them installed as
-    // soon as the player had any one of them.
-    if (!plan.files) {
-      // Not mapped yet. Empty, not the union: a false "not installed" is a
-      // missing badge, a false "installed" is a lie about the player's game.
-      // Named in meta.unmapped so this is visible rather than silent.
-      rec.archives = [];
-      continue;
-    }
-
-    const byFile = entry?.archivesByFile ?? {};
-    const picked = new Set();
-    for (const fileName of plan.files) {
-      for (const name of byFile[fileName] ?? []) picked.add(name);
-    }
-    // A mapping that matched no download resolves empty rather than falling
-    // back to the union, for the same reason: the fallback is the bug.
-    rec.archives = [...picked].sort();
+    rec.archives = resolveArchives({
+      pageArchives: entry?.archives ?? [],
+      archivesByFile: entry?.archivesByFile ?? {},
+      files: plan?.files ?? null,
+      contested: Boolean(plan?.contested),
+    });
   }
   return full;
 }

--- a/worker/src/materialize.js
+++ b/worker/src/materialize.js
@@ -19,6 +19,26 @@
 import { assignDistrict } from './districts.js';
 
 /**
+ * `locations.nexus_files` as an array of Nexus download names, or null.
+ *
+ * null means "not mapped" and is the correct, normal state: only a record
+ * sharing its Nexus page with another record needs a mapping. An empty or
+ * malformed array is also null, so a half-written value cannot be read as
+ * "mapped to nothing".
+ */
+export function parseNexusFiles(value) {
+  if (typeof value !== 'string') return null;
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) return null;
+    const names = parsed.filter((n) => typeof n === 'string' && n.length > 0);
+    return names.length ? names : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Decode one D1 row into the intermediate entry shape.
  *
  * Two round-trip details that a byte-for-byte diff will catch and a "looks
@@ -161,10 +181,40 @@ export function materializeFromD1({
     };
   }
 
+  // How each record's archive list should be resolved. Kept out of `full`
+  // deliberately: `full` is the public payload with a byte-for-byte contract,
+  // and this is internal routing.
+  //
+  // "Contested" is a page that more than one PUBLISHED record points at. That
+  // is the trigger, not "the page has several downloads": 229 of 294 pages
+  // have several downloads (main plus updates and optional patches, all one
+  // location) and exactly one page has several locations. See migration 0011.
+  const perPage = new Map();
+  for (const row of published) {
+    const id = String(row.nexus_id);
+    perPage.set(id, (perPage.get(id) ?? 0) + 1);
+  }
+  const archivePlan = new Map();
+  for (const row of published) {
+    archivePlan.set(row.id, {
+      contested: (perPage.get(String(row.nexus_id)) ?? 0) > 1,
+      files: parseNexusFiles(row.nexus_files),
+    });
+  }
+
   return {
     full,
+    archivePlan,
     meta: {
       skipped,
+      // Records on a page shared with another record that have not been mapped
+      // to a download. Each is served `[]` rather than the whole page, so it
+      // cannot report installed off another location's files, and it is named
+      // here so the state is visible instead of looking like "ships nothing".
+      unmapped: published
+        .filter((r) => (perPage.get(String(r.nexus_id)) ?? 0) > 1
+          && !parseNexusFiles(r.nexus_files))
+        .map((r) => ({ id: r.id, nexus_id: String(r.nexus_id) })),
       // Published in the registry, deliberately not on the map. Named, not
       // counted: "3 records withheld" is a number nobody can check, and the
       // dashboard's drift row has to subtract exactly these.
@@ -182,9 +232,37 @@ export function materializeFromD1({
  * Pure, and shared by the cron and the parity gate so the gate cannot pass
  * against a channel the cron does not use.
  */
-export function attachArchives(full, nexusIndex = new Map()) {
+export function attachArchives(full, nexusIndex = new Map(), archivePlan = new Map()) {
   for (const rec of Object.values(full)) {
-    rec.archives = nexusIndex.get(String(rec.nexus_id))?.archives ?? [];
+    const entry = nexusIndex.get(String(rec.nexus_id));
+    const plan = archivePlan.get(rec.id);
+
+    // The ordinary case, and all but one record today: the only record on its
+    // page, so the page's whole listing is its listing.
+    if (!plan?.contested) {
+      rec.archives = entry?.archives ?? [];
+      continue;
+    }
+
+    // Two or more records share this page, so the union would hand each of them
+    // the others' files and Core would report every one of them installed as
+    // soon as the player had any one of them.
+    if (!plan.files) {
+      // Not mapped yet. Empty, not the union: a false "not installed" is a
+      // missing badge, a false "installed" is a lie about the player's game.
+      // Named in meta.unmapped so this is visible rather than silent.
+      rec.archives = [];
+      continue;
+    }
+
+    const byFile = entry?.archivesByFile ?? {};
+    const picked = new Set();
+    for (const fileName of plan.files) {
+      for (const name of byFile[fileName] ?? []) picked.add(name);
+    }
+    // A mapping that matched no download resolves empty rather than falling
+    // back to the union, for the same reason: the fallback is the bug.
+    rec.archives = [...picked].sort();
   }
   return full;
 }

--- a/worker/src/materialize.js
+++ b/worker/src/materialize.js
@@ -186,7 +186,7 @@ export function materializeFromD1({
   // and this is internal routing.
   //
   // "Contested" is a page that more than one PUBLISHED record points at. That
-  // is the trigger, not "the page has several downloads": 229 of 294 pages
+  // is the trigger, not "the page has several downloads": 229 of 294 pages today
   // have several downloads (main plus updates and optional patches, all one
   // location) and exactly one page has several locations. See migration 0011.
   const perPage = new Map();

--- a/worker/src/nexus-cache.js
+++ b/worker/src/nexus-cache.js
@@ -78,7 +78,7 @@ import {
 /** Columns compared to decide whether a row needs writing. */
 const TRACKED = [
   'name', 'summary', 'uploader', 'updated_at', 'thumbnail_url', 'picture_url',
-  'archives', 'archives_at', 'nczoning_tagged', 'status',
+  'archives', 'archives_by_file', 'archives_at', 'nczoning_tagged', 'status',
 ];
 
 // Per-tick archive budgets, carried over from refresh.js unchanged. Archives are
@@ -177,6 +177,24 @@ function parseArchives(value) {
 }
 
 /**
+ * A stored `archives_by_file` value as `{ [downloadName]: string[] }`. Same
+ * posture as parseArchives: a malformed cell degrades to "no breakdown", which
+ * falls back to the flat union rather than taking the refresh down.
+ */
+function parseArchivesByFile(value) {
+  if (typeof value !== 'string') return {};
+  try {
+    const parsed = JSON.parse(value);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    const out = {};
+    for (const [k, v] of Object.entries(parsed)) if (Array.isArray(v)) out[k] = v;
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/**
  * The four Nexus-derived /v1 fields, keyed by nexus_id, for the materializer to
  * join on. One-to-many: two locations sharing a mod read the same entry.
  *
@@ -187,8 +205,8 @@ function parseArchives(value) {
  */
 export async function readNexusIndex(env) {
   const { results } = await env.DB.prepare(
-    `SELECT nexus_id, updated_at, thumbnail_url, picture_url, archives, archives_at,
-            nczoning_tagged
+    `SELECT nexus_id, updated_at, thumbnail_url, picture_url, archives, archives_by_file,
+            archives_at, nczoning_tagged
        FROM nexus_cache`,
   ).all();
   const index = new Map();
@@ -198,6 +216,10 @@ export async function readNexusIndex(env) {
       pictureUrl: r.picture_url ?? null,
       updatedAt: r.updated_at ?? null,
       archives: parseArchives(r.archives),
+      // The same names grouped by the download they came from. Empty for every
+      // row written before migration 0011 and refilled on that mod's next
+      // listing fetch; consulted only for a page that maps to >1 location.
+      archivesByFile: parseArchivesByFile(r.archives_by_file),
       // Carried so an archives-only write can preserve it: writeRows sets the
       // flag unconditionally, and a candidate that lost it here would quietly
       // drop out of the candidates list.
@@ -206,6 +228,11 @@ export async function readNexusIndex(env) {
       // all -- so the array cannot say whether the listing has ever been read.
       // These two carry that, and only refreshArchives looks at them.
       archivesKnown: r.archives != null,
+      // Distinct from `archivesByFile` being empty: `{}` is a real answer (the
+      // page's downloads had no readable contents), NULL means the breakdown
+      // has never been computed. Only the second is a reason to refetch, and
+      // conflating them would refetch a genuinely empty page every tick.
+      archivesByFileKnown: r.archives_by_file != null,
       archivesAt: r.archives_at ?? null,
     });
   }
@@ -277,8 +304,8 @@ async function writeRows(env, rows, nowIso) {
   const stmt = env.DB.prepare(
     `INSERT INTO nexus_cache
        (nexus_id, name, summary, uploader, updated_at, thumbnail_url, picture_url,
-        archives, archives_at, nczoning_tagged, status, fetched_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        archives, archives_by_file, archives_at, nczoning_tagged, status, fetched_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(nexus_id) DO UPDATE SET
        name            = COALESCE(excluded.name, nexus_cache.name),
        summary         = COALESCE(excluded.summary, nexus_cache.summary),
@@ -287,6 +314,7 @@ async function writeRows(env, rows, nowIso) {
        thumbnail_url   = COALESCE(excluded.thumbnail_url, nexus_cache.thumbnail_url),
        picture_url     = COALESCE(excluded.picture_url, nexus_cache.picture_url),
        archives        = COALESCE(excluded.archives, nexus_cache.archives),
+       archives_by_file = COALESCE(excluded.archives_by_file, nexus_cache.archives_by_file),
        archives_at     = COALESCE(excluded.archives_at, nexus_cache.archives_at),
        nczoning_tagged = excluded.nczoning_tagged,
        status          = COALESCE(excluded.status, nexus_cache.status),
@@ -301,6 +329,7 @@ async function writeRows(env, rows, nowIso) {
     r.thumbnail_url ?? null,
     r.picture_url ?? null,
     r.archives ?? null,
+    r.archives_by_file ?? null,
     r.archives_at ?? null,
     r.nczoning_tagged ?? 0,
     r.status ?? null,
@@ -343,15 +372,30 @@ export async function refreshArchives(env, fetchImpl, { records, index, nowIso }
   const stamp = nowIso ?? new Date().toISOString();
 
   const due = new Map();
+  // Rows whose listing is current but predate migration 0011, so they have no
+  // per-download breakdown. Kept separate from `due`: their `archives` is fine
+  // and must not be re-seeded, they only need the grouping recomputed. Without
+  // this the backfill never happens at all, because a listing that already
+  // matches its `updated_at` is never refetched, and the download picker would
+  // sit on "no breakdown cached" forever.
+  //
+  // Self-limiting: one fetch writes the column (JSON.stringify always yields at
+  // least `{}`), so a row leaves this set permanently. The whole registry
+  // drains in roughly ceil(records / ARCHIVE_MOD_BUDGET) ticks, behind the same
+  // budget as any other archive work.
+  const breakdownDue = new Map();
   for (const rec of records) {
     const id = String(rec.nexus_id);
-    if (!isRealNexusId(id) || due.has(id)) continue;
+    if (!isRealNexusId(id) || due.has(id) || breakdownDue.has(id)) continue;
     const updatedAt = rec.updated_at ?? null;
     const entry = index.get(id);
-    if (entry?.archivesKnown && entry.archivesAt === updatedAt) continue;
+    if (entry?.archivesKnown && entry.archivesAt === updatedAt) {
+      if (!entry.archivesByFileKnown) breakdownDue.set(id, updatedAt);
+      continue;
+    }
     due.set(id, updatedAt);
   }
-  if (!due.size) return summary;
+  if (!due.size && !breakdownDue.size) return summary;
 
   // One-time carry-over from the KV blob this table replaces. Worth the read
   // twice over: it skips a ~20 tick cold fill, and archive-seeds.json holds
@@ -366,15 +410,21 @@ export async function refreshArchives(env, fetchImpl, { records, index, nowIso }
   }
 
   const resolved = new Map();
-  const take = (id, updatedAt, archives) => {
-    resolved.set(id, { archives, updatedAt });
+  // `archivesByFile` is undefined for a seeded listing (archive-seeds.json is a
+  // flat array and has no download breakdown). Left undefined it COALESCEs to
+  // "keep whatever is stored", which is right: a seed must not erase a
+  // breakdown a real fetch already produced.
+  const take = (id, updatedAt, archives, archivesByFile) => {
+    resolved.set(id, { archives, archivesByFile, updatedAt });
     index.set(id, {
       ...(index.get(id) ?? { thumbnailUrl: null, pictureUrl: null, updatedAt }),
       archives,
+      archivesByFile: archivesByFile ?? index.get(id)?.archivesByFile ?? {},
       archivesKnown: true,
       archivesAt: updatedAt,
     });
     due.delete(id);
+    breakdownDue.delete(id);
   };
 
   for (const [id, updatedAt] of [...due]) {
@@ -384,7 +434,14 @@ export async function refreshArchives(env, fetchImpl, { records, index, nowIso }
     summary.seeded += 1;
   }
 
-  const ordered = [...due].sort((a, b) => String(b[1] ?? '').localeCompare(String(a[1] ?? '')));
+  // Listing work first, breakdown backfill with whatever budget is left: a mod
+  // with no file list at all is a worse state than one with a list and no
+  // grouping, and the backfill is a one-off that can take as many ticks as it
+  // needs.
+  const ordered = [
+    ...[...due].sort((a, b) => String(b[1] ?? '').localeCompare(String(a[1] ?? ''))),
+    ...breakdownDue,
+  ];
   let mods = 0;
   let subrequests = 0;
   for (const [id, updatedAt] of ordered) {
@@ -399,10 +456,18 @@ export async function refreshArchives(env, fetchImpl, { records, index, nowIso }
       summary.unlisted += 1;
       continue;
     }
-    take(id, updatedAt, res.archives);
+    // A backfill refetch must never downgrade a listing it was not asked to
+    // change. If Nexus has stopped serving this mod's manifests since the
+    // listing was stored, the fetch comes back empty; taking that would turn a
+    // good file list into "ships nothing" for a mod that only needed grouping.
+    const backfillOnly = breakdownDue.has(id) && !due.has(id);
+    const keep = backfillOnly && !res.archives.length
+      ? (index.get(id)?.archives ?? [])
+      : res.archives;
+    take(id, updatedAt, keep, res.archivesByFile);
     summary.fetched += 1;
   }
-  summary.pending = due.size;
+  summary.pending = due.size + breakdownDue.size;
 
   // A row per mod, same batching and the same 100-bound-parameter ceiling as
   // the sweep. Nothing resolved means nothing written, which is the steady
@@ -411,6 +476,7 @@ export async function refreshArchives(env, fetchImpl, { records, index, nowIso }
     nexus_id: nexusId,
     nczoning_tagged: index.get(nexusId)?.nczoning_tagged ?? 0,
     archives: JSON.stringify(r.archives),
+    archives_by_file: r.archivesByFile ? JSON.stringify(r.archivesByFile) : null,
     archives_at: r.updatedAt,
   }));
   summary.written = await writeRows(env, rows, stamp);

--- a/worker/src/nexus-cache.js
+++ b/worker/src/nexus-cache.js
@@ -386,8 +386,8 @@ export async function refreshArchives(env, fetchImpl, { records, index, nowIso }
   const breakdownDue = new Map();
   // How many served records point at each page. A page with more than one is
   // the only place the breakdown changes an answer: its records are served []
-  // until it arrives, so it is backfilled before the ~294 pages where the
-  // breakdown is stored but never consulted.
+  // until it arrives, so it is backfilled ahead of the pages where the
+  // breakdown is stored but never consulted, which is almost all of them.
   const locationsPerPage = new Map();
   for (const rec of records) {
     const id = String(rec.nexus_id);
@@ -450,9 +450,9 @@ export async function refreshArchives(env, fetchImpl, { records, index, nowIso }
   const ordered = [
     ...[...due].sort((a, b) => String(b[1] ?? '').localeCompare(String(a[1] ?? ''))),
     // Shared pages first: those records are serving [] until their breakdown
-    // lands, so a fair-order drain would leave the one page that needs it
-    // behind ~290 that do not. At 15 mods a tick that is the difference
-    // between the next tick and a hundred minutes.
+    // lands, so a fair-order drain leaves the page that needs it queued behind
+    // every page that does not. At ARCHIVE_MOD_BUDGET a tick that is the
+    // difference between the next tick and most of an hour.
     ...[...breakdownDue].sort(
       (a, b) => (locationsPerPage.get(b[0]) ?? 0) - (locationsPerPage.get(a[0]) ?? 0),
     ),

--- a/worker/src/nexus-cache.js
+++ b/worker/src/nexus-cache.js
@@ -384,6 +384,15 @@ export async function refreshArchives(env, fetchImpl, { records, index, nowIso }
   // drains in roughly ceil(records / ARCHIVE_MOD_BUDGET) ticks, behind the same
   // budget as any other archive work.
   const breakdownDue = new Map();
+  // How many served records point at each page. A page with more than one is
+  // the only place the breakdown changes an answer: its records are served []
+  // until it arrives, so it is backfilled before the ~294 pages where the
+  // breakdown is stored but never consulted.
+  const locationsPerPage = new Map();
+  for (const rec of records) {
+    const id = String(rec.nexus_id);
+    if (isRealNexusId(id)) locationsPerPage.set(id, (locationsPerPage.get(id) ?? 0) + 1);
+  }
   for (const rec of records) {
     const id = String(rec.nexus_id);
     if (!isRealNexusId(id) || due.has(id) || breakdownDue.has(id)) continue;
@@ -440,7 +449,13 @@ export async function refreshArchives(env, fetchImpl, { records, index, nowIso }
   // needs.
   const ordered = [
     ...[...due].sort((a, b) => String(b[1] ?? '').localeCompare(String(a[1] ?? ''))),
-    ...breakdownDue,
+    // Shared pages first: those records are serving [] until their breakdown
+    // lands, so a fair-order drain would leave the one page that needs it
+    // behind ~290 that do not. At 15 mods a tick that is the difference
+    // between the next tick and a hundred minutes.
+    ...[...breakdownDue].sort(
+      (a, b) => (locationsPerPage.get(b[0]) ?? 0) - (locationsPerPage.get(a[0]) ?? 0),
+    ),
   ];
   let mods = 0;
   let subrequests = 0;

--- a/worker/src/nexus.js
+++ b/worker/src/nexus.js
@@ -230,9 +230,15 @@ const CURRENT_FILE_CATEGORIES = new Set(['MAIN', 'OPTIONAL', 'UPDATE']);
 // variants can't blow the run's subrequest budget on its own.
 const ARCHIVE_FILES_PER_MOD = 6;
 
+// `name` is the download's display name ("Watson Little China Tattoo Shop").
+// It is the only stable handle on a download: `uri` embeds version and upload
+// timestamp and changes on every re-upload, while `name` repeats across a
+// download's versions. Archive names are grouped under it so a page hosting two
+// locations can be split. See migration 0011.
 const MOD_FILES_QUERY = `query ModFiles($modId: ID!, $gameId: ID!) {
   modFiles(modId: $modId, gameId: $gameId) {
     uri
+    name
     category
   }
 }`;
@@ -310,7 +316,7 @@ export async function fetchModFileUris(fetchImpl, modId) {
     return {
       files: files
         .filter((f) => typeof f?.uri === 'string' && f.uri.length > 0)
-        .map((f) => ({ uri: f.uri, category: f.category || '' })),
+        .map((f) => ({ uri: f.uri, name: f.name || '', category: f.category || '' })),
       ok: true,
     };
   } catch {
@@ -407,14 +413,32 @@ export async function fetchModArchiveNames(fetchImpl, modId) {
   const chosen = (current.length ? current : filesRes.files).slice(0, ARCHIVE_FILES_PER_MOD);
 
   const all = new Set();
+  // Also kept grouped by download name, so a page whose downloads belong to
+  // different locations can be split. Several files can share a name (one per
+  // version), and their contents are unioned under it.
+  const byFile = new Map();
   for (const f of chosen) {
     const r = await fetchArchiveNamesForFile(fetchImpl, modId, f.uri);
     subrequests += 1;
     if (!r.ok) ok = false;
     if (r.listed) listed = true;
-    for (const name of r.names) all.add(name);
+    const key = f.name || f.uri;
+    if (!byFile.has(key)) byFile.set(key, new Set());
+    for (const name of r.names) {
+      all.add(name);
+      byFile.get(key).add(name);
+    }
+  }
+  const archivesByFile = {};
+  for (const [key, names] of [...byFile].sort((a, b) => a[0].localeCompare(b[0]))) {
+    // A download whose contents could not be read contributes no group at all.
+    // Recording it as `[]` would state "this download ships nothing", which is
+    // the same shape as a real answer and would resolve a mapped location to an
+    // empty archive list on a transient 404.
+    if (!names.size) continue;
+    archivesByFile[key] = [...names].sort();
   }
   return {
-    archives: [...all].sort(), ok, listed, subrequests,
+    archives: [...all].sort(), archivesByFile, ok, listed, subrequests,
   };
 }

--- a/worker/src/refresh.js
+++ b/worker/src/refresh.js
@@ -384,7 +384,7 @@ async function sweepNexusCache(env, fetchImpl, nexusNodes, nowIso) {
  * need a listing, and before the content hash so a re-upload that changes only
  * the file list still moves the ETag.
  */
-async function fillArchives(env, fetchImpl, full, index, nowIso) {
+async function fillArchives(env, fetchImpl, full, index, nowIso, archivePlan) {
   try {
     const r = await refreshArchives(env, fetchImpl, {
       records: Object.values(full), index, nowIso,
@@ -403,7 +403,7 @@ async function fillArchives(env, fetchImpl, full, index, nowIso) {
   } catch (err) {
     console.warn('archive refresh failed (non-fatal):', String(err).slice(0, 200));
   }
-  attachArchives(full, index);
+  attachArchives(full, index, archivePlan);
 }
 
 /**
@@ -464,6 +464,13 @@ async function sourceAndBuild(env, fetchImpl, origin, { nexusNodes, nexusIndex }
       + built.meta.withheld.map((w) => `${w.id} (mod ${w.nexus_id})`).join(', '),
     );
   }
+  if (built.meta.unmapped.length) {
+    console.warn(
+      `${built.meta.unmapped.length} record(s) share a Nexus page with another `
+      + 'record and have no download mapped, so they are served no archives: '
+      + built.meta.unmapped.map((u) => `${u.id} (mod ${u.nexus_id})`).join(', '),
+    );
+  }
   return { ...built, tagsList, districts };
 }
 
@@ -500,13 +507,15 @@ export async function runRefresh(env, fetchImpl = fetch) {
     // leaves some images null for a cycle, it never marks the dataset stale.
     // A D1 read failure, by contrast, throws and lands in the catch below --
     // last-known-good, discovery_stale, alert. Never an empty map.
-    const { full, meta, tagsList, districts } = await sourceAndBuild(
+    const { full, meta, tagsList, districts, archivePlan } = await sourceAndBuild(
       env, fetchImpl, origin, { nexusNodes, nexusIndex },
     );
     const districtsOut = districtsPayload(districts);
 
     // Each record's shipped .archive file names (installed-mod detection).
-    await fillArchives(env, fetchImpl, full, nexusIndex, generatedAt);
+    // `archivePlan` decides whether a record takes its page's whole listing or
+    // only the download(s) it was mapped to; see attachArchives.
+    await fillArchives(env, fetchImpl, full, nexusIndex, generatedAt, archivePlan);
 
     // Hash the content that actually varies (not generated_at). Tags are
     // included so a tags.json edit propagates through the ETag.

--- a/worker/src/registry.js
+++ b/worker/src/registry.js
@@ -16,6 +16,7 @@
 
 import { runRefresh } from './refresh.js';
 import { syncLocationTags, readTagsForLocations } from './tag-registry.js';
+import { parseNexusFiles } from './materialize.js';
 
 /** Payload field -> column, for the fields that map one to one. */
 const COLUMN_FOR = {
@@ -51,6 +52,9 @@ export function rowToAdmin(row, tags = [], nexusUpdatedAt = null) {
     tags,
     status: row.status,
     admin_notes: row.admin_notes,
+    // Array or null, never the raw JSON string: the dashboard renders it as a
+    // set of checkboxes and should not have to parse.
+    nexus_files: parseNexusFiles(row.nexus_files),
     added_at: row.added_at,
     modified_at: row.modified_at,
     // The MOD's update time on Nexus, which is a different thing from both of
@@ -174,6 +178,19 @@ function buildUpdate(payload) {
   }
   if (Object.prototype.hasOwnProperty.call(payload, 'authors')) {
     sets.push('authors = ?'); binds.push(JSON.stringify(payload.authors));
+  }
+  // Which Nexus download(s) this record is, when its page hosts more than one
+  // location. JSON array of download names, like `authors`, so it cannot be
+  // bound raw. An empty array clears the mapping back to NULL rather than
+  // storing `[]`: "not mapped" and "mapped to no downloads" must not be two
+  // different states, because the second would be indistinguishable from a
+  // half-saved edit. See migration 0011.
+  if (Object.prototype.hasOwnProperty.call(payload, 'nexus_files')) {
+    const files = Array.isArray(payload.nexus_files)
+      ? payload.nexus_files.filter((n) => typeof n === 'string' && n.length)
+      : [];
+    sets.push('nexus_files = ?');
+    binds.push(files.length ? JSON.stringify(files) : null);
   }
   if (Object.prototype.hasOwnProperty.call(payload, 'coordinates')) {
     const [x, y, z] = payload.coordinates;

--- a/worker/src/registry.js
+++ b/worker/src/registry.js
@@ -119,11 +119,21 @@ export function archivesView(row) {
  */
 export async function readNexusModMap(env) {
   const { results } = await env.DB.prepare(
-    'SELECT nexus_id, updated_at, archives, archives_at FROM nexus_cache',
+    'SELECT nexus_id, updated_at, archives, archives_by_file, archives_at FROM nexus_cache',
   ).all();
   const map = new Map();
   for (const r of results ?? []) {
-    map.set(String(r.nexus_id), { updated_at: r.updated_at ?? null, ...archivesView(r) });
+    let archivesByFile = {};
+    try {
+      const parsed = JSON.parse(r.archives_by_file ?? '{}');
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) archivesByFile = parsed;
+    } catch {
+      // Same posture as archivesView: a malformed cell degrades to no
+      // breakdown, which the caller resolves as an unsplit page.
+    }
+    map.set(String(r.nexus_id), {
+      updated_at: r.updated_at ?? null, archivesByFile, ...archivesView(r),
+    });
   }
   return map;
 }

--- a/worker/src/validate.js
+++ b/worker/src/validate.js
@@ -34,6 +34,9 @@ const NEXUS_ID_RE = /^(\d+|WIP|Dummy)$/;
 const WRITABLE = new Set([
   'name', 'authors', 'credits', 'coordinates', 'yaw', 'nexus_id',
   'description', 'category', 'tags', 'status', 'admin_notes',
+  // Admin-only, and only meaningful when the record's Nexus page hosts another
+  // location. See migration 0011.
+  'nexus_files',
 ]);
 
 const isPlainObject = (v) => typeof v === 'object' && v !== null && !Array.isArray(v);
@@ -152,6 +155,18 @@ export function validateLocationInput(payload, { tagNames, partial = false } = {
 
   if (has('admin_notes') && payload.admin_notes !== null && typeof payload.admin_notes !== 'string') {
     err('admin_notes must be a string or null');
+  }
+
+  // Nexus download names. `null` and `[]` both mean "not mapped" and are the
+  // normal state; the names themselves are not checked against the page here,
+  // because the page's download list is a live Nexus fact and a stale check
+  // would reject a mapping that is about to become correct.
+  if (has('nexus_files') && payload.nexus_files !== null) {
+    if (!Array.isArray(payload.nexus_files)) {
+      err('nexus_files must be an array of Nexus download names, or null');
+    } else if (payload.nexus_files.some((n) => typeof n !== 'string')) {
+      err('nexus_files entries must be strings');
+    }
   }
 
   return { ok: errors.length === 0, errors };

--- a/worker/test/admin.test.js
+++ b/worker/test/admin.test.js
@@ -823,3 +823,57 @@ test('an untracked mod is 404, and a bad body is 422', async () => {
     "the row is the cron's to delete, not an admin's");
   assert.equal(auditRows(env).length, 0, 'a refused call is not audited');
 });
+
+// The dashboard is where a reviewer CHECKS a download mapping, so it showing
+// the Nexus page's whole listing while /v1 serves the split reads as "the
+// mapping did not work". Both answers come from resolveArchives now; these pin
+// the list route to it.
+const SHARED_PAGE = [
+  { ...ROW, id: 'loc-a', name: 'Little China', nexus_id: '23896', nexus_files: JSON.stringify(['LilChina']) },
+  { ...ROW, id: 'loc-b', name: 'Northside', nexus_id: '23896', nexus_files: JSON.stringify(['Northside']) },
+];
+const SHARED_CACHE = [cacheRow({
+  nexus_id: '23896',
+  archives: JSON.stringify(['lil.archive', 'north.archive']),
+  archives_by_file: JSON.stringify({ LilChina: ['lil.archive'], Northside: ['north.archive'] }),
+  archives_at: '2026-01-02T00:00:00Z',
+})];
+
+const listById = async (env) => {
+  const { locations } = await (await hit(env, 'GET', '/admin/locations')).json();
+  return new Map(locations.map((l) => [l.id, l]));
+};
+
+test('the list shows each shared-page record its own download, not the page', async () => {
+  const env = envFor({
+    locations: SHARED_PAGE,
+    locationTags: [['loc-a', 'apartment'], ['loc-b', 'apartment']],
+    nexusCache: SHARED_CACHE,
+  });
+  const byId = await listById(env);
+  assert.deepEqual(byId.get('loc-a').archives, ['lil.archive']);
+  assert.deepEqual(byId.get('loc-b').archives, ['north.archive']);
+});
+
+test('an unmapped shared-page record shows nothing in the dashboard too', async () => {
+  const env = envFor({
+    locations: [SHARED_PAGE[0], { ...SHARED_PAGE[1], nexus_files: null }],
+    locationTags: [['loc-a', 'apartment'], ['loc-b', 'apartment']],
+    nexusCache: SHARED_CACHE,
+  });
+  const byId = await listById(env);
+  // Matching what /v1 serves it, rather than implying files it does not get.
+  assert.deepEqual(byId.get('loc-b').archives, []);
+});
+
+test('a record alone on its page still shows the whole listing', async () => {
+  const env = envFor({
+    nexusCache: [cacheRow({
+      archives: JSON.stringify(['Loft.archive', 'Loft.xl']),
+      archives_by_file: JSON.stringify({ Main: ['Loft.archive'] }),
+      archives_at: '2026-01-02T00:00:00Z',
+    })],
+  });
+  const loc = await firstLocation(env);
+  assert.deepEqual(loc.archives, ['Loft.archive', 'Loft.xl']);
+});

--- a/worker/test/materialize.test.js
+++ b/worker/test/materialize.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { materializeFromD1, rowToEntry } from '../src/materialize.js';
+import { materializeFromD1, rowToEntry, attachArchives } from '../src/materialize.js';
 
 // These cover the shapes the Phase 1 parity diff structurally CANNOT reach:
 // every record in production today is published, has a Z and (mostly) a yaw, so
@@ -210,4 +210,95 @@ test('rowToEntry tolerates a NULL authors column and a record with no tag links'
   const entry = rowToEntry(row({ authors: null }), new Map());
   assert.deepEqual(entry.authors, []);
   assert.deepEqual(entry.tags, [], 'no join rows is an empty array, not undefined');
+});
+
+// ---------------------------------------------------------------------------
+// Archive resolution when one Nexus page hosts two locations.
+//
+// Modelled on the real case: page 23896 (Watson Tattoo Shops) ships two
+// separate downloads and the registry has a record for each. The old code
+// keyed archives on nexus_id alone, so both records were served all six files
+// and Core reported both installed when the player had either one.
+//
+// The trigger is "the page has >1 LOCATION", not ">1 download": 229 of 294
+// pages have several downloads and are a single location. See migration 0011.
+// ---------------------------------------------------------------------------
+
+const LIL_CHINA = 'Watson Little China Tattoo Shop';
+const NORTHSIDE = 'Watson Northside Tattoo Shop';
+
+const watsonIndex = () => index({
+  23896: {
+    archives: [
+      'Watson Little China Tattoo Shop.archive', 'Watson Northside Tattoo Shop.archive',
+      'watsonlilchinatattooshop1.xl', 'watsonnorthsidetattooshop1.xl',
+    ],
+    archivesByFile: {
+      [LIL_CHINA]: ['Watson Little China Tattoo Shop.archive', 'watsonlilchinatattooshop1.xl'],
+      [NORTHSIDE]: ['Watson Northside Tattoo Shop.archive', 'watsonnorthsidetattooshop1.xl'],
+    },
+  },
+});
+
+const watsonRows = (aFiles, bFiles) => [
+  row({ id: 'a', name: 'Little China Pink Ink', nexus_id: '23896', nexus_files: aFiles }),
+  row({ id: 'b', name: 'Northside Body Mods', nexus_id: '23896', nexus_files: bFiles }),
+];
+
+test('a page with ONE location still takes the whole listing, mapping or not', () => {
+  const { full, archivePlan } = build([row({ nexus_id: '23896' })]);
+  attachArchives(full, watsonIndex(), archivePlan);
+  assert.equal(full['aaaa-1111'].archives.length, 4);
+});
+
+test('two locations on one page each get only their own download', () => {
+  const { full, archivePlan } = build(
+    watsonRows(JSON.stringify([LIL_CHINA]), JSON.stringify([NORTHSIDE])),
+  );
+  attachArchives(full, watsonIndex(), archivePlan);
+  assert.deepEqual(full.a.archives,
+    ['Watson Little China Tattoo Shop.archive', 'watsonlilchinatattooshop1.xl']);
+  assert.deepEqual(full.b.archives,
+    ['Watson Northside Tattoo Shop.archive', 'watsonnorthsidetattooshop1.xl']);
+  // The actual defect: neither may carry the other's .archive.
+  assert.ok(!full.a.archives.includes('Watson Northside Tattoo Shop.archive'));
+  assert.ok(!full.b.archives.includes('Watson Little China Tattoo Shop.archive'));
+});
+
+test('an unmapped record on a shared page is served nothing, not the union', () => {
+  const { full, archivePlan, meta } = build(watsonRows(null, JSON.stringify([NORTHSIDE])));
+  attachArchives(full, watsonIndex(), archivePlan);
+  // Empty is the fail-safe direction: a missing badge, never a false INSTALLED.
+  assert.deepEqual(full.a.archives, []);
+  assert.deepEqual(full.b.archives,
+    ['Watson Northside Tattoo Shop.archive', 'watsonnorthsidetattooshop1.xl']);
+  // ...and it is named rather than silently looking like "ships nothing".
+  assert.deepEqual(meta.unmapped, [{ id: 'a', nexus_id: '23896' }]);
+});
+
+test('a mapping naming a download that no longer exists resolves empty', () => {
+  const { full, archivePlan } = build(
+    watsonRows(JSON.stringify(['Renamed By The Author']), JSON.stringify([NORTHSIDE])),
+  );
+  attachArchives(full, watsonIndex(), archivePlan);
+  assert.deepEqual(full.a.archives, []);
+});
+
+test('a malformed nexus_files cell reads as unmapped, not as mapped-to-nothing', () => {
+  for (const bad of ['not json', '{}', '[]', '[""]']) {
+    const { full, archivePlan, meta } = build(watsonRows(bad, JSON.stringify([NORTHSIDE])));
+    attachArchives(full, watsonIndex(), archivePlan);
+    assert.deepEqual(full.a.archives, [], bad);
+    assert.deepEqual(meta.unmapped, [{ id: 'a', nexus_id: '23896' }], bad);
+  }
+});
+
+test('a draft sharing the page does not make the published record contested', () => {
+  const rows = watsonRows(null, JSON.stringify([NORTHSIDE]));
+  rows[1].status = 'draft';
+  const { full, archivePlan, meta } = build(rows);
+  attachArchives(full, watsonIndex(), archivePlan);
+  // Only one PUBLISHED record points at the page, so it takes the whole listing.
+  assert.equal(full.a.archives.length, 4);
+  assert.deepEqual(meta.unmapped, []);
 });

--- a/worker/test/nexus-cache.test.js
+++ b/worker/test/nexus-cache.test.js
@@ -630,3 +630,35 @@ test('a backfill whose manifests have gone unreadable keeps the stored listing',
     'and the stored row must not be downgraded either',
   );
 });
+
+test('the backfill does a shared page before pages that will never consult it', async () => {
+  const env = { DB: sqliteD1(), DATASET: null };
+  // More cold mods than one tick's budget, with the shared page last in
+  // iteration order so a fair drain would not reach it for many ticks.
+  const many = Array.from({ length: 20 }, (_, i) => record(String(200 + i)));
+  const shared = [record('23896'), record('23896')];
+  let index = await readNexusIndex(env);
+  for (let i = 0; i < 3; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await refreshArchives(env, fakeArchiveFetch(), {
+      records: [...many, ...shared], index, nowIso: NOW,
+    });
+    index = await readNexusIndex(env); // eslint-disable-line no-await-in-loop
+  }
+
+  // Rewind every breakdown, as migration 0011 leaves them.
+  const rewound = await readNexusIndex(env);
+  for (const [id, e] of rewound) {
+    rewound.set(id, { ...e, archivesByFile: {}, archivesByFileKnown: false });
+  }
+  await refreshArchives(env, fakeArchiveFetch(), {
+    records: [...many, ...shared], index: rewound, nowIso: NOW,
+  });
+
+  assert.equal(
+    env.DB.one('SELECT archives_by_file FROM nexus_cache WHERE nexus_id = ?', '23896')
+      .archives_by_file != null,
+    true,
+    'the page whose records are serving [] must not queue behind 20 that are fine',
+  );
+});

--- a/worker/test/nexus-cache.test.js
+++ b/worker/test/nexus-cache.test.js
@@ -565,3 +565,68 @@ test('a location that is not tagged still gets its images backfilled', async () 
   assert.equal(row.name, 'Manual Mod');
   assert.equal(row.nczoning_tagged, 0, 'backfilled locations are not candidates');
 });
+
+// ---------------------------------------------------------------------------
+// Backfill of the per-download breakdown (migration 0011).
+//
+// The listing refetch trigger is "updated_at moved". Rows written before 0011
+// have a current listing and no breakdown, so that trigger never fires for
+// them and the download picker would sit on "no breakdown cached" forever.
+// These cover the separate backfill path and its two safety properties:
+// it terminates, and it never downgrades a listing it only meant to regroup.
+//
+// The pre-0011 row is simulated on the index rather than by writing to the
+// stub, whose test conveniences are read-only by design.
+// ---------------------------------------------------------------------------
+
+/** A read index with one row rewound to its pre-migration-0011 state. */
+async function indexWithoutBreakdown(env, id) {
+  const index = await readNexusIndex(env);
+  index.set(id, { ...index.get(id), archivesByFile: {}, archivesByFileKnown: false });
+  return index;
+}
+
+test('a row with a current listing but no breakdown is backfilled, once', async () => {
+  const env = { DB: sqliteD1(), DATASET: null };
+  await refreshArchives(env, fakeArchiveFetch(), {
+    records: [record('100')], index: await readNexusIndex(env), nowIso: NOW,
+  });
+
+  const stored = await indexWithoutBreakdown(env, '100');
+  const back = await refreshArchives(env, fakeArchiveFetch(), {
+    records: [record('100')], index: stored, nowIso: NOW,
+  });
+  assert.equal(back.fetched, 1, 'the backfill must actually run');
+  assert.deepEqual(stored.get('100').archivesByFile, { 'f0.7z': ['mod_100.archive'] });
+
+  // Terminates: the column is set now, so a fresh read is no longer due.
+  const after = await readNexusIndex(env);
+  assert.equal(after.get('100').archivesByFileKnown, true);
+  const again = await refreshArchives(env, fakeArchiveFetch({ calls: [] }), {
+    records: [record('100')], index: after, nowIso: NOW,
+  });
+  assert.equal(again.fetched, 0, 'the backfill must not refetch the same row every tick');
+});
+
+test('a backfill whose manifests have gone unreadable keeps the stored listing', async () => {
+  const env = { DB: sqliteD1(), DATASET: null };
+  await refreshArchives(env, fakeArchiveFetch(), {
+    records: [record('100')], index: await readNexusIndex(env), nowIso: NOW,
+  });
+
+  // Nexus has since stopped serving this mod's file previews. The mod is old,
+  // so the listing grace window does not apply and the fetch resolves empty.
+  const stored = await indexWithoutBreakdown(env, '100');
+  await refreshArchives(env, fakeArchiveFetch({ preview404: true }), {
+    records: [record('100')], index: stored, nowIso: NOW,
+  });
+  assert.deepEqual(
+    stored.get('100').archives, ['mod_100.archive'],
+    'a regrouping refetch must never turn a good listing into "ships nothing"',
+  );
+  assert.equal(
+    env.DB.one('SELECT archives FROM nexus_cache WHERE nexus_id = ?', '100').archives,
+    JSON.stringify(['mod_100.archive']),
+    'and the stored row must not be downgraded either',
+  );
+});

--- a/worker/test/nexus.test.js
+++ b/worker/test/nexus.test.js
@@ -305,7 +305,7 @@ test('archives: a removal-only mod (ships only .xl) is still detected', async ()
 test('archives: modFiles failure → ok:false, no archives, only the one subrequest', async () => {
   const res = await fetchModArchiveNames(archiveFetch({ routerOk: false }), 1);
   assert.deepEqual(res, {
-    archives: [], ok: false, listed: false, subrequests: 1,
+    archives: [], archivesByFile: {}, ok: false, listed: false, subrequests: 1,
   });
 });
 
@@ -340,7 +340,7 @@ test('archives: a mod whose only file 404s is ok:true but listed:false', async (
   });
   const res = await fetchModArchiveNames(impl, 1);
   assert.deepEqual(res, {
-    archives: [], ok: true, listed: false, subrequests: 2,
+    archives: [], archivesByFile: {}, ok: true, listed: false, subrequests: 2,
   });
 });
 
@@ -368,14 +368,14 @@ test('archives: a mod with no downloadable files at all is listed:false', async 
   // Nothing was read, so nothing is known: the same silence as a 404.
   const res = await fetchModArchiveNames(archiveFetch({ modFiles: [] }), 1);
   assert.deepEqual(res, {
-    archives: [], ok: true, listed: false, subrequests: 1,
+    archives: [], archivesByFile: {}, ok: true, listed: false, subrequests: 1,
   });
 });
 
 test('archives: a thrown fetch degrades to ok:false, never throws', async () => {
   const impl = async () => { throw new Error('network'); };
   assert.deepEqual(await fetchModArchiveNames(impl, 1), {
-    archives: [], ok: false, listed: false, subrequests: 1,
+    archives: [], archivesByFile: {}, ok: false, listed: false, subrequests: 1,
   });
 });
 


### PR DESCRIPTION
Cuts **2.11.0**.

## Added

- Locations sharing a Nexus page can be mapped to the download they actually ship, from a picker in the dashboard. It appears only for a record whose page holds another location.

## Fixed

- Two locations sharing one Nexus page are no longer served each other's `.archive` files, which made both report as installed when the player had either one.
- An unmapped record on a shared page is served no archives rather than the whole page.
- The admin locations search box accepts spaces.
- The dashboard shows what a record is served, not what its Nexus page holds.

## The defect

`nexus_cache` was keyed `nexus_id PRIMARY KEY` and `attachArchives` assigned the page's whole listing to every record with that id. That encodes "one Nexus page = one mod = one location". Page 23896 ships two downloads and the registry has a record for each, so both got all six files.

Trigger chosen from a measurement, not a guess: **229 of 294 pages have more than one download** (main plus updates and patches, all one location) but **exactly 1 maps to more than one location**. So the split keys off locations-per-page, which the board computes itself.

## Migration state

`0011_archives_by_download.sql` is **already applied to both databases** — staging before its deploy, production before this PR. The columns are additive and the current production code does not reference them, so applying ahead of the merge is the safe order and avoids the failure staging hit (new code, old schema, refresh silently falling back to last-known-good).

## Verified on staging

Both Watson records now serve three files each, disjoint:

| Record | Served |
| --- | --- |
| Little China Pink Ink | `Watson Little China Tattoo Shop.archive` + its 2 `.xl` |
| Northside Body Mods | `Watson Northside Tattoo Shop.archive` + its 2 `.xl` |

## After merge

1. The cron backfills `archives_by_file`, shared pages first, so 23896 lands on the next tick rather than after ~290 pages that never consult it.
2. Both Watson records read `[]` until then — the fail-safe, and still correct behaviour.
3. Map each in the production dashboard.

422 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
