### PR TITLE
release: 2.12.0 (alert lifecycle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Submission alerts in Discord say what landed: kind, name, and either the category, Nexus id and coordinates (a create) or the field names an edit changes. The submitter's note, contact and removal reason are still not quoted.
+- The alert links straight to the submission. `/admin/?submission=<id>` opens the Queue tab with it selected, and the Alerts tab gets an "Open submission" button.
+
+### Changed
+
+- An acknowledged alert turns green with a tick in Discord, edited in place, signed with who cleared it.
+- Approving or rejecting a submission acknowledges its alert automatically. Holding does not.
+
 ## [2.11.0] - 2026-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.12.0] - 2026-08-10
 
 ### Added
 

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -2998,6 +2998,25 @@
   // somebody missed.
   const isLogOnly = (a) => a.notify === 0 || a.notify === false;
 
+  /**
+   * Straight to the thing the alert is about.
+   *
+   * The body already carries the same link as text, but following it opens a
+   * second tab on the dashboard the reviewer is already looking at. `ref` is
+   * `type:id`, and a submission is the only type with a destination here today,
+   * so anything else renders nothing rather than a button that lands nowhere.
+   */
+  function alertRefButton(a) {
+    const match = /^submission:(\d+)$/.exec(a.ref || '');
+    if (!match) return null;
+    return h('button', {
+      type: 'button',
+      class: 'btn secondary',
+      style: 'margin-right:var(--space-xs)',
+      onclick: () => openSubmission(Number(match[1])),
+    }, 'Open submission');
+  }
+
   function alertCard(a) {
     const severity = SEVERITY_LABEL[a.severity] ? a.severity : 'info';
     const acknowledged = Boolean(a.acknowledged_at);
@@ -3021,6 +3040,7 @@
       // innerHTML, so a Discord-flavoured body still cannot become markup here.
       a.body ? h('p', { class: 'alert-body' }, bodyNodes(a.body)) : null,
       h('div', { class: 'alert-foot' },
+        alertRefButton(a),
         // No Acknowledge on a log-only alert. Acknowledging clears something
         // from the open count, and a log-only alert was never in it, so the
         // button would be a control that visibly does nothing.
@@ -3414,11 +3434,21 @@
     // Surface a callback error, then strip it so a refresh does not re-show it.
     const params = new URLSearchParams(location.search);
     const err = params.get('error');
+    // Where the alert in Discord points. Read before the sign-in gate and kept
+    // across it: arriving from the channel signed out means bouncing through
+    // GitHub, and the destination has to survive that round trip.
+    const deepLink = Number(params.get('submission'));
     let callbackBanner = null;
     if (err) {
       const [kind, message] = CALLBACK_ERRORS[err] || ['error', `Sign-in failed (${err}).`];
       callbackBanner = h('div', { class: `notice ${kind}`, text: message });
       params.delete('error');
+    }
+    // Stripped either way. The parameter is an instruction for this load, not
+    // state: left in place it would reopen the same submission on every refresh,
+    // including one taken hours later to look at something else.
+    if (err || params.has('submission')) {
+      params.delete('submission');
       history.replaceState({}, '', location.pathname + (params.toString() ? `?${params}` : ''));
     }
 
@@ -3533,6 +3563,37 @@
     // Overview is the landing tab, and its numbers come from what was just
     // loaded, so it is rendered after both rather than on its own fetch.
     await renderOverview();
+
+    // Last, because it overrides the landing tab and needs the queue already
+    // loaded to select a row in it.
+    if (Number.isInteger(deepLink) && deepLink > 0) openSubmission(deepLink);
+  }
+
+  /**
+   * Open one submission from a link, wherever it came from.
+   *
+   * The queue's status filter is cleared first: it defaults to pending, and a
+   * link followed after the submission was already resolved would otherwise land
+   * on a queue that does not contain it and select nothing, which reads as a
+   * broken link rather than as "somebody got here first".
+   *
+   * A submission that is genuinely gone says so, rather than dumping the
+   * reviewer on an empty Queue tab with no explanation.
+   */
+  async function openSubmission(id) {
+    switchTab('queue');
+    // The queue can predate the link: the Alerts tab refreshes on its own, and
+    // a submission that arrived after boot is not in `state.submissions` yet.
+    const missing = () => !state.submissions.some((s) => s.id === id);
+    if (missing()) await loadQueue();
+    if (missing()) {
+      banner('error', `Submission #${id} is not in the queue. It may have been purged.`);
+      return;
+    }
+    state.queueStatus = '';
+    $('#queue-status').value = '';
+    renderQueue();
+    selectSubmission(id);
   }
 
   main();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -238,6 +238,40 @@ Two rules keep this from going wrong:
   has not considered routing is noisy rather than silent. Silence is the
   expensive failure.
 
+#### Closing an alert
+
+An alert is posted once and then **edited** when it is resolved: the cyan "!"
+becomes a green "✅" on the original message, signed with who closed it. The
+Worker posts every alert with `?wait=true` so Discord returns the message id,
+and stores it in `alerts.discord_message_id`. The edit is best-effort and never
+gates the acknowledgement: a row raised before this existed, or one Discord
+refused, has no id and is acknowledged in the dashboard exactly as before.
+
+Two things close an alert:
+
+- **The Acknowledge button** in the dashboard's Alerts tab.
+- **Resolving what it was about.** `alerts.ref` holds a `type:id` string
+  (today only `submission:123`), and approving or rejecting that submission
+  acknowledges every open alert carrying its ref. A **hold** does not: the
+  submission is still waiting on somebody. Only the first close counts, so the
+  channel and the dashboard name the same reviewer.
+
+#### What a submission alert says
+
+The post carries the kind, the subject, and either the payload's category /
+Nexus id / coordinates (a create) or the **names** of the fields being changed
+(an edit). It does **not** quote `submitter_note`, `submitter_contact`, or a
+removal's `reason`: those are unreviewed free text from an anonymous caller and
+the channel is not behind the collaborator gate. The alert says one exists; the
+reviewer reads it in the dashboard. Everything submitter-controlled that *is*
+quoted goes through `escapeDiscord()`, so a mod named `@everyone` renders as its
+own name.
+
+The embed title links to `/admin/?submission=<id>`, which the dashboard reads at
+boot: it opens the Queue tab with that submission selected, clearing the pending
+filter first so an already-resolved one still opens. A query parameter, not a
+hash: the hash belongs to the dashboard's overlay history.
+
 **Why `/internal/` and not `/admin/`.** Every `/admin/*` route is gated on GitHub
 collaborator status, and `index.js` states that as an invariant. The machine
 surface authenticates with a shared secret instead, so it sits on its own prefix

--- a/worker/README.md
+++ b/worker/README.md
@@ -109,20 +109,22 @@ npx wrangler d1 migrations apply nczoning-data --remote
 npx wrangler d1 migrations apply nczoning-data-staging --env staging --remote
 ```
 
-**Do not set `CLOUDFLARE_ACCOUNT_ID`.** This block used to open with
-`export CLOUDFLARE_ACCOUNT_ID=b9937d8d595fad7de8d1549b22390281`, and that line
-is what makes the command fail. The wrangler login is an OAuth token spanning
-two accounts; it resolves the right one from the config on its own, and pinning
-the id makes the API answer
+**If you get a 7403, the login has expired. Run `npx wrangler whoami` and retry.**
 
 ```text
 The given account is not valid or is not authorized to access this service [code: 7403]
 ```
 
-which reads as "you are not logged in" and is not. `npx wrangler whoami` will
-show a valid token with `d1 (write)` while the same shell cannot list a
-migration. Unset it and the command works. The same variable also empties the
-Cloudflare MCP's D1 listing.
+That reads as "this account cannot do D1" and means "this access token is
+stale". The wrangler login is an OAuth token, and it is refreshed by the next
+command that needs it: `whoami` rewrites
+`%APPDATA%\xdg.config\.wrangler\config\default.toml` and everything after it
+works. Nothing about the account or its permissions is wrong, which is why the
+message sends you looking in the wrong place.
+
+`export CLOUDFLARE_ACCOUNT_ID=...` used to head this block and was removed for
+being unnecessary, not for being harmful: with a fresh token the command works
+with or without it. It is gone because the login already resolves the account.
 
 **`--env staging` is not optional on the second line.** Wrangler resolves
 database names from the top-level config only, so without it the staging

--- a/worker/migrations/0012_alert_discord_message.sql
+++ b/worker/migrations/0012_alert_discord_message.sql
@@ -1,0 +1,37 @@
+-- Lets an alert be closed in both places at once: the dashboard row and the
+-- Discord message that announced it.
+--
+-- Until now the two halves of the fan-out were write-once and unlinked. A
+-- reviewer acknowledged a row in the dashboard, or approved the submission it
+-- was about, and the channel still showed a cyan "!" -- so the channel reported
+-- a backlog that had already been cleared, which is the same failure mode the
+-- alerts table was built to avoid, just pointing the other way.
+--
+-- Two columns, because closing the loop needs two different facts.
+
+-- The Discord message this alert became, so it can be EDITED in place rather
+-- than answered with a second post. Discord returns it only when the webhook is
+-- called with `?wait=true`; without that the POST is fire-and-forget and 204s.
+--
+-- NULL is the ordinary state for a log-only alert (never forwarded), for every
+-- row written before this column existed, and for any alert Discord refused.
+-- Nothing downstream may treat NULL as an error: the dashboard is still the
+-- surface that outlives Discord, and an un-editable message costs the tick, not
+-- the acknowledgement.
+ALTER TABLE alerts ADD COLUMN discord_message_id TEXT;
+
+-- What the alert is ABOUT, as `type:id` -- today only `submission:123`.
+--
+-- A scoped string rather than a `submission_id` foreign key: alerts already
+-- span five sources and the next thing worth linking (a location, a Nexus mod)
+-- would need its own nullable column each time. One column that names its own
+-- namespace stays one column.
+--
+-- It carries the auto-acknowledgement: approving or rejecting a submission
+-- resolves the alert that asked for it, which is the only way the two can be
+-- kept in step without a reviewer remembering to clear both.
+ALTER TABLE alerts ADD COLUMN ref TEXT;
+
+-- Resolving by ref is the write path on every approve and reject, and it always
+-- filters to the still-open rows.
+CREATE INDEX idx_alerts_ref ON alerts (ref, acknowledged_at);

--- a/worker/src/alerts.js
+++ b/worker/src/alerts.js
@@ -46,6 +46,22 @@
  *   that has not thought about routing is noisy rather than silent, and every
  *   row written before this existed reads correctly. Silence is the expensive
  *   failure here; noise is the cheap one.
+ *
+ * ## Closing an alert closes it in both places
+ *
+ * An alert is posted once and then EDITED when it is resolved: cyan "!" becomes
+ * green "✅", in place, on the original message. The alternative -- a second
+ * post saying the first one is handled -- doubles the channel's volume to say
+ * nothing new, and the message a reader scrolls back to is still the stale one.
+ *
+ * This needs the message id, which Discord returns only for a webhook called
+ * with `?wait=true`, so that is how every alert is posted. It is stored on the
+ * row (`discord_message_id`) because the resolver runs minutes or days later, in
+ * a different request, in a different isolate.
+ *
+ * Editing is strictly best-effort and never gates the acknowledgement. The
+ * dashboard is the surface that outlives Discord; a failed edit costs a stale
+ * "!" in a channel, which is exactly the cost of not having built this.
  */
 
 /**
@@ -86,6 +102,30 @@ const SEVERITY_ICON = {
 const BODY_MAX = 1500;
 
 /**
+ * Neutralise Discord formatting in a value this Worker did not author.
+ *
+ * Everything passing through here is either submitter free text or a GitHub
+ * login, and an embed description renders markdown, masked links and mentions.
+ * Escaping rather than stripping, so a mod genuinely called `*NCPD*` still
+ * reads as its own name.
+ *
+ * Newlines collapse to spaces because `#` and `>` are formatting only at the
+ * start of a line, and a one-line fact cannot have one. `@` gets a zero-width
+ * space so `@everyone` in a submitted name pings nobody.
+ */
+export function escapeDiscord(text, max = 120) {
+  return String(text ?? '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, max)
+    .replace(/[\\*_~`|]/g, (c) => `\\${c}`)
+    .replace(/@/g, '@\u200b');
+}
+
+/** Plain text for a place that renders no markdown, such as an embed title. */
+const plain = (text, max = 120) => String(text ?? '').replace(/\s+/g, ' ').trim().slice(0, max);
+
+/**
  * Normalise and validate an alert. Returns `{ ok, alert }` or `{ ok, error }`.
  *
  * Exported because `/internal/alerts` validates an untrusted body with it, and
@@ -114,10 +154,26 @@ export function validateAlertInput(input) {
   if (input?.notify != null && typeof input.notify !== 'boolean') {
     errors.push('notify must be a boolean when present');
   }
+  // The embed's title becomes this link, so it is the one field of an alert
+  // that can send a reader somewhere. Restricted to https and to this site's
+  // own origins, because `/internal/alerts` is reachable with a shared secret
+  // and a clickable off-site link in the alerts channel is a phishing primitive
+  // rather than a feature.
+  const link = input?.link == null ? null : String(input.link);
+  if (link !== null && !/^https:\/\/[^\s]+$/.test(link)) {
+    errors.push('link must be an https URL when present');
+  }
+  // `type:id`, and nothing that would need escaping. This is a lookup key, not
+  // anything a person reads.
+  const ref = input?.ref == null ? null : String(input.ref);
+  if (ref !== null && !/^[a-z]+:[A-Za-z0-9_-]+$/.test(ref)) {
+    errors.push('ref must look like "submission:123" when present');
+  }
 
   if (errors.length) return { ok: false, errors };
   return {
-    ok: true, alert: { source, severity, title, body, notify: input?.notify !== false },
+    ok: true,
+    alert: { source, severity, title, body, link, ref, notify: input?.notify !== false },
   };
 }
 
@@ -126,15 +182,32 @@ export function validateAlertInput(input) {
  * decides whether that is fatal (it is not, for `raiseAlert`).
  */
 export async function recordAlert(
-  env, { source, severity, title, body = null, notify = true }, nowMs = Date.now(),
+  env, { source, severity, title, body = null, link = null, ref = null, notify = true },
+  nowMs = Date.now(),
 ) {
   const { meta } = await env.DB.prepare(
-    'INSERT INTO alerts (at, source, severity, title, body, notify) VALUES (?, ?, ?, ?, ?, ?)',
+    `INSERT INTO alerts (at, source, severity, title, body, notify, ref)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
   ).bind(
-    new Date(nowMs).toISOString(), source, severity, title, body, notify === false ? 0 : 1,
+    new Date(nowMs).toISOString(), source, severity, title, composeBody(body, link),
+    notify === false ? 0 : 1, ref,
   ).run();
   return meta?.last_row_id ?? null;
 }
+
+/**
+ * The body a reader sees, link included.
+ *
+ * The link lives IN the body rather than in a column of its own, and this one
+ * function composes it for both consumers: the stored row and the embed. Two
+ * compositions would let the dashboard and Discord show different text for the
+ * same alert, and the resolved embed is rebuilt from the row -- so the row's
+ * body has to already be the message.
+ */
+const composeBody = (body, link) => (link ? `${body ? `${body}\n\n` : ''}${link}` : body ?? null);
+
+/** The dedicated alerts webhook, or the legacy submissions one it replaced. */
+const webhookUrl = (env) => env.NCZ_ALERTS_DISCORD_WEBHOOK_URL || env.DISCORD_WEBHOOK_URL;
 
 /**
  * Post the alert to the map-alerts channel.
@@ -144,17 +217,79 @@ export async function recordAlert(
  * Cloudflare Worker secrets here; the same names also exist as GitHub Actions
  * secrets and are a SEPARATE store. See `learnings/discord-webhook-two-secret-stores`.
  *
- * Returns true if Discord accepted it, false in every other case including
- * "no webhook configured". Never throws.
+ * `?wait=true` makes Discord respond with the created message instead of a bare
+ * 204, which is the only way to learn the id needed to edit it later. It costs a
+ * slower call and it makes the webhook's own rate limit visible as a failure
+ * rather than swallowing it, both of which are worth an alert that can be closed.
+ *
+ * Returns `{ forwarded, messageId }`. `forwarded` is false in every failure case
+ * including "no webhook configured"; `messageId` is null whenever the response
+ * did not carry one, which a caller must treat as ordinary. Never throws.
  */
 export async function forwardToDiscord(env, alert, fetchImpl = fetch) {
-  const webhook = env.NCZ_ALERTS_DISCORD_WEBHOOK_URL || env.DISCORD_WEBHOOK_URL;
-  if (!webhook) return false;
+  const webhook = webhookUrl(env);
+  if (!webhook) return { forwarded: false, messageId: null };
   try {
-    const res = await fetchImpl(webhook, {
+    const res = await fetchImpl(withWait(webhook), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ embeds: [toEmbed(alert)] }),
+    });
+    if (!res?.ok) return { forwarded: false, messageId: null };
+    return { forwarded: true, messageId: await readMessageId(res) };
+  } catch {
+    return { forwarded: false, messageId: null };
+  }
+}
+
+/** `?wait=true` on the webhook, without disturbing anything already in the URL. */
+function withWait(webhook) {
+  try {
+    const url = new URL(webhook);
+    url.searchParams.set('wait', 'true');
+    return url.toString();
+  } catch {
+    return `${webhook}${webhook.includes('?') ? '&' : '?'}wait=true`;
+  }
+}
+
+/**
+ * The message id out of a webhook response, or null.
+ *
+ * Tolerant on purpose: a 204 with no body, a response object without `.json`,
+ * and a body that is not the message are all "no id", not errors. The id is an
+ * optimisation on top of a notification that has already been delivered.
+ */
+async function readMessageId(res) {
+  if (typeof res.json !== 'function') return null;
+  try {
+    const body = await res.json();
+    return typeof body?.id === 'string' && body.id ? body.id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Edit the message an alert already posted, so a resolved alert stops reading
+ * as open in the channel.
+ *
+ * Returns false and does nothing if there is no id, which is the state of every
+ * alert raised before this existed and of every one Discord refused. Never
+ * throws: this runs inside acknowledgement, and a Discord failure must not turn
+ * a successful acknowledgement into a 500.
+ */
+export async function editDiscordMessage(env, messageId, embed, fetchImpl = fetch) {
+  const webhook = webhookUrl(env);
+  if (!webhook || !messageId) return false;
+  // The message route hangs off the webhook path; a `?wait=true` left on the end
+  // would land inside the path segment.
+  const base = String(webhook).split('?')[0].replace(/\/+$/, '');
+  try {
+    const res = await fetchImpl(`${base}/messages/${encodeURIComponent(messageId)}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ embeds: [embed] }),
     });
     return Boolean(res?.ok);
   } catch {
@@ -163,13 +298,47 @@ export async function forwardToDiscord(env, alert, fetchImpl = fetch) {
 }
 
 /** The embed one alert renders as, in the map-alerts channel. */
-function toEmbed({ source, severity, title, body }) {
+function toEmbed({ source, severity, title, body, link }) {
   return {
-    title: `${SEVERITY_ICON[severity] ?? ''} ${title}`.trim(),
-    description: body ? String(body).slice(0, BODY_MAX) : undefined,
+    title: `${SEVERITY_ICON[severity] ?? ''} ${plain(title, 200)}`.trim(),
+    // Discord makes an embed title with a `url` clickable, which is one tap from
+    // the channel to the thing the alert is about. A separate line saying "open
+    // the dashboard" is still in the body for the clients that render titles
+    // plainly.
+    url: link ?? undefined,
+    description: composeBody(body, link)?.slice(0, BODY_MAX) || undefined,
     color: SEVERITY_COLOR[severity] ?? SEVERITY_COLOR.info,
     footer: { text: `NC Zoning Board • ${source}` },
   };
+}
+
+/**
+ * The same embed, resolved: green, ticked, and signed.
+ *
+ * Built from the stored ROW rather than from the alert object, because the only
+ * caller is acknowledgement, which runs in a later request that has the row and
+ * not the original. Body and source are carried through unchanged so scrolling
+ * back to the message still tells the reader what happened, not just that
+ * somebody dealt with it.
+ */
+export function toResolvedEmbed(row, { verb = 'Acknowledged' } = {}) {
+  const link = firstLink(row.body);
+  return {
+    title: `${SEVERITY_ICON.recovery} ${plain(row.title, 200)}`.trim(),
+    url: link ?? undefined,
+    description: row.body ? String(row.body).slice(0, BODY_MAX) : undefined,
+    color: SEVERITY_COLOR.recovery,
+    footer: {
+      text: `NC Zoning Board • ${row.source} • ${verb.toLowerCase()} by `
+        + `${plain(row.acknowledged_by, 60) || 'a reviewer'}`,
+    },
+  };
+}
+
+/** The dashboard URL recordAlert appended, so the resolved embed keeps it. */
+function firstLink(body) {
+  const match = String(body ?? '').match(/https:\/\/\S+/);
+  return match ? match[0] : null;
 }
 
 /**
@@ -183,7 +352,8 @@ function toEmbed({ source, severity, title, body }) {
  * distinguishable: `notified:false` is this alert being log-only by design,
  * `notified:true, forwarded:false` is Discord having refused a real one.
  *
- * @returns {Promise<{id: number|null, recorded: boolean, notified: boolean, forwarded: boolean}>}
+ * @returns {Promise<{id: number|null, recorded: boolean, notified: boolean,
+ *                    forwarded: boolean, messageId: string|null}>}
  */
 export async function raiseAlert(env, alert, { fetchImpl = fetch, nowMs = Date.now() } = {}) {
   let id = null;
@@ -203,8 +373,25 @@ export async function raiseAlert(env, alert, { fetchImpl = fetch, nowMs = Date.n
   // Recording happens either way; only the Discord hop is conditional. A
   // log-only alert is in the dashboard and in `wrangler tail`, which is the
   // whole claim being made about it -- it is quieter, not lost.
-  const forwarded = notified ? await forwardToDiscord(env, alert, fetchImpl) : false;
-  return { id, recorded, notified, forwarded };
+  const posted = notified
+    ? await forwardToDiscord(env, alert, fetchImpl)
+    : { forwarded: false, messageId: null };
+
+  // A third write, after both steps, rather than folding the id into the INSERT:
+  // the id does not exist until Discord has answered, and waiting for that
+  // before recording would put the notification back in front of the history.
+  // The ordering in the module comment is the point; this is the price of it.
+  if (id !== null && posted.messageId) {
+    try {
+      await env.DB.prepare('UPDATE alerts SET discord_message_id = ? WHERE id = ?')
+        .bind(posted.messageId, id).run();
+    } catch {
+      // The alert is recorded and the channel has it. All that is lost is the
+      // ability to tick this one message off later, which is a nicety.
+    }
+  }
+
+  return { id, recorded, notified, forwarded: posted.forwarded, messageId: posted.messageId };
 }
 
 /**
@@ -259,6 +446,17 @@ export async function alertStreak(env, { source, title, resetTitle }) {
 }
 
 /**
+ * What every reader of this table gets. `discord_message_id` is deliberately
+ * NOT here: it is plumbing for the edit, it means nothing to a dashboard, and
+ * the admin API returns these rows to a browser.
+ *
+ * `ref` IS here, because it is what lets the dashboard link an alert to the
+ * submission it is about.
+ */
+const ALERT_COLUMNS = `id, at, source, severity, title, body, notify, ref,
+  acknowledged_by, acknowledged_at`;
+
+/**
  * Most recent first, matching `readAudit`. `unacknowledged` filters to the ones
  * still needing a human, which is what the dashboard badge counts.
  *
@@ -271,8 +469,7 @@ export async function readAlerts(env, { limit = 100, unacknowledged = false } = 
   const capped = Math.min(Math.max(Number(limit) || 100, 1), 500);
   const where = unacknowledged ? 'WHERE acknowledged_at IS NULL AND notify = 1' : '';
   const { results } = await env.DB.prepare(
-    `SELECT id, at, source, severity, title, body, notify, acknowledged_by, acknowledged_at
-       FROM alerts ${where} ORDER BY id DESC LIMIT ?`,
+    `SELECT ${ALERT_COLUMNS} FROM alerts ${where} ORDER BY id DESC LIMIT ?`,
   ).bind(capped).all();
   return results ?? [];
 }
@@ -291,17 +488,73 @@ export async function countUnacknowledged(env) {
  *
  * Acknowledging an already-acknowledged alert is a no-op that returns the row
  * unchanged rather than an error: two admins clearing the same backlog is
- * expected, and the first one to arrive is the one who dealt with it.
+ * expected, and the first one to arrive is the one who dealt with it. The
+ * Discord edit is skipped in that case too -- the message already says green,
+ * and re-editing it would rewrite the first reviewer's name out of the footer.
+ *
+ * `verb` is what the channel says happened: "Acknowledged" from the dashboard
+ * button, "Approved" or "Rejected" when a review resolved it. Same state in D1
+ * either way; the distinction only exists for the person reading the channel,
+ * which is the whole surface this edit serves.
  */
-export async function acknowledgeAlert(env, id, actor, nowMs = Date.now()) {
+export async function acknowledgeAlert(
+  env, id, actor, { nowMs = Date.now(), verb = 'Acknowledged', fetchImpl = fetch } = {},
+) {
   const numeric = Number(id);
   if (!Number.isInteger(numeric)) return null;
-  await env.DB.prepare(
+  const { meta } = await env.DB.prepare(
     `UPDATE alerts SET acknowledged_by = ?, acknowledged_at = ?
       WHERE id = ? AND acknowledged_at IS NULL`,
   ).bind(actor, new Date(nowMs).toISOString(), numeric).run();
-  return env.DB.prepare(
-    `SELECT id, at, source, severity, title, body, notify, acknowledged_by, acknowledged_at
-       FROM alerts WHERE id = ?`,
+
+  const row = await env.DB.prepare(
+    `SELECT ${ALERT_COLUMNS}, discord_message_id FROM alerts WHERE id = ?`,
   ).bind(numeric).first();
+  if (!row) return null;
+
+  // Only on the transition. `changes` is 0 when the row was already
+  // acknowledged, and 0 rows changed is the same answer as "somebody else got
+  // here first".
+  if (meta?.changes && row.discord_message_id) {
+    await editDiscordMessage(env, row.discord_message_id, toResolvedEmbed(row, { verb }), fetchImpl);
+  }
+
+  // `discord_message_id` is plumbing and does not leave this module.
+  const { discord_message_id: _omit, ...visible } = row;
+  return visible;
+}
+
+/**
+ * Acknowledge every open alert about one thing -- today, a submission that has
+ * just been approved or rejected.
+ *
+ * This is what keeps the two surfaces in step without a reviewer clearing the
+ * same item twice. An alert that says "a submission is waiting" is answered by
+ * the submission no longer waiting; leaving it open would make the dashboard
+ * badge and the channel both count work that is done, and a count that is
+ * routinely wrong is a count nobody reads.
+ *
+ * Every open row, not the newest: a re-raised alert about the same submission
+ * would otherwise leave older duplicates standing forever.
+ *
+ * Never throws. It runs after the registry write and after the submission is
+ * resolved, so a failure here must not turn a completed review into an error
+ * the reviewer will retry.
+ */
+export async function resolveAlertsByRef(
+  env, ref, actor, { verb = 'Acknowledged', nowMs = Date.now(), fetchImpl = fetch } = {},
+) {
+  if (!env.DB || !ref) return 0;
+  try {
+    const { results } = await env.DB.prepare(
+      'SELECT id FROM alerts WHERE ref = ? AND acknowledged_at IS NULL',
+    ).bind(ref).all();
+    const open = results ?? [];
+    for (const { id } of open) {
+      await acknowledgeAlert(env, id, actor, { nowMs, verb, fetchImpl });
+    }
+    return open.length;
+  } catch {
+    return 0;
+  }
 }

--- a/worker/src/review.js
+++ b/worker/src/review.js
@@ -65,6 +65,7 @@ import { validateLocationInput } from './validate.js';
 import { readTagSlugs } from './tag-registry.js';
 import { readCandidates } from './nexus-cache.js';
 import { writeAudit } from './audit.js';
+import { resolveAlertsByRef } from './alerts.js';
 import {
   getRow, loadAdminRecord, loadAdminRecordById, materializeAfterWrite,
   insertLocation, patchLocation,
@@ -505,6 +506,20 @@ async function act(request, env, ctx, { id, action, actor }) {
       base_override: applied && body.base_modified_at ? true : undefined,
     },
   });
+
+  // The alert that asked for this is answered by this. Approve and reject only:
+  // a hold sends the submission back and it is still waiting on somebody, so the
+  // dashboard badge and the channel should both keep saying so.
+  //
+  // After resolve() won, so an alert is never closed for a review that lost the
+  // race. Awaited rather than deferred to ctx.waitUntil: it is two small D1
+  // statements and one Discord PATCH, and the reviewer's next screen is the
+  // dashboard, which reads the alert count they just changed.
+  if (action !== 'hold') {
+    await resolveAlertsByRef(env, `submission:${id}`, actor, {
+      verb: action === 'approve' ? 'Approved' : 'Rejected',
+    });
+  }
 
   if (applied) materializeAfterWrite(env, ctx);
 

--- a/worker/src/submissions.js
+++ b/worker/src/submissions.js
@@ -35,7 +35,7 @@ import { validateLocationInput } from './validate.js';
 import { readTagSlugs } from './tag-registry.js';
 import { readCandidates } from './nexus-cache.js';
 import { writeAudit } from './audit.js';
-import { raiseAlert } from './alerts.js';
+import { raiseAlert, escapeDiscord } from './alerts.js';
 
 const KINDS = ['create', 'edit', 'remove'];
 
@@ -166,7 +166,60 @@ function checkText(value, { field, max, required = false }) {
  */
 async function readLocationBase(env, id) {
   if (typeof id !== 'string' || !id) return null;
-  return env.DB.prepare('SELECT id, modified_at FROM locations WHERE id = ?').bind(id).first();
+  // `name` comes along for the alert, which says WHICH record an edit or removal
+  // is about. It is a curated value out of the registry, not submitter text.
+  return env.DB.prepare('SELECT id, name, modified_at FROM locations WHERE id = ?').bind(id).first();
+}
+
+const KIND_LABEL = { create: 'New location', edit: 'Edit', remove: 'Removal' };
+
+/**
+ * The two or three lines that tell a reviewer what landed, without opening
+ * anything.
+ *
+ * ## What is quoted, and what is not
+ *
+ * Structured, validated fields only: the name, the category, the coordinates,
+ * the NAMES of the fields an edit touches. Every one of those has been through
+ * `validateLocationInput` and is bounded, enumerated, or numeric.
+ *
+ * `submitter_note`, `submitter_contact` and a removal's `reason` are still NOT
+ * quoted. They are unreviewed free prose from an anonymous caller and this posts
+ * to a channel; the reviewer reads them in the dashboard, behind the
+ * collaborator gate. The alert says one EXISTS, which is the part that changes
+ * whether the reviewer opens it now.
+ *
+ * `name` is submitter-controlled on a create, so it goes through
+ * `escapeDiscord`: a mod called `@everyone` or `[click here](http://evil)` must
+ * render as its own name and nothing else.
+ */
+function describeSubmission({ kind, stored, base, note, contact }) {
+  const subject = kind === 'create' ? stored?.name : base?.name;
+  const lines = [`**${KIND_LABEL[kind] ?? kind}** · ${subject ? escapeDiscord(subject) : 'unnamed'}`];
+
+  if (kind === 'create') {
+    const facts = [];
+    if (stored?.category) facts.push(`Category: ${escapeDiscord(stored.category, 40)}`);
+    if (stored?.nexus_id) facts.push(`Nexus: ${escapeDiscord(stored.nexus_id, 20)}`);
+    const coords = Array.isArray(stored?.coordinates)
+      ? stored.coordinates.map((n) => Math.round(Number(n))).join(', ')
+      : null;
+    if (coords) facts.push(`At ${coords}`);
+    if (facts.length) lines.push(facts.join(' · '));
+  } else if (kind === 'edit') {
+    // Field NAMES, not values. Which fields moved is what decides how long a
+    // review takes; the values are in the dashboard's diff, next to what they
+    // are replacing, which is the only place they can be judged.
+    const fields = Object.keys(stored ?? {});
+    lines.push(fields.length ? `Changes: ${fields.join(', ')}` : 'Changes: none stated');
+  } else {
+    lines.push('Asks for the pin to come off the map. A reason was given.');
+  }
+
+  const attached = [note ? 'a note' : null, contact ? 'a contact' : null].filter(Boolean);
+  if (attached.length) lines.push(`Submitter left ${attached.join(' and ')}.`);
+
+  return lines.join('\n');
 }
 
 /**
@@ -221,6 +274,8 @@ async function create(request, env, { fetchImpl = fetch, nowMs = Date.now() } = 
   // The version of the record this submission is written against. NULL for a
   // create, which has no base: see migration 0008.
   let baseModifiedAt = null;
+  // The record an edit or removal acts on, kept for the alert below.
+  let base = null;
 
   if (kind === 'create') {
     const tagNames = await readTagSlugs(env);
@@ -228,7 +283,7 @@ async function create(request, env, { fetchImpl = fetch, nowMs = Date.now() } = 
     errors.push(...checked.errors);
     stored = checked.values ?? null;
   } else {
-    const base = await readLocationBase(env, body.location_id);
+    base = await readLocationBase(env, body.location_id);
     if (!base) {
       errors.push('location_id must be an existing location');
     } else {
@@ -291,25 +346,36 @@ async function create(request, env, { fetchImpl = fetch, nowMs = Date.now() } = 
   // its doorbell. See learnings/retiring-a-channel-took-the-only-submission-
   // notification-with-it.
   //
-  // Deliberately a plain "one is waiting" post that links to the dashboard. The
-  // old webhook posted an embed and then EDITED it in place to show merged or
-  // closed, which made Discord the queue's UI; the dashboard holds that state
-  // now and the message-editing machinery is not being rebuilt.
+  // The post says what landed and links straight at it. What it does NOT quote,
+  // and why, is in describeSubmission.
   //
-  // Nothing from the submitter is quoted. The note and contact are unreviewed
-  // free text from an anonymous caller, and this posts to a channel; the
-  // reviewer reads them in the dashboard, behind the collaborator gate.
+  // The old GitHub-issue webhook posted an embed and edited it in place to show
+  // merged or closed. That machinery came back, deliberately and much smaller:
+  // `ref` below is what lets approving or rejecting this submission tick the
+  // message green (see resolveAlertsByRef). Discord is still not the queue's UI
+  // -- it cannot approve anything -- it just stops claiming work is open after
+  // it is done.
+  const origin = env.SITE_ORIGIN ?? 'https://nczoning.net';
   await raiseAlert(env, {
     source: 'submissions',
     severity: 'info',
-    title: `New ${kind} submission awaiting review`,
-    // Plain /admin/, not a deep link: the dashboard has no hash routing, so
-    // /admin/#queue would silently open on Overview and read as a broken link.
-    body: `A ${kind} submission is pending${id === null ? '' : ` (#${id})`}.`
-      + `\n\nReview it in the Queue tab at ${env.SITE_ORIGIN ?? 'https://nczoning.net'}/admin/`,
+    title: `${KIND_LABEL[kind] ?? kind} submission awaiting review`,
+    body: describeSubmission({
+      kind, stored, base, note: body.submitter_note, contact: body.submitter_contact,
+    }),
+    // A deep link, which the dashboard reads at boot: it switches to Queue and
+    // opens this submission. A query parameter rather than a hash, because the
+    // hash is already the overlay history's business (`popstate` in admin.js)
+    // and a second writer of it would fight the drawer.
+    link: id === null ? `${origin}/admin/` : `${origin}/admin/?submission=${id}`,
+    // What this alert is ABOUT, so resolving the submission resolves the alert.
+    ref: id === null ? null : `submission:${id}`,
     // The doorbell. A submission sits in the queue until a human approves or
     // rejects it, so this is the definition of actionable.
     notify: true,
+    // `fetchImpl` is deliberately not threaded through: it is the Turnstile stub
+    // in tests, and handing it the Discord post as well would make one fake
+    // answer for two unrelated services.
   }, { nowMs });
 
   return json({ id, kind, status: 'pending' }, 201);

--- a/worker/test-support/d1-sqlite.mjs
+++ b/worker/test-support/d1-sqlite.mjs
@@ -88,6 +88,7 @@ function statement(db, sql, args = []) {
  * @param {Array}  [seed.nexusCache]     raw `nexus_cache` rows
  * @param {Array}  [seed.dismissed]      raw `dismissed_candidates` rows
  * @param {Array}  [seed.nexusModStatus] raw `nexus_mod_status` rows
+ * @param {Array}  [seed.alerts]         raw `alerts` rows
  */
 export function sqliteD1(seed = {}) {
   const db = new DatabaseSync(':memory:');
@@ -135,6 +136,7 @@ export function sqliteD1(seed = {}) {
   insertRows('nexus_cache', seed.nexusCache);
   insertRows('dismissed_candidates', seed.dismissed);
   insertRows('nexus_mod_status', seed.nexusModStatus);
+  insertRows('alerts', seed.alerts);
 
   return {
     _db: db,

--- a/worker/test/alerts.test.js
+++ b/worker/test/alerts.test.js
@@ -12,21 +12,35 @@ import assert from 'node:assert/strict';
 import {
   raiseAlert, recordAlert, readAlerts, countUnacknowledged, acknowledgeAlert,
   alertedSinceUtcMidnight, validateAlertInput, alertStreak, ALERT_SOURCES,
+  resolveAlertsByRef, escapeDiscord,
 } from '../src/alerts.js';
 import { handleInternal } from '../src/internal.js';
 import { sqliteD1 } from '../test-support/d1-sqlite.mjs';
 
 const WEBHOOK = 'https://discord/webhook';
 
-/** Collects what would have been posted to Discord. */
-function fakeDiscord({ fail = false, throws = false } = {}) {
+/**
+ * Collects what would have been posted to Discord.
+ *
+ * Answers a POST with a message object, because that is what `?wait=true` gets
+ * and the id in it is what every edit later depends on. `noId` is the other real
+ * case: a webhook that 204s, which every alert raised before the edit existed
+ * did.
+ */
+function fakeDiscord({ fail = false, throws = false, noId = false } = {}) {
   const sent = [];
   const impl = async (url, init) => {
     if (throws) throw new Error('network down');
-    sent.push({ url, body: JSON.parse(init.body) });
-    return { ok: !fail, status: fail ? 500 : 204, text: async () => 'x' };
+    sent.push({ url, method: init.method, body: JSON.parse(init.body) });
+    return {
+      ok: !fail,
+      status: fail ? 500 : 200,
+      text: async () => 'x',
+      json: async () => (noId ? {} : { id: `msg-${sent.length}` }),
+    };
   };
   impl.sent = sent;
+  impl.edits = () => sent.filter((s) => s.method === 'PATCH');
   return impl;
 }
 
@@ -100,7 +114,7 @@ test('raiseAlert never throws, whatever fails', async () => {
   const env = { DB: { prepare() { throw new Error('nope'); } }, NCZ_ALERTS_DISCORD_WEBHOOK_URL: WEBHOOK };
   const result = await raiseAlert(env, ALERT, { fetchImpl: fakeDiscord({ throws: true }) });
   assert.deepEqual(result, {
-    id: null, recorded: false, notified: true, forwarded: false,
+    id: null, recorded: false, notified: true, forwarded: false, messageId: null,
   });
 });
 
@@ -116,7 +130,10 @@ test('the legacy submissions webhook is the fallback, not a second post', async 
   const discord = fakeDiscord();
   await raiseAlert(env, ALERT, { fetchImpl: discord });
   assert.equal(discord.sent.length, 1);
-  assert.equal(discord.sent[0].url, 'https://legacy');
+  // `?wait=true` on whichever webhook is in play: the message id is what makes
+  // the alert closable later, and losing it on the fallback would mean the
+  // legacy secret quietly gives you a channel that never goes green.
+  assert.equal(discord.sent[0].url, 'https://legacy/?wait=true');
 });
 
 // ------------------------------------------------------------------ embeds --
@@ -297,6 +314,140 @@ test('unacknowledged filter returns only what still needs a human', async () => 
   assert.equal(open.length, 1);
   assert.equal(open[0].title, 'Second');
   assert.equal((await readAlerts(env)).length, 2, 'the full list still has both');
+});
+
+// ------------------------------------------------- closing it in both places --
+
+test('the posted message id is stored, so the message can be edited later', async () => {
+  const env = newEnv();
+  const discord = fakeDiscord();
+  const result = await raiseAlert(env, ALERT, { fetchImpl: discord });
+
+  assert.equal(result.messageId, 'msg-1');
+  assert.match(discord.sent[0].url, /wait=true/, 'without ?wait=true Discord returns no id');
+  const row = await env.DB.prepare('SELECT discord_message_id FROM alerts WHERE id = ?')
+    .bind(result.id).first();
+  assert.equal(row.discord_message_id, 'msg-1');
+});
+
+test('acknowledging edits the original message green rather than posting again', async () => {
+  const env = newEnv();
+  const discord = fakeDiscord();
+  const { id } = await raiseAlert(env, ALERT, { fetchImpl: discord });
+
+  await acknowledgeAlert(env, id, 'spuddeh', { fetchImpl: discord });
+
+  const edits = discord.edits();
+  assert.equal(edits.length, 1, 'exactly one edit, and no second post');
+  assert.equal(discord.sent.length, 2, 'a second POST would double the channel volume');
+  assert.match(edits[0].url, /\/messages\/msg-1$/);
+  const embed = edits[0].body.embeds[0];
+  assert.equal(embed.color, 0x2ecc71, 'green');
+  assert.match(embed.title, /^✅/);
+  assert.match(embed.footer.text, /acknowledged by spuddeh/);
+  assert.equal(embed.description, 'detail', 'the body has to survive, or the message says nothing');
+});
+
+test('the second acknowledgement does not rewrite the first name into the channel', async () => {
+  // Same rule as the D1 row: the reviewer who got there first is the one who
+  // dealt with it. Editing on a no-op UPDATE would put the later name on the
+  // message and disagree with the dashboard.
+  const env = newEnv();
+  const discord = fakeDiscord();
+  const { id } = await raiseAlert(env, ALERT, { fetchImpl: discord });
+  await acknowledgeAlert(env, id, 'kaoziun', { fetchImpl: discord });
+  await acknowledgeAlert(env, id, 'akiway', { fetchImpl: discord });
+
+  assert.equal(discord.edits().length, 1);
+  assert.match(discord.edits()[0].body.embeds[0].footer.text, /kaoziun/);
+});
+
+test('an alert Discord never carried is still acknowledgeable', async () => {
+  // Every row written before this feature, and every alert Discord refused, has
+  // no message id. Acknowledgement is a dashboard action; it cannot depend on
+  // Discord having worked.
+  const env = newEnv();
+  const discord = fakeDiscord({ noId: true });
+  const { id } = await raiseAlert(env, ALERT, { fetchImpl: discord });
+
+  const row = await acknowledgeAlert(env, id, 'spuddeh', { fetchImpl: discord });
+
+  assert.equal(row.acknowledged_by, 'spuddeh');
+  assert.equal(discord.edits().length, 0);
+});
+
+test('a failing Discord edit does not fail the acknowledgement', async () => {
+  const env = newEnv();
+  const { id } = await raiseAlert(env, ALERT, { fetchImpl: fakeDiscord() });
+
+  const row = await acknowledgeAlert(env, id, 'spuddeh', {
+    fetchImpl: fakeDiscord({ throws: true }),
+  });
+
+  assert.equal(row.acknowledged_by, 'spuddeh');
+  assert.equal(await countUnacknowledged(env), 0);
+});
+
+test('discord_message_id never leaves the module', async () => {
+  // The admin API hands these rows to a browser, and the id is the address of a
+  // message an authenticated webhook can rewrite. It is plumbing, not data.
+  const env = newEnv();
+  const { id } = await raiseAlert(env, ALERT, { fetchImpl: fakeDiscord() });
+  const acked = await acknowledgeAlert(env, id, 'spuddeh', { fetchImpl: fakeDiscord() });
+
+  assert.equal('discord_message_id' in acked, false);
+  assert.equal('discord_message_id' in (await readAlerts(env))[0], false);
+});
+
+test('resolving by ref closes every open alert about one submission', async () => {
+  const env = newEnv();
+  const discord = fakeDiscord();
+  const ref = 'submission:42';
+  await raiseAlert(env, { ...ALERT, source: 'submissions', ref }, { fetchImpl: discord });
+  await raiseAlert(env, { ...ALERT, source: 'submissions', title: 'Reminder', ref },
+    { fetchImpl: discord });
+  await raiseAlert(env, { ...ALERT, source: 'submissions', ref: 'submission:43' },
+    { fetchImpl: discord });
+
+  const closed = await resolveAlertsByRef(env, ref, 'spuddeh', {
+    verb: 'Approved', fetchImpl: discord,
+  });
+
+  assert.equal(closed, 2);
+  assert.equal(await countUnacknowledged(env), 1, 'the other submission is untouched');
+  assert.equal(discord.edits().length, 2);
+  assert.match(discord.edits()[0].body.embeds[0].footer.text, /approved by spuddeh/);
+});
+
+test('resolving a ref nothing matches is zero, not a crash', async () => {
+  const env = newEnv();
+  assert.equal(await resolveAlertsByRef(env, 'submission:999', 'spuddeh'), 0);
+  assert.equal(await resolveAlertsByRef(env, null, 'spuddeh'), 0);
+});
+
+test('the link is one composed body, in D1 and in the embed alike', async () => {
+  // The resolved embed is rebuilt from the ROW, so if the row's body were
+  // missing the link the message would lose it the moment it went green.
+  const env = newEnv();
+  const discord = fakeDiscord();
+  const link = 'https://nczoning.net/admin/?submission=42';
+  const { id } = await raiseAlert(env, { ...ALERT, link }, { fetchImpl: discord });
+
+  const posted = discord.sent[0].body.embeds[0];
+  assert.equal(posted.url, link, 'the embed title is the link');
+  assert.ok(posted.description.includes(link));
+  assert.ok((await readAlerts(env))[0].body.includes(link));
+
+  await acknowledgeAlert(env, id, 'spuddeh', { fetchImpl: discord });
+  assert.equal(discord.edits()[0].body.embeds[0].url, link, 'the link survives resolution');
+});
+
+test('submitter text cannot become Discord formatting', () => {
+  const out = escapeDiscord('**@everyone** look\nat `this`');
+  assert.equal(out.includes('\n'), false, 'a newline re-enables line-start formatting');
+  assert.equal(out.includes('@everyone'), false, 'the mention has to be defused');
+  assert.match(out, /\\\*\\\*/);
+  assert.match(out, /\\`/);
 });
 
 // -------------------------------------------------------------- validation --

--- a/worker/test/review.test.js
+++ b/worker/test/review.test.js
@@ -768,6 +768,70 @@ test('an unknown submission is a 404, not a silent success', async () => {
   }
 });
 
+// -------------------------------------------------- the alert that asked for it ---
+//
+// A submission raises an alert, and resolving the submission is the answer to
+// it. Left unlinked, the dashboard badge and the Discord channel both keep
+// counting work that is finished, and a count that is routinely wrong is a
+// count nobody reads.
+
+/** A pending alert about submission `id`, as submissions.js would have raised it. */
+const openAlert = (id, over = {}) => ({
+  at: '2026-07-27T00:00:00Z',
+  source: 'submissions',
+  severity: 'info',
+  title: 'New location submission awaiting review',
+  body: 'a place',
+  notify: 1,
+  ref: `submission:${id}`,
+  ...over,
+});
+
+const alertRows = (env) => env.DB.rows('SELECT * FROM alerts ORDER BY id');
+
+test('approving acknowledges the alert that asked for the review', async () => {
+  const env = envFor({ submissions: [submission({ id: 1 })], alerts: [openAlert(1)] });
+  await hit(env, 'POST', '/admin/submissions/1/approve');
+
+  const [alert] = alertRows(env);
+  assert.equal(alert.acknowledged_by, 'spuddeh');
+  assert.ok(alert.acknowledged_at);
+});
+
+test('rejecting acknowledges it too: it is resolved either way', async () => {
+  const env = envFor({ submissions: [submission({ id: 1 })], alerts: [openAlert(1)] });
+  await hit(env, 'POST', '/admin/submissions/1/reject', { reason: 'coordinates are in a wall' });
+
+  assert.ok(alertRows(env)[0].acknowledged_at);
+});
+
+test('holding leaves the alert open, because it is still waiting on somebody', async () => {
+  const env = envFor({ submissions: [submission({ id: 1 })], alerts: [openAlert(1)] });
+  await hit(env, 'POST', '/admin/submissions/1/hold', { reason: 'ask Kao' });
+
+  assert.equal(alertRows(env)[0].acknowledged_at, null);
+});
+
+test('only the alerts about THIS submission are closed', async () => {
+  const env = envFor({
+    submissions: [submission({ id: 1 }), submission({ id: 2 })],
+    alerts: [openAlert(1), openAlert(2), openAlert(1, { title: 'Reminder' })],
+  });
+  await hit(env, 'POST', '/admin/submissions/1/approve');
+
+  const acked = alertRows(env).filter((a) => a.acknowledged_at);
+  assert.deepEqual(acked.map((a) => a.ref), ['submission:1', 'submission:1']);
+});
+
+test('a review whose alert is missing still succeeds', async () => {
+  // Every submission raised before the alert carried a ref, and any alert whose
+  // row failed to write. Closing a review must not depend on one existing.
+  const env = envFor({ submissions: [submission({ id: 1 })] });
+  const res = await hit(env, 'POST', '/admin/submissions/1/approve');
+  assert.equal(res.status, 200);
+  assert.equal(subRows(env)[0].status, 'approved');
+});
+
 // ------------------------------------------------------------ write-through ---
 
 test('an approval materializes: an approved change must reach the map', async () => {

--- a/worker/test/submissions.test.js
+++ b/worker/test/submissions.test.js
@@ -356,6 +356,87 @@ test('an unknown kind is refused before anything else happens', async () => {
   assert.deepEqual(calls, []);
 });
 
+// ---------------------------------------------------------------- the alert ---
+//
+// The env carries no webhook, so nothing is posted and the alert ROW is what
+// these read. That is the right surface anyway: the row is what the dashboard
+// shows and what the resolved embed is rebuilt from, so a fact missing here is
+// missing everywhere.
+
+const alerts = (env) => env.DB.rows('SELECT * FROM alerts ORDER BY id');
+
+test('the alert names the submission and links straight at it', async () => {
+  const env = envFor();
+  await submit(env, {
+    kind: 'create', payload: VALID, turnstile_token: 't', submitter_note: 'built it last week',
+  });
+
+  const [alert] = alerts(env);
+  assert.equal(alert.ref, `submission:${rows(env)[0].id}`, 'the ref is what closes it on approval');
+  assert.match(alert.title, /^New location submission/);
+  assert.ok(alert.body.includes('Rooftop Bar'), 'a reviewer has to know what landed');
+  assert.ok(alert.body.includes('new-location'));
+  assert.ok(alert.body.includes('100, 200, 30'));
+  assert.match(alert.body, /\/admin\/\?submission=\d+$/, 'the link goes to the submission');
+});
+
+test('the alert says a note exists and does not repeat it', async () => {
+  // The note and the contact are unreviewed free text from an anonymous caller
+  // and the alerts channel is not behind the collaborator gate. The reviewer
+  // reads them in the dashboard; the alert only says there is something to read.
+  const env = envFor();
+  await submit(env, {
+    kind: 'create',
+    payload: VALID,
+    turnstile_token: 't',
+    submitter_note: 'call me on 555-0100',
+    submitter_contact: 'spud@example.com',
+  });
+
+  const [alert] = alerts(env);
+  assert.equal(alert.body.includes('555-0100'), false);
+  assert.equal(alert.body.includes('spud@example.com'), false);
+  assert.ok(alert.body.includes('a note and a contact'));
+});
+
+test('an edit alert names the record and the fields, not the new values', async () => {
+  const env = envFor();
+  await submit(env, {
+    kind: 'edit', location_id: 'loc-1', turnstile_token: 't',
+    payload: { yaw: 45, description: 'moved a bit' },
+  });
+
+  const [alert] = alerts(env);
+  assert.ok(alert.body.includes('Existing Loft'), 'which record, from the registry not the payload');
+  assert.ok(alert.body.includes('yaw'));
+  assert.ok(alert.body.includes('description'));
+  assert.equal(alert.body.includes('moved a bit'), false, 'values belong in the dashboard diff');
+});
+
+test('a removal alert says what it is asking for, not why', async () => {
+  const env = envFor();
+  await submit(env, {
+    kind: 'remove', location_id: 'loc-1', reason: 'the author asked me to say hello', turnstile_token: 't',
+  });
+
+  const [alert] = alerts(env);
+  assert.ok(alert.body.includes('Existing Loft'));
+  assert.equal(alert.body.includes('say hello'), false);
+});
+
+test('a submitted name cannot carry Discord formatting into the channel', async () => {
+  const env = envFor();
+  await submit(env, {
+    kind: 'create',
+    payload: { ...VALID, name: '@everyone **free** mods' },
+    turnstile_token: 't',
+  });
+
+  const [alert] = alerts(env);
+  assert.equal(alert.body.includes('@everyone'), false);
+  assert.ok(alert.body.includes('\\*\\*free\\*\\*'));
+});
+
 // ------------------------------------------------------------------- limits ---
 
 test('a large payload binds a constant number of parameters', async () => {


### PR DESCRIPTION
Release 2.12.0. Admin-side feedback on the new submission flow: the alert in map-alerts was write-once, so the channel kept reporting a backlog that had already been cleared.

## What ships

**An acknowledged alert goes green in Discord.** Alerts post with `?wait=true`, which is the only way Discord returns the message id, and the id is stored on the row. Acknowledging edits that message in place: green, ✅, footer signed with who cleared it, body preserved. Edited rather than re-posted, so the message you scroll back to is the current one.

Best-effort throughout. An alert with no message id (everything raised before this, and anything Discord refused) acknowledges exactly as it did, and a failing edit never fails the acknowledgement.

**The alert says what the submission is.** Kind, subject, and either the payload's category / Nexus id / coordinates (a create) or the names of the fields an edit changes. The submitter's note, contact and a removal's reason are still not quoted: unreviewed free text from an anonymous caller, and the channel is not behind the collaborator gate. Everything submitter-controlled that is quoted runs through `escapeDiscord()`.

**The link goes straight to the submission.** The embed title links to `/admin/?submission=<id>`; the dashboard reads it at boot, opens the Queue tab and selects the row, clearing the pending filter so an already-resolved submission still opens. The Alerts tab gets the same jump as an "Open submission" button.

**Approving or rejecting auto-acknowledges.** `alerts.ref` holds `submission:<id>` and resolving the submission closes every open alert carrying it. Holding does not: it is still waiting on somebody.

## Migration

`0012_alert_discord_message.sql` adds `alerts.discord_message_id` and `alerts.ref`, both nullable, plus an index.

**Already applied to both production and staging D1** (`nczoning-data`, `nczoning-data-staging`) ahead of this merge. Additive columns are safe in front of the code; code in front of the columns is a 500 on every acknowledgement.

## Testing

442 worker tests, 81 root tests, green on dev. 22 new around the lifecycle: the message is edited once and never re-posted, the second acknowledgement does not rewrite the first reviewer's name, an alert with no message id is still acknowledgeable, resolve-by-ref closes only that submission's alerts, hold leaves them open, and the submitter's free text never reaches the channel.

The end-to-end path (a real submission raising a real Discord post, then going green) cannot be exercised on staging, which is why this is going to main.

## Contents

- #950 feat(alerts): close a submission alert in Discord as well as the dashboard
- docs(worker): correct the wrangler 7403 cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)
